### PR TITLE
Update Frontend Preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           apiToken: ${{ secrets.API_TOKEN }}
           accountId: ${{ secrets.ACCOUNT_ID }}
-          command: pages deploy dist --project-name=${{ vars.PROJECT_NAME }}
+          command: pages deploy dist --project-name=${{ vars.PROJECT_NAME }} --branch ${{ github.head_ref || github.ref }} --commit-hash ${GITHUB_SHA}
           workingDirectory: frontend
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,11 @@
 name: Frontend Preview
 
 on:
-  push:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Only deploy to the preview environment for pull requests and pushes to the `main` branch. This avoids deploys for temporary merge queue branches and other branches where we don't need previews.