### PR TITLE
Remove redundant and incorrectly handled validation

### DIFF
--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -32,10 +32,6 @@ export function PollingStationSelector({
 
   useMemo(() => {
     const parsedInt = parseInt(pollingStationNumber, 10);
-    if (pollingStationNumber !== "" && Number.isNaN(parsedInt)) {
-      return undefined;
-    }
-
     setLoading(true);
     debouncedCallback(
       pollingStations.find((pollingStation: PollingStation) => pollingStation.number === parsedInt),


### PR DESCRIPTION
Fixes a bug where the error message was shown immediately after the user would start typing non-numeric characters, instead of showing a debounced loading message.
We can safely remove this validation, because the isNaN and empty string checks are both already handled by the render logic.