### PR TITLE
More data entry dom-to-db tests

### DIFF
--- a/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/candidates_votes_form/CandidatesVotesForm.test.tsx
@@ -84,6 +84,21 @@ describe("Test CandidatesVotesForm", () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    test("hitting shift+enter does result in api call", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+      const spy = vi.spyOn(global, "fetch");
+
+      const candidate1 = await screen.findByTestId("candidate_votes[0].votes");
+      await user.type(candidate1, "12345");
+      expect(candidate1).toHaveValue("12.345");
+
+      await user.keyboard("{shift>}{enter}{/shift}");
+
+      expect(spy).toHaveBeenCalled();
+    });
+
     test("Form field entry and keybindings", async () => {
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: { errors: [], warnings: [] },

--- a/frontend/app/component/form/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/differences/DifferencesForm.test.tsx
@@ -78,6 +78,21 @@ describe("Test DifferencesForm", () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    test("hitting shift+enter does result in api call", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+      const spy = vi.spyOn(global, "fetch");
+
+      const moreBallotsCount = await screen.findByTestId("more_ballots_count");
+      await user.type(moreBallotsCount, "12345");
+      expect(moreBallotsCount).toHaveValue("12.345");
+
+      await user.keyboard("{shift>}{enter}{/shift}");
+
+      expect(spy).toHaveBeenCalled();
+    });
+
     test("Form field entry and keybindings", async () => {
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: { errors: [], warnings: [] },

--- a/frontend/app/component/form/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/recounted/RecountedForm.test.tsx
@@ -71,6 +71,22 @@ describe("Test RecountedForm", () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    test("hitting shift+enter does result in api call", async () => {
+      const spy = vi.spyOn(global, "fetch");
+
+      const user = userEvent.setup();
+
+      render(Component);
+
+      const yes = screen.getByTestId("yes");
+      await user.click(yes);
+      expect(yes).toBeChecked();
+
+      await user.keyboard("{shift>}{enter}{/shift}");
+
+      expect(spy).toHaveBeenCalled();
+    });
+
     test("Form field entry and keybindings", async () => {
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: { errors: [], warnings: [] },

--- a/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -124,6 +124,21 @@ describe("Test VotersAndVotesForm", () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    test("hitting shift+enter does result in api call", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+      const spy = vi.spyOn(global, "fetch");
+
+      const pollCards = await screen.findByTestId("poll_card_count");
+      await user.type(pollCards, "12345");
+      expect(pollCards).toHaveValue("12.345");
+
+      await user.keyboard("{shift>}{enter}{/shift}");
+
+      expect(spy).toHaveBeenCalled();
+    });
+
     test("Form field entry and keybindings", async () => {
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: { errors: [], warnings: [] },

--- a/frontend/e2e-tests/dom-to-db-tests/abort-data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/abort-data-entry.e2e.ts
@@ -2,7 +2,11 @@ import { expect, test } from "@playwright/test";
 import { AbortInputModal } from "e2e-tests/page-objects/input/AbortInputModalPgObj";
 import { InputPage } from "e2e-tests/page-objects/input/InputPgObj";
 import { RecountedPage } from "e2e-tests/page-objects/input/RecountedPgObj";
-import { VotersVotesPage } from "e2e-tests/page-objects/input/VotersVotesPgObj";
+import {
+  VotersCounts,
+  VotersVotesPage,
+  VotesCounts,
+} from "e2e-tests/page-objects/input/VotersVotesPgObj";
 
 test.describe("Abort data entry", () => {
   test("Save input from empty voters and votes page", async ({ page }) => {
@@ -63,13 +67,13 @@ test.describe("Abort data entry", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 100,
       proxy_certificate_count: 0,
       voter_card_count: 0,
       total_admitted_voters_count: 100,
     };
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 50,
       blank_votes_count: 50, // exceeds threshold
       invalid_votes_count: 0,
@@ -160,13 +164,13 @@ test.describe("Abort data entry", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 100,
       proxy_certificate_count: 0,
       voter_card_count: 0,
       total_admitted_voters_count: 100,
     };
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 50,
       blank_votes_count: 50, // exceeds threshold
       invalid_votes_count: 0,

--- a/frontend/e2e-tests/dom-to-db-tests/abort-data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/abort-data-entry.e2e.ts
@@ -64,16 +64,16 @@ test.describe("Abort data entry", () => {
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
     const voters = {
-      poll_card_count: "100",
-      proxy_certificate_count: "0",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 100,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "50",
-      blank_votes_count: "50", // exceeds threshold
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 50,
+      blank_votes_count: 50, // exceeds threshold
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
     await expect(votersVotesPage.warning).toContainText(
@@ -161,16 +161,16 @@ test.describe("Abort data entry", () => {
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
     const voters = {
-      poll_card_count: "100",
-      proxy_certificate_count: "0",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 100,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "50",
-      blank_votes_count: "50", // exceeds threshold
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 50,
+      blank_votes_count: 50, // exceeds threshold
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
     await expect(votersVotesPage.warning).toContainText(

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -1,11 +1,20 @@
 import { expect, test } from "@playwright/test";
 import { formatNumber } from "e2e-tests/e2e-test-utils";
 import { CandidatesListPage } from "e2e-tests/page-objects/input/CandidatesListPgObj";
-import { DifferencesPage } from "e2e-tests/page-objects/input/DifferencesPgObj";
+import {
+  DifferencesPage,
+  FewerBallotsFields,
+  MoreBallotsFields,
+} from "e2e-tests/page-objects/input/DifferencesPgObj";
 import { InputPage } from "e2e-tests/page-objects/input/InputPgObj";
 import { RecountedPage } from "e2e-tests/page-objects/input/RecountedPgObj";
 import { SaveFormPage } from "e2e-tests/page-objects/input/SaveFormPgObj";
-import { VotersVotesPage } from "e2e-tests/page-objects/input/VotersVotesPgObj";
+import {
+  VotersCounts,
+  VotersRecounts,
+  VotersVotesPage,
+  VotesCounts,
+} from "e2e-tests/page-objects/input/VotersVotesPgObj";
 
 import { pollingStation33 } from "./test-data/PollingStationTestData";
 
@@ -28,13 +37,13 @@ test.describe("data entry", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     await expect(votersVotesPage.heading).toBeVisible();
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 1000,
       proxy_certificate_count: 50,
       voter_card_count: 75,
       total_admitted_voters_count: 1125,
     };
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 1090,
       blank_votes_count: 20,
       invalid_votes_count: 15,
@@ -77,21 +86,21 @@ test.describe("data entry", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     await expect(votersVotesPage.heading).toBeVisible();
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 1000,
       proxy_certificate_count: 50,
       voter_card_count: 75,
       total_admitted_voters_count: 1125,
     };
     await votersVotesPage.inputVotersCounts(voters);
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 1090,
       blank_votes_count: 20,
       invalid_votes_count: 15,
       total_votes_cast_count: 1125,
     };
     await votersVotesPage.inputVotesCounts(votes);
-    const votersRecounts = {
+    const votersRecounts: VotersRecounts = {
       poll_card_recount: 987,
       proxy_certificate_recount: 103,
       voter_card_recount: 35,
@@ -135,14 +144,14 @@ test.describe("data entry", () => {
     const votersVotesPage = new VotersVotesPage(page);
     await expect(votersVotesPage.heading).toBeVisible();
 
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 1000,
       proxy_certificate_count: 50,
       voter_card_count: 75,
       total_admitted_voters_count: 1125,
     };
     await votersVotesPage.inputVotersCounts(voters);
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 1135,
       blank_votes_count: 10,
       invalid_votes_count: 5,
@@ -161,7 +170,7 @@ test.describe("data entry", () => {
     const differencesPage = new DifferencesPage(page);
     await expect(differencesPage.heading).toBeVisible();
 
-    const moreBallotsFields = {
+    const moreBallotsFields: MoreBallotsFields = {
       moreBallotsCount: 25,
       tooManyBallotsHandedOutCount: 9,
       otherExplanationCount: 6,
@@ -199,7 +208,7 @@ test.describe("data entry", () => {
     await expect(votersVotesPage.heading).toBeVisible();
     await expect(votersVotesPage.headingRecount).toBeVisible();
 
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 1000,
       proxy_certificate_count: 50,
       voter_card_count: 75,
@@ -207,7 +216,7 @@ test.describe("data entry", () => {
     };
     await votersVotesPage.inputVotersCounts(voters);
 
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 1090,
       blank_votes_count: 20,
       invalid_votes_count: 15,
@@ -215,7 +224,7 @@ test.describe("data entry", () => {
     };
     await votersVotesPage.inputVotesCounts(votes);
 
-    const votersRecounts = {
+    const votersRecounts: VotersRecounts = {
       poll_card_recount: 1020,
       proxy_certificate_recount: 50,
       voter_card_recount: 75,
@@ -234,7 +243,7 @@ test.describe("data entry", () => {
     const differencesPage = new DifferencesPage(page);
     await expect(differencesPage.heading).toBeVisible();
 
-    const fewerBallotsFields = {
+    const fewerBallotsFields: FewerBallotsFields = {
       fewerBallotsCount: 20,
       unreturnedBallotsCount: 6,
       tooFewBallotsHandedOutCount: 3,
@@ -497,13 +506,13 @@ test.describe("navigation", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 99,
       proxy_certificate_count: 1,
       voter_card_count: 0,
       total_admitted_voters_count: 100,
     };
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 100,
       blank_votes_count: 0,
       invalid_votes_count: 0,
@@ -517,7 +526,7 @@ test.describe("navigation", () => {
     await differencesPage.navPanel.votersAndVotes.click();
     await votersVotesPage.heading.waitFor();
 
-    const votersUpdates = {
+    const votersUpdates: VotersCounts = {
       poll_card_count: 90,
       proxy_certificate_count: 5,
       voter_card_count: 5,
@@ -553,13 +562,13 @@ test.describe("navigation", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
-    const voters = {
+    const voters: VotersCounts = {
       poll_card_count: 99,
       proxy_certificate_count: 1,
       voter_card_count: 0,
       total_admitted_voters_count: 100,
     };
-    const votes = {
+    const votes: VotesCounts = {
       votes_candidates_counts: 100,
       blank_votes_count: 0,
       invalid_votes_count: 0,
@@ -573,7 +582,7 @@ test.describe("navigation", () => {
     await differencesPage.navPanel.votersAndVotes.click();
     await votersVotesPage.heading.waitFor();
 
-    const votersUpdates = {
+    const votersUpdates: VotersCounts = {
       poll_card_count: 90,
       proxy_certificate_count: 5,
       voter_card_count: 5,
@@ -618,13 +627,13 @@ test.describe("navigation", () => {
         "je bent hier",
       );
 
-      const voters = {
+      const voters: VotersCounts = {
         poll_card_count: 100,
         proxy_certificate_count: 0,
         voter_card_count: 0,
         total_admitted_voters_count: 100,
       };
-      const votes = {
+      const votes: VotesCounts = {
         votes_candidates_counts: 100,
         blank_votes_count: 0,
         invalid_votes_count: 0,

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -117,13 +117,14 @@ test.describe("data entry", () => {
     const differencesPage = new DifferencesPage(page);
     await expect(differencesPage.heading).toBeVisible();
 
-    // ToDo: condense
-    await differencesPage.fewerBallotsCount.fill("20");
-    await differencesPage.unreturnedBallotsCount.fill("6");
-    await differencesPage.tooFewBallotsHandedOutCount.fill("3");
-    await differencesPage.otherExplanationCount.fill("7");
-    await differencesPage.noExplanationCount.fill("4");
-
+    const fewerBallotsFields = {
+      fewerBallotsCount: 20,
+      unreturnedBallotsCount: 6,
+      tooFewBallotsHandedOutCount: 3,
+      otherExplanationCount: 7,
+      noExplanationCount: 4,
+    };
+    await differencesPage.fillFewerBallotsFields(fewerBallotsFields);
     await differencesPage.next.click();
 
     const candidatesListPage_1 = new CandidatesListPage(page, "Lijst 1 - Political Group A");

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { formatNumber } from "e2e-tests/e2e-test-utils";
 import { CandidatesListPage } from "e2e-tests/page-objects/input/CandidatesListPgObj";
 import { DifferencesPage } from "e2e-tests/page-objects/input/DifferencesPgObj";
 import { InputPage } from "e2e-tests/page-objects/input/InputPgObj";
@@ -13,64 +14,128 @@ test.describe("data entry", () => {
     await page.goto("/1/input");
 
     const inputPage = new InputPage(page);
+    await expect(inputPage.heading).toBeVisible();
     const pollingStation = pollingStation33;
     await inputPage.pollingstationNumber.fill(pollingStation.number.toString());
     await expect(inputPage.pollingStationFeedback).toHaveText(pollingStation.name);
     await inputPage.clickStart();
 
     const recountedPage = new RecountedPage(page);
-    await recountedPage.heading.waitFor();
+    await expect(recountedPage.heading).toBeVisible();
     await recountedPage.no.check();
     await expect(recountedPage.no).toBeChecked();
     await recountedPage.next.click();
 
-    await expect(recountedPage.error).toBeHidden();
-    await expect(recountedPage.warning).toBeHidden();
-
     const votersVotesPage = new VotersVotesPage(page);
-    await votersVotesPage.heading.waitFor();
-
+    await expect(votersVotesPage.heading).toBeVisible();
     const voters = {
-      poll_card_count: "100",
-      proxy_certificate_count: "10",
-      voter_card_count: "15",
-      total_admitted_voters_count: "125",
+      poll_card_count: 1000,
+      proxy_certificate_count: 50,
+      voter_card_count: 75,
+      total_admitted_voters_count: 1125,
     };
     const votes = {
-      votes_candidates_counts: "122",
-      blank_votes_count: "2",
-      invalid_votes_count: "1",
-      total_votes_cast_count: "125",
+      votes_candidates_counts: 1090,
+      blank_votes_count: 20,
+      invalid_votes_count: 15,
+      total_votes_cast_count: 1125,
     };
-    await votersVotesPage.inputVoters(voters);
-    await votersVotesPage.inputVotes(votes);
-
-    await expect(votersVotesPage.pollCardCount).toHaveValue(voters.poll_card_count);
-
+    await votersVotesPage.inputVotersCounts(voters);
+    await votersVotesPage.inputVotesCounts(votes);
+    await expect(votersVotesPage.pollCardCount).toHaveValue(formatNumber(voters.poll_card_count));
     await votersVotesPage.next.click();
 
-    await expect(votersVotesPage.error).toBeHidden();
-    await expect(votersVotesPage.warning).toBeHidden();
-
     const differencesPage = new DifferencesPage(page);
-    await differencesPage.heading.waitFor();
+    await expect(differencesPage.heading).toBeVisible();
     await differencesPage.next.click();
 
-    await expect(differencesPage.error).toBeHidden();
-    await expect(differencesPage.warning).toBeHidden();
-
     const candidatesListPage_1 = new CandidatesListPage(page, "Lijst 1 - Political Group A");
-    await candidatesListPage_1.heading.waitFor();
+    await expect(candidatesListPage_1.heading).toBeVisible();
 
-    await candidatesListPage_1.fillCandidate(0, 100);
-    await candidatesListPage_1.fillCandidate(1, 22);
-    await candidatesListPage_1.total.fill("122");
+    await candidatesListPage_1.fillCandidatesAndTotal([837, 253], 1090);
     await candidatesListPage_1.next.click();
 
-    await expect(candidatesListPage_1.error).toBeHidden();
-    await expect(candidatesListPage_1.warning).toBeHidden();
+    const saveFormPage = new SaveFormPage(page);
+    await expect(saveFormPage.heading).toBeVisible();
 
-    // TODO: Controleren en opslaan
+    // TODO: extend as part of epic #95: data entry check and finalisation
+  });
+
+  test("recount, differences flow", async ({ page }) => {
+    await page.goto("/1/input");
+
+    const inputPage = new InputPage(page);
+    await expect(inputPage.heading).toBeVisible();
+    const pollingStation = pollingStation33;
+    await inputPage.selectPollingStationAndClickStart(pollingStation.number);
+
+    const recountedPage = new RecountedPage(page);
+    await expect(recountedPage.heading).toBeVisible();
+    await recountedPage.yes.check();
+    await expect(recountedPage.yes).toBeChecked();
+    await recountedPage.next.click();
+
+    const votersVotesPage = new VotersVotesPage(page);
+    await expect(votersVotesPage.heading).toBeVisible();
+    await expect(votersVotesPage.headingRecount).toBeVisible();
+
+    const voters = {
+      poll_card_count: 1000,
+      proxy_certificate_count: 50,
+      voter_card_count: 75,
+      total_admitted_voters_count: 1125,
+    };
+    await votersVotesPage.inputVotersCounts(voters);
+
+    const votes = {
+      votes_candidates_counts: 1090,
+      blank_votes_count: 20,
+      invalid_votes_count: 15,
+      total_votes_cast_count: 1125,
+    };
+    await votersVotesPage.inputVotesCounts(votes);
+
+    const votersRecounts = {
+      poll_card_recount: 1020,
+      proxy_certificate_recount: 50,
+      voter_card_recount: 75,
+      total_admitted_voters_recount: 1145,
+    };
+    await votersVotesPage.inputVotersRecounts(votersRecounts);
+    await expect(votersVotesPage.pollCardRecount).toHaveValue(
+      formatNumber(votersRecounts.poll_card_recount),
+    );
+    await votersVotesPage.next.click();
+
+    await expect(votersVotesPage.warning).toContainText("W.204");
+    await expect(votersVotesPage.warning).toContainText(
+      "Er is een onverwacht verschil tussen het aantal uitgebrachte stemmen (E t/m H) en het herteld aantal toegelaten kiezers (A.2 t/m D.2).",
+    );
+    await votersVotesPage.acceptWarnings.check();
+    await votersVotesPage.next.click();
+
+    const differencesPage = new DifferencesPage(page);
+    await expect(differencesPage.heading).toBeVisible();
+
+    // ToDo: condense
+    await differencesPage.fewerBallotsCount.fill("20");
+    await differencesPage.unreturnedBallotsCount.fill("6");
+    await differencesPage.tooFewBallotsHandedOutCount.fill("3");
+    await differencesPage.otherExplanationCount.fill("7");
+    await differencesPage.noExplanationCount.fill("4");
+
+    await differencesPage.next.click();
+
+    const candidatesListPage_1 = new CandidatesListPage(page, "Lijst 1 - Political Group A");
+    await expect(candidatesListPage_1.heading).toBeVisible();
+
+    await candidatesListPage_1.fillCandidatesAndTotal([837, 253], 1090);
+    await candidatesListPage_1.next.click();
+
+    const saveFormPage = new SaveFormPage(page);
+    await expect(saveFormPage.heading).toBeVisible();
+
+    // TODO: extend as part of epic #95: data entry check and finalisation
   });
 });
 
@@ -84,16 +149,16 @@ test.describe("errors and warnings", () => {
     // fill form with data that results in an error
     const votersVotesPage = new VotersVotesPage(page);
     const voters = {
-      poll_card_count: "1",
-      proxy_certificate_count: "0",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 1,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -105,12 +170,12 @@ test.describe("errors and warnings", () => {
 
     // fill form with corrected data (no errors, no warnings)
     const votersCorrected = {
-      poll_card_count: "98",
-      proxy_certificate_count: "1",
-      voter_card_count: "1",
-      total_admitted_voters_count: "100",
+      poll_card_count: 98,
+      proxy_certificate_count: 1,
+      voter_card_count: 1,
+      total_admitted_voters_count: 100,
     };
-    await votersVotesPage.inputVoters(votersCorrected);
+    await votersVotesPage.inputVotersCounts(votersCorrected);
     await votersVotesPage.next.click();
 
     await expect(votersVotesPage.error).toBeHidden();
@@ -130,16 +195,16 @@ test.describe("errors and warnings", () => {
 
     const votersVotesPage = new VotersVotesPage(page);
     const voters = {
-      poll_card_count: "99",
-      proxy_certificate_count: "1",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 99,
+      proxy_certificate_count: 1,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -177,16 +242,16 @@ test.describe("errors and warnings", () => {
     // fill form with data that results in a warning
     const votersVotesPage = new VotersVotesPage(page);
     const voters = {
-      poll_card_count: "100",
-      proxy_certificate_count: "0",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 100,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -217,16 +282,16 @@ test.describe("errors and warnings", () => {
     // fill form with data that results in a warning
     const votersVotesPage = new VotersVotesPage(page);
     const voters = {
-      poll_card_count: "100",
-      proxy_certificate_count: "0",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 100,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -241,13 +306,13 @@ test.describe("errors and warnings", () => {
 
     // correct the warning
     const votersCorrected = {
-      poll_card_count: "98",
-      proxy_certificate_count: "1",
-      voter_card_count: "1",
-      total_admitted_voters_count: "100",
+      poll_card_count: 98,
+      proxy_certificate_count: 1,
+      voter_card_count: 1,
+      total_admitted_voters_count: 100,
     };
 
-    await votersVotesPage.inputVoters(votersCorrected);
+    await votersVotesPage.inputVotersCounts(votersCorrected);
     // Tab press needed for page to register change after Playwright's fill()
     await votersVotesPage.totalAdmittedVotersCount.press("Tab");
     await votersVotesPage.next.click();
@@ -272,16 +337,16 @@ test.describe("errors and warnings", () => {
     // fill form with data that results in a warning
     const votersVotesPage = new VotersVotesPage(page);
     const voters = {
-      poll_card_count: "100",
-      proxy_certificate_count: "0",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 100,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -315,16 +380,16 @@ test.describe("navigation", () => {
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
     const voters = {
-      poll_card_count: "99",
-      proxy_certificate_count: "1",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 99,
+      proxy_certificate_count: 1,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -335,12 +400,12 @@ test.describe("navigation", () => {
     await votersVotesPage.heading.waitFor();
 
     const votersUpdates = {
-      poll_card_count: "90",
-      proxy_certificate_count: "5",
-      voter_card_count: "5",
-      total_admitted_voters_count: "100",
+      poll_card_count: 90,
+      proxy_certificate_count: 5,
+      voter_card_count: 5,
+      total_admitted_voters_count: 100,
     };
-    await votersVotesPage.inputVoters(votersUpdates);
+    await votersVotesPage.inputVotersCounts(votersUpdates);
     // Tab press needed for page to register change after Playwright's fill()
     await votersVotesPage.totalAdmittedVotersCount.press("Tab");
 
@@ -371,16 +436,16 @@ test.describe("navigation", () => {
     const votersVotesPage = new VotersVotesPage(page);
     await votersVotesPage.heading.waitFor();
     const voters = {
-      poll_card_count: "99",
-      proxy_certificate_count: "1",
-      voter_card_count: "0",
-      total_admitted_voters_count: "100",
+      poll_card_count: 99,
+      proxy_certificate_count: 1,
+      voter_card_count: 0,
+      total_admitted_voters_count: 100,
     };
     const votes = {
-      votes_candidates_counts: "100",
-      blank_votes_count: "0",
-      invalid_votes_count: "0",
-      total_votes_cast_count: "100",
+      votes_candidates_counts: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 100,
     };
     await votersVotesPage.fillInPageAndClickNext(voters, votes);
 
@@ -391,12 +456,12 @@ test.describe("navigation", () => {
     await votersVotesPage.heading.waitFor();
 
     const votersUpdates = {
-      poll_card_count: "90",
-      proxy_certificate_count: "5",
-      voter_card_count: "5",
-      total_admitted_voters_count: "100",
+      poll_card_count: 90,
+      proxy_certificate_count: 5,
+      voter_card_count: 5,
+      total_admitted_voters_count: 100,
     };
-    await votersVotesPage.inputVoters(votersUpdates);
+    await votersVotesPage.inputVotersCounts(votersUpdates);
     // Tab press needed for page to register change after Playwright's fill()
     await votersVotesPage.totalAdmittedVotersCount.press("Tab");
 
@@ -436,16 +501,16 @@ test.describe("navigation", () => {
       );
 
       const voters = {
-        poll_card_count: "100",
-        proxy_certificate_count: "0",
-        voter_card_count: "0",
-        total_admitted_voters_count: "100",
+        poll_card_count: 100,
+        proxy_certificate_count: 0,
+        voter_card_count: 0,
+        total_admitted_voters_count: 100,
       };
       const votes = {
-        votes_candidates_counts: "100",
-        blank_votes_count: "0",
-        invalid_votes_count: "0",
-        total_votes_cast_count: "100",
+        votes_candidates_counts: 100,
+        blank_votes_count: 0,
+        invalid_votes_count: 0,
+        total_votes_cast_count: 100,
       };
       await votersVotesPage.fillInPageAndClickNext(voters, votes);
       await votersVotesPage.acceptWarnings.click();

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -162,7 +162,7 @@ test.describe("data entry", () => {
 
     await expect(votersVotesPage.warning).toContainText("W.203");
     await expect(votersVotesPage.warning).toContainText(
-      "r is een onverwacht verschil tussen het aantal toegelaten kiezers (A t/m D) en het aantal uitgebrachte stemmen (E t/m H).",
+      "Er is een onverwacht verschil tussen het aantal toegelaten kiezers (A t/m D) en het aantal uitgebrachte stemmen (E t/m H).",
     );
     await votersVotesPage.acceptWarnings.check();
     await votersVotesPage.next.click();

--- a/frontend/e2e-tests/e2e-test-utils.ts
+++ b/frontend/e2e-tests/e2e-test-utils.ts
@@ -1,0 +1,7 @@
+const numberFormatter = new Intl.NumberFormat("nl-NL", {
+  maximumFractionDigits: 0,
+});
+
+export function formatNumber(number: number): string {
+  return numberFormatter.format(number);
+}

--- a/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
@@ -6,6 +6,14 @@ export class DifferencesPage extends InputBasePage {
   readonly heading: Locator;
   readonly next: Locator;
 
+  readonly moreBallotsCount: Locator;
+  readonly fewerBallotsCount: Locator;
+  readonly unreturnedBallotsCount: Locator;
+  readonly tooFewBallotsHandedOutCount: Locator;
+  readonly tooManyBallotsHandedOutCount: Locator;
+  readonly otherExplanationCount: Locator;
+  readonly noExplanationCount: Locator;
+
   constructor(page: Page) {
     super(page);
 
@@ -13,6 +21,15 @@ export class DifferencesPage extends InputBasePage {
       level: 2,
       name: "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen",
     });
+
+    this.moreBallotsCount = page.getByRole("textbox", { name: "more_ballots_count" });
+    // this.moreBallotsCount = page.getByTestId("more_ballots_count");
+    this.fewerBallotsCount = page.getByTestId("fewer_ballots_count");
+    this.unreturnedBallotsCount = page.getByTestId("unreturned_ballots_count");
+    this.tooFewBallotsHandedOutCount = page.getByTestId("too_few_ballots_handed_out_count");
+    this.tooManyBallotsHandedOutCount = page.getByTestId("too_many_ballots_handed_out_count");
+    this.otherExplanationCount = page.getByTestId("other_explanation_count");
+    this.noExplanationCount = page.getByTestId("no_explanation_count");
 
     this.next = page.getByRole("button", { name: "Volgende" });
   }

--- a/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
@@ -2,7 +2,14 @@ import { type Locator, type Page } from "@playwright/test";
 
 import { InputBasePage } from "./InputBasePgObj";
 
-interface fewerBallotsFields {
+interface MoreBallotFields {
+  moreBallotsCount: number;
+  tooManyBallotsHandedOutCount: number;
+  otherExplanationCount: number;
+  noExplanationCount: number;
+}
+
+interface FewerBallotsFields {
   fewerBallotsCount: number;
   unreturnedBallotsCount: number;
   tooFewBallotsHandedOutCount: number;
@@ -41,7 +48,14 @@ export class DifferencesPage extends InputBasePage {
     this.next = page.getByRole("button", { name: "Volgende" });
   }
 
-  async fillFewerBallotsFields(fields: fewerBallotsFields) {
+  async fillMoreBallotsFields(fields: MoreBallotFields) {
+    await this.moreBallotsCount.fill(fields.moreBallotsCount.toString());
+    await this.tooManyBallotsHandedOutCount.fill(fields.tooManyBallotsHandedOutCount.toString());
+    await this.otherExplanationCount.fill(fields.otherExplanationCount.toString());
+    await this.noExplanationCount.fill(fields.noExplanationCount.toString());
+  }
+
+  async fillFewerBallotsFields(fields: FewerBallotsFields) {
     await this.fewerBallotsCount.fill(fields.fewerBallotsCount.toString());
     await this.unreturnedBallotsCount.fill(fields.unreturnedBallotsCount.toString());
     await this.tooFewBallotsHandedOutCount.fill(fields.tooFewBallotsHandedOutCount.toString());

--- a/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
@@ -2,14 +2,14 @@ import { type Locator, type Page } from "@playwright/test";
 
 import { InputBasePage } from "./InputBasePgObj";
 
-interface MoreBallotFields {
+export interface MoreBallotsFields {
   moreBallotsCount: number;
   tooManyBallotsHandedOutCount: number;
   otherExplanationCount: number;
   noExplanationCount: number;
 }
 
-interface FewerBallotsFields {
+export interface FewerBallotsFields {
   fewerBallotsCount: number;
   unreturnedBallotsCount: number;
   tooFewBallotsHandedOutCount: number;
@@ -48,7 +48,7 @@ export class DifferencesPage extends InputBasePage {
     this.next = page.getByRole("button", { name: "Volgende" });
   }
 
-  async fillMoreBallotsFields(fields: MoreBallotFields) {
+  async fillMoreBallotsFields(fields: MoreBallotsFields) {
     await this.moreBallotsCount.fill(fields.moreBallotsCount.toString());
     await this.tooManyBallotsHandedOutCount.fill(fields.tooManyBallotsHandedOutCount.toString());
     await this.otherExplanationCount.fill(fields.otherExplanationCount.toString());

--- a/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/DifferencesPgObj.ts
@@ -2,6 +2,14 @@ import { type Locator, type Page } from "@playwright/test";
 
 import { InputBasePage } from "./InputBasePgObj";
 
+interface fewerBallotsFields {
+  fewerBallotsCount: number;
+  unreturnedBallotsCount: number;
+  tooFewBallotsHandedOutCount: number;
+  otherExplanationCount: number;
+  noExplanationCount: number;
+}
+
 export class DifferencesPage extends InputBasePage {
   readonly heading: Locator;
   readonly next: Locator;
@@ -22,8 +30,7 @@ export class DifferencesPage extends InputBasePage {
       name: "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen",
     });
 
-    this.moreBallotsCount = page.getByRole("textbox", { name: "more_ballots_count" });
-    // this.moreBallotsCount = page.getByTestId("more_ballots_count");
+    this.moreBallotsCount = page.getByTestId("more_ballots_count");
     this.fewerBallotsCount = page.getByTestId("fewer_ballots_count");
     this.unreturnedBallotsCount = page.getByTestId("unreturned_ballots_count");
     this.tooFewBallotsHandedOutCount = page.getByTestId("too_few_ballots_handed_out_count");
@@ -32,5 +39,13 @@ export class DifferencesPage extends InputBasePage {
     this.noExplanationCount = page.getByTestId("no_explanation_count");
 
     this.next = page.getByRole("button", { name: "Volgende" });
+  }
+
+  async fillFewerBallotsFields(fields: fewerBallotsFields) {
+    await this.fewerBallotsCount.fill(fields.fewerBallotsCount.toString());
+    await this.unreturnedBallotsCount.fill(fields.unreturnedBallotsCount.toString());
+    await this.tooFewBallotsHandedOutCount.fill(fields.tooFewBallotsHandedOutCount.toString());
+    await this.otherExplanationCount.fill(fields.otherExplanationCount.toString());
+    await this.noExplanationCount.fill(fields.noExplanationCount.toString());
   }
 }

--- a/frontend/e2e-tests/page-objects/input/InputPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/InputPgObj.ts
@@ -27,4 +27,9 @@ export class InputPage {
     // so added timeout to make it fail fast
     await button.click({ timeout: 2000 });
   }
+
+  async selectPollingStationAndClickStart(pollingStationNumber: number) {
+    await this.pollingstationNumber.fill(pollingStationNumber.toString());
+    await this.clickStart();
+  }
 }

--- a/frontend/e2e-tests/page-objects/input/VotersVotesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/VotersVotesPgObj.ts
@@ -2,21 +2,21 @@ import { type Locator, type Page } from "@playwright/test";
 
 import { InputBasePage } from "./InputBasePgObj";
 
-interface VotersCounts {
+export interface VotersCounts {
   poll_card_count: number;
   proxy_certificate_count: number;
   voter_card_count: number;
   total_admitted_voters_count: number;
 }
 
-interface VotesCounts {
+export interface VotesCounts {
   votes_candidates_counts: number;
   blank_votes_count: number;
   invalid_votes_count: number;
   total_votes_cast_count: number;
 }
 
-interface VotersRecounts {
+export interface VotersRecounts {
   poll_card_recount: number;
   proxy_certificate_recount: number;
   voter_card_recount: number;

--- a/frontend/e2e-tests/page-objects/input/VotersVotesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/VotersVotesPgObj.ts
@@ -2,22 +2,31 @@ import { type Locator, type Page } from "@playwright/test";
 
 import { InputBasePage } from "./InputBasePgObj";
 
+// ToDo: do toString in method
 interface VotersCounts {
-  poll_card_count: string;
-  proxy_certificate_count: string;
-  voter_card_count: string;
-  total_admitted_voters_count: string;
+  poll_card_count: number;
+  proxy_certificate_count: number;
+  voter_card_count: number;
+  total_admitted_voters_count: number;
 }
 
 interface VotesCounts {
-  votes_candidates_counts: string;
-  blank_votes_count: string;
-  invalid_votes_count: string;
-  total_votes_cast_count: string;
+  votes_candidates_counts: number;
+  blank_votes_count: number;
+  invalid_votes_count: number;
+  total_votes_cast_count: number;
+}
+
+interface VotersRecounts {
+  poll_card_recount: number;
+  proxy_certificate_recount: number;
+  voter_card_recount: number;
+  total_admitted_voters_recount: number;
 }
 
 export class VotersVotesPage extends InputBasePage {
   readonly heading: Locator;
+  readonly headingRecount: Locator;
   readonly pollCardCount: Locator;
   readonly proxyCertificateCount: Locator;
   readonly voterCardCount: Locator;
@@ -28,6 +37,10 @@ export class VotersVotesPage extends InputBasePage {
   readonly totalVotesCastCount: Locator;
   readonly acceptWarnings: Locator;
   readonly next: Locator;
+  readonly pollCardRecount: Locator;
+  readonly proxyCertificateRecount: Locator;
+  readonly voterCardRecount: Locator;
+  readonly totalAdmittedVotersRecount: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -37,14 +50,28 @@ export class VotersVotesPage extends InputBasePage {
       name: "Toegelaten kiezers en uitgebrachte stemmen",
     });
 
+    this.headingRecount = page.getByRole("heading", {
+      level: 2,
+      name: "Toegelaten kiezers na hertelling door gemeentelijk stembureau",
+    });
+
+    // voters counts
     this.pollCardCount = page.getByTestId("poll_card_count");
     this.proxyCertificateCount = page.getByTestId("proxy_certificate_count");
     this.voterCardCount = page.getByTestId("voter_card_count");
     this.totalAdmittedVotersCount = page.getByTestId("total_admitted_voters_count");
+
+    // votes counts
     this.votesCandidatesCount = page.getByTestId("votes_candidates_counts");
     this.blankVotesCount = page.getByTestId("blank_votes_count");
     this.invalidVotesCount = page.getByTestId("invalid_votes_count");
     this.totalVotesCastCount = page.getByTestId("total_votes_cast_count");
+
+    // voters recounts
+    this.pollCardRecount = page.getByTestId("poll_card_recount");
+    this.proxyCertificateRecount = page.getByTestId("proxy_certificate_recount");
+    this.voterCardRecount = page.getByTestId("voter_card_recount");
+    this.totalAdmittedVotersRecount = page.getByTestId("total_admitted_voters_recount");
 
     this.acceptWarnings = page.getByLabel(
       "Ik heb de aantallen gecontroleerd met het papier en correct overgenomen.",
@@ -53,23 +80,39 @@ export class VotersVotesPage extends InputBasePage {
     this.next = page.getByRole("button", { name: "Volgende" });
   }
 
-  async inputVoters(votersCounts: VotersCounts) {
-    await this.pollCardCount.fill(votersCounts.poll_card_count);
-    await this.proxyCertificateCount.fill(votersCounts.proxy_certificate_count);
-    await this.voterCardCount.fill(votersCounts.voter_card_count);
-    await this.totalAdmittedVotersCount.fill(votersCounts.total_admitted_voters_count);
+  async inputVotersCounts(votersCounts: VotersCounts) {
+    await this.pollCardCount.fill(votersCounts.poll_card_count.toString());
+    await this.proxyCertificateCount.fill(votersCounts.proxy_certificate_count.toString());
+    await this.voterCardCount.fill(votersCounts.voter_card_count.toString());
+    await this.totalAdmittedVotersCount.fill(votersCounts.total_admitted_voters_count.toString());
   }
 
-  async inputVotes(votesCounts: VotesCounts) {
-    await this.votesCandidatesCount.fill(votesCounts.votes_candidates_counts);
-    await this.blankVotesCount.fill(votesCounts.blank_votes_count);
-    await this.invalidVotesCount.fill(votesCounts.invalid_votes_count);
-    await this.totalVotesCastCount.fill(votesCounts.total_votes_cast_count);
+  async inputVotesCounts(votesCounts: VotesCounts) {
+    await this.votesCandidatesCount.fill(votesCounts.votes_candidates_counts.toString());
+    await this.blankVotesCount.fill(votesCounts.blank_votes_count.toString());
+    await this.invalidVotesCount.fill(votesCounts.invalid_votes_count.toString());
+    await this.totalVotesCastCount.fill(votesCounts.total_votes_cast_count.toString());
   }
 
-  async fillInPageAndClickNext(votersCounts: VotersCounts, votesCounts: VotesCounts) {
-    await this.inputVoters(votersCounts);
-    await this.inputVotes(votesCounts);
+  async inputVotersRecounts(votersRecounts: VotersRecounts) {
+    await this.pollCardRecount.fill(votersRecounts.poll_card_recount.toString());
+    await this.proxyCertificateRecount.fill(votersRecounts.proxy_certificate_recount.toString());
+    await this.voterCardRecount.fill(votersRecounts.voter_card_recount.toString());
+    await this.totalAdmittedVotersRecount.fill(
+      votersRecounts.total_admitted_voters_recount.toString(),
+    );
+  }
+
+  async fillInPageAndClickNext(
+    votersCounts: VotersCounts,
+    votesCounts: VotesCounts,
+    votersRecounts?: VotersRecounts,
+  ) {
+    await this.inputVotersCounts(votersCounts);
+    await this.inputVotesCounts(votesCounts);
+    if (votersRecounts) {
+      await this.inputVotersRecounts(votersRecounts);
+    }
     await this.next.click();
   }
 }

--- a/frontend/e2e-tests/page-objects/input/VotersVotesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/input/VotersVotesPgObj.ts
@@ -2,7 +2,6 @@ import { type Locator, type Page } from "@playwright/test";
 
 import { InputBasePage } from "./InputBasePgObj";
 
-// ToDo: do toString in method
 interface VotersCounts {
   poll_card_count: number;
   proxy_certificate_count: number;


### PR DESCRIPTION
changes:
- added RTL test for submitting with Shift+Enter (d2d tests should wait until full support for keyboard navigation)
- added three data entry d2d tests:
  - recount, no differences
  - no recount, difference of more ballots counted
  - recount, difference of fewer ballots counted
- updated existing d2d test with no recount, no differences to use more realistic numbers
- added some convenience methods to page objects
- made page object convenience methods to input counts accept `number`s and do the conversion to string
- explicit typing of arguments for page object method calls