### PR TITLE
Update Cloudflare Pages Preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           apiToken: ${{ secrets.API_TOKEN }}
           accountId: ${{ secrets.ACCOUNT_ID }}
-          command: pages deploy dist --project-name=${{ vars.PROJECT_NAME }} --branch ${{ github.head_ref || github.ref }} --commit-hash ${GITHUB_SHA}
+          command: pages deploy dist --project-name=${{ vars.PROJECT_NAME }} --branch ${{ github.head_ref || github.ref_name }} --commit-hash ${{ github.sha }}
           workingDirectory: frontend
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Fix branch name variable: it was `refs/heads/main` for the `main` branch, which causes Cloudflare Pages to not deploy it to the top-level URL.
- Fix commit hash variable

Reference:
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context