### PR TITLE
Finish data entry abort modal functionality

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
@@ -2,11 +2,11 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
 import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit";
+import { emptyDataEntryRequest } from "app/test/unit/form.ts";
 
 import {
   Election,
   PoliticalGroup,
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
   PollingStationFormController,
   PollingStationValues,
 } from "@kiesraad/api";
@@ -30,42 +30,6 @@ function renderForm(defaultValues: Partial<PollingStationValues> = {}) {
     </PollingStationFormController>,
   );
 }
-
-const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
-  data: {
-    recounted: false,
-    voters_counts: {
-      poll_card_count: 0,
-      proxy_certificate_count: 0,
-      voter_card_count: 0,
-      total_admitted_voters_count: 0,
-    },
-    votes_counts: {
-      votes_candidates_counts: 0,
-      blank_votes_count: 0,
-      invalid_votes_count: 0,
-      total_votes_cast_count: 0,
-    },
-    voters_recounts: undefined,
-    differences_counts: {
-      more_ballots_count: 0,
-      fewer_ballots_count: 0,
-      unreturned_ballots_count: 0,
-      too_few_ballots_handed_out_count: 0,
-      too_many_ballots_handed_out_count: 0,
-      other_explanation_count: 0,
-      no_explanation_count: 0,
-    },
-    political_group_votes: electionMockData.political_groups.map((group) => ({
-      number: group.number,
-      total: 0,
-      candidate_votes: group.candidates.map((candidate) => ({
-        number: candidate.number,
-        votes: 0,
-      })),
-    })),
-  },
-};
 
 describe("Test CandidatesVotesForm", () => {
   describe("CandidatesVotesForm user interactions", () => {
@@ -223,7 +187,7 @@ describe("Test CandidatesVotesForm", () => {
 
       const expectedRequest = {
         data: {
-          ...rootRequest.data,
+          ...emptyDataEntryRequest.data,
           political_group_votes: [
             {
               number: 1,

--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
@@ -74,7 +74,7 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
     return false;
   }, [_IGNORE_WARNINGS_ID]);
 
-  const { saving, sectionValues, errors, warnings, isSaved, submit, ignoreWarnings } =
+  const { status, sectionValues, errors, warnings, isSaved, submit, ignoreWarnings } =
     usePoliticalGroup(group.number, getValues, getIgnoreWarnings);
 
   const shouldWatch = warnings.length > 0 && isSaved;
@@ -186,7 +186,7 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
           </Checkbox>
         </BottomBar.Row>
         <BottomBar.Row>
-          <Button type="submit" size="lg" disabled={saving}>
+          <Button type="submit" size="lg" disabled={status.current === "saving"}>
             Volgende
           </Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/app/component/form/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/differences/DifferencesForm.test.tsx
@@ -2,12 +2,9 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
 import { getUrlMethodAndBody, overrideOnce, render, screen, userTypeInputs } from "app/test/unit";
+import { emptyDataEntryRequest } from "app/test/unit/form.ts";
 
-import {
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
-  PollingStationFormController,
-  PollingStationValues,
-} from "@kiesraad/api";
+import { PollingStationFormController, PollingStationValues } from "@kiesraad/api";
 import { electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { DifferencesForm } from "./DifferencesForm";
@@ -24,42 +21,6 @@ function renderForm(defaultValues: Partial<PollingStationValues> = {}) {
     </PollingStationFormController>,
   );
 }
-
-const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
-  data: {
-    recounted: false,
-    voters_counts: {
-      poll_card_count: 0,
-      proxy_certificate_count: 0,
-      voter_card_count: 0,
-      total_admitted_voters_count: 0,
-    },
-    votes_counts: {
-      votes_candidates_counts: 0,
-      blank_votes_count: 0,
-      invalid_votes_count: 0,
-      total_votes_cast_count: 0,
-    },
-    voters_recounts: undefined,
-    differences_counts: {
-      more_ballots_count: 0,
-      fewer_ballots_count: 0,
-      unreturned_ballots_count: 0,
-      too_few_ballots_handed_out_count: 0,
-      too_many_ballots_handed_out_count: 0,
-      other_explanation_count: 0,
-      no_explanation_count: 0,
-    },
-    political_group_votes: electionMockData.political_groups.map((group) => ({
-      number: group.number,
-      total: 0,
-      candidate_votes: group.candidates.map((candidate) => ({
-        number: candidate.number,
-        votes: 0,
-      })),
-    })),
-  },
-};
 
 describe("Test DifferencesForm", () => {
   describe("DifferencesForm user interactions", () => {
@@ -161,7 +122,7 @@ describe("Test DifferencesForm", () => {
 
       const expectedRequest = {
         data: {
-          ...rootRequest.data,
+          ...emptyDataEntryRequest.data,
           ...votersAndVotesValues,
           differences_counts: {
             more_ballots_count: 2,

--- a/frontend/app/component/form/differences/DifferencesForm.tsx
+++ b/frontend/app/component/form/differences/DifferencesForm.tsx
@@ -76,7 +76,7 @@ export function DifferencesForm() {
     return false;
   }, []);
 
-  const { saving, sectionValues, errors, warnings, isSaved, submit, ignoreWarnings } =
+  const { status, sectionValues, errors, warnings, isSaved, submit, ignoreWarnings } =
     useDifferences(getValues, getIgnoreWarnings);
 
   const shouldWatch = warnings.length > 0 && isSaved;
@@ -231,7 +231,7 @@ export function DifferencesForm() {
           </Checkbox>
         </BottomBar.Row>
         <BottomBar.Row>
-          <Button type="submit" size="lg" disabled={saving}>
+          <Button type="submit" size="lg" disabled={status.current === "saving"}>
             Volgende
           </Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/app/component/form/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/recounted/RecountedForm.test.tsx
@@ -2,11 +2,9 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
 import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit";
+import { emptyDataEntryRequest } from "app/test/unit/form.ts";
 
-import {
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
-  PollingStationFormController,
-} from "@kiesraad/api";
+import { PollingStationFormController } from "@kiesraad/api";
 import { electionMockData } from "@kiesraad/api-mocks";
 
 import { RecountedForm } from "./RecountedForm";
@@ -16,42 +14,6 @@ const Component = (
     <RecountedForm />
   </PollingStationFormController>
 );
-
-const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
-  data: {
-    recounted: false,
-    voters_counts: {
-      poll_card_count: 0,
-      proxy_certificate_count: 0,
-      voter_card_count: 0,
-      total_admitted_voters_count: 0,
-    },
-    votes_counts: {
-      votes_candidates_counts: 0,
-      blank_votes_count: 0,
-      invalid_votes_count: 0,
-      total_votes_cast_count: 0,
-    },
-    voters_recounts: undefined,
-    differences_counts: {
-      more_ballots_count: 0,
-      fewer_ballots_count: 0,
-      unreturned_ballots_count: 0,
-      too_few_ballots_handed_out_count: 0,
-      too_many_ballots_handed_out_count: 0,
-      other_explanation_count: 0,
-      no_explanation_count: 0,
-    },
-    political_group_votes: electionMockData.political_groups.map((group) => ({
-      number: group.number,
-      total: 0,
-      candidate_votes: group.candidates.map((candidate) => ({
-        number: candidate.number,
-        votes: 0,
-      })),
-    })),
-  },
-};
 
 describe("Test RecountedForm", () => {
   describe("RecountedForm user interactions", () => {
@@ -104,7 +66,7 @@ describe("Test RecountedForm", () => {
 
       const expectedRequest = {
         data: {
-          ...rootRequest.data,
+          ...emptyDataEntryRequest.data,
           recounted: true,
         },
       };

--- a/frontend/app/component/form/recounted/RecountedForm.tsx
+++ b/frontend/app/component/form/recounted/RecountedForm.tsx
@@ -25,7 +25,7 @@ export function RecountedForm() {
     return { recounted: elements.yes.checked ? true : elements.no.checked ? false : undefined };
   }, []);
 
-  const { saving, sectionValues, isSaved, submit } = useRecounted(getValues);
+  const { status, sectionValues, isSaved, submit } = useRecounted(getValues);
 
   const handleSubmit = (event: React.FormEvent<RecountedFormElement>) =>
     void (async (event: React.FormEvent<RecountedFormElement>) => {
@@ -84,7 +84,7 @@ export function RecountedForm() {
       </div>
       <BottomBar type="form">
         <BottomBar.Row>
-          <Button type="submit" size="lg" disabled={saving}>
+          <Button type="submit" size="lg" disabled={status.current === "saving"}>
             Volgende
           </Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -2,13 +2,9 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
 import { getUrlMethodAndBody, overrideOnce, render, screen, userTypeInputs } from "app/test/unit";
+import { emptyDataEntryRequest } from "app/test/unit/form.ts";
 
-import {
-  FormState,
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
-  PollingStationFormController,
-  PollingStationValues,
-} from "@kiesraad/api";
+import { FormState, PollingStationFormController, PollingStationValues } from "@kiesraad/api";
 import { electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { VotersAndVotesForm } from "./VotersAndVotesForm";
@@ -70,42 +66,6 @@ function renderForm(defaultValues: Partial<PollingStationValues> = {}) {
     </PollingStationFormController>,
   );
 }
-
-const rootRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
-  data: {
-    recounted: false,
-    voters_counts: {
-      poll_card_count: 0,
-      proxy_certificate_count: 0,
-      voter_card_count: 0,
-      total_admitted_voters_count: 0,
-    },
-    votes_counts: {
-      votes_candidates_counts: 0,
-      blank_votes_count: 0,
-      invalid_votes_count: 0,
-      total_votes_cast_count: 0,
-    },
-    voters_recounts: undefined,
-    differences_counts: {
-      more_ballots_count: 0,
-      fewer_ballots_count: 0,
-      unreturned_ballots_count: 0,
-      too_few_ballots_handed_out_count: 0,
-      too_many_ballots_handed_out_count: 0,
-      other_explanation_count: 0,
-      no_explanation_count: 0,
-    },
-    political_group_votes: electionMockData.political_groups.map((group) => ({
-      number: group.number,
-      total: 0,
-      candidate_votes: group.candidates.map((candidate) => ({
-        number: candidate.number,
-        votes: 0,
-      })),
-    })),
-  },
-};
 
 describe("Test VotersAndVotesForm", () => {
   describe("VotersAndVotesForm user interactions", () => {
@@ -197,7 +157,7 @@ describe("Test VotersAndVotesForm", () => {
     test("VotersAndVotesForm request body is equal to the form data", async () => {
       const expectedRequest = {
         data: {
-          ...rootRequest.data,
+          ...emptyDataEntryRequest.data,
           voters_counts: {
             poll_card_count: 1,
             proxy_certificate_count: 2,

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.tsx
@@ -98,7 +98,7 @@ export function VotersAndVotesForm() {
     return false;
   }, []);
 
-  const { saving, sectionValues, errors, warnings, isSaved, ignoreWarnings, submit, recounted } =
+  const { status, sectionValues, errors, warnings, isSaved, ignoreWarnings, submit, recounted } =
     useVotersAndVotes(getValues, getIgnoreWarnings);
 
   const [warningsWarning, setWarningsWarning] = React.useState(false);
@@ -315,7 +315,7 @@ export function VotersAndVotesForm() {
           </Checkbox>
         </BottomBar.Row>
         <BottomBar.Row>
-          <Button type="submit" size="lg" disabled={saving}>
+          <Button type="submit" size="lg" disabled={status.current === "saving"}>
             Volgende
           </Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
@@ -57,6 +57,7 @@ describe("PollingStationFormNavigation", () => {
   const mockNavigate = vi.fn();
 
   const mockController = {
+    status: "idle",
     formState: mockFormState,
     currentForm: mockCurrentForm,
     error: null,
@@ -85,6 +86,7 @@ describe("PollingStationFormNavigation", () => {
 
   test("It blocks navigation when form has changes", () => {
     (usePollingStationFormController as Mock).mockReturnValueOnce({
+      status: "idle",
       formState: {
         ...mockFormState,
         current: "voters_votes_counts",
@@ -122,6 +124,7 @@ describe("PollingStationFormNavigation", () => {
 
   test("It blocks navigation when form has errors", async () => {
     (usePollingStationFormController as Mock).mockReturnValueOnce({
+      status: "idle",
       formState: {
         ...mockFormState,
         sections: {

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
@@ -23,6 +23,7 @@ export function PollingStationFormNavigation({
 }: PollingStationFormNavigationProps) {
   const _lastKnownSection = React.useRef<FormSectionID | null>(null);
   const {
+    status,
     formState,
     error,
     currentForm,
@@ -66,10 +67,11 @@ export function PollingStationFormNavigation({
 
   const shouldBlock = React.useCallback<BlockerFunction>(
     ({ currentLocation, nextLocation }) => {
-      if (currentLocation.pathname === nextLocation.pathname) {
-        return false;
-      }
-      if (!currentForm) {
+      if (
+        status.current === "deleted" ||
+        currentLocation.pathname === nextLocation.pathname ||
+        !currentForm
+      ) {
         return false;
       }
 
@@ -88,7 +90,7 @@ export function PollingStationFormNavigation({
 
       return false;
     },
-    [formState, currentForm, setTemporaryCache, values],
+    [status, formState, currentForm, setTemporaryCache, values],
   );
 
   const blocker = useBlocker(shouldBlock);

--- a/frontend/app/module/input/PollingStation/AbortDataEntryControl.tsx
+++ b/frontend/app/module/input/PollingStation/AbortDataEntryControl.tsx
@@ -12,26 +12,28 @@ export function AbortDataEntryControl() {
   const [deleting, setDeleting] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const c = usePollingStationFormController();
+  const controller = usePollingStationFormController();
 
   function toggleAbortModal() {
     setOpenAbortModal(!openAbortModal);
   }
 
-  function onAbortModalSave() {
-    // TODO: implement by saving the current form state, this requires functionality from #133;
-    //       right now, only the last submitted form is saved
-    setSaving(true);
-    navigate(`/${election.id}/input`);
-  }
+  const onAbortModalSave = () =>
+    void (async () => {
+      try {
+        setSaving(true);
+        await controller.submitCurrentForm();
+        navigate(`/${election.id}/input`);
+      } finally {
+        setSaving(false);
+      }
+    })();
 
   const onAbortModalDelete = () =>
     void (async () => {
-      // TODO: check if a data entry is already saved, this requires functionality from #133;
-      //       right now, we always delete but ignore 404 errors
       try {
         setDeleting(true);
-        await c.deleteDataEntry();
+        await controller.deleteDataEntry();
         navigate(`/${election.id}/input`);
       } finally {
         setDeleting(false);

--- a/frontend/app/module/input/PollingStation/PollingStation.test.tsx
+++ b/frontend/app/module/input/PollingStation/PollingStation.test.tsx
@@ -11,9 +11,9 @@ const render = () => rtlRender(<Providers router={router} />);
 
 const user = userEvent.setup();
 
-async function submit() {
+const submit = async () => {
   await user.click(screen.getByRole("button", { name: "Volgende" }));
-}
+};
 
 const startPollingStationInput = async () => {
   await router.navigate("/1/input/1");
@@ -132,6 +132,27 @@ const expectElementContainsIcon = async (id: string, ariaLabel: string) => {
   expect(within(el).getByRole("img")).toHaveAccessibleName(ariaLabel);
 };
 
+const abortDataEntry = async () => {
+  await user.click(screen.getByRole("button", { name: "Invoer afbreken" }));
+};
+
+const abortSaveChanges = async () => {
+  await user.click(screen.getByRole("button", { name: "Invoer bewaren" }));
+};
+
+const abortDelete = async () => {
+  await user.click(screen.getByRole("button", { name: "Niet bewaren" }));
+};
+
+const expectPollingStationChoicePage = async () => {
+  await waitFor(() => {
+    expect(router.state.location.pathname).toEqual("/1/input");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("polling-station-choice-form")).toBeInTheDocument();
+  });
+};
+
 type FormIdentifier = "recounted" | "voters_and_votes" | "differences" | `candidates_${number}`;
 
 const gotoForm = async (id: FormIdentifier) => {
@@ -159,6 +180,37 @@ const gotoForm = async (id: FormIdentifier) => {
       break;
   }
 };
+
+// Steps to fill up to the 'voters and votes' form, submit, and leave pending changes
+const stepsForPendingChanges = [
+  startPollingStationInput,
+  expectRecountedForm,
+  fillRecountedFormNo,
+  submit,
+  expectVotersAndVotesForm,
+  fillVotersAndVotesForm,
+  submit,
+  expectDifferencesForm,
+  () => gotoForm("voters_and_votes"),
+  expectVotersAndVotesForm,
+  () =>
+    fillVotersAndVotesForm({
+      poll_card_count: 1,
+      proxy_certificate_count: 1,
+      voter_card_count: 1,
+      total_admitted_voters_count: 2,
+      votes_candidates_counts: 1,
+      blank_votes_count: 1,
+      invalid_votes_count: 1,
+      total_votes_cast_count: 3,
+    }),
+  submit,
+  expectFeedbackError,
+  () =>
+    fillVotersAndVotesForm({
+      total_admitted_voters_count: 3,
+    }),
+];
 
 describe("Polling Station data entry integration tests", () => {
   test("Navigate through complete form", async () => {
@@ -262,37 +314,11 @@ describe("Polling Station data entry integration tests", () => {
     }
   });
 
-  test("Navigate triggers changes modal", async () => {
+  test("Navigating with changes triggers changes modal", async () => {
     render();
 
     const steps = [
-      startPollingStationInput,
-      expectRecountedForm,
-      fillRecountedFormNo,
-      submit,
-      expectVotersAndVotesForm,
-      fillVotersAndVotesForm,
-      submit,
-      expectDifferencesForm,
-      () => gotoForm("voters_and_votes"),
-      expectVotersAndVotesForm,
-      () =>
-        fillVotersAndVotesForm({
-          poll_card_count: 1,
-          proxy_certificate_count: 1,
-          voter_card_count: 1,
-          total_admitted_voters_count: 2,
-          votes_candidates_counts: 1,
-          blank_votes_count: 1,
-          invalid_votes_count: 1,
-          total_votes_cast_count: 3,
-        }),
-      submit,
-      expectFeedbackError,
-      () =>
-        fillVotersAndVotesForm({
-          total_admitted_voters_count: 3,
-        }),
+      ...stepsForPendingChanges,
       () => userEvent.click(screen.getByRole("link", { name: "Verschillen" })),
       expectBlockerModal,
     ];
@@ -434,6 +460,36 @@ describe("Polling Station data entry integration tests", () => {
       submit,
       expectVotersAndVotesForm,
       () => expectElementContainsIcon("list-item-differences", "bevat een fout"),
+    ];
+
+    for (const step of steps) {
+      await step();
+    }
+  });
+
+  test("Aborting and save with pending changes is possible", async () => {
+    render();
+
+    const steps = [
+      ...stepsForPendingChanges,
+      abortDataEntry,
+      abortSaveChanges,
+      expectPollingStationChoicePage,
+    ];
+
+    for (const step of steps) {
+      await step();
+    }
+  });
+
+  test("Abort and delete with pending changes is possible", async () => {
+    render();
+
+    const steps = [
+      ...stepsForPendingChanges,
+      abortDataEntry,
+      abortDelete,
+      expectPollingStationChoicePage,
     ];
 
     for (const step of steps) {

--- a/frontend/app/test/unit/form.ts
+++ b/frontend/app/test/unit/form.ts
@@ -1,0 +1,37 @@
+import { POLLING_STATION_DATA_ENTRY_REQUEST_BODY } from "@kiesraad/api";
+import { electionMockData } from "@kiesraad/api-mocks";
+
+export const emptyDataEntryRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
+  data: {
+    recounted: false,
+    voters_counts: {
+      poll_card_count: 0,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 0,
+    },
+    votes_counts: {
+      votes_candidates_counts: 0,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 0,
+    },
+    differences_counts: {
+      more_ballots_count: 0,
+      fewer_ballots_count: 0,
+      unreturned_ballots_count: 0,
+      too_few_ballots_handed_out_count: 0,
+      too_many_ballots_handed_out_count: 0,
+      other_explanation_count: 0,
+      no_explanation_count: 0,
+    },
+    political_group_votes: electionMockData.political_groups.map((group) => ({
+      number: group.number,
+      total: 0,
+      candidate_votes: group.candidates.map((candidate) => ({
+        number: candidate.number,
+        votes: 0,
+      })),
+    })),
+  },
+};

--- a/frontend/e2e-tests/dom-to-db-tests/abort-data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/abort-data-entry.e2e.ts
@@ -19,7 +19,14 @@ test.describe("Abort data entry", () => {
 
     const abortInputModal = new AbortInputModal(page);
     await abortInputModal.heading.waitFor();
+
+    // TODO: check saved data instead of API call in #137
+    const responsePromise = page.waitForResponse("**/polling_stations/1/data_entries/1");
+
     await abortInputModal.saveInput.click();
+
+    const response = await responsePromise;
+    expect(response.request().method()).toBe("POST");
 
     const inputPage = new InputPage(page);
     await expect(inputPage.heading).toBeVisible();
@@ -46,7 +53,14 @@ test.describe("Abort data entry", () => {
 
     const abortInputModal = new AbortInputModal(page);
     await abortInputModal.heading.waitFor();
+
+    // TODO: check saved data instead of API call in #137
+    const responsePromise = page.waitForResponse("**/polling_stations/1/data_entries/1");
+
     await abortInputModal.saveInput.click();
+
+    const response = await responsePromise;
+    expect(response.request().method()).toBe("POST");
 
     const inputPage = new InputPage(page);
     await expect(inputPage.heading).toBeVisible();
@@ -84,7 +98,14 @@ test.describe("Abort data entry", () => {
 
     const abortInputModal = new AbortInputModal(page);
     await abortInputModal.heading.waitFor();
+
+    // TODO: check saved data instead of API call in #137
+    const responsePromise = page.waitForResponse("**/polling_stations/1/data_entries/1");
+
     await abortInputModal.saveInput.click();
+
+    const response = await responsePromise;
+    expect(response.request().method()).toBe("POST");
 
     const inputPage = new InputPage(page);
     await expect(inputPage.heading).toBeVisible();

--- a/frontend/lib/api/form/pollingstation/useDifferences.ts
+++ b/frontend/lib/api/form/pollingstation/useDifferences.ts
@@ -9,7 +9,7 @@ export function useDifferences(
   getIgnoreWarnings?: () => boolean,
 ) {
   const {
-    saving,
+    status,
     values,
     formState,
     submitCurrentForm,
@@ -48,7 +48,7 @@ export function useDifferences(
   }, [registerCurrentForm, getValues, getIgnoreWarnings]);
 
   return {
-    saving,
+    status,
     sectionValues,
     errors,
     warnings,

--- a/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
+++ b/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
@@ -46,7 +46,7 @@ export function usePoliticalGroup(
   }, [registerCurrentForm, getValues, political_group_number, getIgnoreWarnings]);
 
   return {
-    status: status,
+    status,
     sectionValues,
     errors,
     warnings,

--- a/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
+++ b/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
@@ -8,7 +8,7 @@ export function usePoliticalGroup(
   getIgnoreWarnings?: () => boolean,
 ) {
   const {
-    saving,
+    status,
     values,
     formState,
     setTemporaryCache,
@@ -46,7 +46,7 @@ export function usePoliticalGroup(
   }, [registerCurrentForm, getValues, political_group_number, getIgnoreWarnings]);
 
   return {
-    saving,
+    status: status,
     sectionValues,
     errors,
     warnings,

--- a/frontend/lib/api/form/pollingstation/useRecounted.ts
+++ b/frontend/lib/api/form/pollingstation/useRecounted.ts
@@ -6,7 +6,7 @@ export type RecountedValue = Pick<PollingStationValues, "recounted">;
 
 export function useRecounted(getValues: () => RecountedValue) {
   const {
-    saving,
+    status,
     values,
     formState,
     submitCurrentForm,
@@ -41,7 +41,7 @@ export function useRecounted(getValues: () => RecountedValue) {
   }, [registerCurrentForm, getValues]);
 
   return {
-    saving,
+    status,
     sectionValues,
     errors,
     warnings,

--- a/frontend/lib/api/form/pollingstation/useVotersAndVotes.ts
+++ b/frontend/lib/api/form/pollingstation/useVotersAndVotes.ts
@@ -12,7 +12,7 @@ export function useVotersAndVotes(
   getIgnoreWarnings?: () => boolean,
 ) {
   const {
-    saving,
+    status,
     values,
     formState,
     setTemporaryCache,
@@ -59,7 +59,7 @@ export function useVotersAndVotes(
   }, [formState]);
 
   return {
-    saving,
+    status,
     sectionValues,
     errors,
     warnings,


### PR DESCRIPTION
Finish data entry abort modal functionality:
- Implement save button action
- Expand d2d tests
- Prevent navigation blocking modal ("Je hebt in [..] wijzigingen gemaakt die nog niet zijn opgeslagen") after deleting data entry using delete button

Resolves #212 