### PR TITLE
Some more design fixes

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
@@ -91,7 +91,9 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
     <form onSubmit={handleSubmit} ref={formRef}>
       {/* Temporary while not navigating through form sections */}
       {success && <div id="result">Success</div>}
-      <h2>{group.name}</h2>
+      <h2>
+        Lijst {group.number} - {group.name}
+      </h2>
       {serverError && (
         <Feedback type="error" title="Error">
           <div id="feedback-server-error">

--- a/frontend/app/component/pollingstation/PollingStationProgress.tsx
+++ b/frontend/app/component/pollingstation/PollingStationProgress.tsx
@@ -15,30 +15,52 @@ export function PollingStationProgress() {
   return (
     <ProgressList>
       <ProgressList.Item key="recounted" status="accept" active={targetForm === "recounted"}>
-        <Link to={`/${election.id}/input/${pollingStationId}/recounted`}>Is er herteld?</Link>
+        {targetForm !== "recounted" ? (
+          <Link to={`/${election.id}/input/${pollingStationId}/recounted`}>Is er herteld?</Link>
+        ) : (
+          <span>Is er herteld?</span>
+        )}
       </ProgressList.Item>
       <ProgressList.Item key="numbers" status="idle" active={targetForm === "numbers"}>
-        <Link to={`/${election.id}/input/${pollingStationId}/numbers`}>
-          Aantal kiezers en stemmen
-        </Link>
+        {targetForm !== "numbers" ? (
+          <Link to={`/${election.id}/input/${pollingStationId}/numbers`}>
+            Aantal kiezers en stemmen
+          </Link>
+        ) : (
+          <span>Aantal kiezers en stemmen</span>
+        )}
       </ProgressList.Item>
       <ProgressList.Item key="differences" status="idle" active={targetForm === "differences"}>
-        <Link to={`/${election.id}/input/${pollingStationId}/differences`}>Verschillen</Link>
+        {targetForm !== "differences" ? (
+          <Link to={`/${election.id}/input/${pollingStationId}/differences`}>Verschillen</Link>
+        ) : (
+          <span>Verschillen</span>
+        )}
       </ProgressList.Item>
       <ProgressList.Ruler key="ruler1" />
       {lists.map((list, index) => {
         const listId = `${index + 1}`;
         return (
           <ProgressList.Item key={`list${listId}`} status="idle" active={listNumber === listId}>
-            <Link to={`/${election.id}/input/${pollingStationId}/list/${listId}`}>
-              Lijst {list.number} - {list.name}
-            </Link>
+            {listNumber !== listId ? (
+              <Link to={`/${election.id}/input/${pollingStationId}/list/${listId}`}>
+                Lijst {list.number} - {list.name}
+              </Link>
+            ) : (
+              <span>
+                Lijst {list.number} - {list.name}
+              </span>
+            )}
           </ProgressList.Item>
         );
       })}
       <ProgressList.Ruler key="ruler2" />
       <ProgressList.Item key="save" status="idle" active={targetForm === "save"}>
-        <Link to={`/${election.id}/input/${pollingStationId}/save`}>Controleren en opslaan</Link>
+        {targetForm !== "save" ? (
+          <Link to={`/${election.id}/input/${pollingStationId}/save`}>Controleren en opslaan</Link>
+        ) : (
+          <span>Controleren en opslaan</span>
+        )}
       </ProgressList.Item>
     </ProgressList>
   );

--- a/frontend/app/component/pollingstation/PollingStationProgress.tsx
+++ b/frontend/app/component/pollingstation/PollingStationProgress.tsx
@@ -30,7 +30,9 @@ export function PollingStationProgress() {
         const listId = `${index + 1}`;
         return (
           <ProgressList.Item key={`list${listId}`} status="idle" active={listNumber === listId}>
-            <Link to={`/${election.id}/input/${pollingStationId}/list/${listId}`}>{list.name}</Link>
+            <Link to={`/${election.id}/input/${pollingStationId}/list/${listId}`}>
+              Lijst {list.number} - {list.name}
+            </Link>
           </ProgressList.Item>
         );
       })}

--- a/frontend/app/module/input/PollingStation/PollingStationLayout.tsx
+++ b/frontend/app/module/input/PollingStation/PollingStationLayout.tsx
@@ -5,7 +5,14 @@ import { PollingStationProgress } from "app/component/pollingstation/PollingStat
 
 import { PollingStationFormController, useElection, usePollingStation } from "@kiesraad/api";
 import { IconCross } from "@kiesraad/icon";
-import { Badge, Button, Modal, PollingStationNumber, WorkStationNumber } from "@kiesraad/ui";
+import {
+  Badge,
+  Button,
+  Modal,
+  PageTitle,
+  PollingStationNumber,
+  WorkStationNumber,
+} from "@kiesraad/ui";
 
 export function PollingStationLayout() {
   const { election } = useElection();
@@ -31,6 +38,7 @@ export function PollingStationLayout() {
       pollingStationId={pollingStation.id}
       entryNumber={1}
     >
+      <PageTitle title={`Invoeren ${pollingStation.number} ${pollingStation.name} - Abacus`} />
       <header>
         <section>
           <PollingStationNumber>{pollingStation.number}</PollingStationNumber>

--- a/frontend/app/module/input/page/InputHomePage.tsx
+++ b/frontend/app/module/input/page/InputHomePage.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { PollingStationChoiceForm } from "app/component/form/polling_station_choice/PollingStationChoiceForm";
 
 import { useElection } from "@kiesraad/api";
-import { Alert, WorkStationNumber } from "@kiesraad/ui";
+import { Alert, PageTitle, WorkStationNumber } from "@kiesraad/ui";
 
 export function InputHomePage() {
   const { election } = useElection();
@@ -15,6 +15,7 @@ export function InputHomePage() {
 
   return (
     <>
+      <PageTitle title="Kies een stembureau - Abacus" />
       <header>
         <section>
           <h1>{election.name}</h1>

--- a/frontend/app/module/overview/OverviewLayout.tsx
+++ b/frontend/app/module/overview/OverviewLayout.tsx
@@ -3,10 +3,12 @@ import { Outlet } from "react-router-dom";
 import { Footer } from "app/component/footer/Footer";
 
 import { ElectionListProvider } from "@kiesraad/api";
+import { PageTitle } from "@kiesraad/ui";
 
 export function OverviewLayout() {
   return (
     <div className="app-layout">
+      <PageTitle title="Overzicht verkiezingen - Abacus" />
       <nav>
         <span className="active">Overzicht</span>
       </nav>

--- a/frontend/app/module/user/page/AccountSetupPage.tsx
+++ b/frontend/app/module/user/page/AccountSetupPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { AccountSetupForm } from "app/component/form/account_setup/AccountSetupForm";
 
-import { Alert, WorkStationNumber } from "@kiesraad/ui";
+import { Alert, PageTitle, WorkStationNumber } from "@kiesraad/ui";
 
 export function AccountSetupPage() {
   const [showAlert, setShowAlert] = useState(true);
@@ -13,6 +13,7 @@ export function AccountSetupPage() {
 
   return (
     <>
+      <PageTitle title="Account instellen - Abacus" />
       <header>
         <section>
           <h1>Account instellen</h1>

--- a/frontend/app/module/user/page/LoginPage.tsx
+++ b/frontend/app/module/user/page/LoginPage.tsx
@@ -1,10 +1,11 @@
 import { LoginForm } from "app/component/form/login/LoginForm";
 
-import { WorkStationNumber } from "@kiesraad/ui";
+import { PageTitle, WorkStationNumber } from "@kiesraad/ui";
 
 export function LoginPage() {
   return (
     <>
+      <PageTitle title="Inloggen - Abacus" />
       <header>
         <section>
           <h1>Inloggen</h1>

--- a/frontend/lib/api-mocks/ElectionMockData.ts
+++ b/frontend/lib/api-mocks/ElectionMockData.ts
@@ -8,7 +8,7 @@ import {
 
 export const politicalGroupMockData: PoliticalGroup = {
   number: 1,
-  name: "Lijst 1 - Vurige Vleugels Partij",
+  name: "Vurige Vleugels Partij",
   candidates: [
     {
       number: 1,
@@ -238,97 +238,97 @@ const politicalGroupsMockData: PoliticalGroup[] = [
   politicalGroupMockData,
   {
     number: 2,
-    name: "Lijst 2 - Wijzen van Water en Wind",
+    name: "Wijzen van Water en Wind",
     candidates: candidates,
   },
   {
     number: 3,
-    name: "Lijst 3 - Eeuwenoude Aarde Unie",
+    name: "Eeuwenoude Aarde Unie",
     candidates: candidates,
   },
   {
     number: 4,
-    name: "Lijst 4 - Verbond van Licht en Leven",
+    name: "Verbond van Licht en Leven",
     candidates: candidates,
   },
   {
     number: 5,
-    name: "Lijst 5 - Nieuwe Horizon Beweging",
+    name: "Nieuwe Horizon Beweging",
     candidates: candidates,
   },
   {
     number: 6,
-    name: "Lijst 6 - VRG",
+    name: "VRG",
     candidates: candidates,
   },
   {
     number: 7,
-    name: "Lijst 7 - Harmonie van Hemel en Aarde",
+    name: "Harmonie van Hemel en Aarde",
     candidates: candidates,
   },
   {
     number: 8,
-    name: "Lijst 8 - Stralende Sterren Alliantie",
+    name: "Stralende Sterren Alliantie",
     candidates: candidates,
   },
   {
     number: 9,
-    name: "Lijst 9 - Tijdloze Toekomst Partij",
+    name: "Tijdloze Toekomst Partij",
     candidates: candidates,
   },
   {
     number: 10,
-    name: "Lijst 10 - Kosmische Kracht Coalitie",
+    name: "Kosmische Kracht Coalitie",
     candidates: candidates,
   },
   {
     number: 11,
-    name: "Lijst 11 - Magische Melodieën Beweging",
+    name: "Magische Melodieën Beweging",
     candidates: candidates,
   },
   {
     number: 12,
-    name: "Lijst 12 - Zilveren Zonnestralen Partij",
+    name: "Zilveren Zonnestralen Partij",
     candidates: candidates,
   },
   {
     number: 13,
-    name: "Lijst 13 - Mystieke Maanlicht Liga",
+    name: "Mystieke Maanlicht Liga",
     candidates: candidates,
   },
   {
     number: 14,
-    name: "Lijst 14 - GVR",
+    name: "GVR",
     candidates: candidates,
   },
   {
     number: 15,
-    name: "Lijst 15 - Partij voor de ontwikkeling",
+    name: "Partij voor de ontwikkeling",
     candidates: candidates,
   },
   {
     number: 16,
-    name: "Lijst 16 - Bond van de kiezers",
+    name: "Bond van de kiezers",
     candidates: candidates,
   },
   {
     number: 17,
-    name: "Lijst 17 - Omega",
+    name: "Omega",
     candidates: candidates,
   },
   {
     number: 18,
-    name: "Lijst 18 - Partij van de werkers",
+    name: "Partij van de werkers",
     candidates: candidates,
   },
   {
     number: 19,
-    name: "Lijst 19 - Sterrenpartij",
+    name: "Sterrenpartij",
     candidates: candidates,
   },
   {
     number: 20,
-    name: "Lijst 20 - Partij voor de zon",
+    name: "Partij voor de zon",
     candidates: candidates,
   },
 ];

--- a/frontend/lib/ui/ProgressList/ProgressList.module.css
+++ b/frontend/lib/ui/ProgressList/ProgressList.module.css
@@ -1,4 +1,4 @@
-.progresslist {
+.progress-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -6,7 +6,7 @@
 
   li {
     padding: 0.625rem 0.75rem;
-    min-height: 2.75rem;
+    height: 2.75rem;
     border-radius: 0.5rem;
     display: flex;
     align-items: center;
@@ -30,6 +30,9 @@
     &:global(.active) {
       background-color: var(--color-hover);
       font-weight: 500;
+      a {
+        cursor: auto;
+      }
     }
 
     &:global(.updates) {
@@ -65,7 +68,10 @@
     }
     a {
       color: inherit;
+      display: inline-block;
       width: 100%;
+      height: 100%;
+      vertical-align: middle;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;

--- a/frontend/lib/ui/ProgressList/ProgressList.module.css
+++ b/frontend/lib/ui/ProgressList/ProgressList.module.css
@@ -30,9 +30,6 @@
     &:global(.active) {
       background-color: var(--color-hover);
       font-weight: 500;
-      a {
-        cursor: auto;
-      }
     }
 
     &:global(.updates) {

--- a/frontend/lib/ui/ProgressList/ProgressList.tsx
+++ b/frontend/lib/ui/ProgressList/ProgressList.tsx
@@ -17,7 +17,7 @@ export interface ProgressListProps {
 }
 
 export function ProgressList({ children }: ProgressListProps) {
-  return <ul className={cls.progresslist}>{children}</ul>;
+  return <ul className={cls["progress-list"]}>{children}</ul>;
 }
 
 ProgressList.Ruler = () => <li className="ruler">&nbsp;</li>;

--- a/frontend/lib/ui/index.ts
+++ b/frontend/lib/ui/index.ts
@@ -15,4 +15,4 @@ export * from "./Modal/Modal";
 export * from "./ProgressList/ProgressList";
 export * from "./Spinner/Spinner";
 export * from "./Tooltip";
-export * from "./util/Util";
+export * from "./util";

--- a/frontend/lib/ui/util/PageTitle.tsx
+++ b/frontend/lib/ui/util/PageTitle.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const PageTitle = ({ title }: { title: string }) => {
+  const location = useLocation();
+
+  useEffect(() => {
+    document.title = title;
+  }, [location, title]);
+
+  return null;
+};

--- a/frontend/lib/ui/util/index.ts
+++ b/frontend/lib/ui/util/index.ts
@@ -1,0 +1,2 @@
+export * from "./PageTitle";
+export * from "./Util";


### PR DESCRIPTION
- [x] The clickable area for items in the navigation menu in /input/030/ consists of just the text of the link. Ideally the clickable target is a big as the box we highlight for selected menu-items
- [x] The selected menu-item is a link. This should not be the case, do not link to the current page.
- [x] In the nav-menu and in the h2, the name of the political group should be prepended with `Lijst <lijstnummer> - ` 
- [x] All pages have 'Abacus' as page title. Pages should have descriptive titles
  - /user/login --> Inloggen - Abacus
  - /user/account/setup --> Account instellen  - Abacus
  - /overview --> Overzicht verkiezingen - Abacus
  - /input --> Kies een stembureau - Abacus
  - /input/030 --> Invoeren `<stembureau nummer>` `<stembureau naam>`  - Abacus