### PR TITLE
Add no console lint rule

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -28,6 +28,8 @@ module.exports = {
         allowBoolean: true,
       },
     ],
+    "no-console":
+      process.env.ESLINT_ENV === "production" ? ["error", { allow: ["warn", "error"] }] : "off",
   },
   parserOptions: {
     project: "**/tsconfig.json",

--- a/frontend/lib/api/useApiGetRequest.ts
+++ b/frontend/lib/api/useApiGetRequest.ts
@@ -37,7 +37,7 @@ export function useApiGetRequest<DATA>(path: string): UseApiGetRequestReturn<DAT
 
     if (path !== "") {
       doRequest(path).catch((e: unknown) => {
-        console.log("Error", e);
+        console.error("Error", e);
       });
     }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "dev:server": "cross-env API_MODE=local vite",
     "build": "tsc && cross-env API_MODE=local vite build",
     "build:msw": "cross-env API_MODE=mock vite build && cp mockServiceWorker.js dist/",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "cross-env ESLINT_ENV=production eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "prettier": "prettier --ignore-unknown --write .",
     "preview": "vite preview",
     "test": "vitest",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,4 +27,4 @@ pre-commit:
     frontend-linter:
       root: "frontend/"
       glob: "*.{ts,tsx}"
-      run: npm run lint {staged_files}
+      run: export ESLINT_ENV=production && npm run lint {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,4 +27,4 @@ pre-commit:
     frontend-linter:
       root: "frontend/"
       glob: "*.{ts,tsx}"
-      run: export ESLINT_ENV=production && npm run lint {staged_files}
+      run: npm run lint {staged_files}


### PR DESCRIPTION
Add a rule that prevents committing console.log statements (warn and error are allowed)
the rule is only active when running through lefthook but not during development.