### PR TITLE
Add Git commit and branch details to footer

### DIFF
--- a/frontend/app/component/footer/Footer.tsx
+++ b/frontend/app/component/footer/Footer.tsx
@@ -1,10 +1,36 @@
 export function Footer() {
+  const gitBranch = import.meta.env.GIT_BRANCH as string | undefined;
+  let gitBranchShort = gitBranch;
+  if (gitBranch && gitBranch.length > 32) {
+    gitBranchShort = gitBranch.substring(0, 32) + "…";
+  }
+  const gitCommit = import.meta.env.GIT_COMMIT as string | undefined;
+  const gitDirty = import.meta.env.GIT_DIRTY as boolean;
+  let mode = (import.meta.env.MODE as string | undefined) || "unknown";
+  mode = (mode[0]?.toUpperCase() ?? "") + mode.slice(1);
+
   return (
     <footer>
-      <section>Abacus</section>
       <section>
-        <strong>Server</strong> {process.env.MSW ? "Mocked" : "Live"} &nbsp;&nbsp;
-        <strong>Versie</strong> v{process.env.VERSION}
+        Abacus{" "}
+        {gitBranch && (
+          <>
+            — <a href={"https://github.com/kiesraad/abacus/tree/" + gitBranch}>{gitBranchShort}</a>
+          </>
+        )}
+      </section>
+      <section>
+        <strong>Server</strong> {process.env.MSW ? "Mock Service Worker" : "Live"} &nbsp;&nbsp;
+        <strong>Versie</strong>{" "}
+        {gitCommit ? (
+          gitDirty ? (
+            <>{gitCommit}-dirty</>
+          ) : (
+            <a href={"https://github.com/kiesraad/abacus/commit/" + gitCommit}>{gitCommit}</a>
+          )
+        ) : (
+          mode
+        )}
       </section>
     </footer>
   );

--- a/frontend/app/component/footer/Footer.tsx
+++ b/frontend/app/component/footer/Footer.tsx
@@ -1,11 +1,11 @@
 export function Footer() {
-  const gitBranch = import.meta.env.GIT_BRANCH as string | undefined;
-  let gitBranchShort = gitBranch;
+  const gitBranch = __GIT_BRANCH__;
+  let gitBranchShort = __GIT_BRANCH__;
   if (gitBranch && gitBranch.length > 32) {
     gitBranchShort = gitBranch.substring(0, 32) + "…";
   }
-  const gitCommit = import.meta.env.GIT_COMMIT as string | undefined;
-  const gitDirty = import.meta.env.GIT_DIRTY as boolean;
+  const gitCommit = __GIT_COMMIT__;
+  const gitDirty = __GIT_DIRTY__;
   let mode = (import.meta.env.MODE as string | undefined) || "unknown";
   mode = (mode[0]?.toUpperCase() ?? "") + mode.slice(1);
 
@@ -20,7 +20,7 @@ export function Footer() {
         )}
       </section>
       <section>
-        <strong>Server</strong> {process.env.MSW ? "Mock Service Worker" : "Live"} &nbsp;&nbsp;
+        <strong>Server</strong> {__API_MSW__ ? "Mock Service Worker" : "Live"} &nbsp;&nbsp;
         <strong>Versie</strong>{" "}
         {gitCommit ? (
           gitDirty ? (

--- a/frontend/app/component/footer/Footer.tsx
+++ b/frontend/app/component/footer/Footer.tsx
@@ -15,7 +15,10 @@ export function Footer() {
         Abacus{" "}
         {gitBranch && (
           <>
-            — <a href={"https://github.com/kiesraad/abacus/tree/" + gitBranch}>{gitBranchShort}</a>
+            —{" "}
+            <a href={"https://github.com/kiesraad/abacus/tree/" + gitBranch} target="_blank">
+              {gitBranchShort}
+            </a>
           </>
         )}
       </section>
@@ -26,7 +29,9 @@ export function Footer() {
           gitDirty ? (
             <>{gitCommit}-dirty</>
           ) : (
-            <a href={"https://github.com/kiesraad/abacus/commit/" + gitCommit}>{gitCommit}</a>
+            <a href={"https://github.com/kiesraad/abacus/commit/" + gitCommit} target="_blank">
+              {gitCommit}
+            </a>
           )
         ) : (
           mode

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
@@ -266,7 +266,7 @@ describe("Test CandidatesVotesForm", () => {
 
       expect(spy).toHaveBeenCalled();
       const { url, method, body } = getUrlMethodAndBody(spy.mock.calls);
-      expect(url).toEqual("http://testhost/api/polling_stations/1/data_entries/1");
+      expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
       expect(body).toEqual(expectedRequest);
     });

--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
@@ -53,7 +53,7 @@ describe("Test CheckAndSaveForm", () => {
 
     // check that the finalisation request was made
     expect(request_method).toBe("POST");
-    expect(request_url).toBe("http://testhost/api/polling_stations/1/data_entries/1/finalise");
+    expect(request_url).toBe("http://localhost:3000/api/polling_stations/1/data_entries/1/finalise");
 
     // check that the user is navigated back to the data entry page
     expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry#data-entry-saved");

--- a/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
@@ -206,7 +206,7 @@ describe("Test DifferencesForm", () => {
 
       expect(spy).toHaveBeenCalled();
       const { url, method, body } = getUrlMethodAndBody(spy.mock.calls);
-      expect(url).toEqual("http://testhost/api/polling_stations/1/data_entries/1");
+      expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
       expect(body).toEqual(expectedRequest);
     });

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
@@ -106,7 +106,7 @@ describe("Test RecountedForm", () => {
       expect(spy).toHaveBeenCalled();
       const { url, method, body } = getUrlMethodAndBody(spy.mock.calls);
 
-      expect(url).toEqual("http://testhost/api/polling_stations/1/data_entries/1");
+      expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
       expect(body).toEqual(expectedRequest);
     });

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -255,7 +255,7 @@ describe("Test VotersAndVotesForm", () => {
       expect(spy).toHaveBeenCalled();
       const { url, method, body } = getUrlMethodAndBody(spy.mock.calls);
 
-      expect(url).toEqual("http://testhost/api/polling_stations/1/data_entries/1");
+      expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
       expect(body).toEqual(expectedRequest);
     });

--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -22,7 +22,7 @@ function render() {
 
   root.render(
     <StrictMode>
-      <ApiProvider host={(__API_HOST__ as string | undefined) || ""}>
+      <ApiProvider>
         <RouterProvider router={router} />
       </ApiProvider>
     </StrictMode>,

--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -22,14 +22,14 @@ function render() {
 
   root.render(
     <StrictMode>
-      <ApiProvider host={process.env.API_HOST || ""}>
+      <ApiProvider host={(__API_HOST__ as string | undefined) || ""}>
         <RouterProvider router={router} />
       </ApiProvider>
     </StrictMode>,
   );
 }
 
-if (process.env.MSW) {
+if (__API_MSW__) {
   startMockAPI()
     .then(render)
     .catch((e: unknown) => {

--- a/frontend/app/module/DevHomePage.tsx
+++ b/frontend/app/module/DevHomePage.tsx
@@ -22,7 +22,7 @@ export function DevHomePage() {
           </li>
         </ul>
 
-        {process.env.MSW && <MockTest />}
+        {__API_MSW__ && <MockTest />}
       </div>
     </div>
   );

--- a/frontend/app/module/data_entry/PollingStation/AbortDataEntryControl.test.tsx
+++ b/frontend/app/module/data_entry/PollingStation/AbortDataEntryControl.test.tsx
@@ -72,7 +72,7 @@ describe("Test AbortDataEntryControl", () => {
     let request_body: POLLING_STATION_DATA_ENTRY_REQUEST_BODY | undefined;
     server.use(
       http.post<never, POLLING_STATION_DATA_ENTRY_REQUEST_BODY, DataEntryResponse | ErrorResponse>(
-        "http://testhost/api/polling_stations/1/data_entries/1",
+        "/api/polling_stations/1/data_entries/1",
         async ({ request }) => {
           request_body = await request.json();
           return HttpResponse.json({ validation_results: { errors: [], warnings: [] } }, { status: 200 });
@@ -122,7 +122,7 @@ describe("Test AbortDataEntryControl", () => {
 
     // check that the delete request was made and the user is navigated back to the data entry page
     expect(request_method).toBe("DELETE");
-    expect(request_url).toBe("http://testhost/api/polling_stations/1/data_entries/1");
+    expect(request_url).toBe("http://localhost:3000/api/polling_stations/1/data_entries/1");
 
     // check that the user is navigated back to the data entry page
     expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry");

--- a/frontend/app/routes.test.tsx
+++ b/frontend/app/routes.test.tsx
@@ -30,7 +30,7 @@ describe("routes", () => {
     // NOTE: We're not using the wrapped render function here,
     // since we want control over our own memory router.
     rtlRender(
-      <ApiProvider host="http://testhost">
+      <ApiProvider>
         <RouterProvider router={router} />
       </ApiProvider>,
     );
@@ -45,7 +45,7 @@ describe("routes", () => {
     // NOTE: We're not using the wrapped render function here,
     // since we want control over our own memory router.
     rtlRender(
-      <ApiProvider host="http://testhost">
+      <ApiProvider>
         <RouterProvider router={router} />
       </ApiProvider>,
     );
@@ -63,7 +63,7 @@ describe("routes", () => {
     // NOTE: We're not using the wrapped render function here,
     // since we want control over our own memory router.
     rtlRender(
-      <ApiProvider host="http://testhost">
+      <ApiProvider>
         <RouterProvider router={router} />
       </ApiProvider>,
     );
@@ -82,7 +82,7 @@ describe("routes", () => {
     // NOTE: We're not using the wrapped render function here,
     // since we want control over our own memory router.
     rtlRender(
-      <ApiProvider host="http://testhost">
+      <ApiProvider>
         <RouterProvider router={router} />
       </ApiProvider>,
     );

--- a/frontend/app/test/unit/Providers.tsx
+++ b/frontend/app/test/unit/Providers.tsx
@@ -15,7 +15,7 @@ export const Providers = ({
   router?: RemixRouter;
 }) => {
   return (
-    <ApiProvider host="http://testhost">
+    <ApiProvider>
       <RouterProvider router={router} />
     </ApiProvider>
   );

--- a/frontend/app/test/unit/server.ts
+++ b/frontend/app/test/unit/server.ts
@@ -12,13 +12,7 @@ import { setupServer } from "msw/node";
 
 import { handlers } from "@kiesraad/api-mocks";
 
-export const server = setupServer(
-  ...handlers.map((h) => {
-    // Node's Fetch implementation does not accept URLs with a protocol and host
-    h.info.path = "http://testhost" + h.info.path.toString();
-    return h;
-  }),
-);
+export const server = setupServer(...handlers);
 
 // Override request handlers in order to test special cases
 export function overrideOnce(
@@ -30,7 +24,7 @@ export function overrideOnce(
 ) {
   server.use(
     http[method](
-      `http://testhost${path}`,
+      path,
       async () => {
         if (delayResponse) {
           await delay(delayResponse);

--- a/frontend/app/vite-env.d.ts
+++ b/frontend/app/vite-env.d.ts
@@ -1,0 +1,6 @@
+declare const __API_MSW__: boolean;
+declare const __APP_VERSION__: string | undefined;
+declare const __API_HOST__: string;
+declare const __GIT_DIRTY__: boolean | undefined;
+declare const __GIT_BRANCH__: string | undefined;
+declare const __GIT_COMMIT__: string | undefined;

--- a/frontend/app/vite-env.d.ts
+++ b/frontend/app/vite-env.d.ts
@@ -1,6 +1,5 @@
 declare const __API_MSW__: boolean;
 declare const __APP_VERSION__: string | undefined;
-declare const __API_HOST__: string;
 declare const __GIT_DIRTY__: boolean | undefined;
 declare const __GIT_BRANCH__: string | undefined;
 declare const __GIT_COMMIT__: string | undefined;

--- a/frontend/lib/api/ApiClient.test.ts
+++ b/frontend/lib/api/ApiClient.test.ts
@@ -8,7 +8,7 @@ describe("ApiClient", () => {
   test("200 response is parsed as success", async () => {
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, { fizz: "buzz" });
 
-    const client = new ApiClient("testhost");
+    const client = new ApiClient("http://testhost");
     const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
       data: null,
     });
@@ -24,7 +24,7 @@ describe("ApiClient", () => {
     const responseBody = { fizz: "buzz" };
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", 422, responseBody);
 
-    const client = new ApiClient("testhost");
+    const client = new ApiClient("http://testhost");
     const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
       data: null,
     });
@@ -40,7 +40,7 @@ describe("ApiClient", () => {
     const responseBody = { error: "foo" };
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, responseBody);
 
-    const client = new ApiClient("testhost");
+    const client = new ApiClient("http://testhost");
     const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
       data: null,
     });
@@ -56,7 +56,7 @@ describe("ApiClient", () => {
     const responseStatus = 318;
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", responseStatus, "");
 
-    const client = new ApiClient("testhost");
+    const client = new ApiClient("http://testhost");
 
     await expect(async () => {
       await client.postRequest("/api/polling_stations/1/data_entries/1", { data: null });
@@ -66,7 +66,7 @@ describe("ApiClient", () => {
   test("Get request returns expected data", async () => {
     overrideOnce("get", "/api/test/1", 200, { fizz: "buzz" });
 
-    const client = new ApiClient("testhost");
+    const client = new ApiClient("http://testhost");
     const parsedResponse = await client.getRequest("/api/test/1");
 
     expect(parsedResponse).toStrictEqual({
@@ -79,7 +79,7 @@ describe("ApiClient", () => {
   test("Invalid server response throws an error", async () => {
     overrideOnce("get", "/api/test/1", 200, "invalid");
 
-    const client = new ApiClient("testhost");
+    const client = new ApiClient("http://testhost");
 
     // error is expected
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/frontend/lib/api/ApiClient.test.ts
+++ b/frontend/lib/api/ApiClient.test.ts
@@ -8,7 +8,7 @@ describe("ApiClient", () => {
   test("200 response is parsed as success", async () => {
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, { fizz: "buzz" });
 
-    const client = new ApiClient("http://testhost");
+    const client = new ApiClient();
     const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
       data: null,
     });
@@ -24,7 +24,7 @@ describe("ApiClient", () => {
     const responseBody = { fizz: "buzz" };
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", 422, responseBody);
 
-    const client = new ApiClient("http://testhost");
+    const client = new ApiClient();
     const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
       data: null,
     });
@@ -40,7 +40,7 @@ describe("ApiClient", () => {
     const responseBody = { error: "foo" };
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, responseBody);
 
-    const client = new ApiClient("http://testhost");
+    const client = new ApiClient();
     const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
       data: null,
     });
@@ -56,7 +56,7 @@ describe("ApiClient", () => {
     const responseStatus = 318;
     overrideOnce("post", "/api/polling_stations/1/data_entries/1", responseStatus, "");
 
-    const client = new ApiClient("http://testhost");
+    const client = new ApiClient();
 
     await expect(async () => {
       await client.postRequest("/api/polling_stations/1/data_entries/1", { data: null });
@@ -66,7 +66,7 @@ describe("ApiClient", () => {
   test("Get request returns expected data", async () => {
     overrideOnce("get", "/api/test/1", 200, { fizz: "buzz" });
 
-    const client = new ApiClient("http://testhost");
+    const client = new ApiClient();
     const parsedResponse = await client.getRequest("/api/test/1");
 
     expect(parsedResponse).toStrictEqual({
@@ -79,7 +79,7 @@ describe("ApiClient", () => {
   test("Invalid server response throws an error", async () => {
     overrideOnce("get", "/api/test/1", 200, "invalid");
 
-    const client = new ApiClient("http://testhost");
+    const client = new ApiClient();
 
     // error is expected
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/frontend/lib/api/ApiClient.ts
+++ b/frontend/lib/api/ApiClient.ts
@@ -19,12 +19,6 @@ export type ApiError = {
 };
 
 export class ApiClient {
-  host: string;
-
-  constructor(host: string) {
-    this.host = host;
-  }
-
   async responseHandler<T>(response: Response): Promise<ApiResult<T>> {
     let body;
     if (response.headers.get("Content-Type") === "application/json") {
@@ -81,13 +75,13 @@ export class ApiClient {
         body: JSON.stringify(requestBody),
       };
     }
-    const response = await fetch(this.host + path, requestInit);
+    const response = await fetch(path, requestInit);
 
     return this.responseHandler<T>(response);
   }
 
   async getRequest<T>(path: string): Promise<ApiResult<T>> {
-    const response = await fetch(this.host + path, {
+    const response = await fetch(path, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -98,7 +92,7 @@ export class ApiClient {
   }
 
   async deleteRequest<T>(path: string): Promise<ApiResult<T>> {
-    const response = await fetch(this.host + path, { method: "DELETE" });
+    const response = await fetch(path, { method: "DELETE" });
     return this.responseHandler<T>(response);
   }
 }

--- a/frontend/lib/api/ApiClient.ts
+++ b/frontend/lib/api/ApiClient.ts
@@ -69,8 +69,6 @@ export class ApiClient {
   }
 
   async postRequest<T>(path: string, requestBody?: object): Promise<ApiResult<T>> {
-    const host = process.env.NODE_ENV === "test" ? "http://testhost" : "";
-
     let requestInit: RequestInit = {
       method: "POST",
     };
@@ -83,15 +81,13 @@ export class ApiClient {
         body: JSON.stringify(requestBody),
       };
     }
-    const response = await fetch(host + path, requestInit);
+    const response = await fetch(this.host + path, requestInit);
 
     return this.responseHandler<T>(response);
   }
 
   async getRequest<T>(path: string): Promise<ApiResult<T>> {
-    const host = process.env.NODE_ENV === "test" ? "http://testhost" : "";
-
-    const response = await fetch(host + path, {
+    const response = await fetch(this.host + path, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -102,8 +98,7 @@ export class ApiClient {
   }
 
   async deleteRequest<T>(path: string): Promise<ApiResult<T>> {
-    const host = process.env.NODE_ENV === "test" ? "http://testhost" : "";
-    const response = await fetch(host + path, { method: "DELETE" });
+    const response = await fetch(this.host + path, { method: "DELETE" });
     return this.responseHandler<T>(response);
   }
 }

--- a/frontend/lib/api/ApiProvider.tsx
+++ b/frontend/lib/api/ApiProvider.tsx
@@ -9,16 +9,16 @@ export interface iApiProviderContext {
 export const ApiProviderContext = React.createContext<iApiProviderContext | null>(null);
 
 export interface ApiProviderProps {
-  host: string;
   children: React.ReactNode;
 }
 
-export function ApiProvider({ children, host }: ApiProviderProps) {
-  const context = React.useMemo(() => {
-    return {
-      client: new ApiClient(host),
-    };
-  }, [host]);
+export function ApiProvider({ children }: ApiProviderProps) {
+  const context = React.useMemo(
+    () => ({
+      client: new ApiClient(),
+    }),
+    [],
+  );
 
   return <ApiProviderContext.Provider value={context}>{children}</ApiProviderContext.Provider>;
 }

--- a/frontend/lib/api/api.test.ts
+++ b/frontend/lib/api/api.test.ts
@@ -6,7 +6,7 @@ type Response = {
 
 describe("Mock api works", () => {
   test("echos a value", async () => {
-    const resp = await fetch("http://testhost/ping", {
+    const resp = await fetch("/ping", {
       method: "POST",
       headers: {
         "content-type": "application/json",

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
@@ -8,7 +8,7 @@ import { ApiProvider, PollingStationFormController, usePollingStationFormControl
 import { electionMockData } from "@kiesraad/api-mocks";
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <ApiProvider host="http://testhost">
+  <ApiProvider>
     <PollingStationFormController election={electionMockData} pollingStationId={1} entryNumber={1}>
       {children}
     </PollingStationFormController>

--- a/frontend/lib/ui/style/layout.css
+++ b/frontend/lib/ui/style/layout.css
@@ -73,6 +73,13 @@
     padding: 2rem 5rem;
     font-size: 0.875rem;
     line-height: 1.25rem;
+    a {
+      color: var(--color-help-text);
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,60 +1,74 @@
 import react from "@vitejs/plugin-react-swc";
+import { execSync } from "node:child_process";
 import path from "path";
-import { defineConfig } from "vite";
+import { defineConfig, UserConfig } from "vite";
 
 import pkgjson from "./package.json";
 import tsConfig from "./tsconfig.json";
 
-const apiMode = process.env.API_MODE ?? "mock";
-const apiHost = process.env.API_HOST ?? (apiMode === "mock" ? "" : "http://localhost:8080");
-const viteHost = process.env.VITE_HOST ?? undefined;
-
-// https://vitejs.dev/config/
-export default defineConfig(() => ({
-  build: {
-    outDir: path.resolve(__dirname, "dist"),
-    emptyOutDir: true,
-    sourcemap: true,
-    minify: false,
-    rollupOptions: {
-      input: {
-        app: "index.html",
-      },
-    },
-  },
-  define: {
-    "process.env.MSW": apiMode === "mock",
-    "process.env.VERSION": JSON.stringify(pkgjson.version),
-    "process.env.API_HOST": JSON.stringify(apiHost),
-  },
-  optimizeDeps: { exclude: ["msw"] },
-  plugins: [react()],
-  resolve: {
-    alias: mapObj(
-      tsConfig.compilerOptions.paths,
-      (k) => k.replace("/*", ""),
-      (paths) => {
-        if (!paths[0]) throw new Error("No path found");
-        return path.resolve(__dirname, paths[0].replace("/*", ""));
-      },
-    ),
-  },
-  server: {
-    port: 3000,
-    host: viteHost,
-    proxy: {
-      "/api": {
-        target: apiHost,
-        changeOrigin: true,
-      },
-    },
-  },
-  test: {
-    environment: "jsdom",
-    setupFiles: ["app/test/unit/setup.ts"],
-    includeSource: ["app/**/*.ts", "lib/**/*.ts"],
-  },
-}));
-
 const mapObj = <V0, V>(obj: Record<string, V0>, kf: (t: string) => string, vf: (t: V0) => V): Record<string, V> =>
   Object.fromEntries(Object.entries(obj).map(([k, v]) => [kf(k), vf(v)]));
+
+// https://vitejs.dev/config/
+export default defineConfig(({ command }) => {
+  const apiMode = process.env.API_MODE ?? "mock";
+  const apiHost = process.env.API_HOST ?? (apiMode === "mock" ? "" : "http://localhost:8080");
+
+  let gitDetails = {};
+  if (command == "build") {
+    const gitDirty = execSync("git status --porcelain").toString().trimEnd().length > 0;
+    const gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trimEnd();
+    const gitCommit = execSync("git rev-parse --short HEAD").toString().trimEnd();
+    gitDetails = {
+      "import.meta.env.GIT_DIRTY": JSON.stringify(gitDirty),
+      "import.meta.env.GIT_BRANCH": JSON.stringify(gitBranch),
+      "import.meta.env.GIT_COMMIT": JSON.stringify(gitCommit),
+    };
+  }
+
+  return {
+    build: {
+      outDir: path.resolve(__dirname, "dist"),
+      emptyOutDir: true,
+      sourcemap: true,
+      minify: false,
+      rollupOptions: {
+        input: {
+          app: "index.html",
+        },
+      },
+    },
+    define: {
+      "process.env.MSW": apiMode === "mock",
+      "process.env.VERSION": JSON.stringify(pkgjson.version),
+      "process.env.API_HOST": JSON.stringify(apiHost),
+      ...gitDetails,
+    },
+    optimizeDeps: { exclude: ["msw"] },
+    plugins: [react()],
+    resolve: {
+      alias: mapObj(
+        tsConfig.compilerOptions.paths,
+        (k) => k.replace("/*", ""),
+        (paths) => {
+          if (!paths[0]) throw new Error("No path found");
+          return path.resolve(__dirname, paths[0].replace("/*", ""));
+        },
+      ),
+    },
+    server: {
+      port: 3000,
+      proxy: {
+        "/api": {
+          target: apiHost,
+          changeOrigin: true,
+        },
+      },
+    },
+    test: {
+      environment: "jsdom",
+      setupFiles: ["app/test/unit/setup.ts"],
+      includeSource: ["app/**/*.ts", "lib/**/*.ts"],
+    },
+  } satisfies UserConfig;
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,15 +14,19 @@ export default defineConfig(({ command }) => {
   const apiMode = process.env.API_MODE ?? "mock";
   const apiHost = process.env.API_HOST ?? (apiMode === "mock" ? "" : "http://localhost:8080");
 
-  let gitDetails = {};
+  let gitDetails = {
+    __GIT_DIRTY__: undefined as string | undefined,
+    __GIT_BRANCH__: undefined as string | undefined,
+    __GIT_COMMIT__: undefined as string | undefined,
+  };
   if (command == "build") {
     const gitDirty = execSync("git status --porcelain").toString().trimEnd().length > 0;
     const gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trimEnd();
     const gitCommit = execSync("git rev-parse --short HEAD").toString().trimEnd();
     gitDetails = {
-      "import.meta.env.GIT_DIRTY": JSON.stringify(gitDirty),
-      "import.meta.env.GIT_BRANCH": JSON.stringify(gitBranch),
-      "import.meta.env.GIT_COMMIT": JSON.stringify(gitCommit),
+      __GIT_DIRTY__: JSON.stringify(gitDirty),
+      __GIT_BRANCH__: JSON.stringify(gitBranch),
+      __GIT_COMMIT__: JSON.stringify(gitCommit),
     };
   }
 
@@ -39,9 +43,9 @@ export default defineConfig(({ command }) => {
       },
     },
     define: {
-      "process.env.MSW": apiMode === "mock",
-      "process.env.VERSION": JSON.stringify(pkgjson.version),
-      "process.env.API_HOST": JSON.stringify(apiHost),
+      __API_MSW__: JSON.stringify(apiMode === "mock"),
+      __APP_VERSION__: JSON.stringify(pkgjson.version),
+      __API_HOST__: JSON.stringify(apiHost),
       ...gitDetails,
     },
     optimizeDeps: { exclude: ["msw"] },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(({ command }) => {
   };
   if (command == "build") {
     const gitDirty = execSync("git status --porcelain").toString().trimEnd().length > 0;
-    const gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trimEnd();
+    const gitBranch = process.env.GITHUB_HEAD_REF ?? execSync("git rev-parse --abbrev-ref HEAD").toString().trimEnd();
     const gitCommit = execSync("git rev-parse --short HEAD").toString().trimEnd();
     gitDetails = {
       __GIT_DIRTY__: JSON.stringify(gitDirty),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,7 @@ const mapObj = <V0, V>(obj: Record<string, V0>, kf: (t: string) => string, vf: (
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
   const apiMode = process.env.API_MODE ?? "mock";
-  const apiHost = process.env.API_HOST ?? (apiMode === "mock" ? "" : "http://localhost:8080");
+  const apiHost = process.env.API_HOST ?? "";
 
   let gitDetails = {
     __GIT_DIRTY__: undefined as string | undefined,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,9 +11,9 @@ const mapObj = <V0, V>(obj: Record<string, V0>, kf: (t: string) => string, vf: (
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
-  const apiMode = process.env.API_MODE ?? "mock";
-  const apiHost = process.env.API_HOST ?? "";
+  const apiHost = process.env.API_HOST ?? "http://localhost:8080";
 
+  const mswEnabled = process.env.API_MODE == "mock";
   let gitDetails = {
     __GIT_DIRTY__: undefined as string | undefined,
     __GIT_BRANCH__: undefined as string | undefined,
@@ -43,9 +43,8 @@ export default defineConfig(({ command }) => {
       },
     },
     define: {
-      __API_MSW__: JSON.stringify(apiMode === "mock"),
+      __API_MSW__: JSON.stringify(mswEnabled),
       __APP_VERSION__: JSON.stringify(pkgjson.version),
-      __API_HOST__: JSON.stringify(apiHost),
       ...gitDetails,
     },
     optimizeDeps: { exclude: ["msw"] },


### PR DESCRIPTION
Add Git commit and branch details to footer, but only for Vite builds. During Vite serve (e.g. `npm run dev`) the Git tree might change without a chance to reload the variables, and we do not want to show stale details.

The second commit cleans up up Vite `define` usage to use global variables as used in the Vite docs:
https://vitejs.dev/config/shared-options.html#define

It also fixes the `host` field in `ApiClient` being unused.

Closes #328.