### PR TITLE
Test loading messages in pollingstation choice form

### DIFF
--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -70,6 +70,28 @@ describe("Test PollingStationChoiceForm", () => {
     ).toBeVisible();
   });
 
+  test("Form displays message when searching", async () => {
+    overrideOnce(
+      "get",
+      "/api/elections/1/polling_stations",
+      200,
+      pollingStationsMockResponse,
+      "infinite",
+    );
+    const user = userEvent.setup();
+    render(
+      <PollingStationListProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationListProvider>,
+    );
+    const pollingStation = screen.getByTestId("pollingStation");
+
+    // Test if the polling station name is shown
+    await user.type(pollingStation, "33");
+    const pollingStationSearching = await screen.findByTestId("pollingStationSelectorLoading");
+    expect(within(pollingStationSearching).getByText("aan het zoeken …")).toBeVisible();
+  });
+
   test("Polling station list", async () => {
     overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
     const user = userEvent.setup();
@@ -169,5 +191,31 @@ describe("Test PollingStationChoiceForm", () => {
         "Voer een geldig nummer van een stembureau in om te beginnen",
       ),
     ).toBeVisible();
+  });
+
+  test("Polling station list shows message while loading", async () => {
+    overrideOnce(
+      "get",
+      "/api/elections/1/polling_stations",
+      200,
+      {
+        polling_stations: [],
+      },
+      "infinite",
+    );
+    const user = userEvent.setup();
+
+    render(
+      <PollingStationListProvider electionId={1}>
+        <PollingStationChoiceForm />
+      </PollingStationListProvider>,
+    );
+
+    const openPollingStationList = screen.getByTestId("openPollingStationList");
+    await user.click(openPollingStationList);
+    expect(screen.getByText("Kies het stembureau")).toBeVisible();
+
+    // check if the loading message is visible
+    expect(screen.getByText("aan het laden …")).toBeVisible();
   });
 });

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -8,214 +8,219 @@ import { PollingStationListProvider } from "@kiesraad/api";
 import { pollingStationsMockResponse } from "@kiesraad/api-mocks";
 
 describe("Test PollingStationChoiceForm", () => {
-  test("Form field entry", async () => {
-    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
-    const user = userEvent.setup();
+  describe("Polling station input form", () => {
+    test("Form field entry", async () => {
+      overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
+      const user = userEvent.setup();
 
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
 
-    const pollingStation = screen.getByTestId("pollingStation");
+      const pollingStation = screen.getByTestId("pollingStation");
 
-    // Test if the feedback field shows an error
-    await user.type(pollingStation, "abc");
-    const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
-    expect(
-      within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer abc"),
-    ).toBeVisible();
+      // Test if the feedback field shows an error
+      await user.type(pollingStation, "abc");
+      const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
+      expect(
+        within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer abc"),
+      ).toBeVisible();
 
-    await user.clear(pollingStation);
+      await user.clear(pollingStation);
 
-    // Test if maxLength on field works
-    await user.type(pollingStation, "1234567");
-    expect(pollingStation).toHaveValue("123456");
+      // Test if maxLength on field works
+      await user.type(pollingStation, "1234567");
+      expect(pollingStation).toHaveValue("123456");
 
-    await user.clear(pollingStation);
-  });
-
-  test("Selecting a valid polling station", async () => {
-    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
-    const user = userEvent.setup();
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
-    const pollingStation = screen.getByTestId("pollingStation");
-
-    // Test if the polling station name is shown
-    await user.type(pollingStation, "33");
-    const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
-    expect(within(pollingStationFeedback).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
-  });
-
-  test("Selecting a non-existing polling station", async () => {
-    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
-    const user = userEvent.setup();
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
-    const pollingStation = screen.getByTestId("pollingStation");
-
-    // Test if the polling station name is shown
-    await user.type(pollingStation, "99");
-    const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
-    expect(
-      within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer 99"),
-    ).toBeVisible();
-  });
-
-  test("Form displays message when searching", async () => {
-    overrideOnce(
-      "get",
-      "/api/elections/1/polling_stations",
-      200,
-      pollingStationsMockResponse,
-      "infinite",
-    );
-    const user = userEvent.setup();
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
-    const pollingStation = screen.getByTestId("pollingStation");
-
-    // Test if the polling station name is shown
-    await user.type(pollingStation, "33");
-    const pollingStationSearching = await screen.findByTestId("pollingStationSelectorLoading");
-    expect(within(pollingStationSearching).getByText("aan het zoeken …")).toBeVisible();
-  });
-
-  test("Polling station list", async () => {
-    overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
-    const user = userEvent.setup();
-
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
-
-    expect(screen.getByText("Kies het stembureau")).not.toBeVisible();
-    const openPollingStationList = screen.getByTestId("openPollingStationList");
-    await user.click(openPollingStationList);
-
-    expect(screen.getByText("Kies het stembureau")).toBeVisible();
-
-    // Check if the station number and name exist and are visible
-    const pollingStationList = screen.getByTestId("polling_station_list");
-    expect(within(pollingStationList).getByText("33")).toBeVisible();
-    expect(within(pollingStationList).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
-    expect(within(pollingStationList).getByText("34")).toBeVisible();
-    expect(within(pollingStationList).getByText("Testplek")).toBeVisible();
-  });
-
-  test("Polling station list no stations", async () => {
-    overrideOnce("get", "/api/elections/1/polling_stations", 200, {
-      polling_stations: [],
+      await user.clear(pollingStation);
     });
-    const user = userEvent.setup();
 
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
+    test("Selecting a valid polling station", async () => {
+      overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
+      const user = userEvent.setup();
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
+      const pollingStation = screen.getByTestId("pollingStation");
 
-    const openPollingStationList = screen.getByTestId("openPollingStationList");
-    await user.click(openPollingStationList);
-    expect(screen.getByText("Kies het stembureau")).toBeVisible();
-
-    // Check if the error message is visible
-    expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
-  });
-
-  test("Polling station request returns 404", async () => {
-    overrideOnce("get", "/api/elections/1/polling_stations", 404, {
-      error: "Resource not found",
+      // Test if the polling station name is shown
+      await user.type(pollingStation, "33");
+      const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
+      expect(within(pollingStationFeedback).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
     });
-    const user = userEvent.setup();
 
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
+    test("Selecting a non-existing polling station", async () => {
+      overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
+      const user = userEvent.setup();
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
+      const pollingStation = screen.getByTestId("pollingStation");
 
-    const openPollingStationList = screen.getByTestId("openPollingStationList");
-    await user.click(openPollingStationList);
-    expect(screen.getByText("Kies het stembureau")).toBeVisible();
+      // Test if the polling station name is shown
+      await user.type(pollingStation, "99");
+      const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
+      expect(
+        within(pollingStationFeedback).getByText("Geen stembureau gevonden met nummer 99"),
+      ).toBeVisible();
+    });
 
-    // Check if the error message is visible
-    expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
+    test("Submitting an empty or invalid polling station shows alert", async () => {
+      const user = userEvent.setup();
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
+
+      const pollingStation = screen.getByTestId("pollingStation");
+      const submitButton = screen.getByRole("button", { name: "Beginnen" });
+
+      await user.click(submitButton);
+
+      // Test that an alert is visible
+      const pollingStationSubmitFeedback = await screen.findByTestId(
+        "pollingStationSubmitFeedback",
+      );
+      expect(
+        within(pollingStationSubmitFeedback).getByText(
+          "Voer een geldig nummer van een stembureau in om te beginnen",
+        ),
+      ).toBeVisible();
+
+      // Now start typing an invalid polling station number
+      await user.type(pollingStation, "abc");
+
+      // Test that the alert disappeared
+      expect(pollingStationSubmitFeedback).not.toBeVisible();
+
+      // Click submit again and see that the alert appeared again
+      await user.click(submitButton);
+
+      expect(
+        within(screen.getByTestId("pollingStationSubmitFeedback")).getByText(
+          "Voer een geldig nummer van een stembureau in om te beginnen",
+        ),
+      ).toBeVisible();
+    });
+
+    test("Form displays message when searching", async () => {
+      overrideOnce(
+        "get",
+        "/api/elections/1/polling_stations",
+        200,
+        pollingStationsMockResponse,
+        "infinite",
+      );
+      const user = userEvent.setup();
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
+      const pollingStation = screen.getByTestId("pollingStation");
+
+      await user.type(pollingStation, "33");
+      const pollingStationSearching = await screen.findByTestId("pollingStationSelectorLoading");
+      expect(within(pollingStationSearching).getByText("aan het zoeken …")).toBeVisible();
+    });
   });
 
-  test("Submitting an empty or invalid polling station shows alert", async () => {
-    const user = userEvent.setup();
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
+  describe("Polling station list", () => {
+    test("Display polling station list", async () => {
+      overrideOnce("get", "/api/elections/1/polling_stations", 200, pollingStationsMockResponse);
+      const user = userEvent.setup();
 
-    const pollingStation = screen.getByTestId("pollingStation");
-    const submitButton = screen.getByRole("button", { name: "Beginnen" });
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
 
-    await user.click(submitButton);
+      expect(screen.getByText("Kies het stembureau")).not.toBeVisible();
+      const openPollingStationList = screen.getByTestId("openPollingStationList");
+      await user.click(openPollingStationList);
 
-    // Test that an alert is visible
-    const pollingStationSubmitFeedback = await screen.findByTestId("pollingStationSubmitFeedback");
-    expect(
-      within(pollingStationSubmitFeedback).getByText(
-        "Voer een geldig nummer van een stembureau in om te beginnen",
-      ),
-    ).toBeVisible();
+      expect(screen.getByText("Kies het stembureau")).toBeVisible();
 
-    // Now start typing an invalid polling station number
-    await user.type(pollingStation, "abc");
+      // Check if the station number and name exist and are visible
+      const pollingStationList = screen.getByTestId("polling_station_list");
+      expect(within(pollingStationList).getByText("33")).toBeVisible();
+      expect(within(pollingStationList).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
+      expect(within(pollingStationList).getByText("34")).toBeVisible();
+      expect(within(pollingStationList).getByText("Testplek")).toBeVisible();
+    });
 
-    // Test that the alert disappeared
-    expect(pollingStationSubmitFeedback).not.toBeVisible();
-
-    // Click submit again and see that the alert appeared again
-    await user.click(submitButton);
-
-    expect(
-      within(screen.getByTestId("pollingStationSubmitFeedback")).getByText(
-        "Voer een geldig nummer van een stembureau in om te beginnen",
-      ),
-    ).toBeVisible();
-  });
-
-  test("Polling station list shows message while loading", async () => {
-    overrideOnce(
-      "get",
-      "/api/elections/1/polling_stations",
-      200,
-      {
+    test("Polling station list no stations", async () => {
+      overrideOnce("get", "/api/elections/1/polling_stations", 200, {
         polling_stations: [],
-      },
-      "infinite",
-    );
-    const user = userEvent.setup();
+      });
+      const user = userEvent.setup();
 
-    render(
-      <PollingStationListProvider electionId={1}>
-        <PollingStationChoiceForm />
-      </PollingStationListProvider>,
-    );
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
 
-    const openPollingStationList = screen.getByTestId("openPollingStationList");
-    await user.click(openPollingStationList);
-    expect(screen.getByText("Kies het stembureau")).toBeVisible();
+      const openPollingStationList = screen.getByTestId("openPollingStationList");
+      await user.click(openPollingStationList);
+      expect(screen.getByText("Kies het stembureau")).toBeVisible();
 
-    // check if the loading message is visible
-    expect(screen.getByText("aan het laden …")).toBeVisible();
+      // Check if the error message is visible
+      expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
+    });
+
+    test("Polling station request returns 404", async () => {
+      overrideOnce("get", "/api/elections/1/polling_stations", 404, {
+        error: "Resource not found",
+      });
+      const user = userEvent.setup();
+
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
+
+      const openPollingStationList = screen.getByTestId("openPollingStationList");
+      await user.click(openPollingStationList);
+      expect(screen.getByText("Kies het stembureau")).toBeVisible();
+
+      // Check if the error message is visible
+      expect(screen.getByText("Geen stembureaus gevonden")).toBeVisible();
+    });
+
+    test("Polling station list shows message while loading", async () => {
+      overrideOnce(
+        "get",
+        "/api/elections/1/polling_stations",
+        200,
+        {
+          polling_stations: [],
+        },
+        "infinite",
+      );
+      const user = userEvent.setup();
+
+      render(
+        <PollingStationListProvider electionId={1}>
+          <PollingStationChoiceForm />
+        </PollingStationListProvider>,
+      );
+
+      const openPollingStationList = screen.getByTestId("openPollingStationList");
+      await user.click(openPollingStationList);
+      expect(screen.getByText("Kies het stembureau")).toBeVisible();
+
+      // check if the loading message is visible
+      expect(screen.getByText("aan het laden …")).toBeVisible();
+    });
   });
 });

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.tsx
@@ -113,7 +113,7 @@ export function PollingStationChoiceForm() {
             return (
               <div className="flex">
                 <Icon icon={<Spinner size="lg" />} />
-                aan het zoeken …
+                aan het laden …
               </div>
             );
           } else if (pollingStations.length === 0) {

--- a/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationSelector.tsx
@@ -53,7 +53,7 @@ export function PollingStationSelector({
         (() => {
           if (pollingStationsLoading || loading) {
             return (
-              <div className={cls.message}>
+              <div id="pollingStationSelectorLoading" className={cls.message}>
                 <span className={cls.icon}>
                   <Icon icon={<Spinner size="md" />} />
                 </span>

--- a/frontend/app/test/unit/server.ts
+++ b/frontend/app/test/unit/server.ts
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { http, HttpResponse, JsonBodyType } from "msw";
+import { delay, http, HttpResponse, JsonBodyType } from "msw";
 import { setupServer } from "msw/node";
 
 import { handlers } from "@kiesraad/api-mocks";
@@ -24,11 +24,15 @@ export function overrideOnce(
   path: string,
   status: number,
   body: string | null | JsonBodyType,
+  delayResponse?: "infinite" | number,
 ) {
   server.use(
     http[method](
       `http://testhost${path}`,
-      () => {
+      async () => {
+        if (delayResponse) {
+          await delay(delayResponse);
+        }
         // https://mswjs.io/docs/api/response/once
         if (typeof body === "string" || body === null) {
           return new HttpResponse(body, { status });


### PR DESCRIPTION
- Added option to delay response in `overrideOnce()`
- Added test for "aan het zoeken..." text for the polling station input field
- Changed polling station list loading text from "aan het zoeken..." to "aan het laden..."
- Added test for "aan het laden..." text for the polling station list
- Split tests across two `describe`s: one for the input field and one for the list (separate commit)