### PR TITLE
Run CodeQL workflow in merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '27 7 * * 2'
 


### PR DESCRIPTION
This will allow us to enforce the CodeQL analyze result as a required check.