### PR TITLE
Add warning for when votes and voters counts are the same

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -408,7 +408,8 @@
         "enum": [
           "OutOfRange",
           "IncorrectTotal",
-          "AboveThreshold"
+          "AboveThreshold",
+          "EqualInput"
         ]
       },
       "ValidationResults": {

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -27,6 +27,7 @@ pub enum ValidationResultCode {
     OutOfRange,
     IncorrectTotal,
     AboveThreshold,
+    EqualInput,
 }
 
 impl fmt::Display for ValidationResultCode {
@@ -35,6 +36,7 @@ impl fmt::Display for ValidationResultCode {
             ValidationResultCode::OutOfRange => write!(f, "Out of range"),
             ValidationResultCode::IncorrectTotal => write!(f, "Incorrect sum"),
             ValidationResultCode::AboveThreshold => write!(f, "Above threshold"),
+            ValidationResultCode::EqualInput => write!(f, "Equal input"),
         }
     }
 }


### PR DESCRIPTION
This implements the backend logic warning for when votes and voters counts are the same.

Related to #70 