### PR TITLE
Add API command flag to seed data into the database on startup

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -39,8 +39,10 @@ jobs:
         run: sqlx database setup
       - name: Check rustfmt
         run: cargo --verbose --locked fmt --all -- --check
-      - name: Check clippy
+      - name: Check Clippy with all features
         run: cargo --verbose --locked clippy --all-targets --all-features -- -D warnings
+      - name: Check Clippy without default features
+        run: cargo --verbose --locked clippy --all-targets --no-default-features -- -D warnings
       - name: Run tests
         run: cargo --verbose --locked test
       - name: Build

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono"] }
 chrono = { version = "0.4", features = ["alloc", "std", "serde"] }
-clap = { version = "4.5", default-features = false, features = ["derive", "std"] }
+clap = { version = "4.5", default-features = false, features = ["derive", "std", "help"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,8 +6,13 @@ license = "EUPL-1.2"
 rust-version = "1.75"
 
 [features]
-default = ["openapi"]
+default = ["openapi", "dev-database"]
 openapi = ["dep:utoipa-swagger-ui"]
+dev-database = []
+
+[[bin]]
+name = "gen-openapi"
+required-features = ["openapi"]
 
 [dependencies]
 axum = { version = "0.7", features = ["macros"] }

--- a/backend/src/bin/api.rs
+++ b/backend/src/bin/api.rs
@@ -25,10 +25,12 @@ struct Args {
     port: u16,
 
     /// Seed the database with initial data using the fixtures
+    #[cfg(feature = "dev-database")]
     #[arg(short, long)]
     seed_data: bool,
 
     /// Reset the database
+    #[cfg(feature = "dev-database")]
     #[arg(short, long)]
     reset_database: bool,
 }
@@ -38,7 +40,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let pool = create_sqlite_pool(args.reset_database, args.seed_data).await?;
+    let pool = create_sqlite_pool(&args).await?;
     let app = router(pool)?;
 
     let app = if let Some(fd) = args.frontend_dist {
@@ -59,24 +61,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
 /// Create a SQLite database if needed, then connect to it and run migrations.
 /// Return a connection pool.
 async fn create_sqlite_pool(
-    reset_database: bool,
-    load_fixtures: bool,
+    #[cfg_attr(not(feature = "dev-database"), allow(unused_variables))] args: &Args,
 ) -> Result<SqlitePool, Box<dyn Error>> {
     let opts = SqliteConnectOptions::from_str(DB_URL)?.create_if_missing(true);
-    if reset_database {
+
+    #[cfg(feature = "dev-database")]
+    if args.reset_database {
         // remove the file, ignoring any errors that occured (such as the file not existing)
         let _ = tokio::fs::remove_file(opts.get_filename()).await;
     }
+
     let pool = SqlitePool::connect_with(opts).await?;
     sqlx::migrate!().run(&pool).await?;
 
-    if load_fixtures {
+    #[cfg(feature = "dev-database")]
+    if args.seed_data {
         fixtures::seed_fixture_data(&pool).await?;
     }
 
     Ok(pool)
 }
 
+#[cfg(feature = "dev-database")]
 mod fixtures {
     /// Macro to convert a single fixture name to the contents of a fixture file
     macro_rules! load_fixture {

--- a/backend/src/bin/api.rs
+++ b/backend/src/bin/api.rs
@@ -19,9 +19,18 @@ struct Args {
     /// Path to the frontend dist directory to serve through the API server
     #[arg(short, long)]
     frontend_dist: Option<PathBuf>,
-    // Server port, optional
+
+    /// Server port, optional
     #[arg(short, long, default_value_t = 8080)]
     port: u16,
+
+    /// Seed the database with initial data using the fixtures
+    #[arg(short, long)]
+    seed_data: bool,
+
+    /// Reset the database
+    #[arg(short, long)]
+    reset_database: bool,
 }
 
 /// Main entry point for the application, sets up the database and starts the
@@ -29,7 +38,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let pool = create_sqlite_pool().await?;
+    let pool = create_sqlite_pool(args.reset_database, args.seed_data).await?;
     let app = router(pool)?;
 
     let app = if let Some(fd) = args.frontend_dist {
@@ -49,9 +58,53 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 /// Create a SQLite database if needed, then connect to it and run migrations.
 /// Return a connection pool.
-async fn create_sqlite_pool() -> Result<SqlitePool, Box<dyn Error>> {
+async fn create_sqlite_pool(
+    reset_database: bool,
+    load_fixtures: bool,
+) -> Result<SqlitePool, Box<dyn Error>> {
     let opts = SqliteConnectOptions::from_str(DB_URL)?.create_if_missing(true);
+    if reset_database {
+        // remove the file, ignoring any errors that occured (such as the file not existing)
+        let _ = tokio::fs::remove_file(opts.get_filename()).await;
+    }
     let pool = SqlitePool::connect_with(opts).await?;
     sqlx::migrate!().run(&pool).await?;
+
+    if load_fixtures {
+        fixtures::seed_fixture_data(&pool).await?;
+    }
+
     Ok(pool)
+}
+
+mod fixtures {
+    macro_rules! load_fixture {
+        ($fixture:literal) => {
+            Fixture {
+                data: include_str!(concat!("../../fixtures/", $fixture, ".sql")),
+            }
+        };
+    }
+
+    macro_rules! load_fixtures {
+        ([$($fix:literal),* $(,)?]) => {
+            &[$(load_fixture!($fix),)*]
+        }
+    }
+
+    const FIXTURES: &[Fixture] = load_fixtures!(["elections", "polling_stations",]);
+
+    struct Fixture {
+        data: &'static str,
+    }
+
+    pub async fn seed_fixture_data(
+        pool: &sqlx::SqlitePool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for fixture in FIXTURES {
+            sqlx::raw_sql(fixture.data).execute(pool).await?;
+        }
+
+        Ok(())
+    }
 }

--- a/backend/src/bin/api.rs
+++ b/backend/src/bin/api.rs
@@ -78,6 +78,7 @@ async fn create_sqlite_pool(
 }
 
 mod fixtures {
+    /// Macro to convert a single fixture name to the contents of a fixture file
     macro_rules! load_fixture {
         ($fixture:literal) => {
             Fixture {
@@ -86,18 +87,26 @@ mod fixtures {
         };
     }
 
+    /// Macro to convert the list of fixtures to their contents
     macro_rules! load_fixtures {
         ([$($fix:literal),* $(,)?]) => {
             &[$(load_fixture!($fix),)*]
         }
     }
 
+    /// List of fixtures to load when data seeding is requested.
+    ///
+    /// This list should be updated manually when a new fixture is added that
+    /// needs to be loaded when seeding fixtures.
     const FIXTURES: &[Fixture] = load_fixtures!(["elections", "polling_stations",]);
 
+    /// The data contained in a fixture file
     struct Fixture {
         data: &'static str,
     }
 
+    /// Function that loads the fixture data into the given connection
+    /// Each fixture may contain multiple SQL statements.
     pub async fn seed_fixture_data(
         pool: &sqlx::SqlitePool,
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,7 +10,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use sqlx::Error::RowNotFound;
 use sqlx::SqlitePool;
-use utoipa::{OpenApi, ToSchema};
+use utoipa::ToSchema;
 #[cfg(feature = "openapi")]
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -62,6 +62,8 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
 
 #[cfg(feature = "openapi")]
 pub fn create_openapi() -> utoipa::openapi::OpenApi {
+    use utoipa::OpenApi;
+
     #[derive(OpenApi)]
     #[openapi(
         paths(


### PR DESCRIPTION
Resolves #154 

This also adds a `--reset-database` flag to allow quickly re-initializing the database.

The fixture seeding is implemented as a list of fixtures that needs to be updated manually, this allows setting a different set of fixtures for data loading (i.e. allowing you to skip some fixtures that are only useful in specific tests for example).