### PR TITLE
Strict parse int

### DIFF
--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { usePollingStationList } from "@kiesraad/api";
 import { Alert, BottomBar, Button, Icon, Spinner } from "@kiesraad/ui";
+import { parseIntStrict } from "@kiesraad/util";
 
 import { PollingStationSelector } from "./PollingStationSelector";
 import { PollingStationsList } from "./PollingStationsList";
@@ -14,7 +15,7 @@ export function PollingStationChoiceForm() {
   const [pollingStationNumber, setPollingStationNumber] = useState<string>("");
 
   const handleSubmit = () => {
-    const parsedStationNumber = parseInt(pollingStationNumber, 10);
+    const parsedStationNumber = parseIntStrict(pollingStationNumber);
     const pollingStation = pollingStations.find(
       (pollingStation) => pollingStation.number === parsedStationNumber,
     );

--- a/frontend/app/module/input/PollingStation/CandidatesVotesPage.tsx
+++ b/frontend/app/module/input/PollingStation/CandidatesVotesPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { CandidatesVotesForm } from "app/component/form/candidates_votes_form/CandidatesVotesForm";
 
 import { useElection } from "@kiesraad/api";
+import { parseIntStrict } from "@kiesraad/util";
 
 export function CandidatesVotesPage() {
   const { listNumber } = useParams();
@@ -12,9 +13,8 @@ export function CandidatesVotesPage() {
     throw Error("Missing 'listNumber' parameter");
   }
 
-  const group = election.political_groups.find(
-    (group) => group.number === parseInt(listNumber, 10),
-  );
+  const parsedListNumber = parseIntStrict(listNumber);
+  const group = election.political_groups.find((group) => group.number === parsedListNumber);
 
   if (!group) {
     return <div>Geen lijst gevonden voor {listNumber}</div>;

--- a/frontend/lib/util/hook/useNumericParam.ts
+++ b/frontend/lib/util/hook/useNumericParam.ts
@@ -1,5 +1,7 @@
 import { useParams } from "react-router-dom";
 
+import { parseIntStrict } from "../strings";
+
 // Takes a parameter key, then tries to find it in the URL params.
 // When it is found, it tries to validate it as a number and returns it.
 // Throws an error when the paramater key is not found or not an integer
@@ -12,9 +14,10 @@ export function useNumericParam(parameterKey: string): number {
   }
 
   // Matches only if the whole string is numeric
-  if (!/^\d+$/.test(param)) {
+  const parsedParam = parseIntStrict(param);
+  if (!parsedParam) {
     throw Error(`Parameter ${parameterKey} is not numeric`);
   }
 
-  return parseInt(param, 10);
+  return parsedParam;
 }

--- a/frontend/lib/util/strings.test.ts
+++ b/frontend/lib/util/strings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { ellipsis } from "./strings";
+import { ellipsis, parseIntStrict } from "./strings";
 
 describe("Strings util", () => {
   test.each([
@@ -10,5 +10,21 @@ describe("Strings util", () => {
     ["", "", 20],
   ])("ellipsis %s as %s", (input: string, expected: string, maxLength: number) => {
     expect(ellipsis(input, maxLength)).equals(expected);
+  });
+
+  test.each([
+    ["123", 123],
+    ["00123"],
+    ["123a"],
+    ["a123"],
+    ["123 456"],
+    [" 123456 "],
+    ["/123/456"],
+    ["'123456'"],
+    ["six"],
+  ])("parseIntStrict %s", (input: string, expected: number | undefined = undefined) => {
+    expected
+      ? expect(parseIntStrict(input)).toBe(expected)
+      : expect(parseIntStrict(input)).toBeUndefined;
   });
 });

--- a/frontend/lib/util/strings.ts
+++ b/frontend/lib/util/strings.ts
@@ -8,6 +8,6 @@ export function ellipsis(text: string, maxLength: number = 20): string {
 
 // Checks if the _whole_ string is numeric, returning it as a number
 // returns undefined when non-numeric characters are encountered
-export function parseIntStrict(text: string): number | undefined {
-  return /^\d+$/.test(text) ? parseInt(text, 10) : undefined;
+export function parseIntStrict(text: string, radix: number = 10): number | undefined {
+  return /^\d+$/.test(text) ? parseInt(text, radix) : undefined;
 }

--- a/frontend/lib/util/strings.ts
+++ b/frontend/lib/util/strings.ts
@@ -8,6 +8,7 @@ export function ellipsis(text: string, maxLength: number = 20): string {
 
 // Checks if the _whole_ string is numeric, returning it as a number
 // returns undefined when non-numeric characters are encountered
-export function parseIntStrict(text: string, radix: number = 10): number | undefined {
-  return /^\d+$/.test(text) ? parseInt(text, radix) : undefined;
+export function parseIntStrict(text: string): number | undefined {
+  const num = parseInt(text, 10);
+  return !isNaN(num) && num.toString() === text ? num : undefined;
 }

--- a/frontend/lib/util/strings.ts
+++ b/frontend/lib/util/strings.ts
@@ -5,3 +5,9 @@ export function ellipsis(text: string, maxLength: number = 20): string {
 
   return text.substring(0, maxLength - 3) + "...";
 }
+
+// Checks if the _whole_ string is numeric, returning it as a number
+// returns undefined when non-numeric characters are encountered
+export function parseIntStrict(text: string): number | undefined {
+  return /^\d+$/.test(text) ? parseInt(text, 10) : undefined;
+}


### PR DESCRIPTION
Note: this PR will rebase onto the `not-found` branch.

It creates a `parseInt` function replacement that doesn't allow _any_ non-numeric characters to be present in the string.

Let me know if I should go ahead and replace all relevent `parseInt` calls.