### PR TITLE
Improve polling station form tests

### DIFF
--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -95,7 +95,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Polling station list no stations", async () => {
-    overrideOnce("get", "/api/polling_stations/1", 200, {
+    overrideOnce("get", "/api/elections/1/polling_stations", 200, {
       polling_stations: [],
     });
     const user = userEvent.setup();

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -113,4 +113,24 @@ describe("Test PollingStationChoiceForm", () => {
     // Check if the error message is visible
     expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
   });
+
+  test("Polling station request returns 404", async () => {
+    overrideOnce("get", "/api/elections/1/polling_stations", 404, {
+      error: "Resource not found",
+    });
+    const user = userEvent.setup();
+
+    render(
+      <PollingStationProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationProvider>,
+    );
+
+    const openPollingStationList = screen.getByTestId("openPollingStationList");
+    await user.click(openPollingStationList);
+    expect(screen.getByText("Kies het stembureau")).toBeVisible();
+
+    // Check if the error message is visible
+    expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
+  });
 });

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -9,7 +9,7 @@ import { pollingStationMock } from "@kiesraad/api-mocks";
 
 describe("Test PollingStationChoiceForm", () => {
   test("Form field entry", async () => {
-    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
+    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationMock);
     const user = userEvent.setup();
 
     render(
@@ -37,7 +37,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Selecting a valid polling station", async () => {
-    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
+    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationMock);
     const user = userEvent.setup();
     render(
       <PollingStationProvider electionId={1}>
@@ -53,7 +53,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Selecting a non-existing polling station", async () => {
-    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
+    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationMock);
     const user = userEvent.setup();
     render(
       <PollingStationProvider electionId={1}>
@@ -71,7 +71,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Polling station list", async () => {
-    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
+    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationMock);
     const user = userEvent.setup();
 
     render(

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -2,12 +2,14 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test } from "vitest";
 
 import { PollingStationChoiceForm } from "app/component/form/polling_station_choice/PollingStationChoiceForm.tsx";
-import { render, screen, within } from "app/test/unit";
+import { overrideOnce, render, screen, within } from "app/test/unit";
 
-import { PollingStationProvider, PollingStationsContext } from "@kiesraad/api";
+import { PollingStationProvider } from "@kiesraad/api";
+import { pollingStationMock } from "@kiesraad/api-mocks";
 
 describe("Test PollingStationChoiceForm", () => {
   test("Form field entry", async () => {
+    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
     const user = userEvent.setup();
 
     render(
@@ -35,6 +37,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Selecting a valid polling station", async () => {
+    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
     const user = userEvent.setup();
     render(
       <PollingStationProvider electionId={1}>
@@ -50,6 +53,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Selecting a non-existing polling station", async () => {
+    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
     const user = userEvent.setup();
     render(
       <PollingStationProvider electionId={1}>
@@ -67,6 +71,7 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Polling station list", async () => {
+    overrideOnce("get", "/api/polling_stations/1", 200, pollingStationMock);
     const user = userEvent.setup();
 
     render(
@@ -90,17 +95,15 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Polling station list no stations", async () => {
+    overrideOnce("get", "/api/polling_stations/1", 200, {
+      polling_stations: [],
+    });
     const user = userEvent.setup();
 
     render(
-      <PollingStationsContext.Provider
-        value={{
-          pollingStationsLoading: false,
-          pollingStations: [],
-        }}
-      >
+      <PollingStationProvider electionId={1}>
         <PollingStationChoiceForm />
-      </PollingStationsContext.Provider>,
+      </PollingStationProvider>,
     );
 
     const openPollingStationList = screen.getByTestId("openPollingStationList");

--- a/frontend/lib/api-mocks/index.ts
+++ b/frontend/lib/api-mocks/index.ts
@@ -7,6 +7,7 @@ import {
   PoliticalGroup,
   POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS,
+  PollingStationListResponse,
   VotersCounts,
   VotesCounts,
 } from "@kiesraad/api";
@@ -16,6 +17,7 @@ import { pollingStationMockData } from "./PollingStationMockData.ts";
 
 export const electionMock = electionMockData as Required<Election>;
 export const politicalGroupMock = politicalGroupMockData as Required<PoliticalGroup>;
+export const pollingStationMock = pollingStationMockData as Required<PollingStationListResponse>;
 
 type ParamsToString<T> = {
   [P in keyof T]: string;


### PR DESCRIPTION
Closes #163 

Using `overrideOnce` at the start of every test to make clear what data is used for the test. Also making it more explicit when testing edge cases.

This PR leaves out the 404 test as discussed in the issue, as it is dependent on the decision made in #179 