### PR TITLE
Remove quotes from fixture polling station name

### DIFF
--- a/backend/fixtures/polling_stations.sql
+++ b/backend/fixtures/polling_stations.sql
@@ -1,5 +1,5 @@
 INSERT INTO polling_stations (id, election_id, name, number, number_of_voters, polling_station_type, street, house_number, house_number_addition, postal_code, locality)
 VALUES
-(1, 1, 'Stembureau "Op Rolletjes"', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag'),
+(1, 1, 'Op Rolletjes', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag'),
 (2, 1, 'Testplek', 34, 1000, 'bijzonder', 'Teststraat', '2', 'b', '1234 QY', 'Testdorp'),
 (3, 2, 'Testgebouw', 35, NULL, 'vaste_locatie', 'Testweg', '3', NULL, '1234 QA', 'Teststad');

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -407,7 +407,7 @@ mod tests {
         let _ = query!(r#"
 INSERT INTO polling_stations (id, election_id, name, number, number_of_voters, polling_station_type, street, house_number, house_number_addition, postal_code, locality)
 VALUES
-(1, 1, 'Stembureau "Op Rolletjes"', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag'),
+(1, 1, 'Op Rolletjes', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag'),
 (2, 1, 'Testplek', 34, NULL, 'bijzonder', 'Teststraat', '2', 'b', '1234 QY', 'Testdorp')
 "#)
             .execute(&pool)
@@ -418,7 +418,7 @@ VALUES
         let _ = query!(r#"
 INSERT INTO polling_stations (id, election_id, name, number, number_of_voters, polling_station_type, street, house_number, house_number_addition, postal_code, locality)
 VALUES
-(3, 2, 'Stembureau "Op Rolletjes"', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag');
+(3, 2, 'Op Rolletjes', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag');
 "#)
             .execute(&pool)
             .await
@@ -428,7 +428,7 @@ VALUES
         let result = query!(r#"
 INSERT INTO polling_stations (id, election_id, name, number, number_of_voters, polling_station_type, street, house_number, house_number_addition, postal_code, locality)
 VALUES
-(4, 1, 'Stembureau "Op Rolletjes"', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag');
+(4, 1, 'Op Rolletjes', 33, NULL, 'mobiel', 'Rijksweg A12', '1', NULL, '1234 YQ', 'Den Haag');
 "#)
             .execute(&pool)
             .await;

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -25,7 +25,7 @@ async fn test_polling_station_listing_works(pool: SqlitePool) {
     assert!(body
         .polling_stations
         .iter()
-        .any(|ps| ps.name == "Stembureau \"Op Rolletjes\""));
+        .any(|ps| ps.name == "Op Rolletjes"));
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("elections", "polling_stations")))]

--- a/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -48,7 +48,7 @@ describe("Test PollingStationChoiceForm", () => {
       // Test if the polling station name is shown
       await user.type(pollingStation, "33");
       const pollingStationFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
-      expect(await within(pollingStationFeedback).findByText('Stembureau "Op Rolletjes"')).toBeVisible();
+      expect(await within(pollingStationFeedback).findByText("Op Rolletjes")).toBeVisible();
     });
 
     test("Selecting a valid polling station with leading zeros", async () => {
@@ -161,7 +161,7 @@ describe("Test PollingStationChoiceForm", () => {
       // Check if the station number and name exist and are visible
       const pollingStationList = screen.getByTestId("polling_station_list");
       expect(within(pollingStationList).getByText("33")).toBeVisible();
-      expect(within(pollingStationList).getByText('Stembureau "Op Rolletjes"')).toBeVisible();
+      expect(within(pollingStationList).getByText("Op Rolletjes")).toBeVisible();
       expect(within(pollingStationList).getByText("34")).toBeVisible();
       expect(within(pollingStationList).getByText("Testplek")).toBeVisible();
     });

--- a/frontend/e2e-tests/dom-to-db-tests/test-data/PollingStationTestData.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/test-data/PollingStationTestData.ts
@@ -5,7 +5,7 @@ import { PollingStation } from "@kiesraad/api";
 export const pollingStation33: PollingStation = {
   id: 1,
   election_id: 1,
-  name: 'Stembureau "Op Rolletjes"',
+  name: "Op Rolletjes",
   number: 33,
   number_of_voters: undefined,
   polling_station_type: "Mobiel",

--- a/frontend/lib/api-mocks/PollingStationMockData.ts
+++ b/frontend/lib/api-mocks/PollingStationMockData.ts
@@ -3,7 +3,7 @@ import { PollingStation, PollingStationListResponse } from "@kiesraad/api";
 export const pollingStationMockData: PollingStation = {
   id: 1,
   election_id: 1,
-  name: 'Stembureau "Op Rolletjes"',
+  name: "Op Rolletjes",
   number: 33,
   number_of_voters: undefined,
   polling_station_type: "Mobiel",


### PR DESCRIPTION
Makes the curly typewriter quotes in the Space Grotesk font less obvious
during test/demo usage.

See https://github.com/kiesraad/abacus/issues/263#issuecomment-2296767475