### PR TITLE
Block navigation with a modal when navigating outside data entry flow

### DIFF
--- a/frontend/app/module/input/PollingStation/AbortDataEntryControl.tsx
+++ b/frontend/app/module/input/PollingStation/AbortDataEntryControl.tsx
@@ -1,44 +1,20 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useElection, usePollingStationFormController } from "@kiesraad/api";
-import { Button, Modal } from "@kiesraad/ui";
+import { useElection } from "@kiesraad/api";
+import { Button } from "@kiesraad/ui";
+
+import { AbortDataEntryModal } from "./AbortDataEntryModal";
 
 export function AbortDataEntryControl() {
   const navigate = useNavigate();
   const { election } = useElection();
 
   const [openAbortModal, setOpenAbortModal] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [saving, setSaving] = useState(false);
-
-  const controller = usePollingStationFormController();
 
   function toggleAbortModal() {
     setOpenAbortModal(!openAbortModal);
   }
-
-  const onAbortModalSave = () =>
-    void (async () => {
-      try {
-        setSaving(true);
-        await controller.submitCurrentForm();
-        navigate(`/${election.id}/input`);
-      } finally {
-        setSaving(false);
-      }
-    })();
-
-  const onAbortModalDelete = () =>
-    void (async () => {
-      try {
-        setDeleting(true);
-        await controller.deleteDataEntry();
-        navigate(`/${election.id}/input`);
-      } finally {
-        setDeleting(false);
-      }
-    })();
 
   return (
     <>
@@ -46,24 +22,15 @@ export function AbortDataEntryControl() {
         Invoer afbreken
       </Button>
       {openAbortModal && (
-        <Modal onClose={toggleAbortModal}>
-          <h2>Wat wil je doen met je invoer?</h2>
-          <p>
-            Ga je op een later moment verder met het invoeren van dit stembureau? Dan kan je de invoer die je al hebt
-            gedaan bewaren.
-            <br />
-            <br />
-            Twijfel je? Overleg dan met de coördinator.
-          </p>
-          <nav>
-            <Button size="lg" onClick={onAbortModalSave} disabled={saving}>
-              Invoer bewaren
-            </Button>
-            <Button size="lg" variant="secondary" onClick={onAbortModalDelete} disabled={deleting}>
-              Niet bewaren
-            </Button>
-          </nav>
-        </Modal>
+        <AbortDataEntryModal
+          onCancel={toggleAbortModal}
+          onSave={() => {
+            navigate(`/${election.id}/input`);
+          }}
+          onDelete={() => {
+            navigate(`/${election.id}/input`);
+          }}
+        />
       )}
     </>
   );

--- a/frontend/app/module/input/PollingStation/AbortDataEntryModal.tsx
+++ b/frontend/app/module/input/PollingStation/AbortDataEntryModal.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+
+import { usePollingStationFormController } from "@kiesraad/api";
+import { Button, Modal } from "@kiesraad/ui";
+
+export interface AbortDataEntryModalProps {
+  onCancel: () => void;
+  onSave: () => void;
+  onDelete: () => void;
+}
+
+export function AbortDataEntryModal({ onCancel, onSave, onDelete }: AbortDataEntryModalProps) {
+  const [deleting, setDeleting] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const controller = usePollingStationFormController();
+
+  const onAbortModalSave = () =>
+    void (async () => {
+      try {
+        setSaving(true);
+        await controller.submitCurrentForm(false, true);
+        onSave();
+      } finally {
+        setSaving(false);
+      }
+    })();
+
+  const onAbortModalDelete = () =>
+    void (async () => {
+      try {
+        setDeleting(true);
+        await controller.deleteDataEntry();
+        onDelete();
+      } finally {
+        setDeleting(false);
+      }
+    })();
+
+  return (
+    <Modal onClose={onCancel}>
+      <h2 id="abort-modal-title">Wat wil je doen met je invoer?</h2>
+      <p>
+        Ga je op een later moment verder met het invoeren van dit stembureau? Dan kan je de invoer die je al hebt gedaan
+        bewaren.
+        <br />
+        <br />
+        Twijfel je? Overleg dan met de coördinator.
+      </p>
+      <nav>
+        <Button size="lg" onClick={onAbortModalSave} disabled={saving}>
+          Invoer bewaren
+        </Button>
+        <Button size="lg" variant="secondary" onClick={onAbortModalDelete} disabled={deleting}>
+          Niet bewaren
+        </Button>
+      </nav>
+    </Modal>
+  );
+}

--- a/frontend/app/module/input/PollingStation/PollingStation.test.tsx
+++ b/frontend/app/module/input/PollingStation/PollingStation.test.tsx
@@ -352,6 +352,27 @@ describe("Polling Station data entry integration tests", () => {
     }
   });
 
+  test("Navigating away from data entry shows abort modal", async () => {
+    render();
+    const steps = [
+      startPollingStationInput,
+      expectRecountedForm,
+      fillRecountedFormNo,
+      submit,
+      expectVotersAndVotesForm,
+      fillVotersAndVotesForm,
+    ];
+
+    for (const step of steps) {
+      await step();
+    }
+
+    await router.navigate("/");
+
+    const modal = await screen.findByTestId("abort-modal-title");
+    expect(modal).toHaveTextContent("Wat wil je doen met je invoer?");
+  });
+
   test("Progress list shows correct icons", async () => {
     render();
 


### PR DESCRIPTION
PollingStationFormNavigation is updated to block navigation outside the path of the data entry flow.
It shows the abortDataEntry modal when acticated.

closes #265 