### PR TITLE
adds vitest-fail-on-console

### DIFF
--- a/frontend/app/test/unit/setup.ts
+++ b/frontend/app/test/unit/setup.ts
@@ -2,11 +2,15 @@ import "@testing-library/jest-dom/vitest";
 
 import { cleanup, configure } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll } from "vitest";
+import failOnConsole from "vitest-fail-on-console";
+
 import { server } from "./server";
 
 configure({
   testIdAttribute: "id",
 });
+
+failOnConsole();
 
 beforeAll(() => {
   server.listen({

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,7 +48,8 @@
         "vite": "^5.2.8",
         "vite-node": "^1.5.0",
         "vite-plugin-html": "^3.2.2",
-        "vitest": "^1.4.0"
+        "vitest": "^1.4.0",
+        "vitest-fail-on-console": "^0.7.0"
       },
       "engines": {
         "node": ">=20.11.1"
@@ -12244,6 +12245,31 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-fail-on-console": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/vitest-fail-on-console/-/vitest-fail-on-console-0.7.0.tgz",
+      "integrity": "sha512-oXxHkCJTDL4eA7DQYHa8D0e9RBKeU/mI3nxI54Qjt7MR/m+jeO623apek8kpIaIEjm0/M6syk3evfTm6zFNSCg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "5.3.0"
+      },
+      "peerDependencies": {
+        "vite": ">=4.5.2",
+        "vitest": ">=0.26.2"
+      }
+    },
+    "node_modules/vitest-fail-on-console/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/vitest/node_modules/pathe": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,8 @@
     "vite": "^5.2.8",
     "vite-node": "^1.5.0",
     "vite-plugin-html": "^3.2.2",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "vitest-fail-on-console": "^0.7.0"
   },
   "msw": {
     "workerDirectory": [


### PR DESCRIPTION
closes #74

short version: testing for errors and warnings in the console is a lot easier with vitest, vitest-fail-on-console, and (React) Testing Library than with Playwright. Coverage will also be higher, because we intend to have a lot more tests using (React) Testing Library than using Playwright.

slightly longer version: see issue #74.

See branch `74-test-for-console-errors-and-warnings` for both a vitest and a Playwright test that fails because of a console error.