### PR TITLE
Add TypeScript compilation check to Lefthook 

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,10 @@ pre-commit:
       root: "frontend/"
       run: npx prettier --ignore-unknown --write {staged_files}
       stage_fixed: true
+    frontend-typescript:
+      root: "frontend/"
+      glob: "*.{ts,tsx}"
+      run: npx tsc
     frontend-linter:
       root: "frontend/"
       glob: "*.{ts,tsx}"


### PR DESCRIPTION
This is not part of `npm run lint` but important enough to be done in a pre-commit hook.