### PR TITLE
Make candidates' first name optional

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -337,7 +337,6 @@
         "required": [
           "number",
           "initials",
-          "first_name",
           "last_name",
           "locality"
         ],
@@ -347,7 +346,8 @@
             "nullable": true
           },
           "first_name": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "gender": {
             "allOf": [

--- a/backend/src/election/structs.rs
+++ b/backend/src/election/structs.rs
@@ -37,7 +37,8 @@ pub struct PoliticalGroup {
 pub struct Candidate {
     pub number: u8,
     pub initials: String,
-    pub first_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name_prefix: Option<String>,
     pub last_name: String,
@@ -79,7 +80,7 @@ pub(crate) mod tests {
                     .map(|j| Candidate {
                         number: j + 1,
                         initials: "A.B.".to_string(),
-                        first_name: "John".to_string(),
+                        first_name: Some("John".to_string()),
                         last_name_prefix: Some("van".to_string()),
                         last_name: "Doe".to_string(),
                         locality: "Juinen".to_string(),

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -42,7 +42,7 @@ export type POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PATH =
  */
 export interface Candidate {
   country_code?: string;
-  first_name: string;
+  first_name?: string;
   gender?: CandidateGender;
   initials: string;
   last_name: string;


### PR DESCRIPTION
Not all political groups publish the first names of their candidates on the official candidate list.