### PR TITLE
adds check for zero errors to alert about accepting warnings

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.tsx
@@ -101,16 +101,20 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
   const handleSubmit = (event: React.FormEvent<CandidatesVotesFormElement>) =>
     void (async (event: React.FormEvent<CandidatesVotesFormElement>) => {
       event.preventDefault();
-      const ignoreWarnings = (
-        document.getElementById(
-          `candidates_votes_form_ignore_warnings_${group.number}`,
-        ) as HTMLInputElement
-      ).checked;
 
-      if (!hasChanges && warnings.length > 0 && !ignoreWarnings) {
-        setWarningsWarning(true);
+      if (errors.length === 0 && warnings.length > 0) {
+        const ignoreWarnings = (
+          document.getElementById(
+            `candidates_votes_form_ignore_warnings_${group.number}`,
+          ) as HTMLInputElement
+        ).checked;
+        if (!hasChanges && !ignoreWarnings) {
+          setWarningsWarning(true);
+        } else {
+          await submit(ignoreWarnings);
+        }
       } else {
-        await submit(ignoreWarnings);
+        await submit();
       }
     })(event);
 

--- a/frontend/app/component/form/differences/DifferencesForm.tsx
+++ b/frontend/app/component/form/differences/DifferencesForm.tsx
@@ -95,13 +95,17 @@ export function DifferencesForm() {
   const handleSubmit = (event: React.FormEvent<DifferencesFormElement>) =>
     void (async (event: React.FormEvent<DifferencesFormElement>) => {
       event.preventDefault();
-      const ignoreWarnings = (document.getElementById(_IGNORE_WARNINGS_ID) as HTMLInputElement)
-        .checked;
 
-      if (!hasChanges && warnings.length > 0 && !ignoreWarnings) {
-        setWarningsWarning(true);
+      if (errors.length === 0 && warnings.length > 0) {
+        const ignoreWarnings = (document.getElementById(_IGNORE_WARNINGS_ID) as HTMLInputElement)
+          .checked;
+        if (!hasChanges && !ignoreWarnings) {
+          setWarningsWarning(true);
+        } else {
+          await submit(ignoreWarnings);
+        }
       } else {
-        await submit(ignoreWarnings);
+        await submit();
       }
     })(event);
 

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.tsx
@@ -117,13 +117,17 @@ export function VotersAndVotesForm() {
   const handleSubmit = (event: React.FormEvent<VotersAndVotesFormElement>) =>
     void (async (event: React.FormEvent<VotersAndVotesFormElement>) => {
       event.preventDefault();
-      const ignoreWarnings = (document.getElementById(_IGNORE_WARNINGS_ID) as HTMLInputElement)
-        .checked;
 
-      if (!hasChanges && warnings.length > 0 && !ignoreWarnings) {
-        setWarningsWarning(true);
+      if (errors.length === 0 && warnings.length > 0) {
+        const ignoreWarnings = (document.getElementById(_IGNORE_WARNINGS_ID) as HTMLInputElement)
+          .checked;
+        if (!hasChanges && !ignoreWarnings) {
+          setWarningsWarning(true);
+        } else {
+          await submit(ignoreWarnings);
+        }
       } else {
-        await submit(ignoreWarnings);
+        await submit();
       }
     })(event);
 


### PR DESCRIPTION
closes #309, so fixes the issue that if there are both errors and warnings, and you click "Volgende", the alert about accepting warnings "Je kan alleen verder als je het papieren proces-verbaal hebt gecontroleerd." was shown.