### PR TITLE
Add Dependabot ignores for some major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
- Ignore `@types/node` major upgrades because we use Node.js v20 (LTS).
- Ignore `eslint` major upgrades because of breaking changes in v9 (relates to #213).