### PR TITLE
Frontend: A few design fixes

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
@@ -131,7 +131,7 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
         </InputGrid.Header>
         <InputGrid.Body>
           {group.candidates.map((candidate, index) => {
-            const addSeparator = (index + 1) % 25 == 0;
+            const addSeparator = (index + 1) % 25 == 0 && index + 1 !== group.candidates.length;
             const defaultValue = sectionValues?.candidate_votes[index]?.votes || "";
             return (
               <InputGridRow

--- a/frontend/lib/ui/Alert/Alert.module.css
+++ b/frontend/lib/ui/Alert/Alert.module.css
@@ -28,7 +28,7 @@
   }
 
   &.error {
-    border-color: var(--color-error);
+    border-color: var(--color-error-darkest);
     background-color: var(--color-error-bg);
     button:hover {
       background: var(--color-error-hover);
@@ -38,7 +38,7 @@
     }
   }
   &.warning {
-    border-color: var(--color-warning);
+    border-color: var(--color-warning-darker);
     background-color: var(--color-warning-bg);
     button:hover {
       background: var(--color-warning-hover);

--- a/frontend/lib/ui/InputGrid/InputGrid.tsx
+++ b/frontend/lib/ui/InputGrid/InputGrid.tsx
@@ -129,13 +129,9 @@ InputGrid.Header = ({
 InputGrid.Body = ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>;
 
 InputGrid.Separator = () => (
-  // 2 trs are needed to make sure zebra styling is according to design
-  <>
-    <tr className="sep_row"></tr>
-    <tr className="sep_row">
-      <td className="sep" colSpan={3}></td>
-    </tr>
-  </>
+  <tr className="sep_row">
+    <td className="sep" colSpan={3}></td>
+  </tr>
 );
 
 InputGrid.Row = ({

--- a/frontend/lib/ui/style/variables.css
+++ b/frontend/lib/ui/style/variables.css
@@ -61,7 +61,7 @@
   --color-warning-text: #93370d;
 
   --color-notify: #2e90fa;
-  --color-notify-bg: #f0f9ff;
+  --color-notify-bg: #e0f2fe;
   --color-notify-hover: #b9e6fe;
 
   --color-success: #12b76a;


### PR DESCRIPTION
## Done:
- [x] Alert Figma design changes (see https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp?node-id=985-19666&m=dev#863283465)

Fixed from #101 :
- [x] when a list has exactly n\*25 candidates, the spacer/separator for the next 25 candidates is shown. The separator should only be added if there is a (n\*25)+1'nd  candidate.  ![Scherm­afbeelding 2024-08-01 om 11 13 17](https://github.com/user-attachments/assets/3f53492a-67ba-4b51-9b33-b3c92a219699)
- [x] The zebra-striping of the rows does not match the striping used in the paper forms. On paper, the first row of each 25 rows is white. In our digital form, row 26 and row 76 have a dark background. Each block of 25 rows should start with a white background.
![Scherm­afbeelding 2024-08-05 om 09 49 33](https://github.com/user-attachments/assets/9bf0d1d3-137e-41a8-be00-45be93a54869)
