### PR TITLE
Add 'get elections' endpoint to OpenAPI spec

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -9,6 +9,47 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/api/elections": {
+      "get": {
+        "tags": [
+          "election"
+        ],
+        "summary": "Get a list of all elections, without their candidate lists",
+        "operationId": "election_list",
+        "responses": {
+          "200": {
+            "description": "Election list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ElectionListResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/elections/{election_id}": {
       "get": {
         "tags": [
@@ -273,6 +314,21 @@
         "properties": {
           "election": {
             "$ref": "#/components/schemas/Election"
+          }
+        }
+      },
+      "ElectionListResponse": {
+        "type": "object",
+        "description": "Election list response\n\nDoes not include the candidate list (political groups) to keep the response size small.",
+        "required": [
+          "elections"
+        ],
+        "properties": {
+          "elections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Election"
+            }
           }
         }
       },

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -24,7 +24,7 @@ pub struct ElectionDetailsResponse {
     pub election: Election,
 }
 
-// Get a list of all elections, without their candidate lists
+/// Get a list of all elections, without their candidate lists
 #[utoipa::path(
         get,
         path = "/api/elections",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -33,6 +33,7 @@ pub fn create_openapi() -> utoipa::openapi::OpenApi {
     #[derive(OpenApi)]
     #[openapi(
         paths(
+            election::election_list,
             election::election_details,
             polling_station::polling_station_data_entry,
         ),
@@ -47,6 +48,7 @@ pub fn create_openapi() -> utoipa::openapi::OpenApi {
                 election::PoliticalGroup,
                 election::Candidate,
                 election::CandidateGender,
+                election::ElectionListResponse,
                 election::ElectionDetailsResponse,
                 polling_station::DataEntryRequest,
                 polling_station::DataEntryResponse,


### PR DESCRIPTION
It was accidentally missing from the main OpenAPI macro and thus from
the OpenAPI spec (`openapi.json`).