### PR TITLE
Added pointer cursor to polling station summary block

### DIFF
--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -49,7 +49,7 @@ export function PollingStationChoiceForm() {
           <p>
             Weet je het nummer niet?
             <br />
-            <span id="openPollingStationList" className="underlined">
+            <span id="openPollingStationList" className="underlined pointer">
               Bekijk de lijst met alle stembureaus
             </span>
           </p>

--- a/frontend/lib/ui/style/table.css
+++ b/frontend/lib/ui/style/table.css
@@ -84,6 +84,9 @@ summary {
     text-decoration: underline;
     color: #1570ef;
   }
+  .pointer {
+    cursor: pointer;
+  }
 }
 
 h2.table_title {


### PR DESCRIPTION
Small fix that adds a `cursor: pointer` to the polling station summary block button