### PR TITLE
Use cases toegevoegd, markdown gefixt

### DIFF
--- a/documentatie/use-cases/GSB-gebruikersdoelen.md
+++ b/documentatie/use-cases/GSB-gebruikersdoelen.md
@@ -1,6 +1,6 @@
 # Use cases GSB - gebruikersdoel, zee 🌊
 
-## 1. De eerste of tweede invoerder voert de resultaten van de telling in
+## De eerste of tweede invoerder voert de resultaten van de telling in
 
 __niveau:__ gebruikersdoel, zee, 🌊
 
@@ -8,7 +8,7 @@ __precondities:__
 
 - De invoerder is ingelogd in de applicatie.
 
-### 1.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ De coördinator geeft het SB PV en eventueel SB corrigendum PV aan de invoerder.
 
@@ -32,16 +32,16 @@ __uitbreidingen__:
 
 3a. De invoer voldoet niet aan de validatieregels voor fouten:  
 &emsp; 3a1. De applicatie toont een foutmelding voor elke gefaalde validatieregel.  
-&emsp; 3a2. [De invoerder handelt de fout(en) af.](./GSB-subfuncties.md#1-de-invoerder-handelt-de-fouten-af)  
+&emsp; 3a2. [De invoerder handelt de fout(en) af.](./GSB-subfuncties.md#de-invoerder-handelt-de-fouten-af)  
 4a. De invoer voldoet niet aan de plausibiliteitschecks:  
 &emsp; 4a1. De applicatie toont een waarschuwing voor elke gefaalde plausibiliteitscheck.  
-&emsp; 4a2. [De invoerder handelt de waarschuwing(en) af.](./GSB-subfuncties.md#2-de-invoerder-handelt-de-waarschuwingen-af)  
+&emsp; 4a2. [De invoerder handelt de waarschuwing(en) af.](./GSB-subfuncties.md#de-invoerder-handelt-de-waarschuwingen-af)  
 
-## 2. De coördinator lost de verschillen tussen de twee invoeren op
+## De coördinator lost de verschillen tussen de twee invoeren op
 
 __niveau:__ gebruikersdoel, zee, 🌊
 
-### 2.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ De applicatie stelt vast dat beide invoeren niet gelijk zijn.
 
@@ -56,15 +56,15 @@ __uitbreidingen__:
 &emsp; 2a1. De coördinator verwijdert beide invoeren.  
 &emsp; 2a2. De coördinator laat het stembureau opnieuw invoeren door twee invoerders.  
 
-### 2.2. Open punten
+### Open punten
 
 - Als geen van beide invoeren correct zijn, moeten dan beide invoeren verwijderd en opnieuw ingevoerd worden? Of is er binnen de Kieswet / het Kiesbesluit ruimte voor andere oplossingen?
 
-## 3. GSB installeert de applicatie
+## GSB installeert de applicatie
 
 __niveau:__ gebruikersdoel, zee, 🌊
 
-### 3.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ De Kiesraad maakt de applicatie beschikbaar.
 
@@ -82,21 +82,21 @@ __uitbreidingen__:
 
 3a. De server en client zijn dezelfde machine:
 
-### 3.2. Open punten
+### Open punten
 
 - Hoe vaak wordt de server ook als client gebruikt? Bijvoorbeeld door de coördinator.
 - OSV richt de server ook gelijk als client in. Willen wij dit ook?
 - Afzenderverificatie ontbreekt nog, want nog geen beslissing over oplossing.
 
-## 4. GSB richt de applicatie in
+## GSB richt de applicatie in
 
 __niveau:__ gebruikersdoel, zee, 🌊
 
-### 4.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__  
 
-- [GSB installeert de applicatie.](#3-gsb-installeert-de-applicatie)
+- [GSB installeert de applicatie.](#gsb-installeert-de-applicatie)
 - Het GSB maakt de kandidatenlijst beschikbaar.
 - De Kiesraad maakt de verkiezingsdefinitie beschikbaar.
 
@@ -116,7 +116,7 @@ __uitbreidingen__:
 3b. De lijst met stembureaus moet aangevuld of aangepast worden:  
 3c. Er is geen lijst met stembureaus:  
 
-### 4.2. Open punten
+### Open punten
 
 - Het is niet helemaal duidelijk hoe de stembureaus aangemaakt worden. Dit kan handmatig of door het importeren van een bestand. We weten niet hoe vaak welke van deze twee manieren of een combinatie van de twee gebruikt worden. Een stembureau-bestand kan door OSV geëxporteerd worden, maar er zouden ook andere tools bestaan die zo'n bestand kunnen genereren.
 - Bij het invoeren/beheren van stembureaus toont de applicatie een waarschuwing als het aantal kiesgerechtigden niet is ingevuld. De gebruiker heeft twee opties: (1) aantal kiesgerechtigden invullen, (2) aangeven dat aantal kiesgerechtigden bewust leeg wordt gelaten.

--- a/documentatie/use-cases/GSB-gebruikersdoelen.md
+++ b/documentatie/use-cases/GSB-gebruikersdoelen.md
@@ -1,0 +1,122 @@
+# Use cases GSB - gebruikersdoel, zee 🌊
+
+## 1. De eerste of tweede invoerder voert de resultaten van de telling in
+
+__niveau:__ gebruikersdoel, zee, 🌊
+
+__precondities:__  
+
+- De invoerder is ingelogd in de applicatie.
+
+### 1.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ De coördinator geeft het SB PV en eventueel SB corrigendum PV aan de invoerder.
+
+__hoofdscenario__:  
+
+1. De invoerder selecteert het stembureau van het PV in de applicatie.
+2. De invoerder vult de resultaten van de telling in.
+3. (tijdens invoer) De applicatie controleert dat de invoer voldoet aan de [validatieregels voor fouten](./GSB-validatieregels-plausibiliteitschecks.md#validatieregels-geven-fouten)
+4. (tijdens invoer) De applicatie controleert dat de invoer voldoet aan de [plausibiliteitschecks](./GSB-validatieregels-plausibiliteitschecks.md#plausibiliteitschecks-geven-waarschuwingen).
+5. De invoerder bevestigt in de applicatie klaar te zijn met de invoer van het stembureau.
+
+__uitbreidingen__:  
+1a. De invoerder kan het stembureau op het PV niet in de applicatie vinden:  
+&emsp; 1a1. De invoerder verwittigt de coördinator.  
+&emsp; 1a2. De coördinator en de invoerder vinden alsnog het stembureau.  
+&emsp; &emsp; 1a2a. Het stembureau is niet aanwezig in de applicatie:  
+&emsp; &emsp; &emsp; 1a2a1. De coördinator voegt het stembureau toe in de applicatie.  
+1b. De tweede invoerder heeft ook de eerste invoer gedaan:  
+1c. De invoerder selecteert het verkeerde stembureau:  
+1d. De invoerder selecteert een stembureau waar iemand anders mee bezig is:  
+
+3a. De invoer voldoet niet aan de validatieregels voor fouten:  
+&emsp; 3a1. De applicatie toont een foutmelding voor elke gefaalde validatieregel.  
+&emsp; 3a2. [De invoerder handelt de fout(en) af.](./GSB-subfuncties.md#1-de-invoerder-handelt-de-fouten-af)  
+4a. De invoer voldoet niet aan de plausibiliteitschecks:  
+&emsp; 4a1. De applicatie toont een waarschuwing voor elke gefaalde plausibiliteitscheck.  
+&emsp; 4a2. [De invoerder handelt de waarschuwing(en) af.](./GSB-subfuncties.md#2-de-invoerder-handelt-de-waarschuwingen-af)  
+
+## 2. De coördinator lost de verschillen tussen de twee invoeren op
+
+__niveau:__ gebruikersdoel, zee, 🌊
+
+### 2.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ De applicatie stelt vast dat beide invoeren niet gelijk zijn.
+
+__hoofdscenario__:  
+
+1. De coördinator bekijkt de verschillen tussen de twee invoeren.  
+2. De coördinator stelt vast dat één van de twee invoeren correct is.  
+3. De coördinator accepteert de correcte invoer.  
+
+__uitbreidingen__:  
+2a. Geen van beide invoeren is correct:  
+&emsp; 2a1. De coördinator verwijdert beide invoeren.  
+&emsp; 2a2. De coördinator laat het stembureau opnieuw invoeren door twee invoerders.  
+
+### 2.2. Open punten
+
+- Als geen van beide invoeren correct zijn, moeten dan beide invoeren verwijderd en opnieuw ingevoerd worden? Of is er binnen de Kieswet / het Kiesbesluit ruimte voor andere oplossingen?
+
+## 3. GSB installeert de applicatie
+
+__niveau:__ gebruikersdoel, zee, 🌊
+
+### 3.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ De Kiesraad maakt de applicatie beschikbaar.
+
+__hoofdscenario__:  
+
+1. De beheerder bereidt één server voor.
+2. De beheerder installeert de applicatie.
+3. (voor elke client) De beheerder bereidt de client-machine voor.
+4. (voor elke client) De beheerder zorgt dat de client met de server kan verbinden.
+
+__uitbreidingen__:  
+1a. De beheerder bereidt één of meerdere reserve-servers voor:
+
+2a. De installatie van de applicatie geeft een foutmelding:
+
+3a. De server en client zijn dezelfde machine:
+
+### 3.2. Open punten
+
+- Hoe vaak wordt de server ook als client gebruikt? Bijvoorbeeld door de coördinator.
+- OSV richt de server ook gelijk als client in. Willen wij dit ook?
+- Afzenderverificatie ontbreekt nog, want nog geen beslissing over oplossing.
+
+## 4. GSB richt de applicatie in
+
+__niveau:__ gebruikersdoel, zee, 🌊
+
+### 4.1. Hoofdscenario en uitbreidingen
+
+__trigger:__  
+
+- [GSB installeert de applicatie.](#3-gsb-installeert-de-applicatie)
+- Het GSB maakt de kandidatenlijst beschikbaar.
+- De Kiesraad maakt de verkiezingsdefinitie beschikbaar.
+
+__hoofdscenario__:  
+
+1. De beheerder leest de verkiezingsdefinitie in.
+2. De beheerder leest de kandidatenlijst in.
+3. De beheerder maakt de stembureaus aan.
+4. De beheerder maakt de gebruikers aan.
+
+__uitbreidingen__:  
+1a. De applicatie geeft een foutmelding bij het inlezen van de verkiezingsdefinitie:  
+
+2a. De applicatie geeft een foutmelding bij het inlezen van de kandidatenlijst:  
+
+3a. De applicatie geeft een foutmelding bij het inlezen van de lijst met stembureaus:  
+3b. De lijst met stembureaus moet aangevuld of aangepast worden:  
+3c. Er is geen lijst met stembureaus:  
+
+### 4.2. Open punten
+
+- Het is niet helemaal duidelijk hoe de stembureaus aangemaakt worden. Dit kan handmatig of door het importeren van een bestand. We weten niet hoe vaak welke van deze twee manieren of een combinatie van de twee gebruikt worden. Een stembureau-bestand kan door OSV geëxporteerd worden, maar er zouden ook andere tools bestaan die zo'n bestand kunnen genereren.
+- Bij het invoeren/beheren van stembureaus toont de applicatie een waarschuwing als het aantal kiesgerechtigden niet is ingevuld. De gebruiker heeft twee opties: (1) aantal kiesgerechtigden invullen, (2) aangeven dat aantal kiesgerechtigden bewust leeg wordt gelaten.

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -1,0 +1,77 @@
+# Use cases GSB - hoog-over, vlieger 🪁
+
+## 1. Het GSB voert de PV's en eventuele SB corrigenda's (DSO) in de applicatie in
+
+__niveau:__ hoog-over, vlieger, 🪁
+
+__precondities:__
+
+- [GSB installeert de applicatie](./GSB-gebruikersdoelen.md#3-gsb-installeert-de-applicatie)
+- [GSB richt de applicatie in](./GSB-gebruikersdoelen.md#4-gsb-richt-de-applicatie-in)
+
+### 1.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ Het geplande tijdstip om invoer te starten breekt aan.
+
+__hoofdscenario__:  
+
+1. De coördinator stelt invoer open.
+2. (voor elk SB PV evt met corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#2-de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
+3. De coördinator sluit de invoer af.
+4. De applicatie genereert de PVs en emls etc.
+
+__uitbreidingen__:  
+3a. De applicatie stelt vast dat niet voor niet alle stembureaus resultaten zijn ingevoerd:  
+3b. De applicatie stelt vast dat er stembureaus met waarschuwingen zijn:  
+
+### 1.2. Open punten
+
+- Moet de applicatie een preview van het gegenereerde PV tonen, zodat de coördinator die kan controleren?
+
+## 2. De invoerders vullen de resultaten van de tellingen in
+
+__niveau:__ hoog-over, vlieger, 🪁
+
+### 2.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ De coördinator ontvangt een SB PV evt met corrigendum.
+
+__hoofdscenario__:
+
+1. De coördinator geeft het SB PV evt met corrigendum aan de eerste invoerder.
+2. [De eerste invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#1-de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
+3. De coördinator geeft het SB PV evt met corrigendum aan de tweede invoerder.
+4. [De tweede invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#1-de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
+5. De applicatie stelt vast dat beide invoeren gelijk zijn.
+6. De applicatie slaat het resultaat op.
+
+__uitbreidingen__:  
+5a. De applicatie stelt vast dat beide invoeren niet gelijk zijn:  
+&emsp; 5a1. [De coördinator lost de verschillen tussen de twee invoeren op.](./GSB-gebruikersdoelen.md#2-de-coördinator-lost-de-verschillen-tussen-de-twee-invoeren-op)
+
+## 3. Het GSB voert de corrigendum PV's in de applicatie in
+
+__niveau:__ hoog-over, vlieger, 🪁
+
+__precondities:__
+
+- [GSB installeert de applicatie](./GSB-gebruikersdoelen.md#3-gsb-installeert-de-applicatie)
+- [GSB richt de applicatie in](./GSB-gebruikersdoelen.md#4-gsb-richt-de-applicatie-in)
+- [Het GSB voert de PV's in de applicatie in](#1-het-gsb-voert-de-pvs-en-eventuele-sb-corrigendas-dso-in-de-applicatie-in)
+
+### 3.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ Er is een corrigendum PV opgesteld.
+
+__hoofdscenario__:  
+
+1. (voor elk corrigendum) De coördinator stelt invoer open voor het stembureau met corrigendum.
+2. (voor elk corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#2-de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
+3. De coördinator genereert de PVs en emls etc.
+
+__uitbreidingen__:  
+...
+
+### 3.2. Open punten
+
+- Hoe worden de gecorrigeerde tellingen ingevoerd? Volledige invoer van oorspronkelijk PV en corrigendum? Alleen invoer van de aantallen uit het corrigendum?

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -45,7 +45,7 @@ __hoofdscenario__:
 2. [De eerste invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
 3. De coördinator geeft het SB PV evt met corrigendum aan de tweede invoerder.
 4. [De tweede invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
-5. (na eerste en/of tweede invoer) De applicatie controleert dat de invoer niet resulteerde in (geaccepteerde) waarschuwingen.
+5. (na eerste en/of tweede invoer) De applicatie stelt vast dat de invoer geen (geaccepteerde) waarschuwingen bevat.
 6. De applicatie stelt vast dat beide invoeren gelijk zijn.
 7. De applicatie slaat het definitieve resultaat van het stembureau op.
 

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -1,22 +1,22 @@
 # Use cases GSB - hoog-over, vlieger 🪁
 
-## 1. Het GSB voert de PV's en eventuele SB corrigenda's (DSO) in de applicatie in
+## Het GSB voert de PV's en eventuele SB corrigenda's (DSO) in de applicatie in
 
 __niveau:__ hoog-over, vlieger, 🪁
 
 __precondities:__
 
-- [GSB installeert de applicatie](./GSB-gebruikersdoelen.md#3-gsb-installeert-de-applicatie)
-- [GSB richt de applicatie in](./GSB-gebruikersdoelen.md#4-gsb-richt-de-applicatie-in)
+- [GSB installeert de applicatie](./GSB-gebruikersdoelen.md#gsb-installeert-de-applicatie)
+- [GSB richt de applicatie in](./GSB-gebruikersdoelen.md#gsb-richt-de-applicatie-in)
 
-### 1.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ Het geplande tijdstip om invoer te starten breekt aan.
 
 __hoofdscenario__:  
 
 1. De coördinator stelt invoer open.
-2. (voor elk SB PV evt met corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#2-de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
+2. (voor elk SB PV evt met corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
 3. De coördinator sluit de invoer af.
 4. De applicatie genereert de PVs en emls etc.
 
@@ -24,54 +24,54 @@ __uitbreidingen__:
 3a. De applicatie stelt vast dat niet voor niet alle stembureaus resultaten zijn ingevoerd:  
 3b. De applicatie stelt vast dat er stembureaus met waarschuwingen zijn:  
 
-### 1.2. Open punten
+### Open punten
 
 - Moet de applicatie een preview van het gegenereerde PV tonen, zodat de coördinator die kan controleren?
 
-## 2. De invoerders vullen de resultaten van de tellingen in
+## De invoerders vullen de resultaten van de tellingen in
 
 __niveau:__ hoog-over, vlieger, 🪁
 
-### 2.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ De coördinator ontvangt een SB PV evt met corrigendum.
 
 __hoofdscenario__:
 
 1. De coördinator geeft het SB PV evt met corrigendum aan de eerste invoerder.
-2. [De eerste invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#1-de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
+2. [De eerste invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
 3. De coördinator geeft het SB PV evt met corrigendum aan de tweede invoerder.
-4. [De tweede invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#1-de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
+4. [De tweede invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
 5. De applicatie stelt vast dat beide invoeren gelijk zijn.
 6. De applicatie slaat het resultaat op.
 
 __uitbreidingen__:  
 5a. De applicatie stelt vast dat beide invoeren niet gelijk zijn:  
-&emsp; 5a1. [De coördinator lost de verschillen tussen de twee invoeren op.](./GSB-gebruikersdoelen.md#2-de-coördinator-lost-de-verschillen-tussen-de-twee-invoeren-op)
+&emsp; 5a1. [De coördinator lost de verschillen tussen de twee invoeren op.](./GSB-gebruikersdoelen.md#de-coördinator-lost-de-verschillen-tussen-de-twee-invoeren-op)
 
-## 3. Het GSB voert de corrigendum PV's in de applicatie in
+## Het GSB voert de corrigendum PV's in de applicatie in
 
 __niveau:__ hoog-over, vlieger, 🪁
 
 __precondities:__
 
-- [GSB installeert de applicatie](./GSB-gebruikersdoelen.md#3-gsb-installeert-de-applicatie)
-- [GSB richt de applicatie in](./GSB-gebruikersdoelen.md#4-gsb-richt-de-applicatie-in)
-- [Het GSB voert de PV's in de applicatie in](#1-het-gsb-voert-de-pvs-en-eventuele-sb-corrigendas-dso-in-de-applicatie-in)
+- [GSB installeert de applicatie](./GSB-gebruikersdoelen.md#gsb-installeert-de-applicatie)
+- [GSB richt de applicatie in](./GSB-gebruikersdoelen.md#gsb-richt-de-applicatie-in)
+- [Het GSB voert de PV's in de applicatie in](#het-gsb-voert-de-pvs-en-eventuele-sb-corrigendas-dso-in-de-applicatie-in)
 
-### 3.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ Er is een corrigendum PV opgesteld.
 
 __hoofdscenario__:  
 
 1. (voor elk corrigendum) De coördinator stelt invoer open voor het stembureau met corrigendum.
-2. (voor elk corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#2-de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
+2. (voor elk corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
 3. De coördinator genereert de PVs en emls etc.
 
 __uitbreidingen__:  
 ...
 
-### 3.2. Open punten
+### Open punten
 
 - Hoe worden de gecorrigeerde tellingen ingevoerd? Volledige invoer van oorspronkelijk PV en corrigendum? Alleen invoer van de aantallen uit het corrigendum?

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -45,15 +45,18 @@ __hoofdscenario__:
 2. [De eerste invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
 3. De coördinator geeft het SB PV evt met corrigendum aan de tweede invoerder.
 4. [De tweede invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
-5. De applicatie stelt vast dat beide invoeren gelijk zijn.
-6. De applicatie slaat het resultaat op.
+5. (na eerste en/of tweede invoer) De applicatie controleert dat de invoer niet resulteerde in (geaccepteerde) waarschuwingen.
+6. De applicatie controleert dat beide invoeren gelijk zijn.
+7. De applicatie slaat het resultaat op.
 
 __uitbreidingen__:  
-5a. De applicatie stelt vast dat beide invoeren niet gelijk zijn:  
-&emsp; 5a1. [De coördinator lost de verschillen tussen de twee invoeren op.](./GSB-gebruikersdoelen.md#de-coördinator-lost-de-verschillen-tussen-de-twee-invoeren-op)
+5a. De applicatie stelt vast dat een invoerder waarschuwingen heeft geaccepteerd:  
+&emsp; 5a1. De coördinator beoordeeldt de geaccepteerde waarschuwingen.
 
-5b. De applicatie stelt vast dat een invoerder waarschuwingen heeft geaccepteerd:  
-&emsp; 5b1. De coördinator beoordeeldt de geaccepteerde waarschuwingen.
+6a. De applicatie stelt vast dat beide invoeren niet gelijk zijn:  
+&emsp; 6a1. [De coördinator lost de verschillen tussen de twee invoeren op.](./GSB-gebruikersdoelen.md#de-coördinator-lost-de-verschillen-tussen-de-twee-invoeren-op)
+
+
 
 ## Het GSB voert de corrigendum PV's in de applicatie in
 

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -18,8 +18,8 @@ __hoofdscenario__:
 1. De coördinator stelt invoer open.
 2. (voor elk SB PV evt met corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
 3. De coördinator sluit de invoer af.
-4. De applicatie controleert dat voor alle stembureaus resultaten zijn ingevoerd.
-5. De applicatie controleert dat er geen stembureaus met waarschuwingen zijn.
+4. De applicatie stelt vast dat voor alle stembureaus resultaten zijn ingevoerd.
+5. De applicatie stelt vast dat er geen stembureaus met (geaccepteerde) waarschuwingen zijn.
 5. De applicatie genereert de PVs en emls etc.
 
 __uitbreidingen__:  
@@ -46,8 +46,8 @@ __hoofdscenario__:
 3. De coördinator geeft het SB PV evt met corrigendum aan de tweede invoerder.
 4. [De tweede invoerder voert de resultaten van de telling in.](./GSB-gebruikersdoelen.md#de-eerste-of-tweede-invoerder-voert-de-resultaten-van-de-telling-in)
 5. (na eerste en/of tweede invoer) De applicatie controleert dat de invoer niet resulteerde in (geaccepteerde) waarschuwingen.
-6. De applicatie controleert dat beide invoeren gelijk zijn.
-7. De applicatie slaat het resultaat op.
+6. De applicatie stelt vast dat beide invoeren gelijk zijn.
+7. De applicatie slaat het definitieve resultaat van het stembureau op.
 
 __uitbreidingen__:  
 5a. De applicatie stelt vast dat een invoerder waarschuwingen heeft geaccepteerd:  

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -18,11 +18,14 @@ __hoofdscenario__:
 1. De coördinator stelt invoer open.
 2. (voor elk SB PV evt met corrigendum) [De invoerders vullen de resultaten van de tellingen in.](#de-invoerders-vullen-de-resultaten-van-de-tellingen-in)
 3. De coördinator sluit de invoer af.
-4. De applicatie genereert de PVs en emls etc.
+4. De applicatie controleert dat voor alle stembureaus resultaten zijn ingevoerd.
+5. De applicatie controleert dat er geen stembureaus met waarschuwingen zijn.
+5. De applicatie genereert de PVs en emls etc.
 
 __uitbreidingen__:  
-3a. De applicatie stelt vast dat niet voor niet alle stembureaus resultaten zijn ingevoerd:  
-3b. De applicatie stelt vast dat er stembureaus met waarschuwingen zijn:  
+4a. De applicatie stelt vast dat niet voor niet alle stembureaus resultaten zijn ingevoerd:
+
+5a. De applicatie stelt vast dat er stembureaus met waarschuwingen zijn:
 
 ### Open punten
 

--- a/documentatie/use-cases/GSB-hoogover.md
+++ b/documentatie/use-cases/GSB-hoogover.md
@@ -49,6 +49,9 @@ __uitbreidingen__:
 5a. De applicatie stelt vast dat beide invoeren niet gelijk zijn:  
 &emsp; 5a1. [De coördinator lost de verschillen tussen de twee invoeren op.](./GSB-gebruikersdoelen.md#de-coördinator-lost-de-verschillen-tussen-de-twee-invoeren-op)
 
+5b. De applicatie stelt vast dat een invoerder waarschuwingen heeft geaccepteerd:  
+&emsp; 5b1. De coördinator beoordeeldt de geaccepteerde waarschuwingen.
+
 ## Het GSB voert de corrigendum PV's in de applicatie in
 
 __niveau:__ hoog-over, vlieger, 🪁

--- a/documentatie/use-cases/GSB-subfuncties.md
+++ b/documentatie/use-cases/GSB-subfuncties.md
@@ -1,10 +1,10 @@
 # Use cases GSB - subfunctie,  vis 🐟
 
-## 1. De invoerder handelt de fout(en) af
+## De invoerder handelt de fout(en) af
 
 __niveau:__ subfunctie, vis, 🐟
 
-### 1.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ De controles geven een foutmelding vanwege de [validatieregels voor fouten](./GSB-validatieregels-plausibiliteitschecks.md#validatieregels-geven-fouten).
 
@@ -24,15 +24,15 @@ __uitbreidingen__:
 &emsp; 2a3. De invoerder breekt de invoer af.  
 &emsp; 2a4. De applicatie verwijdert de ingevoerde data.  
 
-### 1.2. Open punten
+### Open punten
 
 - Als de coördinator het PV terugstuurt in het proces, naar welk punt dan precies?
 
-## 2. De invoerder handelt de waarschuwing(en) af
+## De invoerder handelt de waarschuwing(en) af
 
 __niveau:__ subfunctie, vis, 🐟
 
-### 2.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ De controles geven een waarschuwing vanwege de [plausibiliteitschecks](./GSB-validatieregels-plausibiliteitschecks.md#plausibiliteitschecks-geven-waarschuwingen).
 
@@ -56,7 +56,7 @@ __uitbreidingen__:
 &emsp; 4a2. De invoerder breekt de invoer af.  
 &emsp; 4a3. De applicatie verwijdert de ingevoerde data.  
 
-### 2.2. Open punten
+### Open punten
 
 - De eerste stap van invoer is aangeven of er herteld is vanwege een verschil tussen aantal toegelaten kiezers en aantal uitgebrachte stemmen. Hoe verhoudt de invoer van die stap zich tot het oplossen van waarschuwingen over aantallen toegelaten kiezers en uitgebrachte stemmen?
 - Als de coördinator het PV terugstuurt in het proces, naar welk punt dan precies?

--- a/documentatie/use-cases/GSB-subfuncties.md
+++ b/documentatie/use-cases/GSB-subfuncties.md
@@ -43,18 +43,11 @@ Voor elke waarschuwing:
 
 1. De invoerder controleert de waarschuwing.
 2. De invoerder constateert dat de invoer klopt met het PV.
-3. De invoerder meldt de waarschuwing bij de coördinator.
-4. De coördinator beslist dat de waarschuwing genegeerd kan worden.
-5. De invoerder accepteert de waarschuwing in de applicatie.
+3. De invoerder accepteert de waarschuwing in de applicatie.
 
 __uitbreidingen__:  
 2a. De invoerder constateert dat hij/zij een fout heeft gemaakt in de invoer.  
 &emsp; 2a1. De invoerder corrigeert de fout in de invoer.  
-
-4a. De coördinator beslist dat de waarschuwing niet genegeerd kan worden:  
-&emsp; 4a1. De coördinator stuurt het PV terug in het proces.  
-&emsp; 4a2. De invoerder breekt de invoer af.  
-&emsp; 4a3. De applicatie verwijdert de ingevoerde data.  
 
 ### Open punten
 

--- a/documentatie/use-cases/GSB-subfuncties.md
+++ b/documentatie/use-cases/GSB-subfuncties.md
@@ -1,0 +1,62 @@
+# Use cases GSB - subfunctie,  vis 🐟
+
+## 1. De invoerder handelt de fout(en) af
+
+__niveau:__ subfunctie, vis, 🐟
+
+### 1.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ De controles geven een foutmelding vanwege de [validatieregels voor fouten](./GSB-validatieregels-plausibiliteitschecks.md#validatieregels-geven-fouten).
+
+*Foutmelding*: De ingevoerde waardes kunnen niet correct zijn. Bijvoorbeeld: het totaal van de stemmen op een lijst komt niet overeen met de som van de stemmen van de kandidaten op die lijst.
+
+__hoofdscenario__:  
+Voor elke foutmelding:  
+
+1. De invoerder controleert de foutmelding.
+2. De invoerder constateert dat hij/zij een fout heeft gemaakt in de invoer.
+3. De invoerder corrigeert de fout in de invoer.
+
+__uitbreidingen__:  
+2a. De invoerder stelt een fout op het PV vast en kan de foutmelding niet oplossen:  
+&emsp; 2a1. De invoerder meldt de fout op het PV bij de coördinator.  
+&emsp; 2a2. De coördinator stuurt het PV terug in het proces.  
+&emsp; 2a3. De invoerder breekt de invoer af.  
+&emsp; 2a4. De applicatie verwijdert de ingevoerde data.  
+
+### 1.2. Open punten
+
+- Als de coördinator het PV terugstuurt in het proces, naar welk punt dan precies?
+
+## 2. De invoerder handelt de waarschuwing(en) af
+
+__niveau:__ subfunctie, vis, 🐟
+
+### 2.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ De controles geven een waarschuwing vanwege de [plausibiliteitschecks](./GSB-validatieregels-plausibiliteitschecks.md#plausibiliteitschecks-geven-waarschuwingen).
+
+*Waarschuwing*: De ingevoerde waardes zijn mogelijk niet correct. Bijvoorbeeld: er is een groot aantal blanco stemmen of de tweede invoer klopt niet met de eerste invoer.
+
+__hoofdscenario__:  
+Voor elke waarschuwing:  
+
+1. De invoerder controleert de waarschuwing.
+2. De invoerder constateert dat de invoer klopt met het PV.
+3. De invoerder meldt de waarschuwing bij de coördinator.
+4. De coördinator beslist dat de waarschuwing genegeerd kan worden.
+5. De invoerder accepteert de waarschuwing in de applicatie.
+
+__uitbreidingen__:  
+2a. De invoerder constateert dat hij/zij een fout heeft gemaakt in de invoer.  
+&emsp; 2a1. De invoerder corrigeert de fout in de invoer.  
+
+4a. De coördinator beslist dat de waarschuwing niet genegeerd kan worden:  
+&emsp; 4a1. De coördinator stuurt het PV terug in het proces.  
+&emsp; 4a2. De invoerder breekt de invoer af.  
+&emsp; 4a3. De applicatie verwijdert de ingevoerde data.  
+
+### 2.2. Open punten
+
+- De eerste stap van invoer is aangeven of er herteld is vanwege een verschil tussen aantal toegelaten kiezers en aantal uitgebrachte stemmen. Hoe verhoudt de invoer van die stap zich tot het oplossen van waarschuwingen over aantallen toegelaten kiezers en uitgebrachte stemmen?
+- Als de coördinator het PV terugstuurt in het proces, naar welk punt dan precies?

--- a/documentatie/use-cases/GSB-validatieregels-plausibiliteitschecks.md
+++ b/documentatie/use-cases/GSB-validatieregels-plausibiliteitschecks.md
@@ -1,0 +1,265 @@
+# Use cases GSB - validatieregels en plausibiliteitschecks
+
+## Validatieregels geven fouten
+
+Aan validatieregels moet voldaan worden. Als de fout optreedt, kan de gebruiker niet verder naar de volgende stap. De invoer wordt wel opgeslagen, maar is nog niet afgerond. De foutmelding wordt getoond als de regel evalueert naar `FALSE`.
+
+De foutmelding die wordt getoond bestaat uit vier onderdelen:
+
+- titel
+- nummer
+- toelichting
+- handelingsperspectief
+
+Titel, nummer en toelichting zijn uniek voor iedere foutmelding. Het handelingsperspectief is voor alle foutmeldingen gelijk, en is als volgt:
+
+> - Heb je iets niet goed overgenomen? Herstel de fout en ga verder.
+> - Heb je alles goed overgenomen en blijft de fout? Dan mag je niet verder. Overleg met de coördinator.
+
+### Regels voor alle numerieke invoervelden (reeks F.0xx)
+
+Er zijn geen regels omdat het niet mogelijk is om foute aantallen in te vullen in de frontend, dus er wordt een error vanuit de backend gegeven als er toch met de aantallen geknoeid is en ze niet toegestaan zijn.
+
+### Regels voor hertelling GSB (reeks F.1xx)
+
+#### F.101: Vraag 'Is er herteld?' moet beantwoord worden
+
+> **Controleer het papieren proces-verbaal** (F.101)  
+> Is op pagina 1 aangegeven dat er in opdracht van het Gemeentelijk Stembureau is herteld?
+>
+> - Controleer of rubriek 3 is ingevuld. Is dat zo? Kies hieronder 'ja'.
+> - Wel een vinkje, maar rubriek 3 niet ingevuld? Overleg met de coördinator.
+> - Geen vinkje? Kies dan 'nee'.
+
+Velden markeren: geen (laat alleen error zien op de pagina)
+
+### Regels voor totalen (reeks F.2xx)
+
+#### F.201: (Als niet herteld) `stempassen + volmachten + kiezerspassen = totaal toegelaten kiezers`
+
+> **Controleer toegelaten kiezers** (F.201)  
+> De invoer bij A, B, C of D klopt niet.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: A, B, C en D
+
+#### F.202: `stemmen op kandidaten + blanco stemmen + ongeldige stemmen = totaal uitgebrachte stemmen`
+
+> **Controleer uitgebrachte stemmen** (F.202)  
+> De invoer bij E, F, G of H klopt niet.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: E, F, G en H
+
+[Voorbeeld in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=126-5677&t=zTY4ajWtsFkiTOYP-4)
+
+#### F.203: (Als herteld) `hertelde stempassen + hertelde volmachten + hertelde kiezerspassen = herteld totaal toegelaten kiezers`
+
+> **Controleer hertelde toegelaten kiezers** (F.203)  
+> De invoer bij A.2, B.2, C.2 of D.2 klopt niet.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: A.2, B.2, C.2 en D.2
+
+#### F.204: `stemmen op kandidaten = som van uitgebrachte stemmen op de lijsten`
+
+> **Controleer (totaal) aantal stemmen op kandidaten** (F.204)  
+> De optelling van alle lijsten is niet gelijk aan de invoer bij E.  
+> Check of je invoer bij E gelijk is aan het papieren proces-verbaal. En check of je alle lijsten hebt ingevoerd.
+
+Veld markeren: E (dit gebeurt pas zodra alle lijsten zijn ingevuld, en er is dan een redirect naar _Aantal kiezers en stemmers_ om de error te laten zien)
+
+### Regels voor verschillen (reeks F.3xx)
+
+#### F.301 (Als (herteld) totaal aantal kiezers < totaal aantal uitgebrachte stemmen) `meer stembiljetten geteld = totaal aantal uitgebrachte stemmen - (herteld) aantal toegelaten kiezers`
+
+> **Controleer I (stembiljetten meer geteld)** (F.301)  
+> Je hebt bij _Aantal kiezers en stemmers_ ingevuld dat er meer stemmen dan kiezers waren. Het aantal dat je bij I hebt ingevuld is niet gelijk aan het aantal meer getelde stembiljetten.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: I
+
+#### F.302 (Als (herteld) totaal aantal kiezers < totaal aantal uitgebrachte stemmen en J is ingevuld) `meer stembiljetten geteld = totaal aantal uitgebrachte stemmen - (herteld) aantal toegelaten kiezers`
+
+> **Controleer J (stembiljetten minder geteld)** (F.302)  
+> Je hebt bij _Aantal kiezers en stemmers_ ingevuld dat er meer stemmen dan kiezers waren. Daarom mag J niet ingevuld zijn.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: J
+
+#### F.303 (Als (herteld) totaal aantal kiezers > totaal aantal uitgebrachte stemmen) `minder stembiljetten geteld = aantal toegelaten kiezers - totaal aantal uitgebrachte stemmen`
+
+> **Controleer J (stembiljetten minder geteld)** (F.303)  
+> Je hebt bij _Aantal kiezers en stemmers_ ingevuld dat er minder stemmen dan kiezers waren. Het aantal dat je bij J hebt ingevuld is niet gelijk aan het aantal minder getelde stembiljetten.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: J
+
+#### F.304 (Als (herteld) totaal aantal kiezers > totaal aantal uitgebrachte stemmen en I is ingevuld) `minder stembiljetten geteld = herteld aantal toegelaten kiezers - totaal aantal uitgebrachte stemmen`
+
+> **Controleer I (stembiljetten meer geteld)** (F.304)  
+> Je hebt bij _Aantal kiezers en stemmers_ ingevuld dat er minder stemmen dan kiezers waren. Daarom mag I niet ingevuld zijn.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: I
+
+#### F.305 (Als (herteld) totaal aantal kiezers == totaal aantal uitgebrachte stemmen) `minder stembiljetten geteld = 0 EN meer stembiljetten geteld = 0 EN niet ingeleverde stembiljetten EN te weinig uitgereikte stembiljetten EN te veel uitgereikte stembiljetten EN andere verklaring EN geen verklaring = 0`
+
+> **Controleer ingevulde verschillen** (F.305)  
+>
+> Je hebt bij _Aantal kiezers en stemmers_ ingevuld dat er evenveel stemmen als kiezers waren. Maar je hebt wel verschillen ingevuld.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: velden uit set (I, J, K, L, M, N, O) die zijn ingevuld
+
+### Regels voor kandidaten en lijsttotalen (reeks F.4xx)
+
+#### F.401 `Totaal aantal stemmen op een lijst = som van aantal stemmen op de kandidaten van die lijst`
+
+> **Controleer ingevoerde aantallen** (F.401)  
+> De opgetelde stemmen op de kandidaten en het ingevoerde totaal zijn niet gelijk.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: geen (laat alleen error zien op de pagina)
+
+[Voorbeeld in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=1635-58277&t=zTY4ajWtsFkiTOYP-4)
+
+## Plausibiliteitschecks geven waarschuwingen
+
+Plausbiliteitschecks vragen de gebruiker de invoer extra te controleren. Ze resulteren in een niet-blokkerende waarschuwing. De waarschuwing wordt getoond als de check evalueert naar `FALSE`.
+
+De foutmelding die wordt getoond bestaat uit dezelfde onderdelen als bij de validatieregels. Het handelingsperspectief voor alle plausibiliteitschecks is als volgt:
+
+> - Heb je iets niet goed overgenomen? Herstel de fout en ga verder.
+> - Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.
+
+### (Bij tweede invoer) Alle ingevoerde waardes van de tweede invoer zijn gelijk aan die van de eerste invoer
+
+> **Verschil met eerste invoer. Extra controle nodig**  
+> Check of je de gemarkeerde velden goed hebt overgenomen van het papieren proces-verbaal.
+
+[Voorbeeld in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=130-10813&t=zTY4ajWtsFkiTOYP-11)
+
+### Checks voor hertelling GSB (reeks W.1xx)
+
+Geen checks.
+
+### Checks voor totalen (reeks W.2xx)
+
+#### W.201 aantal blanco stemmen is minder dan 3% van het totaal uitgebrachte stemmen
+
+> **Controleer aantal blanco stemmen** (W.201)  
+> Het aantal blanco stemmen is erg hoog.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: F
+
+[Voorbeeld in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=137-3939&t=zTY4ajWtsFkiTOYP-4)
+
+#### W.202: Aantal ongeldige stemmen is minder dan 3% van het totaal uitgebrachte stemmen
+
+> **Controleer aantal ongeldige stemmen** (W.202)  
+> Het aantal ongeldige stemmen is erg hoog.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: G
+
+#### W.203: Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is minder dan 2% en minder dan 15
+
+- 2% of meer: abs(toegelaten kiezers - getelde stembiljetten) / getelde stembiljetten \>= 0.02
+- 15 of meer: abs(toegelaten kiezers - getelde stembiljetten) \>= 15
+
+> **Controleer aantal toegelaten kiezers en aantal uitgebrachte stemmen** (W.203)  
+> Er is een onverwacht verschil tussen het aantal toegelaten kiezers (A t/m D) en het aantal uitgebrachte stemmen (E t/m H).  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: D en H
+
+#### W.204: Verschil tussen herteld totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is minder dan 2% en minder dan 15
+
+- 2% of meer: abs(herteld toegelaten kiezers - getelde stembiljetten) / getelde stembiljetten \>= 0.02
+- 15 of meer: abs(herteld toegelaten kiezers - getelde stembiljetten) \>= 15
+
+> **Controleer aantal uitgebrachte stemmen en herteld aantal toegelaten kiezers** (W.204)  
+> Er is een onverwacht verschil tussen het aantal uitgebrachte stemmen (E t/m H) en het herteld aantal toegelaten kiezers (A.2 t/m D.2).  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: H en D.2
+
+#### W.205 Totaal aantal uitgebrachte stemmen niet leeg en groter dan 0
+
+> **Controleer aantal uitgebrachte stemmen** (W.205)  
+> Het totaal aantal uitgebrachte stemmen (H) is nul.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: H
+
+#### W.206 (Als niet herteld en alleen als aantal kiesgerechtigden is ingevuld) Totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen zijn niet groter dan het aantal kiesgerechtigden
+
+> **Controleer aantal toegelaten kiezers en aantal uitgebrachte stemmen** (W.206)  
+> Het totaal aantal toegelaten kiezers (D) en/of het totaal aantal uitgebrachte stemmen (H) is hoger dan het aantal kiesgerechtigden voor dit stembureau.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: D en H
+
+#### W.207 (Als herteld en alleen als aantal kiesgerechtigden is ingevuld) Totaal aantal uitgebrachte stemmen en totaal herteld aantal toegelaten kiezers is niet groter dan het aantal kiesgerechtigden
+
+> **Controleer aantal uitgebrachte stemmen en herteld aantal toegelaten kiezers** (W.207)  
+> Het totaal aantal uitgebrachte stemmen (H) en/of het herteld totaal aantal toegelaten kiezers (D.2) is hoger dan het aantal kiesgerechtigden voor dit stembureau.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Veld markeren: H en D.2
+
+#### W.208 Getallen in blok toegelaten kiezers (A t/m D) zijn niet allemaal gelijk aan getallen in blok uitgebrachte stemmen (E t/m H)
+
+> **Controleer A t/m D en E t/m H** (W.208)  
+> De getallen bij A t/m D zijn precies hetzelfde als E t/m H.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: geen (laat alleen error zien op de pagina)
+
+#### W.209 Getallen in blok uitgebrachte stemmen (E t/m H) zijn niet allemaal gelijk aan getallen in blok hertelde toegelaten kiezers (A.2 t/m D.2)
+
+> **Controleer E t/m H en A.2 t/m D.2** (W.209)  
+> De getallen bij E t/m H zijn precies hetzelfde als A.2 t/m D.2.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: E, F, G, H, A.2, B.2, C.2, D.2
+
+### Checks voor verschillen (reeks W.3xx)
+
+#### W.301: (Alleen als (herteld) totaal aantal kiezers < totaal aantal uitgebrachte stemmen) `te veel uitgereikte stembiljetten + andere verklaring + geen verklaring - niet ingeleverde stembiljetten - te weinig uitgereikte stembiljetten = meer stembiljetten geteld`
+
+> **Controleer ingevulde verschillen** (W.301)  
+> De invoer bij I, K, L, M, N of O klopt niet.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: I, K, L, M, N en O
+
+#### W.302: (Alleen als (herteld) totaal aantal kiezers > totaal aantal uitgebrachte stemmen) `niet ingeleverde stembiljetten + te weinig uitgereikte stembiljetten + andere verklaring + geen verklaring - te veel uitgereikte stembiljetten = minder stembiljetten geteld`
+
+> **Controleer ingevulde verschillen** (W.302)  
+> De invoer bij J, K, L, M, N of O klopt niet.  
+> Check of je het papieren proces-verbaal goed hebt overgenomen.
+
+Velden markeren: J, K, L, M, N en O
+
+### Checks voor kandidaten en lijsttotalen (reeks W.4xx)
+
+Geen checks.
+
+## Meerdere fouten en waarschuwingen in 1 response
+
+Een request naar de backend kan meerdere fouten en waarschuwingen teruggeven.
+
+In de user interface behandelen we die als volgt:
+
+- Als er waarschuwingen zijn in stappen **vóór** de hoogste stap waar de gebruiker invoer voor heeft gedaan, dan tonen we bij die stap in de navigatiebalk een waarschuwings-icoon ([voorbeeld in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=137-4359&t=6BRGJQMHbKwihTCh-4)).
+- **Fouten** in stappen vóór de hoogste stap waar de gebruiker invoer voor heeft gedaan kunnen in principe niet voorkomen (want een fout is blokkerend, je kan niet verder). Is dit toch het geval, dan redirecten we naar de eerste stap met een fout.
+- Fouten of waarschuwingen **voorbij** de hoogste stap waar de gebruiker invoer voor heeft gedaan, tonen we niet.
+- Zijn er fouten in de stap waar de gebruiker is, dan tonen we alleen de fouten en negeren we eventuele waarschuwingen in die stap.
+- Zijn er geen fouten in de huidige stap, dan tonen we de waarschuwingen.
+- Zijn er meerdere fouten of waarschuwingen in de huidige stap, dan tonen we alle waarschuwingen of fouten ([voorbeeld in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=2871-9169&t=FtsIfhKtOeDxlo9v-4)).
+  - We tonen van elke melding de titel, het nummer en de toelichting.
+  - Omdat het handelingsperspectief voor alle meldingen hetzelfde is, tonen we deze maar één keer.
+  - We markeren alle invoervelden waar een foutmelding of waarschuwing op is. Gaat melding 1 over veld A, B en C, en melding 2 over veld C en D, dan markeren we dus A, B, C en D.

--- a/documentatie/use-cases/README-use-cases.md
+++ b/documentatie/use-cases/README-use-cases.md
@@ -1,0 +1,92 @@
+# README use cases
+
+Deze beschrijving van use cases is gebaseerd op "Writing Effective Use Cases" van Alistair Cockburn (2000).
+
+De belangrijkste ideeën uit dat boek zijn:
+
+- Use cases worden in tekst uitgewerkt, diagrammen (UML) zijn een aanvulling.
+- Use cases vormen een boomstructuur waarin elke stap in een use case uitgewerkt kan worden tot een onderliggende use case.
+- Use cases moeten niet uitgebreider/formeler/gedetailleerder zijn dan strikt nodig is.
+
+Waarom deze werkwijze nuttig kan zijn:
+
+- De boomstructuur is makkelijk te lezen en te navigeren.
+- Het geeft een goed overzicht van stakeholders en hun belangen (daar zijn er veel van).
+- Het geeft een goed overzicht van varianten ('uitbreidingen') op het hoofdscenario (het 'main success scenario').
+- Het is een beschrijving van buitenaf wat de applicatie(s) moet(en) doen, niet hoe.
+- Het faciliteert feedback en reviews door stakeholders.
+
+## Hoe use cases te schrijven
+
+### 1. Het grote plaatje
+
+- In/out of scope-lijst
+- Lijst van primaire actoren (menselijke en niet-menselijke)
+- Lijst van gebruikersdoelen (actor-doel-lijst)
+
+### 2. De uiterste use cases
+
+- Uiterste hoog-over use cases (één voor elke primaire actor)
+
+### 3. Verder uitwerken van use cases
+
+1. Kies één use case om verder uit te werken.
+2. Schrijf op welke stakeholders en belangen, precondities en garanties er zijn.
+3. Schrijf het hoofdscenario (meest eenvoudige succes-scenario) uit.
+4. Stel de lijst van uitbreidingen op, zowel scenario's waar de primaire actor zijn/haar doel bereikt, als waar dat niet lukt.
+5. Schrijf de stappen voor het behandelen van de uitbreidingen uit.
+6. Extraheer complexe flows tot onderliggende use cases.
+7. Herhaal het proces door weer bovenaan deze lijst te beginnen.
+
+## Use case template
+
+De meest minimale versie van een use case bestaat uit scope, niveau en beschrijving. De onderstaande lijst met minimale en optionele velden is dus niet definitief en kan aangepast worden. We kunnen ook velden toevoegen, zoals "verkiezingen" (voor welke verkiezingen geldt deze use case?) of input/output-bestanden (EML's, PV's, CSV's, ...)
+
+### Minimale velden
+
+__Niveau:__  
+
+- Heel hoog-over (wolk) ☁️
+- Hoog-over (vlieger) 🪁
+- Gebruikersdoel (zee) 🌊
+  - 1 persoon, 1 sessie (ca. 2-20 minuten)
+  - Dit is het deale niveau voor use cases.
+- Subfunctie (vis) 🐟
+  - Schrijf deze alleen wanneer dit echt nodig is.
+- Te laag (schelp) 🐚
+  - Dit niveau is te granulair, gooi ze weg.
+
+__Trigger__: trigger van de use case
+
+__Hoofdscenario:__
+
+- Dit is het meest eenvoudige succes-scenario.
+- Het scenario bevat 5-9 stappen.
+- Beschrijft de acties van actoren om het doel van de primaire actor te bereiken.
+- Er zijn drie soorten acties (stappen):
+  - Interactie tussen twee actoren om een doel te bereiken
+  - Een validatie om een stakeholder te beschermen
+  - Een *internal state change* namens een stakeholder
+
+__uitbreidingen:__
+
+- De nummering van een uitbreiding komt overeen met de stap in het hoofdscenario waarvan het een uitbreiding is.
+
+__open punten:__  
+
+- Schrijf hier open punten op die gerelateerd zijn aan deze use case.
+- Dit kopje is niet aanwezig als er geen open punten zijn.
+
+### Mogelijke extra velden
+
+- Precondities
+- Open punten
+- Stakeholders en belangen van stakeholders die door de use case beschermd worden
+- Minimale garanties
+- Succesgaranties
+- Primaire actor
+- Doel binnen de context
+- Prioriteit
+- Releases
+- Scope: organisatie, systeem of component; black-box of white-box
+- Verkiezingen: Tweede Kamer (TK), Europees Parlement (EP), Provinciale Staten (PS), Waterschappen (AB), Kiescolleges Eerste Kamer (KC), Eerste Kamer (EK), Eilandsraden (ER), Gemeenteraad/Herindeling (GR)

--- a/documentatie/use-cases/README.md
+++ b/documentatie/use-cases/README.md
@@ -1,0 +1,20 @@
+# Over deze use cases
+
+Scope van deze use cases zijn de Gemeenteraadsverkiezingen.
+
+Verwachting is dat de Eilandsraadverkiezingen makkelijk in dezelfde use cases opgenomen kunnen worden, omdat ze heel gelijkaardig zijn aan Gemeenteraadsverkiezingen.
+
+Voor alle andere verkiezingen wordt een eerste stap het bijhouden van een apart bestand met de belangrijkste verschillen met Gemeenteraadsverkiezingen. Tot dat bestand er is, zie ["Wie doet welke stembureaus"](../verkiezingsproces/wie-doet-welke-stembureaus.md) en ["Wie mag waarvoor stemmen"](../verkiezingsproces/wie-mag-waarvoor-stemmen.md).
+
+De use cases zijn niet specifiek over welke documenten (bijv PVs) en bestanden (bijv EMLs) gegenereerd of gebruikt worden. Hiervoor is een apart overzicht: ["Verloop verkiezingen"](../verkiezingsproces/verloop-verkiezingen.md).
+
+Voor een uitleg over de methode die we hanteren voor use cases, zie [README-use-cases.md](./README-use-cases.md).
+
+Voor een use case-template, zie [template-use-cases.md](./template-use-case.md).
+
+## Opdeling use cases in bestanden
+
+De naam van elk bestand met use cases bestaat uit twee delen:
+
+- de naam van de primaire actor, bijv GSB, CSB, Kiesraad
+- het niveau van de use case: uiterste -> hoogover -> gebruikersdoelen -> subfuncties

--- a/documentatie/use-cases/autorisatiematrix.md
+++ b/documentatie/use-cases/autorisatiematrix.md
@@ -1,0 +1,41 @@
+# Autorisatiematrix
+
+## Achtergrond
+
+Deze matrix beschrijft welke functionaliteiten in de software voor welk type gebruiker beschikbaar zijn.
+De matrix beschrijft de rollen zoals ze voor het Gemeentelijke Stembureau (GSB) / Stembureau Openbaar Lichaam (SOL) worden ingericht.
+Het GSB/SOL verwerkt de tellingen / processen-verbaal van stembureau's, en genereert haar eigen proces-verbaal.
+
+## Rollen
+
+| Rol                | Beschrijving/doel   |
+|--------------------|---------------------|
+| Technisch beheerder | Kan de applicatie inrichten en klaarzetten voor gebruik. Geen bevoegdheden in het uitslagen / telproces. Primair bedoeld voor technische medewerkers die verder geen rol in het verkiezingsproces hebben. |
+| Coördinator | Kan stembureaus en gebruikers beheren, zittingen starten, schorsen, conflicten oplossen en processen-verbaal maken. |
+| Invoerder | Kan alleen tellingen invoeren. |
+
+## Rollen en rechten
+
+| Functionaliteit / Rol                            | Technisch beheerder | Coördinator    | Invoerder |
+|--------------------------------------------------|-----------|----------------|-----------|
+| **Voorbereiding zitting/telling GSB**            |           |                |           |
+| Applicatie installeren                           | X         |                |           |
+| Verkiezing configureren                          | X         |                |           |
+| Invoerstations beheren                           | X         |                |           |
+| Stembureaus beheren                              | X         | X              |           |
+| Gebruikers beheren                               | X         | X              |           |
+| **Tijdens de zitting GSB**                       |           |                |           |
+| Een nieuwe zitting openen                        |           | X              |           |
+| Invoer starten/schorsen/stoppen                  |           | X              |           |
+| Tellingen SB invoeren en waarschuwingen oplossen |           |                | X         |
+| Conflicten en waarschuwingen oplossen            |           | X              |           |
+| Bezwaren en bijzonderheden SB invoeren           |           | X              |           |
+| Volledig ingevoerde tellingen SB's bekijken      | X         | X              | X         |
+| **Zitting GSB afronden**                         |           |                |           |
+| Bezwaren en bijzonderheden zitting GSB invoeren  |           | X              |           |
+| Proces-verbaal maken                             |           | X              |           |
+| **Zitting HSB**                                  |           |                |           |
+| Zetelverdeling vaststellen                       |           | X              |           |
+| Proces-verbaal maken                             |           | X              |           |
+| **Algemeen**                                     |           |                |           |
+| Logs raadplegen                                  | X         | X              | ?         |

--- a/documentatie/use-cases/template-use-case.md
+++ b/documentatie/use-cases/template-use-case.md
@@ -1,0 +1,27 @@
+# Template use case
+
+## naam use case
+
+__niveau:__ ...  (☁️/🪁/🌊/🐟)
+
+__precondities:__  
+
+- ...
+
+### Hoofdscenario en uitbreidingen
+
+__trigger:__  
+
+- ...
+
+__hoofdscenario__:  
+
+1. ...  
+
+__uitbreidingen__:  
+1a. conditie van de uitbreiding:  
+&emsp; 1a1: eerste actie  
+
+### open punten
+
+- ...  

--- a/documentatie/use-cases/uiterste-use-cases.md
+++ b/documentatie/use-cases/uiterste-use-cases.md
@@ -1,10 +1,10 @@
 # GSB - Uiterste use cases
 
-## 1. Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting
+## Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting
 
 _niveau:__ hoog-over, wolk, ☁️
 
-### 1.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ dag na de verkiezingen
 
@@ -12,7 +12,7 @@ __hoofdscenario__:
 
 1. Het GSB opent de zitting.
 2. (voor elk stembureau) Het GSB stelt de uitslag van een stembureau vast.
-3. (voor elk stembureau) [Het GSB voert de PV's en eventuele SB corrigenda's (DSO) in de applicatie in.](./GSB-hoogover.md#1-het-gsb-voert-de-pvs-en-eventuele-sb-corrigendas-dso-in-de-applicatie-in)
+3. (voor elk stembureau) [Het GSB voert de PV's en eventuele SB corrigenda's (DSO) in de applicatie in.](./GSB-hoogover.md#het-gsb-voert-de-pvs-en-eventuele-sb-corrigendas-dso-in-de-applicatie-in)
 4. Het GSB voert het controleprotocol (handmatige controle optellingen software) uit en stelt geen verschillen vast.
 5. Het GSB sluit de zitting.
 6. Het GSB stelt de benodigde bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
@@ -26,11 +26,11 @@ __uitbreidingen__:
 &emsp;&emsp; 4a2a. Het GSB vindt geen fout en bevestigt een verschil tussen de controles en de resultaten van de applicatie:  
 &emsp;&emsp;&emsp; 4a2a1. Het GSB neemt contact op met de Kiesraad.  
 
-## 2. Gemeentelijk stembureau (GSB) stelt uitslag vast in tweede zitting (corrigenda)
+## Gemeentelijk stembureau (GSB) stelt uitslag vast in tweede zitting (corrigenda)
 
 __niveau:__ hoog-over, wolk, ☁️
 
-### 2.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __trigger:__ één of meer stembureaus moeten herteld worden nav verzoek CSB
 
@@ -38,7 +38,7 @@ __hoofdscenario__:
 
 1. Het GSB opent de zitting.
 2. (voor elk te hertellen stembureau) Het GSB stelt de uitslag van een stembureau opnieuw vast.
-3. (voor elk herteld stembureau met gewijzigde uitslag) [Het GSB voert de corrigendum PV's in de applicatie in.](./GSB-hoogover.md#3-het-gsb-voert-de-corrigendum-pvs-in-de-applicatie-in)
+3. (voor elk herteld stembureau met gewijzigde uitslag) [Het GSB voert de corrigendum PV's in de applicatie in.](./GSB-hoogover.md#het-gsb-voert-de-corrigendum-pvs-in-de-applicatie-in)
 4. Het GSB sluit de zitting.
 5. Het GSB stelt de benodigde bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
 
@@ -46,17 +46,17 @@ __uitbreidingen__:
 2a. Er zijn hertelde stembureaus met ongewijzigde uitslag:  
 2b. Er zijn alleen hertelde stembureaus met ongewijzigde uitslag:  
 
-### 2.2. Open punten
+### Open punten
 
 - Hoe ziet de trigger voor hertelling er precies uit voor gemeenteraadskverkiezingen? Het GSB (dus de gemeente) stelt de telling op gemeente-niveau vast, het CSB (ook de gemeente) controleert die telling en verzoekt als nodig om onderzoek en/of hertelling?
 
 ---
 
-## 3. Centraal stembureau (CSB) stelt verkiezingsuitslag vast ☁️
+## Centraal stembureau (CSB) stelt verkiezingsuitslag vast ☁️
 
 __niveau:__ hoog-over, wolk
 
-### 3.1. Hoofdscenario en uitbreidingen
+### Hoofdscenario en uitbreidingen
 
 __hoofdscenario__:  
 

--- a/documentatie/use-cases/uiterste-use-cases.md
+++ b/documentatie/use-cases/uiterste-use-cases.md
@@ -1,0 +1,68 @@
+# GSB - Uiterste use cases
+
+## 1. Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting
+
+_niveau:__ hoog-over, wolk, ☁️
+
+### 1.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ dag na de verkiezingen
+
+__hoofdscenario__:  
+
+1. Het GSB opent de zitting.
+2. (voor elk stembureau) Het GSB stelt de uitslag van een stembureau vast.
+3. (voor elk stembureau) [Het GSB voert de PV's en eventuele SB corrigenda's (DSO) in de applicatie in.](./GSB-hoogover.md#1-het-gsb-voert-de-pvs-en-eventuele-sb-corrigendas-dso-in-de-applicatie-in)
+4. Het GSB voert het controleprotocol (handmatige controle optellingen software) uit en stelt geen verschillen vast.
+5. Het GSB sluit de zitting.
+6. Het GSB stelt de benodigde bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
+
+__uitbreidingen__:  
+3a. De eerste invoer in de applicatie is gebruikt om verschillende optellingen te controleren:  
+
+4a. Het GSB stelt verschillen vast dmv het controleprotocol (handmatige controle optellingen software):  
+&emsp; 4a1. Het GSB controleert de resultaten van het controleprotocol.  
+&emsp; 4a2. Het GSB vindt een fout en corrigeert de resultaten van het controleprotocol.  
+&emsp;&emsp; 4a2a. Het GSB vindt geen fout en bevestigt een verschil tussen de controles en de resultaten van de applicatie:  
+&emsp;&emsp;&emsp; 4a2a1. Het GSB neemt contact op met de Kiesraad.  
+
+## 2. Gemeentelijk stembureau (GSB) stelt uitslag vast in tweede zitting (corrigenda)
+
+__niveau:__ hoog-over, wolk, ☁️
+
+### 2.1. Hoofdscenario en uitbreidingen
+
+__trigger:__ één of meer stembureaus moeten herteld worden nav verzoek CSB
+
+__hoofdscenario__:  
+
+1. Het GSB opent de zitting.
+2. (voor elk te hertellen stembureau) Het GSB stelt de uitslag van een stembureau opnieuw vast.
+3. (voor elk herteld stembureau met gewijzigde uitslag) [Het GSB voert de corrigendum PV's in de applicatie in.](./GSB-hoogover.md#3-het-gsb-voert-de-corrigendum-pvs-in-de-applicatie-in)
+4. Het GSB sluit de zitting.
+5. Het GSB stelt de benodigde bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
+
+__uitbreidingen__:
+2a. Er zijn hertelde stembureaus met ongewijzigde uitslag:  
+2b. Er zijn alleen hertelde stembureaus met ongewijzigde uitslag:  
+
+### 2.2. Open punten
+
+- Hoe ziet de trigger voor hertelling er precies uit voor gemeenteraadskverkiezingen? Het GSB (dus de gemeente) stelt de telling op gemeente-niveau vast, het CSB (ook de gemeente) controleert die telling en verzoekt als nodig om onderzoek en/of hertelling?
+
+---
+
+## 3. Centraal stembureau (CSB) stelt verkiezingsuitslag vast ☁️
+
+__niveau:__ hoog-over, wolk
+
+### 3.1. Hoofdscenario en uitbreidingen
+
+__hoofdscenario__:  
+
+1. De applicatie berekent de zetelverdeling.  
+2. De applicatie wijst de zetels toe.  
+3. De applicatie genereert de benodigde bestanden.  
+4. Het CSB voert het controleprotocol uit.
+5. Het CSB stelt de verkiezingsuitslag vast in de CSB-zitting.
+6. De gemeente publiceert de resultaten.


### PR DESCRIPTION
- ~Kopjes voorzien van nummering tbv markdown linting~
- Verdere markdown-issues gefixt
- Links in alle documenten gefixt
- GSB-validatieregels-en-plausibiliteitschecks.md: 'Aantal kiezers en stemmen' was een niet-bestaande link, die heb ik verwijderd en de tekst onderstreept.
- GSB-validatieregels-en-plausibiliteitschecks.md: Figma-links werken maar vereisen wel een wachtwoord, wellicht moeten de links nog aangepast worden naar publieke  Figma.
- korte check op taal