### PR TITLE
Fix concurrency for Cloudflare Pages workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ permissions:
   deployments: write
 
 concurrency:
-  group: preview
+  group: preview-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Allow concurrent preview deployments of multiple branches.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-concurrency-groups