### PR TITLE
Fix false positives in tests

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
@@ -5,18 +5,25 @@ import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit
 
 import {
   Election,
+  ElectionProvider,
   PoliticalGroup,
   POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   PollingStationFormController,
 } from "@kiesraad/api";
-import { electionMock, politicalGroupMock } from "@kiesraad/api-mocks";
+import { electionMock, politicalGroupMock, pollingStationMock } from "@kiesraad/api-mocks";
 
 import { CandidatesVotesForm } from "./CandidatesVotesForm";
 
 const Component = (
-  <PollingStationFormController election={electionMock} pollingStationId={1} entryNumber={1}>
-    <CandidatesVotesForm group={politicalGroupMock} />
-  </PollingStationFormController>
+  <ElectionProvider electionId={1}>
+    <PollingStationFormController
+      pollingStationId={pollingStationMock.id}
+      entryNumber={1}
+      election={electionMock}
+    >
+      <CandidatesVotesForm group={politicalGroupMock} />
+    </PollingStationFormController>
+  </ElectionProvider>
 );
 
 const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
@@ -59,12 +66,12 @@ describe("Test CandidatesVotesForm", () => {
   });
   describe("CandidatesVotesForm user interactions", () => {
     test("hitting enter key does not result in api call", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
       const user = userEvent.setup();
       render(Component);
 
-      const candidate1 = screen.getByTestId("candidate_votes[0].votes");
+      const spy = vi.spyOn(global, "fetch");
+
+      const candidate1 = await screen.findByTestId("candidate_votes[0].votes");
       await user.type(candidate1, "12345");
       expect(candidate1).toHaveValue("12.345");
 
@@ -82,7 +89,7 @@ describe("Test CandidatesVotesForm", () => {
 
       render(Component);
 
-      const candidate1 = screen.getByTestId("candidate_votes[0].votes");
+      const candidate1 = await screen.findByTestId("candidate_votes[0].votes");
       expect(candidate1).toHaveFocus();
       await user.type(candidate1, "12345");
       expect(candidate1).toHaveValue("12.345");
@@ -148,8 +155,6 @@ describe("Test CandidatesVotesForm", () => {
 
   describe("CandidatesVotesForm API request and response", () => {
     test("CandidateVotesForm request body is equal to the form data", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
       const politicalGroupMockData: PoliticalGroup = {
         number: 1,
         name: "Lijst 1 - Vurige Vleugels Partij",
@@ -171,7 +176,7 @@ describe("Test CandidatesVotesForm", () => {
         ],
       };
 
-      const electionMockData: Election = {
+      const electionMockData: Required<Election> = {
         id: 1,
         name: "Gemeenteraadsverkiezingen 2026",
         category: "Municipal",
@@ -203,13 +208,18 @@ describe("Test CandidatesVotesForm", () => {
         ],
       };
 
-      const electionMock = electionMockData as Required<Election>;
       const politicalGroupMock = politicalGroupMockData as Required<PoliticalGroup>;
 
       const Component = (
-        <PollingStationFormController election={electionMock} pollingStationId={1} entryNumber={1}>
-          <CandidatesVotesForm group={politicalGroupMock} />
-        </PollingStationFormController>
+        <ElectionProvider electionId={1}>
+          <PollingStationFormController
+            pollingStationId={pollingStationMock.id}
+            entryNumber={1}
+            election={electionMockData}
+          >
+            <CandidatesVotesForm group={politicalGroupMock} />
+          </PollingStationFormController>
+        </ElectionProvider>
       );
 
       const expectedRequest = {
@@ -249,11 +259,12 @@ describe("Test CandidatesVotesForm", () => {
       };
 
       const user = userEvent.setup();
-
       render(Component);
 
+      const spy = vi.spyOn(global, "fetch");
+
       await user.type(
-        screen.getByTestId("candidate_votes[0].votes"),
+        await screen.findByTestId("candidate_votes[0].votes"),
         expectedRequest.data.political_group_votes[0]?.candidate_votes[0]?.votes.toString() ?? "0",
       );
 
@@ -289,7 +300,7 @@ describe("Test CandidatesVotesForm", () => {
 
       render(Component);
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
       const feedbackServerError = await screen.findByTestId("feedback-server-error");
       expect(feedbackServerError).toHaveTextContent(/^Error422 error from mock$/);
@@ -305,7 +316,7 @@ describe("Test CandidatesVotesForm", () => {
 
       render(Component);
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
       const feedbackServerError = await screen.findByTestId("feedback-server-error");
       expect(feedbackServerError).toHaveTextContent(/^Error500 error from mock$/);
@@ -332,7 +343,7 @@ describe("Test CandidatesVotesForm", () => {
 
       // Since the component does not allow to input invalid values such as -3,
       // not inputting any values and just clicking the submit button.
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackError = await screen.findByTestId("feedback-error");
@@ -357,7 +368,7 @@ describe("Test CandidatesVotesForm", () => {
       render(Component);
       const user = userEvent.setup();
 
-      await user.type(screen.getByTestId("candidate_votes[0].votes"), "1");
+      await user.type(await screen.findByTestId("candidate_votes[0].votes"), "1");
       await user.type(screen.getByTestId("candidate_votes[1].votes"), "2");
       await user.type(screen.getByTestId("total"), "10");
 
@@ -391,7 +402,7 @@ describe("Test CandidatesVotesForm", () => {
 
       // Since no warnings exist for the fields on this page,
       // not inputting any values and just clicking submit.
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackWarning = await screen.findByTestId("feedback-warning");

--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
@@ -5,7 +5,6 @@ import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit
 
 import {
   Election,
-  ElectionProvider,
   PoliticalGroup,
   POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   PollingStationFormController,
@@ -15,15 +14,13 @@ import { electionMock, politicalGroupMock, pollingStationMock } from "@kiesraad/
 import { CandidatesVotesForm } from "./CandidatesVotesForm";
 
 const Component = (
-  <ElectionProvider electionId={1}>
-    <PollingStationFormController
-      pollingStationId={pollingStationMock.id}
-      entryNumber={1}
-      election={electionMock}
-    >
-      <CandidatesVotesForm group={politicalGroupMock} />
-    </PollingStationFormController>
-  </ElectionProvider>
+  <PollingStationFormController
+    pollingStationId={pollingStationMock.id}
+    entryNumber={1}
+    election={electionMock}
+  >
+    <CandidatesVotesForm group={politicalGroupMock} />
+  </PollingStationFormController>
 );
 
 const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
@@ -211,15 +208,13 @@ describe("Test CandidatesVotesForm", () => {
       const politicalGroupMock = politicalGroupMockData as Required<PoliticalGroup>;
 
       const Component = (
-        <ElectionProvider electionId={1}>
-          <PollingStationFormController
-            pollingStationId={pollingStationMock.id}
-            entryNumber={1}
-            election={electionMockData}
-          >
-            <CandidatesVotesForm group={politicalGroupMock} />
-          </PollingStationFormController>
-        </ElectionProvider>
+        <PollingStationFormController
+          pollingStationId={pollingStationMock.id}
+          entryNumber={1}
+          election={electionMockData}
+        >
+          <CandidatesVotesForm group={politicalGroupMock} />
+        </PollingStationFormController>
       );
 
       const expectedRequest = {

--- a/frontend/app/component/form/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/differences/DifferencesForm.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit";
 
 import {
-  ElectionProvider,
   POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   PollingStationFormController,
 } from "@kiesraad/api";
@@ -16,15 +15,13 @@ import { electionMock, pollingStationMock } from "@kiesraad/api-mocks";
 import { DifferencesForm } from "./DifferencesForm";
 
 const Component = (
-  <ElectionProvider electionId={1}>
-    <PollingStationFormController
-      pollingStationId={pollingStationMock.id}
-      entryNumber={1}
-      election={electionMock}
-    >
-      <DifferencesForm />
-    </PollingStationFormController>
-  </ElectionProvider>
+  <PollingStationFormController
+    pollingStationId={pollingStationMock.id}
+    entryNumber={1}
+    election={electionMock}
+  >
+    <DifferencesForm />
+  </PollingStationFormController>
 );
 
 const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { getUrlMethodAndBody, overrideOnce, render, screen, userTypeInputs } from "app/test/unit";
 
 import {
-  ElectionProvider,
   POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   PollingStationFormController,
 } from "@kiesraad/api";
@@ -16,15 +15,13 @@ import { electionMock, pollingStationMock } from "@kiesraad/api-mocks";
 import { VotersAndVotesForm } from "./VotersAndVotesForm";
 
 const Component = (
-  <ElectionProvider electionId={1}>
-    <PollingStationFormController
-      pollingStationId={pollingStationMock.id}
-      entryNumber={1}
-      election={electionMock}
-    >
-      <VotersAndVotesForm />
-    </PollingStationFormController>
-  </ElectionProvider>
+  <PollingStationFormController
+    pollingStationId={pollingStationMock.id}
+    entryNumber={1}
+    election={electionMock}
+  >
+    <VotersAndVotesForm />
+  </PollingStationFormController>
 );
 
 const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -7,17 +7,24 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { getUrlMethodAndBody, overrideOnce, render, screen, userTypeInputs } from "app/test/unit";
 
 import {
+  ElectionProvider,
   POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   PollingStationFormController,
 } from "@kiesraad/api";
-import { electionMock } from "@kiesraad/api-mocks";
+import { electionMock, pollingStationMock } from "@kiesraad/api-mocks";
 
 import { VotersAndVotesForm } from "./VotersAndVotesForm";
 
 const Component = (
-  <PollingStationFormController election={electionMock} pollingStationId={1} entryNumber={1}>
-    <VotersAndVotesForm />
-  </PollingStationFormController>
+  <ElectionProvider electionId={1}>
+    <PollingStationFormController
+      pollingStationId={pollingStationMock.id}
+      entryNumber={1}
+      election={electionMock}
+    >
+      <VotersAndVotesForm />
+    </PollingStationFormController>
+  </ElectionProvider>
 );
 
 const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
@@ -61,13 +68,12 @@ describe("Test VotersAndVotesForm", () => {
 
   describe("VotersAndVotesForm user interactions", () => {
     test("hitting enter key does not result in api call", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
       const user = userEvent.setup();
 
       render(Component);
+      const spy = vi.spyOn(global, "fetch");
 
-      const pollCards = screen.getByTestId("poll_card_count");
+      const pollCards = await screen.findByTestId("poll_card_count");
       await user.type(pollCards, "12345");
       expect(pollCards).toHaveValue("12.345");
 
@@ -85,7 +91,7 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      const pollCards = screen.getByTestId("poll_card_count");
+      const pollCards = await screen.findByTestId("poll_card_count");
       expect(pollCards).toHaveFocus();
       await user.type(pollCards, "12345");
       expect(pollCards).toHaveValue("12.345");
@@ -150,8 +156,6 @@ describe("Test VotersAndVotesForm", () => {
 
   describe("VotersAndVotesForm API request and response", () => {
     test("VotersAndVotesForm request body is equal to the form data", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
       const expectedRequest = {
         data: {
           ...rootRequest.data,
@@ -173,6 +177,7 @@ describe("Test VotersAndVotesForm", () => {
       const user = userEvent.setup();
 
       render(Component);
+      const spy = vi.spyOn(global, "fetch");
 
       await userTypeInputs(user, {
         ...expectedRequest.data.voters_counts,
@@ -202,7 +207,7 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
       const feedbackServerError = await screen.findByTestId("feedback-server-error");
       expect(feedbackServerError).toHaveTextContent(/^Error422 error from mock$/);
@@ -221,7 +226,7 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
       const feedbackServerError = await screen.findByTestId("feedback-server-error");
       expect(feedbackServerError).toHaveTextContent(/^Error500 error from mock$/);
@@ -251,7 +256,7 @@ describe("Test VotersAndVotesForm", () => {
 
       // Since the component does not allow to input invalid values such as -3,
       // not inputting any values and just clicking the submit button.
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackError = await screen.findByTestId("feedback-error");
@@ -282,7 +287,8 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      await user.type(screen.getByTestId("poll_card_count"), "1");
+      // We await the first element to appear, so we know the page is loaded
+      await user.type(await screen.findByTestId("poll_card_count"), "1");
       await user.type(screen.getByTestId("proxy_certificate_count"), "1");
       await user.type(screen.getByTestId("voter_card_count"), "1");
       await user.type(screen.getByTestId("total_admitted_voters_count"), "4");
@@ -322,7 +328,8 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      await user.type(screen.getByTestId("votes_candidates_counts"), "1");
+      // We await the first element to appear, so we know the page is loaded
+      await user.type(await screen.findByTestId("votes_candidates_counts"), "1");
       await user.type(screen.getByTestId("blank_votes_count"), "1");
       await user.type(screen.getByTestId("invalid_votes_count"), "1");
       await user.type(screen.getByTestId("total_votes_cast_count"), "4");
@@ -358,7 +365,7 @@ describe("Test VotersAndVotesForm", () => {
 
       // Since the component does not allow to input values for non-existing fields,
       // not inputting any values and just clicking the submit button.
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       expect(screen.queryByTestId("result")).toBeNull();
@@ -389,7 +396,8 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      await user.type(screen.getByTestId("votes_candidates_counts"), "0");
+      // We await the first element to appear, so we know the page is loaded
+      await user.type(await screen.findByTestId("votes_candidates_counts"), "0");
       await user.type(screen.getByTestId("blank_votes_count"), "1");
       await user.type(screen.getByTestId("invalid_votes_count"), "0");
       await user.type(screen.getByTestId("total_votes_cast_count"), "1");
@@ -423,7 +431,8 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      await user.type(screen.getByTestId("votes_candidates_counts"), "0");
+      // We await the first element to appear, so we know the page is loaded
+      await user.type(await screen.findByTestId("votes_candidates_counts"), "0");
       await user.type(screen.getByTestId("blank_votes_count"), "0");
       await user.type(screen.getByTestId("invalid_votes_count"), "1");
       await user.type(screen.getByTestId("total_votes_cast_count"), "1");
@@ -459,7 +468,8 @@ describe("Test VotersAndVotesForm", () => {
 
       render(Component);
 
-      await user.type(screen.getByTestId("poll_card_count"), "1");
+      // We await the first element to appear, so we know the page is loaded
+      await user.type(await screen.findByTestId("poll_card_count"), "1");
       await user.type(screen.getByTestId("proxy_certificate_count"), "0");
       await user.type(screen.getByTestId("voter_card_count"), "0");
       await user.type(screen.getByTestId("total_admitted_voters_count"), "1");

--- a/frontend/app/test/unit/test-utils.ts
+++ b/frontend/app/test/unit/test-utils.ts
@@ -40,7 +40,7 @@ export function getUrlMethodAndBody(
 
 export async function userTypeInputs(user: UserEvent, inputs: { [key: string]: string | number }) {
   for (const [key, value] of Object.entries(inputs)) {
-    const input = screen.getByTestId(key);
+    const input = await screen.findByTestId(key);
     await user.type(input, value.toString());
     expect(input).toHaveValue(value.toString());
   }


### PR DESCRIPTION
Closes #108 

Since most of issue #108 will be fixed in #197 and #193, this PR now only addresses the tests

- ~~Adds an API endpoint to fetch a single Polling Station~~ implemented in #197
- Updated tests so that the 'fetch spies' are ran _after_ rendering, this prevents unintentionally triggering on API calls in providers.
- Updated tests so that the test waits (`findBy*` calls) for the expected components to appear, since we now show a spinner while loading data from the backend.