### PR TITLE
Frontend: use API to show list of polling stations on polling station select page

### DIFF
--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -1,7 +1,9 @@
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test } from "vitest";
-import { render, screen, within } from "app/test/unit";
+
 import { PollingStationChoiceForm } from "app/component/form/polling_station_choice/PollingStationChoiceForm.tsx";
+import { render, screen, within } from "app/test/unit";
+
 import { PollingStationProvider } from "@kiesraad/api";
 
 describe("Test PollingStationChoiceForm", () => {

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import { PollingStationChoiceForm } from "app/component/form/polling_station_choice/PollingStationChoiceForm.tsx";
 import { render, screen } from "app/test/unit";
+import { PollingStationProvider } from "@kiesraad/api";
 
 describe("Test PollingStationChoiceForm", () => {
   test("Form field entry and buttons", async () => {
@@ -23,13 +24,28 @@ describe("Test PollingStationChoiceForm", () => {
     await user.type(pollingStation, "1234567");
     expect(pollingStation).toHaveValue("123456");
 
-    expect(screen.getByText("Kies het stembureau")).not.toBeVisible();
+    await user.click(submitButton);
+  });
 
+  test("Polling station list", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PollingStationProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationProvider>,
+    );
+
+    expect(screen.getByText("Kies het stembureau")).not.toBeVisible();
     const openPollingStationList = screen.getByTestId("openPollingStationList");
     await user.click(openPollingStationList);
 
     expect(screen.getByText("Kies het stembureau")).toBeVisible();
 
-    await user.click(submitButton);
+    // Check if the station number and name exist and are visible
+    expect(screen.getByText("20")).toBeVisible();
+    expect(screen.getByText('Stembureau "Op Rolletjes"')).toBeVisible();
+    expect(screen.getByText("21")).toBeVisible();
+    expect(screen.getByText("Testplek")).toBeVisible();
   });
 });

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -18,7 +18,7 @@ describe("Test PollingStationChoiceForm", () => {
 
     // Test if the feedback field shows an error
     await user.type(pollingStation, "abc");
-    const pollingStationFeedback = screen.getByTestId("pollingStationSelectorFeedback");
+    const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
     expect(
       within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer abc"),
     ).toBeVisible();
@@ -43,7 +43,7 @@ describe("Test PollingStationChoiceForm", () => {
 
     // Test if the polling station name is shown
     await user.type(pollingStation, "20");
-    const pollingStationFeedback = screen.getByTestId("pollingStationSelectorFeedback");
+    const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
     expect(within(pollingStationFeedback).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
   });
 
@@ -58,7 +58,7 @@ describe("Test PollingStationChoiceForm", () => {
 
     // Test if the polling station name is shown
     await user.type(pollingStation, "99");
-    const pollingStationFeedback = screen.getByTestId("pollingStationSelectorFeedback");
+    const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
     expect(
       within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer 99"),
     ).toBeVisible();

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { PollingStationChoiceForm } from "app/component/form/polling_station_choice/PollingStationChoiceForm.tsx";
 import { render, screen, within } from "app/test/unit";
 
-import { PollingStationProvider } from "@kiesraad/api";
+import { PollingStationProvider, PollingStationsContext } from "@kiesraad/api";
 
 describe("Test PollingStationChoiceForm", () => {
   test("Form field entry", async () => {
@@ -87,5 +87,27 @@ describe("Test PollingStationChoiceForm", () => {
     expect(within(pollingStationList).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
     expect(within(pollingStationList).getByText("21")).toBeVisible();
     expect(within(pollingStationList).getByText("Testplek")).toBeVisible();
+  });
+
+  test("Polling station list no stations", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PollingStationsContext.Provider
+        value={{
+          pollingStationsLoading: false,
+          pollingStations: [],
+        }}
+      >
+        <PollingStationChoiceForm />
+      </PollingStationsContext.Provider>,
+    );
+
+    const openPollingStationList = screen.getByTestId("openPollingStationList");
+    await user.click(openPollingStationList);
+    expect(screen.getByText("Kies het stembureau")).toBeVisible();
+
+    // Check if the error message is visible
+    expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
   });
 });

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -1,8 +1,7 @@
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test } from "vitest";
-
+import { render, screen, within } from "app/test/unit";
 import { PollingStationChoiceForm } from "app/component/form/polling_station_choice/PollingStationChoiceForm.tsx";
-import { render, screen } from "app/test/unit";
 import { PollingStationProvider } from "@kiesraad/api";
 
 describe("Test PollingStationChoiceForm", () => {
@@ -43,9 +42,10 @@ describe("Test PollingStationChoiceForm", () => {
     expect(screen.getByText("Kies het stembureau")).toBeVisible();
 
     // Check if the station number and name exist and are visible
-    expect(screen.getByText("20")).toBeVisible();
-    expect(screen.getByText('Stembureau "Op Rolletjes"')).toBeVisible();
-    expect(screen.getByText("21")).toBeVisible();
-    expect(screen.getByText("Testplek")).toBeVisible();
+    const pollingStationList = screen.getByTestId("polling_station_list");
+    expect(within(pollingStationList).getByText("20")).toBeVisible();
+    expect(within(pollingStationList).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
+    expect(within(pollingStationList).getByText("21")).toBeVisible();
+    expect(within(pollingStationList).getByText("Testplek")).toBeVisible();
   });
 });

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -5,25 +5,63 @@ import { PollingStationChoiceForm } from "app/component/form/polling_station_cho
 import { PollingStationProvider } from "@kiesraad/api";
 
 describe("Test PollingStationChoiceForm", () => {
-  test("Form field entry and buttons", async () => {
+  test("Form field entry", async () => {
     const user = userEvent.setup();
 
-    render(<PollingStationChoiceForm />);
+    render(
+      <PollingStationProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationProvider>,
+    );
 
     const pollingStation = screen.getByTestId("pollingStation");
-    const submitButton = screen.getByRole("button", { name: "Beginnen" });
 
-    // Test if pattern on field works
+    // Test if the feedback field shows an error
     await user.type(pollingStation, "abc");
-    await user.click(submitButton);
-    expect(pollingStation).toBeInvalid();
+    const pollingStationFeedback = screen.getByTestId("pollingStationSelectorFeedback");
+    expect(
+      within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer abc"),
+    ).toBeVisible();
+
     await user.clear(pollingStation);
 
     // Test if maxLength on field works
     await user.type(pollingStation, "1234567");
     expect(pollingStation).toHaveValue("123456");
 
-    await user.click(submitButton);
+    await user.clear(pollingStation);
+  });
+
+  test("Selecting a valid polling station", async () => {
+    const user = userEvent.setup();
+    render(
+      <PollingStationProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationProvider>,
+    );
+    const pollingStation = screen.getByTestId("pollingStation");
+
+    // Test if the polling station name is shown
+    await user.type(pollingStation, "20");
+    const pollingStationFeedback = screen.getByTestId("pollingStationSelectorFeedback");
+    expect(within(pollingStationFeedback).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
+  });
+
+  test("Selecting a non-existing polling station", async () => {
+    const user = userEvent.setup();
+    render(
+      <PollingStationProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationProvider>,
+    );
+    const pollingStation = screen.getByTestId("pollingStation");
+
+    // Test if the polling station name is shown
+    await user.type(pollingStation, "99");
+    const pollingStationFeedback = screen.getByTestId("pollingStationSelectorFeedback");
+    expect(
+      within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer 99"),
+    ).toBeVisible();
   });
 
   test("Polling station list", async () => {

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -16,13 +16,11 @@ export function PollingStationChoiceForm() {
   const navigate = useNavigate();
   const pollingStations = usePollingStationListRequest({
     //election_id: parseInt(id || ""),
-    election_id: 1,
+    election_id: 1, // TODO
   });
-
-  console.log(pollingStations);
   
-  const handleRowClick = () => {
-    navigate(`./030/recounted`);
+  const handleRowClick = (pollingStationNumber: number) => () => {
+    navigate(`./${pollingStationNumber}`);
   };
   function handleSubmit(event: React.FormEvent<PollingStationChoiceFormElement>) {
     event.preventDefault();
@@ -73,20 +71,22 @@ export function PollingStationChoiceForm() {
             </tr>
           </thead>
           <tbody>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                1
-              </td>
-              <td>
-                <span>Nachthemelstraat 21</span>
-                <Badge type="first_entry" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
+            {pollingStations.data?.polling_stations.map((pollingStation: any) => (
+              <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
+                <td width="6.5rem" className="number">
+                  {pollingStation.number}
+                </td>
+                <td>
+                  <span>{pollingStation.name}</span>
+                  <Badge type="first_entry" />
+                </td>
+                <td width="5rem">
+                  <div className="link">
+                    <IconChevronRight />
+                  </div>
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </details>

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -19,7 +19,7 @@ export function PollingStationChoiceForm() {
   const { pollingStations, pollingStationsLoading } = useContext(PollingStationsContext);
 
   const handleRowClick = (pollingStationNumber: number) => () => {
-    navigate(`./${pollingStationNumber}`);
+    navigate(`./${pollingStationNumber}/recounted`);
   };
   function handleSubmit(event: React.FormEvent<PollingStationChoiceFormElement>) {
     event.preventDefault();

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { PollingStationsContext } from "@kiesraad/api";
-import { BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
+import { Alert, BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
 
 import { PollingStationSelector } from "./PollingStationSelector";
 import { PollingStationsList } from "./PollingStationsList";
@@ -61,14 +61,20 @@ export function PollingStationChoiceForm() {
           </p>
         </summary>
         <h2 className="form_title table_title">Kies het stembureau</h2>
-        {pollingStationsLoading ? (
-          <div className="flex">
-            <Icon icon={<Spinner size="lg" />} />
-            aan het zoeken …
-          </div>
-        ) : (
-          <PollingStationsList pollingStations={pollingStations} />
-        )}
+        {(() => {
+          if (pollingStationsLoading) {
+            return (
+              <div className="flex">
+                <Icon icon={<Spinner size="lg" />} />
+                aan het zoeken …
+              </div>
+            );
+          } else if (pollingStations.length === 0) {
+            return <Alert type={"error"}>geen stembureaus gevonden.</Alert>;
+          } else {
+            return <PollingStationsList pollingStations={pollingStations} />;
+          }
+        })()}
       </details>
     </form>
   );

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { IconChevronRight } from "@kiesraad/icon";
 import { PollingStation, PollingStationsContext } from "@kiesraad/api";
 import { PollingStationSelector } from "./PollingStationSelector";
-import { useContext } from "react";
+import { FormEvent, useContext } from "react";
 
 interface FormElements extends HTMLFormControlsCollection {
   number: HTMLInputElement;
@@ -21,7 +21,7 @@ export function PollingStationChoiceForm() {
   const handleRowClick = (pollingStationNumber: number) => () => {
     navigate(`./${pollingStationNumber}/recounted`);
   };
-  function handleSubmit(event: React.FormEvent<PollingStationChoiceFormElement>) {
+  function handleSubmit(event: FormEvent<PollingStationChoiceFormElement>) {
     event.preventDefault();
     navigate("./030/recounted");
   }

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -23,10 +23,14 @@ export function PollingStationChoiceForm() {
   const handleRowClick = (pollingStationNumber: number) => () => {
     navigate(`./${pollingStationNumber}/recounted`);
   };
-  function handleSubmit(event: FormEvent<PollingStationChoiceFormElement>) {
+
+  const handleSubmit = (event: FormEvent<PollingStationChoiceFormElement>) => {
+    const pollingStationNumber = parseInt(event.currentTarget.elements.number.value, 10);
     event.preventDefault();
-    navigate("./030/recounted");
-  }
+    if (pollingStations.some((ps) => ps.number === pollingStationNumber)) {
+      navigate(`./${pollingStationNumber}/recounted`);
+    }
+  };
 
   return (
     <form onSubmit={handleSubmit}>

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -55,35 +55,33 @@ export function PollingStationChoiceForm() {
         {pollingStationsLoading ? (
           <div>aan het zoeken …</div>
         ) : (
-          <>
-            <table id="polling_station_list" className="overview_table">
-              <thead>
-                <tr>
-                  <th className="align-center">Nummer</th>
-                  <th>Stembureau</th>
-                  <th></th>
+          <table id="polling_station_list" className="overview_table">
+            <thead>
+              <tr>
+                <th className="align-center">Nummer</th>
+                <th>Stembureau</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {pollingStations.map((pollingStation: PollingStation) => (
+                <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
+                  <td width="6.5rem" className="number">
+                    {pollingStation.number}
+                  </td>
+                  <td>
+                    <span>{pollingStation.name}</span>
+                    {/* TODO: <Badge type="first_entry" />*/}
+                  </td>
+                  <td width="5rem">
+                    <div className="link">
+                      <IconChevronRight />
+                    </div>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {pollingStations.map((pollingStation: PollingStation) => (
-                  <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
-                    <td width="6.5rem" className="number">
-                      {pollingStation.number}
-                    </td>
-                    <td>
-                      <span>{pollingStation.name}</span>
-                      {/* TODO: <Badge type="first_entry" />*/}
-                    </td>
-                    <td width="5rem">
-                      <div className="link">
-                        <IconChevronRight />
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
+              ))}
+            </tbody>
+          </table>
         )}
       </details>
     </form>

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -1,48 +1,51 @@
-import { FormEvent, useContext } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { PollingStation, PollingStationsContext } from "@kiesraad/api";
-import { IconChevronRight } from "@kiesraad/icon";
+import { PollingStationsContext } from "@kiesraad/api";
 import { BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
 
 import { PollingStationSelector } from "./PollingStationSelector";
-
-interface FormElements extends HTMLFormControlsCollection {
-  number: HTMLInputElement;
-}
-
-interface PollingStationChoiceFormElement extends HTMLFormElement {
-  readonly elements: FormElements;
-}
+import { PollingStationsList } from "./PollingStationsList";
 
 export function PollingStationChoiceForm() {
   const navigate = useNavigate();
 
   const { pollingStations, pollingStationsLoading } = useContext(PollingStationsContext);
+  const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
 
-  const handleRowClick = (pollingStationNumber: number) => () => {
-    navigate(`./${pollingStationNumber}/recounted`);
-  };
-
-  const handleSubmit = (event: FormEvent<PollingStationChoiceFormElement>) => {
-    const pollingStationNumber = parseInt(event.currentTarget.elements.number.value, 10);
-    event.preventDefault();
-    if (pollingStations.some((ps) => ps.number === pollingStationNumber)) {
+  const handleSubmit = () => {
+    const parsedStationNumber = parseInt(pollingStationNumber, 10);
+    if (pollingStations.some((ps) => ps.number === parsedStationNumber)) {
       navigate(`./${pollingStationNumber}/recounted`);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        return;
+      }}
+    >
       <h2 className="form_title">Welk stembureau ga je invoeren?</h2>
-      <PollingStationSelector />
+      <PollingStationSelector
+        pollingStationNumber={pollingStationNumber}
+        setPollingStationNumber={setPollingStationNumber}
+        handleSubmit={handleSubmit}
+      />
       <p className="md">
         Klopt de naam van het stembureau met de naam op je papieren proces verbaal?
         <br />
         Dan kan je beginnen.
       </p>
       <BottomBar type="form">
-        <Button type="submit" size="lg">
+        <Button
+          type="button"
+          size="lg"
+          onClick={() => {
+            handleSubmit();
+          }}
+        >
           Beginnen
         </Button>
         <span className="button_hint">SHIFT + Enter</span>
@@ -64,33 +67,7 @@ export function PollingStationChoiceForm() {
             aan het zoeken …
           </div>
         ) : (
-          <table id="polling_station_list" className="overview_table">
-            <thead>
-              <tr>
-                <th className="align-center">Nummer</th>
-                <th>Stembureau</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {pollingStations.map((pollingStation: PollingStation) => (
-                <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
-                  <td width="6.5rem" className="number">
-                    {pollingStation.number}
-                  </td>
-                  <td>
-                    <span>{pollingStation.name}</span>
-                    {/* TODO: <Badge type="first_entry" />*/}
-                  </td>
-                  <td width="5rem">
-                    <div className="link">
-                      <IconChevronRight />
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <PollingStationsList pollingStations={pollingStations} />
         )}
       </details>
     </form>

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -1,4 +1,4 @@
-import { BottomBar, Button } from "@kiesraad/ui";
+import { BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
 import { useNavigate } from "react-router-dom";
 import { IconChevronRight } from "@kiesraad/icon";
 import { PollingStation, PollingStationsContext } from "@kiesraad/api";
@@ -53,7 +53,10 @@ export function PollingStationChoiceForm() {
         </summary>
         <h2 className="form_title table_title">Kies het stembureau</h2>
         {pollingStationsLoading ? (
-          <div>aan het zoeken …</div>
+          <div className="flex">
+            <Icon icon={<Spinner size="lg" />} />
+            aan het zoeken …
+          </div>
         ) : (
           <table id="polling_station_list" className="overview_table">
             <thead>

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -30,16 +30,7 @@ export function PollingStationChoiceForm() {
   return (
     <form onSubmit={handleSubmit}>
       <h2 className="form_title">Welk stembureau ga je invoeren?</h2>
-      <InputField
-        id="pollingStation"
-        name="number"
-        label="Voer het nummer in:"
-        fieldWidth="narrow"
-        margin={false}
-        pattern="\d+"
-        title="Alleen positieve nummers toegestaan"
-        maxLength={6}
-      />
+      <PollingStationSelector />      
       <p className="md">
         Klopt de naam van het stembureau met de naam op je papieren proces verbaal?
         <br />

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -1,7 +1,9 @@
+import { Badge, BottomBar, Button } from "@kiesraad/ui";
 import { useNavigate } from "react-router-dom";
-
 import { IconChevronRight } from "@kiesraad/icon";
-import { Badge, BottomBar, Button, InputField } from "@kiesraad/ui";
+import { PollingStation, PollingStationsContext } from "@kiesraad/api";
+import { PollingStationSelector } from "./PollingStationSelector";
+import { useContext } from "react";
 
 interface FormElements extends HTMLFormControlsCollection {
   number: HTMLInputElement;
@@ -12,13 +14,10 @@ interface PollingStationChoiceFormElement extends HTMLFormElement {
 }
 
 export function PollingStationChoiceForm() {
-  const { id } = useParams();
   const navigate = useNavigate();
-  const pollingStations = usePollingStationListRequest({
-    //election_id: parseInt(id || ""),
-    election_id: 1, // TODO
-  });
-  
+
+  const { pollingStations, pollingStationsLoading } = useContext(PollingStationsContext);
+
   const handleRowClick = (pollingStationNumber: number) => () => {
     navigate(`./${pollingStationNumber}`);
   };
@@ -30,7 +29,7 @@ export function PollingStationChoiceForm() {
   return (
     <form onSubmit={handleSubmit}>
       <h2 className="form_title">Welk stembureau ga je invoeren?</h2>
-      <PollingStationSelector />      
+      <PollingStationSelector />
       <p className="md">
         Klopt de naam van het stembureau met de naam op je papieren proces verbaal?
         <br />
@@ -53,33 +52,39 @@ export function PollingStationChoiceForm() {
           </p>
         </summary>
         <h2 className="form_title table_title">Kies het stembureau</h2>
-        <table id="polling_station_list" className="overview_table">
-          <thead>
-            <tr>
-              <th className="align-center">Nummer</th>
-              <th>Stembureau</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {pollingStations.data?.polling_stations.map((pollingStation: any) => (
-              <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
-                <td width="6.5rem" className="number">
-                  {pollingStation.number}
-                </td>
-                <td>
-                  <span>{pollingStation.name}</span>
-                  <Badge type="first_entry" />
-                </td>
-                <td width="5rem">
-                  <div className="link">
-                    <IconChevronRight />
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {pollingStationsLoading ? (
+          <div>aan het zoeken …</div>
+        ) : (
+          <>
+            <table id="polling_station_list" className="overview_table">
+              <thead>
+                <tr>
+                  <th className="align-center">Nummer</th>
+                  <th>Stembureau</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {pollingStations.map((pollingStation: PollingStation) => (
+                  <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
+                    <td width="6.5rem" className="number">
+                      {pollingStation.number}
+                    </td>
+                    <td>
+                      <span>{pollingStation.name}</span>
+                      <Badge type="first_entry" />
+                    </td>
+                    <td width="5rem">
+                      <div className="link">
+                        <IconChevronRight />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
       </details>
     </form>
   );

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -1,9 +1,11 @@
-import { BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
-import { useNavigate } from "react-router-dom";
-import { IconChevronRight } from "@kiesraad/icon";
-import { PollingStation, PollingStationsContext } from "@kiesraad/api";
-import { PollingStationSelector } from "./PollingStationSelector";
 import { FormEvent, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { PollingStation, PollingStationsContext } from "@kiesraad/api";
+import { IconChevronRight } from "@kiesraad/icon";
+import { BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
+
+import { PollingStationSelector } from "./PollingStationSelector";
 
 interface FormElements extends HTMLFormControlsCollection {
   number: HTMLInputElement;

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -12,7 +12,15 @@ interface PollingStationChoiceFormElement extends HTMLFormElement {
 }
 
 export function PollingStationChoiceForm() {
+  const { id } = useParams();
   const navigate = useNavigate();
+  const pollingStations = usePollingStationListRequest({
+    //election_id: parseInt(id || ""),
+    election_id: 1,
+  });
+
+  console.log(pollingStations);
+  
   const handleRowClick = () => {
     navigate(`./030/recounted`);
   };
@@ -72,90 +80,6 @@ export function PollingStationChoiceForm() {
               <td>
                 <span>Nachthemelstraat 21</span>
                 <Badge type="first_entry" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                2
-              </td>
-              <td>
-                <span>Schoolstraat 78</span>
-                <Badge type="second_entry" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                3
-              </td>
-              <td>
-                <span>Fluisterbosdreef 8</span>
-                <Badge type="extra_entry" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                4
-              </td>
-              <td>
-                <span>Wilhelminastraat 21</span>
-                <Badge type="objections" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                5
-              </td>
-              <td>
-                <span>Tuinstraat 2</span>
-                <Badge type="difference" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                6
-              </td>
-              <td>
-                <span>Rietland 31</span>
-                <Badge type="correction" />
-              </td>
-              <td width="5rem">
-                <div className="link">
-                  <IconChevronRight />
-                </div>
-              </td>
-            </tr>
-            <tr onClick={handleRowClick}>
-              <td width="6.5rem" className="number">
-                7
-              </td>
-              <td>
-                <span>Grote Markt 1</span>
-                <Badge type="definitive" />
               </td>
               <td width="5rem">
                 <div className="link">

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -1,4 +1,4 @@
-import { Badge, BottomBar, Button } from "@kiesraad/ui";
+import { BottomBar, Button } from "@kiesraad/ui";
 import { useNavigate } from "react-router-dom";
 import { IconChevronRight } from "@kiesraad/icon";
 import { PollingStation, PollingStationsContext } from "@kiesraad/api";
@@ -72,7 +72,7 @@ export function PollingStationChoiceForm() {
                     </td>
                     <td>
                       <span>{pollingStation.name}</span>
-                      <Badge type="first_entry" />
+                      {/* TODO: <Badge type="first_entry" />*/}
                     </td>
                     <td width="5rem">
                       <div className="link">

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -70,7 +70,7 @@ export function PollingStationChoiceForm() {
               </div>
             );
           } else if (pollingStations.length === 0) {
-            return <Alert type={"error"}>geen stembureaus gevonden.</Alert>;
+            return <Alert type={"error"}>Geen stembureaus gevonden</Alert>;
           } else {
             return <PollingStationsList pollingStations={pollingStations} />;
           }

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
@@ -24,6 +24,6 @@
 
   .icon {
     padding-top: 6px;
-    padding-right: 0.5em;
+    padding-right: 1em;
   }
 }

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
@@ -11,13 +11,18 @@
   width: 100%;
   align-content: center;
   font-size: var(--font-size-body);
-}
-
-.loading {
   display: flex;
   align-items: center;
-}
 
-.loadingMessage {
-  margin-left: 1rem;
+  span {
+    margin-left: 1rem;
+  }
+
+  &.error {
+    background-color: var(--color-error-bg);
+  }
+
+  &.success {
+    background-color: var(--color-success-bg);
+  }
 }

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
@@ -14,15 +14,16 @@
   display: flex;
   align-items: center;
 
-  span {
-    margin-left: 1rem;
-  }
-
   &.error {
     background-color: var(--color-error-bg);
   }
 
   &.success {
     background-color: var(--color-success-bg);
+  }
+
+  .icon {
+    padding-top: 6px;
+    padding-right: 0.5em;
   }
 }

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.module.css
@@ -1,0 +1,23 @@
+.container {
+  display: flex;
+  align-items: center;
+}
+
+.result {
+  margin: 0 1em;
+  padding: 0 2em;
+  background-color: var(--bg-gray-darker);
+  height: 4em;
+  width: 100%;
+  align-content: center;
+  font-size: var(--font-size-body);
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+}
+
+.loadingMessage {
+  margin-left: 1rem;
+}

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -1,6 +1,7 @@
 import { PollingStation, PollingStationsContext } from "@kiesraad/api";
-import { InputField } from "@kiesraad/ui";
+import { InputField, Spinner } from "@kiesraad/ui";
 import { useContext, useMemo, useState } from "react";
+import cls from "./PollingStationSelector.module.css";
 
 const ERROR_MESSAGE: string = "Alleen positieve nummers toegestaan";
 
@@ -23,7 +24,7 @@ export function PollingStationSelector() {
   }, [pollingStationNumber, pollingStations]);
 
   return (
-    <div>
+    <div className={cls.container}>
       <InputField
         id="pollingStation"
         name="number"
@@ -39,17 +40,24 @@ export function PollingStationSelector() {
           setPollingStationNumber(e.target.value);
         }}
       />
+      <div className={cls.result}>
       {(() => {
         if (pollingStationNumber.trim() === "") {
           return null;
         } else if (pollingStationsLoading) {
-          return <div>aan het zoeken …</div>;
+          return (
+            <div className={cls.loading}>
+              <Spinner size="lg" />
+              <p className={cls.loadingMessage}>aan het zoeken …</p>
+            </div>
+          );
         } else if (currentPollingStation) {
           return <div>{currentPollingStation.name}</div>;
         } else {
           return <div>Geen stembureau gevonden met nummer {pollingStationNumber}</div>;
         }
       })()}
+      </div>
     </div>
   );
 }

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -1,9 +1,11 @@
-import { PollingStation, PollingStationsContext } from "@kiesraad/api";
-import { Icon, InputField, Spinner } from "@kiesraad/ui";
 import { useContext, useMemo, useState } from "react";
-import cls from "./PollingStationSelector.module.css";
-import { cn, useDebouncedCallback } from "@kiesraad/util";
+
+import { PollingStation, PollingStationsContext } from "@kiesraad/api";
 import { IconError } from "@kiesraad/icon";
+import { Icon, InputField, Spinner } from "@kiesraad/ui";
+import { cn, useDebouncedCallback } from "@kiesraad/util";
+
+import cls from "./PollingStationSelector.module.css";
 
 export function PollingStationSelector() {
   const [pollingStationNumber, setPollingStationNumber] = useState<string>("");

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from "react";
+import { Dispatch, SetStateAction, useContext, useMemo, useState } from "react";
 
 import { PollingStation, PollingStationsContext } from "@kiesraad/api";
 import { IconError } from "@kiesraad/icon";
@@ -7,8 +7,17 @@ import { cn, useDebouncedCallback } from "@kiesraad/util";
 
 import cls from "./PollingStationSelector.module.css";
 
-export function PollingStationSelector() {
-  const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
+export interface PollingStationSelectorProps {
+  pollingStationNumber: string;
+  setPollingStationNumber: Dispatch<SetStateAction<string>>;
+  handleSubmit: () => void;
+}
+
+export function PollingStationSelector({
+  pollingStationNumber,
+  setPollingStationNumber,
+  handleSubmit,
+}: PollingStationSelectorProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [currentPollingStation, setCurrentPollingStation] = useState<PollingStation | undefined>(
     undefined,
@@ -45,6 +54,11 @@ export function PollingStationSelector() {
         maxLength={6}
         onChange={(e) => {
           setPollingStationNumber(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.shiftKey && e.key === "Enter") {
+            handleSubmit();
+          }
         }}
       />
       {pollingStationNumber.trim() !== "" &&

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -50,7 +50,9 @@ export function PollingStationSelector() {
           if (pollingStationsLoading || loading) {
             return (
               <div className={cls.result}>
-                <Icon icon={<Spinner size="lg" />} />
+                <span className={cls.icon}>
+                  <Icon icon={<Spinner size="md" />} />
+                </span>
                 <span>aan het zoeken …</span>
               </div>
             );
@@ -64,7 +66,9 @@ export function PollingStationSelector() {
           } else {
             return (
               <div id="pollingStationSelectorFeedback" className={cn(cls.result, cls.error)}>
-                <Icon icon={<IconError />} color="error" />
+                <span className={cls.icon}>
+                  <Icon icon={<IconError />} color="error" />
+                </span>
                 <span>Geen stembureau gevonden met nummer {pollingStationNumber}</span>
               </div>
             );

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -5,21 +5,16 @@ import cls from "./PollingStationSelector.module.css";
 import { cn } from "@kiesraad/util";
 import { IconError } from "@kiesraad/icon";
 
-const ERROR_MESSAGE: string = "Alleen positieve nummers toegestaan";
-
 export function PollingStationSelector() {
   const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
-  const [error, setError] = useState<string>("");
   const { pollingStations, pollingStationsLoading } = useContext(PollingStationsContext);
 
   const currentPollingStation = useMemo(() => {
     const parsedInt = parseInt(pollingStationNumber, 10);
     if (pollingStationNumber !== "" && Number.isNaN(parsedInt)) {
-      setError(ERROR_MESSAGE);
       return undefined;
     }
 
-    setError("");
     return pollingStations.find(
       (pollingStation: PollingStation) => pollingStation.number === parsedInt,
     );
@@ -35,7 +30,6 @@ export function PollingStationSelector() {
         fieldWidth="narrow"
         margin={false}
         pattern="\d+"
-        title={ERROR_MESSAGE}
         maxLength={6}
         onChange={(e) => {
           setPollingStationNumber(e.target.value);
@@ -43,14 +37,7 @@ export function PollingStationSelector() {
       />
       {pollingStationNumber.trim() !== "" &&
         (() => {
-          if (error) {
-            return (
-              <div className={cn(cls.result, cls.error)}>
-                <Icon icon={<IconError />} color="error" />
-                <span>{error}</span>
-              </div>
-            );
-          } else if (pollingStationsLoading) {
+          if (pollingStationsLoading) {
             return (
               <div className={cls.result}>
                 <Icon icon={<Spinner size="lg" />} />

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -1,0 +1,62 @@
+import { PollingStation, usePollingStationListRequest } from "@kiesraad/api";
+import { InputField } from "@kiesraad/ui";
+import { useMemo, useState } from "react";
+
+export function PollingStationSelector() {
+  const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
+  const pollingStations = usePollingStationListRequest({
+    //election_id: parseInt(id || ""),
+    election_id: 1, // TODO
+  });
+
+  const currentPollingStation = useMemo(() => {
+    const parsedInt = parseInt(pollingStationNumber, 10);
+    if (Number.isNaN(parsedInt)) {
+      return undefined;
+    }
+    
+    return pollingStations.data?.polling_stations
+      .find((pollingStation: PollingStation) => pollingStation.number === parsedInt);
+    
+  }, [pollingStationNumber, pollingStations]);
+
+  return (
+    <div>
+      <InputField
+        id="pollingStation"
+        name="number"
+        value={pollingStationNumber}
+        label="Voer het nummer in:"
+        fieldWidth="narrow"
+        margin={false}
+        pattern="\d+"
+        title="Alleen positieve nummers toegestaan"
+        maxLength={6}
+        onChange={(e) => setPollingStationNumber(e.target.value)}
+      />
+      {(() => {
+        if (pollingStationNumber === "") {
+          return null;
+        } else if (pollingStations.loading) {
+          return (
+            <div>
+              aan het zoeken …
+            </div>
+          );
+        } else if (currentPollingStation) {
+          return (
+            <div>
+              {currentPollingStation.name}
+            </div>
+          )
+        } else if (currentPollingStation === undefined) {
+          return (
+            <div>
+              Geen stembureau gevonden met nummer {pollingStationNumber}
+            </div>
+          );
+        }
+      })()}
+    </div>
+  );
+}

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -61,6 +61,7 @@ export function PollingStationSelector() {
             return (
               <div className={cn(cls.result, cls.success)}>
                 <span className={"bold"}>{currentPollingStation.name}</span>
+                {/* TODO: <Badge type="first_entry" />*/}
               </div>
             );
           } else {

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -2,16 +2,21 @@ import { PollingStation, PollingStationsContext } from "@kiesraad/api";
 import { InputField } from "@kiesraad/ui";
 import { useContext, useMemo, useState } from "react";
 
+const ERROR_MESSAGE: string = "Alleen positieve nummers toegestaan";
+
 export function PollingStationSelector() {
   const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
+  const [error, setError] = useState<string>("");
   const { pollingStations, pollingStationsLoading } = useContext(PollingStationsContext);
 
   const currentPollingStation = useMemo(() => {
     const parsedInt = parseInt(pollingStationNumber, 10);
-    if (Number.isNaN(parsedInt)) {
+    if (pollingStationNumber !== "" && Number.isNaN(parsedInt)) {
+      setError(ERROR_MESSAGE);
       return undefined;
     }
 
+    setError("");
     return pollingStations.find(
       (pollingStation: PollingStation) => pollingStation.number === parsedInt,
     );
@@ -27,7 +32,8 @@ export function PollingStationSelector() {
         fieldWidth="narrow"
         margin={false}
         pattern="\d+"
-        title="Alleen positieve nummers toegestaan"
+        title={ERROR_MESSAGE}
+        error={error}
         maxLength={6}
         onChange={(e) => {
           setPollingStationNumber(e.target.value);

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -29,7 +29,6 @@ export function PollingStationSelector() {
         label="Voer het nummer in:"
         fieldWidth="narrow"
         margin={false}
-        pattern="\d+"
         maxLength={6}
         onChange={(e) => {
           setPollingStationNumber(e.target.value);
@@ -46,14 +45,14 @@ export function PollingStationSelector() {
             );
           } else if (currentPollingStation) {
             return (
-              <div className={cn(cls.result, cls.success)}>
+              <div id="pollingStationSelectorFeedback" className={cn(cls.result, cls.success)}>
                 <span className={"bold"}>{currentPollingStation.name}</span>
                 {/* TODO: <Badge type="first_entry" />*/}
               </div>
             );
           } else {
             return (
-              <div className={cn(cls.result, cls.error)}>
+              <div id="pollingStationSelectorFeedback" className={cn(cls.result, cls.error)}>
                 <Icon icon={<IconError />} color="error" />
                 <span>Geen stembureau gevonden met nummer {pollingStationNumber}</span>
               </div>

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -1,23 +1,20 @@
-import { PollingStation, usePollingStationListRequest } from "@kiesraad/api";
+import { PollingStation, PollingStationsContext } from "@kiesraad/api";
 import { InputField } from "@kiesraad/ui";
-import { useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 
 export function PollingStationSelector() {
   const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
-  const pollingStations = usePollingStationListRequest({
-    //election_id: parseInt(id || ""),
-    election_id: 1, // TODO
-  });
+  const { pollingStations, pollingStationsLoading } = useContext(PollingStationsContext);
 
   const currentPollingStation = useMemo(() => {
     const parsedInt = parseInt(pollingStationNumber, 10);
     if (Number.isNaN(parsedInt)) {
       return undefined;
     }
-    
-    return pollingStations.data?.polling_stations
-      .find((pollingStation: PollingStation) => pollingStation.number === parsedInt);
-    
+
+    return pollingStations.find(
+      (pollingStation: PollingStation) => pollingStation.number === parsedInt,
+    );
   }, [pollingStationNumber, pollingStations]);
 
   return (
@@ -32,29 +29,19 @@ export function PollingStationSelector() {
         pattern="\d+"
         title="Alleen positieve nummers toegestaan"
         maxLength={6}
-        onChange={(e) => setPollingStationNumber(e.target.value)}
+        onChange={(e) => {
+          setPollingStationNumber(e.target.value);
+        }}
       />
       {(() => {
-        if (pollingStationNumber === "") {
+        if (pollingStationNumber.trim() === "") {
           return null;
-        } else if (pollingStations.loading) {
-          return (
-            <div>
-              aan het zoeken …
-            </div>
-          );
+        } else if (pollingStationsLoading) {
+          return <div>aan het zoeken …</div>;
         } else if (currentPollingStation) {
-          return (
-            <div>
-              {currentPollingStation.name}
-            </div>
-          )
-        } else if (currentPollingStation === undefined) {
-          return (
-            <div>
-              Geen stembureau gevonden met nummer {pollingStationNumber}
-            </div>
-          );
+          return <div>{currentPollingStation.name}</div>;
+        } else {
+          return <div>Geen stembureau gevonden met nummer {pollingStationNumber}</div>;
         }
       })()}
     </div>

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -1,7 +1,9 @@
 import { PollingStation, PollingStationsContext } from "@kiesraad/api";
-import { InputField, Spinner } from "@kiesraad/ui";
+import { Icon, InputField, Spinner } from "@kiesraad/ui";
 import { useContext, useMemo, useState } from "react";
 import cls from "./PollingStationSelector.module.css";
+import { cn } from "@kiesraad/util";
+import { IconError } from "@kiesraad/icon";
 
 const ERROR_MESSAGE: string = "Alleen positieve nummers toegestaan";
 
@@ -34,30 +36,42 @@ export function PollingStationSelector() {
         margin={false}
         pattern="\d+"
         title={ERROR_MESSAGE}
-        error={error}
         maxLength={6}
         onChange={(e) => {
           setPollingStationNumber(e.target.value);
         }}
       />
-      <div className={cls.result}>
-      {(() => {
-        if (pollingStationNumber.trim() === "") {
-          return null;
-        } else if (pollingStationsLoading) {
-          return (
-            <div className={cls.loading}>
-              <Spinner size="lg" />
-              <p className={cls.loadingMessage}>aan het zoeken …</p>
-            </div>
-          );
-        } else if (currentPollingStation) {
-          return <div>{currentPollingStation.name}</div>;
-        } else {
-          return <div>Geen stembureau gevonden met nummer {pollingStationNumber}</div>;
-        }
-      })()}
-      </div>
+      {pollingStationNumber.trim() !== "" &&
+        (() => {
+          if (error) {
+            return (
+              <div className={cn(cls.result, cls.error)}>
+                <Icon icon={<IconError />} color="error" />
+                <span>{error}</span>
+              </div>
+            );
+          } else if (pollingStationsLoading) {
+            return (
+              <div className={cls.result}>
+                <Icon icon={<Spinner size="lg" />} />
+                <span>aan het zoeken …</span>
+              </div>
+            );
+          } else if (currentPollingStation) {
+            return (
+              <div className={cn(cls.result, cls.success)}>
+                <span className={"bold"}>{currentPollingStation.name}</span>
+              </div>
+            );
+          } else {
+            return (
+              <div className={cn(cls.result, cls.error)}>
+                <Icon icon={<IconError />} color="error" />
+                <span>Geen stembureau gevonden met nummer {pollingStationNumber}</span>
+              </div>
+            );
+          }
+        })()}
     </div>
   );
 }

--- a/frontend/app/component/form/polling_station_choice/PollingStationsList.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationsList.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from "react-router-dom";
+
+import { PollingStation } from "@kiesraad/api";
+import { IconChevronRight } from "@kiesraad/icon";
+
+export interface PollingStationsListProps {
+  pollingStations: PollingStation[];
+}
+
+export function PollingStationsList({ pollingStations }: PollingStationsListProps) {
+  const navigate = useNavigate();
+
+  const handleRowClick = (pollingStationNumber: number) => () => {
+    navigate(`./${pollingStationNumber}/recounted`);
+  };
+
+  return (
+    <table id="polling_station_list" className="overview_table">
+      <thead>
+        <tr>
+          <th className="align-center">Nummer</th>
+          <th>Stembureau</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {pollingStations.map((pollingStation: PollingStation) => (
+          <tr onClick={handleRowClick(pollingStation.number)} key={pollingStation.number}>
+            <td width="6.5rem" className="number">
+              {pollingStation.number}
+            </td>
+            <td>
+              <span>{pollingStation.name}</span>
+              {/* TODO: <Badge type="first_entry" />*/}
+            </td>
+            <td width="5rem">
+              <div className="link">
+                <IconChevronRight />
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/app/module/input/InputLayout.tsx
+++ b/frontend/app/module/input/InputLayout.tsx
@@ -1,15 +1,18 @@
-import { Outlet } from "react-router-dom";
-
 import { Footer } from "app/component/footer/Footer";
+import { PollingStationProvider } from "@kiesraad/api";
+import { Outlet, useParams } from "react-router-dom";
 
 export function InputLayout() {
+  const { electionId } = useParams();
   return (
-    <div className="app-layout">
-      <nav>Hello world</nav>
+    <PollingStationProvider electionId={parseInt(electionId ?? "", 10)}>
+      <div className="app-layout">
+        <nav>Hello world</nav>
 
-      <Outlet />
+        <Outlet />
 
-      <Footer />
-    </div>
+        <Footer />
+      </div>
+    </PollingStationProvider>
   );
 }

--- a/frontend/app/module/input/InputLayout.tsx
+++ b/frontend/app/module/input/InputLayout.tsx
@@ -1,6 +1,8 @@
-import { Footer } from "app/component/footer/Footer";
-import { PollingStationProvider } from "@kiesraad/api";
 import { Outlet, useParams } from "react-router-dom";
+
+import { Footer } from "app/component/footer/Footer";
+
+import { PollingStationProvider } from "@kiesraad/api";
 
 export function InputLayout() {
   const { electionId } = useParams();

--- a/frontend/lib/api-mocks/PollingStationMockData.ts
+++ b/frontend/lib/api-mocks/PollingStationMockData.ts
@@ -4,13 +4,23 @@ export const pollingStationMockData: PollingStationListResponse = {
   polling_stations: [
     {
       id: 1,
-      number: 1,
+      number: 20,
       name: 'Stembureau "Op Rolletjes"',
       house_number: "33",
       locality: "Den Haag",
       polling_station_type: "Mobiel",
       postal_code: "1234 YQ",
       street: "Rijksweg A12",
+    },
+    {
+      id: 2,
+      number: 21,
+      name: "Testplek",
+      house_number: "34",
+      locality: "Testdorp",
+      polling_station_type: "Bijzonder",
+      postal_code: "1234 QY",
+      street: "Teststraat",
     },
   ],
 };

--- a/frontend/lib/api-mocks/PollingStationMockData.ts
+++ b/frontend/lib/api-mocks/PollingStationMockData.ts
@@ -1,0 +1,16 @@
+import { PollingStationListResponse } from "@kiesraad/api";
+
+export const pollingStationMockData: PollingStationListResponse = {
+  polling_stations: [
+    {
+      id: 1,
+      number: 1,
+      name: 'Stembureau "Op Rolletjes"',
+      house_number: "33",
+      locality: "Den Haag",
+      polling_station_type: "Mobiel",
+      postal_code: "1234 YQ",
+      street: "Rijksweg A12",
+    },
+  ],
+};

--- a/frontend/lib/api-mocks/index.ts
+++ b/frontend/lib/api-mocks/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@kiesraad/api";
 
 import { electionMockData, electionsMockData, politicalGroupMockData } from "./ElectionMockData.ts";
+import { pollingStationMockData } from "./PollingStationMockData.ts";
 
 export const electionMock = electionMockData as Required<Election>;
 export const politicalGroupMock = politicalGroupMockData as Required<PoliticalGroup>;
@@ -184,9 +185,17 @@ export const ElectionRequestHandler = http.get<ParamsToString<{ election_id: num
   },
 );
 
+export const PollingStationListRequestHandler = http.get<ParamsToString<{ election_id: number }>>(
+  "/api/polling_stations/:id",
+  () => {
+    return HttpResponse.json(pollingStationMockData, { status: 200 });
+  },
+);
+
 export const handlers: HttpHandler[] = [
   pingHandler,
   pollingStationDataEntryHandler,
+  PollingStationListRequestHandler,
   ElectionListRequestHandler,
   ElectionRequestHandler,
 ];

--- a/frontend/lib/api/PollingStationProvider.tsx
+++ b/frontend/lib/api/PollingStationProvider.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { PollingStation } from "./gen/openapi";
 import { usePollingStationListRequest } from "./usePollingStation";
 

--- a/frontend/lib/api/PollingStationProvider.tsx
+++ b/frontend/lib/api/PollingStationProvider.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { PollingStation } from "./gen/openapi";
+import { usePollingStationListRequest } from "./usePollingStation";
+
+export interface iPollingStationsContext {
+  pollingStationsLoading: boolean;
+  pollingStations: PollingStation[];
+}
+
+export const PollingStationsContext = React.createContext<iPollingStationsContext>({
+  pollingStationsLoading: true,
+  pollingStations: [],
+});
+
+export interface PollingStationProviderProps {
+  electionId: number | undefined;
+  children: React.ReactNode;
+}
+
+export function PollingStationProvider({ electionId, children }: PollingStationProviderProps) {
+  const { data, loading } = usePollingStationListRequest({ election_id: electionId as number });
+
+  return (
+    <PollingStationsContext.Provider
+      value={{
+        pollingStationsLoading: loading,
+        pollingStations: data?.polling_stations ?? [],
+      }}
+    >
+      {children}
+    </PollingStationsContext.Provider>
+  );
+}

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -16,8 +16,7 @@ export type ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${number}`;
 export interface POLLING_STATION_LIST_REQUEST_PARAMS {
   election_id: number;
 }
-export type POLLING_STATION_LIST_REQUEST_PATH =
-  `/api/polling_stations/${number}`;
+export type POLLING_STATION_LIST_REQUEST_PATH = `/api/polling_stations/${number}`;
 
 // /api/polling_stations/{polling_station_id}/data_entries/{entry_number}
 export interface POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS {

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -16,7 +16,8 @@ export type ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${number}`;
 export interface POLLING_STATION_LIST_REQUEST_PARAMS {
   election_id: number;
 }
-export type POLLING_STATION_LIST_REQUEST_PATH = `/api/polling_stations/${number}`;
+export type POLLING_STATION_LIST_REQUEST_PATH =
+  `/api/polling_stations/${number}`;
 
 // /api/polling_stations/{polling_station_id}/data_entries/{entry_number}
 export interface POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS {
@@ -135,6 +136,29 @@ export interface PoliticalGroupVotes {
   candidate_votes: CandidateVotes[];
   number: number;
   total: number;
+}
+
+/**
+ * Polling station of a certain [Election]
+ */
+export interface PollingStation {
+  house_number: string;
+  house_number_addition?: string;
+  id: number;
+  locality: string;
+  name: string;
+  number: number;
+  number_of_voters?: number;
+  polling_station_type: PollingStationType;
+  postal_code: string;
+  street: string;
+}
+
+/**
+ * Polling station list response
+ */
+export interface PollingStationListResponse {
+  polling_stations: PollingStation[];
 }
 
 /**

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -1,11 +1,4 @@
 export * from "./election";
-export * from "./ApiProvider";
-export * from "./ApiClient";
-export * from "./useApiPostRequest";
-export * from "./useApiGetRequest";
-export * from "./useElectionDataRequest";
-export * from "./usePollingStationDataEntry";
-export * from "./usePollingStation";
 export * from "./gen/openapi";
 export type * from "./api.d.ts";
 export * from "./ApiClient";
@@ -15,4 +8,5 @@ export * from "./useApiPostRequest";
 export * from "./useElectionDataRequest";
 export * from "./useElectionListRequest";
 export * from "./usePollingStationDataEntry";
+export * from "./usePollingStation";
 export * from "./form";

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -1,4 +1,11 @@
 export * from "./election";
+export * from "./ApiProvider";
+export * from "./ApiClient";
+export * from "./useApiPostRequest";
+export * from "./useApiGetRequest";
+export * from "./useElectionDataRequest";
+export * from "./usePollingStationDataEntry";
+export * from "./usePollingStation";
 export * from "./gen/openapi";
 export type * from "./api.d.ts";
 export * from "./ApiClient";

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -3,6 +3,7 @@ export * from "./gen/openapi";
 export type * from "./api.d.ts";
 export * from "./ApiClient";
 export * from "./ApiProvider";
+export * from "./PollingStationProvider";
 export * from "./useApiGetRequest";
 export * from "./useApiPostRequest";
 export * from "./useElectionDataRequest";

--- a/frontend/lib/api/usePollingStation.ts
+++ b/frontend/lib/api/usePollingStation.ts
@@ -1,0 +1,6 @@
+import { useApiGetRequest } from "./useApiGetRequest";
+import { PollingStation, POLLING_STATION_REQUEST_PARAMS } from "./gen/openapi";
+
+export function usePollingStationListRequest(params: POLLING_STATION_REQUEST_PARAMS) {
+  return useApiGetRequest<PollingStation>(`/api/polling_stations/${params.election_id}`);
+}

--- a/frontend/lib/api/usePollingStation.ts
+++ b/frontend/lib/api/usePollingStation.ts
@@ -1,5 +1,5 @@
-import { useApiGetRequest } from "./useApiGetRequest";
 import { POLLING_STATION_LIST_REQUEST_PARAMS, PollingStationListResponse } from "./gen/openapi";
+import { useApiGetRequest } from "./useApiGetRequest";
 
 export function usePollingStationListRequest(params: POLLING_STATION_LIST_REQUEST_PARAMS) {
   return useApiGetRequest<PollingStationListResponse>(

--- a/frontend/lib/api/usePollingStation.ts
+++ b/frontend/lib/api/usePollingStation.ts
@@ -1,6 +1,6 @@
 import { useApiGetRequest } from "./useApiGetRequest";
-import { PollingStation, POLLING_STATION_REQUEST_PARAMS } from "./gen/openapi";
+import { POLLING_STATION_LIST_REQUEST_PARAMS, PollingStationListResponse } from "./gen/openapi";
 
-export function usePollingStationListRequest(params: POLLING_STATION_REQUEST_PARAMS) {
-  return useApiGetRequest<PollingStation>(`/api/polling_stations/${params.election_id}`);
+export function usePollingStationListRequest(params: POLLING_STATION_LIST_REQUEST_PARAMS) {
+  return useApiGetRequest<PollingStationListResponse>(`/api/polling_stations/${params.election_id}`);
 }

--- a/frontend/lib/api/usePollingStation.ts
+++ b/frontend/lib/api/usePollingStation.ts
@@ -2,5 +2,7 @@ import { useApiGetRequest } from "./useApiGetRequest";
 import { POLLING_STATION_LIST_REQUEST_PARAMS, PollingStationListResponse } from "./gen/openapi";
 
 export function usePollingStationListRequest(params: POLLING_STATION_LIST_REQUEST_PARAMS) {
-  return useApiGetRequest<PollingStationListResponse>(`/api/polling_stations/${params.election_id}`);
+  return useApiGetRequest<PollingStationListResponse>(
+    `/api/polling_stations/${params.election_id}`,
+  );
 }

--- a/frontend/lib/ui/Icon/Icon.module.css
+++ b/frontend/lib/ui/Icon/Icon.module.css
@@ -14,6 +14,12 @@
     }
   }
 
+  &.error {
+    svg {
+      fill: var(--color-error);
+    }
+  }
+
   &.xs {
     svg {
       width: 16px;

--- a/frontend/lib/ui/Icon/Icon.tsx
+++ b/frontend/lib/ui/Icon/Icon.tsx
@@ -8,7 +8,7 @@ import cls from "./Icon.module.css";
 export interface IconProps {
   icon: React.ReactNode;
   size?: Size;
-  color?: "primary" | "warning";
+  color?: "primary" | "warning" | "error";
   spacing?: number;
 }
 

--- a/frontend/lib/util/hook/useDebouncedCallback.test.ts
+++ b/frontend/lib/util/hook/useDebouncedCallback.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "app/test/unit";
+import { useDebouncedCallback } from "./useDebouncedCallback";
+
+describe("useDebouncedCallback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("Debounces callback with given delay", () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(callback, 100));
+    result.current();
+    result.current();
+    result.current();
+    expect(callback).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test("Calls callback with correct arguments", () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(callback, 100));
+    result.current(1);
+    result.current(2);
+    result.current(3);
+    vi.advanceTimersByTime(100);
+    expect(callback).toHaveBeenCalledWith(3);
+  });
+});

--- a/frontend/lib/util/hook/useDebouncedCallback.test.ts
+++ b/frontend/lib/util/hook/useDebouncedCallback.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
 import { renderHook } from "app/test/unit";
+
 import { useDebouncedCallback } from "./useDebouncedCallback";
 
 describe("useDebouncedCallback", () => {

--- a/frontend/lib/util/hook/useDebouncedCallback.ts
+++ b/frontend/lib/util/hook/useDebouncedCallback.ts
@@ -4,7 +4,9 @@ export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
   callback: T,
   delay: number,
 ) {
+  const callbackRef = useRef(callback);
   const debounceTimerRef = useRef(0);
+
   useEffect(() => {
     return () => {
       window.clearTimeout(debounceTimerRef.current);
@@ -14,9 +16,8 @@ export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
   return useCallback(
     (...args: Parameters<T>) => {
       window.clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = window.setTimeout(() => callback(...args), delay);
+      debounceTimerRef.current = window.setTimeout(() => callbackRef.current(...args), delay);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [delay],
   );
 }

--- a/frontend/lib/util/hook/useDebouncedCallback.ts
+++ b/frontend/lib/util/hook/useDebouncedCallback.ts
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
+  callback: T,
+  delay: number,
+) {
+  const debounceTimerRef = useRef(0);
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      window.clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = window.setTimeout(() => callback(...args), delay);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [delay],
+  );
+}

--- a/frontend/lib/util/index.ts
+++ b/frontend/lib/util/index.ts
@@ -4,3 +4,4 @@ export * from "./fields";
 export * from "./strings";
 export * from "./hook/usePositiveNumberInputMask";
 export * from "./hook/usePreventFormEnterSubmit";
+export * from "./hook/useDebouncedCallback";


### PR DESCRIPTION
This PR replaces hard coded polling stations with polling stations provided by the backend. It also adds a lookup when the user enters a polling station number.