### PR TITLE
Update GitHub Actions workflows triggers

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,8 +1,8 @@
 name: Backend
 
 on:
-  push:
   workflow_dispatch:
+  pull_request:
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,8 +1,8 @@
 name: Frontend
 
 on:
-  push:
   workflow_dispatch:
+  pull_request:
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
Do not trigger Frontend and Backend workflows on push, but only for pull request and merge queue (merge group). Because commits to `main` are already checked in the merge group, they do not need to run on push. Also, the `pull_request` trigger will run on the PR merge branch instead of the PR branch, which lets us find potential test failures sooner (in the PR of only when the merge queue checks run).