### PR TITLE
Form component shortcuts

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
@@ -12,16 +12,13 @@ import {
   Button,
   Checkbox,
   Feedback,
+  Form,
   InputGrid,
   InputGridRow,
   KeyboardKey,
   KeyboardKeys,
 } from "@kiesraad/ui";
-import {
-  candidateNumberFromId,
-  usePositiveNumberInputMask,
-  usePreventFormEnterSubmit,
-} from "@kiesraad/util";
+import { candidateNumberFromId, usePositiveNumberInputMask } from "@kiesraad/util";
 
 import { useWatchForChanges } from "../useWatchForChanges";
 
@@ -77,8 +74,6 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
     return false;
   }, [_IGNORE_WARNINGS_ID]);
 
-  usePreventFormEnterSubmit(formRef);
-
   const { sectionValues, errors, warnings, loading, isSaved, submit, ignoreWarnings } =
     usePoliticalGroup(group.number, getValues, getIgnoreWarnings);
 
@@ -123,7 +118,7 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
   const hasValidationWarning = warnings.length > 0;
 
   return (
-    <form onSubmit={handleSubmit} ref={formRef} id={`candidates_form_${group.number}`}>
+    <Form onSubmit={handleSubmit} ref={formRef} id={`candidates_form_${group.number}`}>
       <h2>
         Lijst {group.number} - {group.name}
       </h2>
@@ -209,6 +204,6 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
         </BottomBar.Row>
       </BottomBar>
-    </form>
+    </Form>
   );
 }

--- a/frontend/app/component/form/differences/DifferencesForm.tsx
+++ b/frontend/app/component/form/differences/DifferencesForm.tsx
@@ -7,13 +7,14 @@ import {
   Button,
   Checkbox,
   Feedback,
+  Form,
   InputGrid,
   InputGridRow,
   KeyboardKey,
   KeyboardKeys,
   useTooltip,
 } from "@kiesraad/ui";
-import { usePositiveNumberInputMask, usePreventFormEnterSubmit } from "@kiesraad/util";
+import { usePositiveNumberInputMask } from "@kiesraad/util";
 
 import { useWatchForChanges } from "../useWatchForChanges";
 
@@ -42,7 +43,6 @@ export function DifferencesForm() {
     resetWarnings,
   } = usePositiveNumberInputMask();
   const formRef = React.useRef<DifferencesFormElement>(null);
-  usePreventFormEnterSubmit(formRef);
 
   const getValues = React.useCallback(() => {
     const form = formRef.current;
@@ -127,7 +127,7 @@ export function DifferencesForm() {
   const hasValidationWarning = warnings.length > 0;
 
   return (
-    <form onSubmit={handleSubmit} ref={formRef} id="differences_form">
+    <Form onSubmit={handleSubmit} ref={formRef} id="differences_form">
       <h2>Verschil tussen aantal kiezers en getelde stemmen</h2>
       {isSaved && hasValidationError && (
         <Feedback type="error" title="Controleer ingevulde verschillen">
@@ -259,6 +259,6 @@ export function DifferencesForm() {
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
         </BottomBar.Row>
       </BottomBar>
-    </form>
+    </Form>
   );
 }

--- a/frontend/app/component/form/recounted/RecountedForm.tsx
+++ b/frontend/app/component/form/recounted/RecountedForm.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 
 import { useRecounted } from "@kiesraad/api";
-import { BottomBar, Button, Feedback, KeyboardKey, KeyboardKeys } from "@kiesraad/ui";
-import { usePreventFormEnterSubmit } from "@kiesraad/util";
+import { BottomBar, Button, Feedback, Form, KeyboardKey, KeyboardKeys } from "@kiesraad/ui";
 
 interface FormElements extends HTMLFormControlsCollection {
   yes: HTMLInputElement;
@@ -16,7 +15,6 @@ interface RecountedFormElement extends HTMLFormElement {
 export function RecountedForm() {
   const [hasValidationError, setHasValidationError] = React.useState(false);
   const formRef = React.useRef<RecountedFormElement>(null);
-  usePreventFormEnterSubmit(formRef);
 
   const getValues = React.useCallback(() => {
     const form = document.getElementById("recounted_form") as RecountedFormElement | null;
@@ -48,7 +46,7 @@ export function RecountedForm() {
   }, [isSaved]);
 
   return (
-    <form onSubmit={handleSubmit} ref={formRef} id="recounted_form">
+    <Form onSubmit={handleSubmit} ref={formRef} id="recounted_form">
       <h2>Is er herteld?</h2>
       {hasValidationError && (
         <Feedback type="error" title="Controleer het papieren proces-verbaal" code="F.101">
@@ -94,6 +92,6 @@ export function RecountedForm() {
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
         </BottomBar.Row>
       </BottomBar>
-    </form>
+    </Form>
   );
 }

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.tsx
@@ -7,13 +7,14 @@ import {
   Button,
   Checkbox,
   Feedback,
+  Form,
   InputGrid,
   InputGridRow,
   KeyboardKey,
   KeyboardKeys,
   useTooltip,
 } from "@kiesraad/ui";
-import { usePositiveNumberInputMask, usePreventFormEnterSubmit } from "@kiesraad/util";
+import { usePositiveNumberInputMask } from "@kiesraad/util";
 
 import { useWatchForChanges } from "../useWatchForChanges";
 
@@ -47,7 +48,6 @@ export function VotersAndVotesForm() {
     resetWarnings,
   } = usePositiveNumberInputMask();
   const formRef = React.useRef<VotersAndVotesFormElement>(null);
-  usePreventFormEnterSubmit(formRef);
 
   const getValues = React.useCallback(() => {
     const form = formRef.current;
@@ -149,7 +149,7 @@ export function VotersAndVotesForm() {
   const hasValidationWarning = warnings.length > 0;
 
   return (
-    <form onSubmit={handleSubmit} ref={formRef} id="voters_and_votes_form">
+    <Form onSubmit={handleSubmit} ref={formRef} id="voters_and_votes_form">
       <h2>Toegelaten kiezers en uitgebrachte stemmen</h2>
       {isSaved && hasValidationError && (
         <Feedback type="error" title="Controleer uitgebrachte stemmen">
@@ -343,6 +343,6 @@ export function VotersAndVotesForm() {
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
         </BottomBar.Row>
       </BottomBar>
-    </form>
+    </Form>
   );
 }

--- a/frontend/lib/ui/Form/Form.stories.tsx
+++ b/frontend/lib/ui/Form/Form.stories.tsx
@@ -1,0 +1,13 @@
+import type { Story } from "@ladle/react";
+
+import { Form } from "./Form";
+
+/** Story stub for form */
+
+export const DefaultForm: Story = () => (
+  <Form>
+    <input id="test1" />
+    <input id="test2" />
+    <button type="submit" />
+  </Form>
+);

--- a/frontend/lib/ui/Form/Form.test.tsx
+++ b/frontend/lib/ui/Form/Form.test.tsx
@@ -72,4 +72,16 @@ describe("UI Component: Form", () => {
 
     expect(onSubmit).toHaveBeenCalled();
   });
+
+  test("Ref is forwarded", () => {
+    const ref = { current: null };
+
+    render(
+      <Form ref={ref}>
+        <input id="test" />
+      </Form>,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLFormElement);
+  });
 });

--- a/frontend/lib/ui/Form/Form.test.tsx
+++ b/frontend/lib/ui/Form/Form.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+import { Form } from "./Form";
+
+describe("UI Component: Form", () => {
+  test("Form renders with children", () => {
+    render(
+      <Form>
+        <input id="test" />
+      </Form>,
+    );
+
+    expect(screen.getByTestId("test")).toBeInTheDocument();
+  });
+
+  test("Enter does not submit the form", async () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <Form onSubmit={onSubmit} id="test-form">
+        <input id="test-input" />
+      </Form>,
+    );
+    const user = userEvent.setup();
+    await user.type(screen.getByTestId("test-input"), "hello world");
+
+    await user.type(screen.getByTestId("test-form"), "{enter}");
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("Shift+Enter does submit the form", async () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <Form onSubmit={onSubmit} id="test-form">
+        <input id="test-input" defaultValue="fizz" />
+      </Form>,
+    );
+    const user = userEvent.setup();
+
+    await user.type(screen.getByTestId("test-input"), "hello world");
+
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  test("Enter submits when submit button has focus", async () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => {
+      e.preventDefault();
+    });
+
+    render(
+      <Form onSubmit={onSubmit} id="test-form">
+        <input id="test-input" defaultValue="fizz" />
+        <button id="test-submit-button" type="submit">
+          Submit
+        </button>
+      </Form>,
+    );
+    const user = userEvent.setup();
+
+    await user.type(screen.getByTestId("test-input"), "hello world");
+
+    await user.keyboard("{enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    screen.getByTestId("test-submit-button").focus();
+    await user.keyboard("{Enter}");
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/frontend/lib/ui/Form/Form.tsx
+++ b/frontend/lib/ui/Form/Form.tsx
@@ -3,37 +3,51 @@ import * as React from "react";
 export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   children: React.ReactNode;
 }
-export function Form({ children, ...formProps }: FormProps) {
-  const ref = React.useRef<HTMLFormElement>(null);
+export const Form = React.forwardRef<HTMLFormElement, FormProps>(
+  ({ children, ...formProps }, ref) => {
+    const innerRef = React.useRef<HTMLFormElement>(null);
 
-  React.useEffect(() => {
-    const submitButton = ref.current?.querySelector(
-      "button[type=submit]",
-    ) as HTMLButtonElement | null;
+    React.useEffect(() => {
+      const submitButton = innerRef.current?.querySelector(
+        "button[type=submit]",
+      ) as HTMLButtonElement | null;
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Enter") {
-        if (event.shiftKey || document.activeElement === submitButton) {
-          //ref.current.submit fails in testing environment (jsdom)
-          ref.current?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-        } else {
-          event.preventDefault();
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Enter") {
+          if (event.shiftKey || document.activeElement === submitButton) {
+            //ref.current.submit fails in testing environment (jsdom)
+            innerRef.current?.dispatchEvent(
+              new Event("submit", { bubbles: true, cancelable: true }),
+            );
+          } else {
+            event.preventDefault();
+          }
         }
-      }
-    };
-
-    const node = ref.current;
-    if (node) {
-      node.addEventListener("keydown", handleKeyDown);
-      return () => {
-        node.removeEventListener("keydown", handleKeyDown);
       };
-    }
-  }, [ref]);
 
-  return (
-    <form ref={ref} {...formProps}>
-      {children}
-    </form>
-  );
-}
+      const node = innerRef.current;
+      if (node) {
+        node.addEventListener("keydown", handleKeyDown);
+        return () => {
+          node.removeEventListener("keydown", handleKeyDown);
+        };
+      }
+    }, []);
+
+    return (
+      <form
+        ref={(node) => {
+          if (node) (innerRef as React.MutableRefObject<HTMLFormElement>).current = node;
+          if (typeof ref === "function") {
+            ref(node);
+          } else if (ref) {
+            ref.current = node;
+          }
+        }}
+        {...formProps}
+      >
+        {children}
+      </form>
+    );
+  },
+);

--- a/frontend/lib/ui/Form/Form.tsx
+++ b/frontend/lib/ui/Form/Form.tsx
@@ -5,7 +5,8 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 }
 export const Form = React.forwardRef<HTMLFormElement, FormProps>(
   ({ children, ...formProps }, ref) => {
-    const innerRef: MutableRefObject<HTMLFormElement > = React.useRef<HTMLFormElement>(null);
+    const innerRef: React.MutableRefObject<HTMLFormElement | null> =
+      React.useRef<HTMLFormElement>(null);
 
     React.useEffect(() => {
       const submitButton = innerRef.current?.querySelector(

--- a/frontend/lib/ui/Form/Form.tsx
+++ b/frontend/lib/ui/Form/Form.tsx
@@ -37,7 +37,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
     return (
       <form
         ref={(node) => {
-          if (node) (innerRef as React.MutableRefObject<HTMLFormElement>).current = node;
+          if (node) innerRef.current = node;
           if (typeof ref === "function") {
             ref(node);
           } else if (ref) {

--- a/frontend/lib/ui/Form/Form.tsx
+++ b/frontend/lib/ui/Form/Form.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
+  children: React.ReactNode;
+}
+export function Form({ children, ...formProps }: FormProps) {
+  const ref = React.useRef<HTMLFormElement>(null);
+
+  React.useEffect(() => {
+    const submitButton = ref.current?.querySelector(
+      "button[type=submit]",
+    ) as HTMLButtonElement | null;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        if (event.shiftKey || document.activeElement === submitButton) {
+          //ref.current.submit fails in testing environment (jsdom)
+          ref.current?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        } else {
+          event.preventDefault();
+        }
+      }
+    };
+
+    const node = ref.current;
+    if (node) {
+      node.addEventListener("keydown", handleKeyDown);
+      return () => {
+        node.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [ref]);
+
+  return (
+    <form ref={ref} {...formProps}>
+      {children}
+    </form>
+  );
+}

--- a/frontend/lib/ui/Form/Form.tsx
+++ b/frontend/lib/ui/Form/Form.tsx
@@ -5,7 +5,7 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 }
 export const Form = React.forwardRef<HTMLFormElement, FormProps>(
   ({ children, ...formProps }, ref) => {
-    const innerRef = React.useRef<HTMLFormElement>(null);
+    const innerRef: MutableRefObject<HTMLFormElement > = React.useRef<HTMLFormElement>(null);
 
     React.useEffect(() => {
       const submitButton = innerRef.current?.querySelector(

--- a/frontend/lib/ui/index.ts
+++ b/frontend/lib/ui/index.ts
@@ -19,3 +19,4 @@ export * from "./Spinner/Spinner";
 export * from "./Tooltip";
 export * from "./util";
 export * from "./ui.types.d";
+export * from "./Form/Form";


### PR DESCRIPTION
Introduces a Form component that handles "prevent Enter to submit" (except when a submit button has focus) 
and provides "Shift + enter" for submitting a form.

part of #263 