### PR TITLE
Allow setting vite host

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,8 +5,9 @@ import { defineConfig } from "vite";
 import pkgjson from "./package.json";
 import tsConfig from "./tsconfig.json";
 
-const apiMode = process.env.API_MODE || "mock";
-const apiHost = process.env.API_HOST || apiMode === "mock" ? "" : "http://localhost:8080";
+const apiMode = process.env.API_MODE ?? "mock";
+const apiHost = process.env.API_HOST ?? (apiMode === "mock" ? "" : "http://localhost:8080");
+const viteHost = process.env.VITE_HOST ?? undefined;
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
@@ -47,6 +48,7 @@ export default defineConfig(() => ({
   },
   server: {
     port: 3000,
+    host: viteHost,
     proxy: {
       "/api": {
         target: apiHost,


### PR DESCRIPTION
This change allows setting the Vite host and fixes the other existing variables in the Vite config. This allows us to set up a local docker compose development environment to start abacus development with a single command. For now I've left the docker compose part of this out, because I'd like to test it for a little while.