### PR TITLE
Resume data entry (without form state)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -210,12 +210,75 @@
       }
     },
     "/api/polling_stations/{polling_station_id}/data_entries/{entry_number}": {
+      "get": {
+        "tags": [
+          "polling_station"
+        ],
+        "summary": "Get an in-progress (not finalised) data entry for a polling station",
+        "operationId": "polling_station_data_entry_get",
+        "parameters": [
+          {
+            "name": "polling_station_id",
+            "in": "path",
+            "description": "Polling station database id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "entry_number",
+            "in": "path",
+            "description": "Data entry number (first or second data entry)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Data entry retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDataEntryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "polling_station"
         ],
         "summary": "Save or update a data entry for a polling station",
-        "operationId": "polling_station_data_entry",
+        "operationId": "polling_station_data_entry_save",
         "parameters": [
           {
             "name": "polling_station_id",
@@ -244,7 +307,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DataEntryRequest"
+                "$ref": "#/components/schemas/SaveDataEntryRequest"
               }
             }
           },
@@ -256,7 +319,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataEntryResponse"
+                  "$ref": "#/components/schemas/SaveDataEntryResponse"
                 }
               }
             }
@@ -393,14 +456,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Data entry finalised successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DataEntryResponse"
-                }
-              }
-            }
+            "description": "Data entry finalised successfully"
           },
           "404": {
             "description": "Not found",
@@ -519,30 +575,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          }
-        }
-      },
-      "DataEntryRequest": {
-        "type": "object",
-        "description": "Request structure for data entry of polling station results",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/PollingStationResults"
-          }
-        }
-      },
-      "DataEntryResponse": {
-        "type": "object",
-        "description": "Response structure for data entry of polling station results",
-        "required": [
-          "validation_results"
-        ],
-        "properties": {
-          "validation_results": {
-            "$ref": "#/components/schemas/ValidationResults"
           }
         }
       },
@@ -717,6 +749,22 @@
         "properties": {
           "error": {
             "type": "string"
+          }
+        }
+      },
+      "GetDataEntryResponse": {
+        "type": "object",
+        "description": "Response structure for getting data entry of polling station results",
+        "required": [
+          "data",
+          "validation_results"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PollingStationResults"
+          },
+          "validation_results": {
+            "$ref": "#/components/schemas/ValidationResults"
           }
         }
       },
@@ -902,6 +950,30 @@
           "Bijzonder",
           "Mobiel"
         ]
+      },
+      "SaveDataEntryRequest": {
+        "type": "object",
+        "description": "Request structure for saving data entry of polling station results",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PollingStationResults"
+          }
+        }
+      },
+      "SaveDataEntryResponse": {
+        "type": "object",
+        "description": "Response structure for saving data entry of polling station results",
+        "required": [
+          "validation_results"
+        ],
+        "properties": {
+          "validation_results": {
+            "$ref": "#/components/schemas/ValidationResults"
+          }
+        }
       },
       "ValidationResult": {
         "type": "object",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -33,7 +33,11 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
     let polling_station_routes = Router::new()
         .route(
             "/:polling_station_id/data_entries/:entry_number",
-            post(polling_station::polling_station_data_entry),
+            post(polling_station::polling_station_data_entry_save),
+        )
+        .route(
+            "/:polling_station_id/data_entries/:entry_number",
+            get(polling_station::polling_station_data_entry_get),
         )
         .route(
             "/:polling_station_id/data_entries/:entry_number",
@@ -86,7 +90,8 @@ pub fn create_openapi() -> utoipa::openapi::OpenApi {
             election::election_details,
             election::election_status,
             election::election_download_results,
-            polling_station::polling_station_data_entry,
+            polling_station::polling_station_data_entry_save,
+            polling_station::polling_station_data_entry_get,
             polling_station::polling_station_data_entry_delete,
             polling_station::polling_station_data_entry_finalise,
         ),
@@ -105,8 +110,9 @@ pub fn create_openapi() -> utoipa::openapi::OpenApi {
                 election::ElectionDetailsResponse,
                 election::ElectionStatusResponse,
                 polling_station::CandidateVotes,
-                polling_station::DataEntryRequest,
-                polling_station::DataEntryResponse,
+                polling_station::SaveDataEntryRequest,
+                polling_station::SaveDataEntryResponse,
+                polling_station::GetDataEntryResponse,
                 polling_station::DifferencesCounts,
                 polling_station::PoliticalGroupVotes,
                 polling_station::PollingStationResults,

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, ToSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, ToSchema, Debug, Default, PartialEq, Eq)]
 pub struct ValidationResults {
     pub errors: Vec<ValidationResult>,
     pub warnings: Vec<ValidationResult>,
@@ -22,7 +22,7 @@ impl ValidationResults {
     }
 }
 
-#[derive(Serialize, Deserialize, ToSchema, Debug)]
+#[derive(Serialize, Deserialize, ToSchema, Debug, PartialEq, Eq)]
 pub struct ValidationResult {
     pub fields: Vec<String>,
     pub code: ValidationResultCode,

--- a/backend/tests/shared.rs
+++ b/backend/tests/shared.rs
@@ -3,13 +3,13 @@
 use std::net::SocketAddr;
 
 use backend::polling_station::{
-    CandidateVotes, DataEntryRequest, DataEntryResponse, DifferencesCounts, PoliticalGroupVotes,
-    PollingStationResults, VotersCounts, VotesCounts,
+    CandidateVotes, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
+    SaveDataEntryRequest, SaveDataEntryResponse, VotersCounts, VotesCounts,
 };
 use hyper::StatusCode;
 
-pub fn example_data_entry() -> DataEntryRequest {
-    DataEntryRequest {
+pub fn example_data_entry() -> SaveDataEntryRequest {
+    SaveDataEntryRequest {
         data: PollingStationResults {
             recounted: false,
             voters_counts: VotersCounts {
@@ -69,7 +69,7 @@ pub async fn create_and_finalise_data_entry(addr: &SocketAddr) {
         println!("Response body: {:?}", &response.text().await.unwrap());
         panic!("Unexpected response status: {:?}", status);
     }
-    let validation_results: DataEntryResponse = response.json().await.unwrap();
+    let validation_results: SaveDataEntryResponse = response.json().await.unwrap();
     assert_eq!(validation_results.validation_results.errors.len(), 0);
     assert_eq!(validation_results.validation_results.warnings.len(), 0);
 

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
@@ -285,7 +285,7 @@ describe("Test CandidatesVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -316,7 +316,7 @@ describe("Test CandidatesVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =

--- a/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
@@ -177,7 +177,7 @@ describe("Test DifferencesForm", () => {
         ...expectedRequest.data.differences_counts,
       });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       expect(spy).toHaveBeenCalled();
@@ -201,7 +201,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -235,7 +235,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: true });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -269,7 +269,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -303,7 +303,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: true });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -349,7 +349,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -397,7 +397,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -464,7 +464,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -510,7 +510,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
@@ -18,13 +18,12 @@ const Component = (
 describe("Test RecountedForm", () => {
   describe("RecountedForm user interactions", () => {
     test("hitting enter key does not result in api call", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
-      const user = userEvent.setup();
-
       render(Component);
 
-      const yes = screen.getByTestId("yes");
+      const user = userEvent.setup();
+      const spy = vi.spyOn(global, "fetch");
+
+      const yes = await screen.findByTestId("yes");
       await user.click(yes);
       expect(yes).toBeChecked();
 
@@ -34,13 +33,12 @@ describe("Test RecountedForm", () => {
     });
 
     test("hitting shift+enter does result in api call", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
-      const user = userEvent.setup();
-
       render(Component);
 
-      const yes = screen.getByTestId("yes");
+      const user = userEvent.setup();
+      const spy = vi.spyOn(global, "fetch");
+
+      const yes = await screen.findByTestId("yes");
       await user.click(yes);
       expect(yes).toBeChecked();
 
@@ -58,8 +56,8 @@ describe("Test RecountedForm", () => {
 
       render(Component);
 
-      const yes = screen.getByTestId("yes");
-      const no = screen.getByTestId("no");
+      const yes = await screen.findByTestId("yes");
+      const no = await screen.findByTestId("no");
 
       expect(yes).not.toBeChecked();
       expect(no).not.toBeChecked();
@@ -78,8 +76,6 @@ describe("Test RecountedForm", () => {
 
   describe("RecountedForm API request and response", () => {
     test("RecountedForm request body is equal to the form data", async () => {
-      const spy = vi.spyOn(global, "fetch");
-
       const expectedRequest = {
         data: {
           ...emptyDataEntryRequest.data,
@@ -93,14 +89,15 @@ describe("Test RecountedForm", () => {
         },
       };
 
-      const user = userEvent.setup();
-
       render(Component);
 
-      const yes = screen.getByTestId("yes");
+      const spy = vi.spyOn(global, "fetch");
+      const user = userEvent.setup();
+
+      const yes = await screen.findByTestId("yes");
       await user.click(yes);
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       expect(spy).toHaveBeenCalled();
@@ -122,8 +119,8 @@ describe("Test RecountedForm", () => {
 
       render(Component);
 
-      const yes = screen.getByTestId("yes");
-      const no = screen.getByTestId("no");
+      const yes = await screen.findByTestId("yes");
+      const no = await screen.findByTestId("no");
       const submitButton = screen.getByRole("button", { name: "Volgende" });
 
       expect(yes).not.toBeChecked();

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -226,7 +226,7 @@ describe("Test VotersAndVotesForm", () => {
         ...expectedRequest.data.votes_counts,
       });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       expect(spy).toHaveBeenCalled();
@@ -261,7 +261,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -308,7 +308,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -355,7 +355,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: true });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -399,7 +399,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -484,7 +484,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -519,7 +519,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -559,7 +559,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -601,7 +601,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: true });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -640,7 +640,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -680,7 +680,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -722,7 +722,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: true });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -765,7 +765,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =
@@ -813,7 +813,7 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: true });
 
-      const submitButton = screen.getByRole("button", { name: "Volgende" });
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
 
       const feedbackMessage =

--- a/frontend/app/module/data_entry/PollingStation/AbortDataEntryControl.test.tsx
+++ b/frontend/app/module/data_entry/PollingStation/AbortDataEntryControl.test.tsx
@@ -9,11 +9,11 @@ import { overrideOnce, render, screen, server } from "app/test/unit";
 import { emptyDataEntryRequest } from "app/test/unit/form";
 
 import {
-  DataEntryResponse,
   ElectionProvider,
   ErrorResponse,
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   PollingStationFormController,
+  SaveDataEntryResponse,
 } from "@kiesraad/api";
 import { electionDetailsMockResponse, electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
@@ -69,9 +69,9 @@ describe("Test AbortDataEntryControl", () => {
 
     // set up a custom request handler that saves the request body
     // this cannot be done with a listener because it would consume the request body
-    let request_body: POLLING_STATION_DATA_ENTRY_REQUEST_BODY | undefined;
+    let request_body: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY | undefined;
     server.use(
-      http.post<never, POLLING_STATION_DATA_ENTRY_REQUEST_BODY, DataEntryResponse | ErrorResponse>(
+      http.post<never, POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY, SaveDataEntryResponse | ErrorResponse>(
         "/api/polling_stations/1/data_entries/1",
         async ({ request }) => {
           request_body = await request.json();

--- a/frontend/app/test/unit/form.ts
+++ b/frontend/app/test/unit/form.ts
@@ -1,7 +1,7 @@
-import { FormState, POLLING_STATION_DATA_ENTRY_REQUEST_BODY, ValidationResult } from "@kiesraad/api";
+import { FormState, POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY, ValidationResult } from "@kiesraad/api";
 import { electionMockData } from "@kiesraad/api-mocks";
 
-export const emptyDataEntryRequest: POLLING_STATION_DATA_ENTRY_REQUEST_BODY = {
+export const emptyDataEntryRequest: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY = {
   data: {
     recounted: false,
     voters_counts: {

--- a/frontend/lib/api-mocks/RequestHandlers.ts
+++ b/frontend/lib/api-mocks/RequestHandlers.ts
@@ -1,10 +1,10 @@
 import { http, type HttpHandler, HttpResponse } from "msw";
 
 import {
-  DataEntryResponse,
   ErrorResponse,
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
-  POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS,
+  SaveDataEntryResponse,
 } from "@kiesraad/api";
 
 import { electionListMockResponse, electionStatusMockResponse, getElectionMockData } from "./ElectionMockData";
@@ -60,15 +60,15 @@ export const ElectionStatusRequestHandler = http.get<ParamsToString<{ election_i
 );
 
 export const PollingStationDataEntryHandler = http.post<
-  ParamsToString<POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS>,
-  POLLING_STATION_DATA_ENTRY_REQUEST_BODY,
-  DataEntryResponse | ErrorResponse
+  ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
+  SaveDataEntryResponse | ErrorResponse
 >("/api/polling_stations/:polling_station_id/data_entries/:entry_number", async ({ request }) => {
-  let json: POLLING_STATION_DATA_ENTRY_REQUEST_BODY;
+  let json: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY;
 
   try {
     json = await request.json();
-    const response: DataEntryResponse = {
+    const response: SaveDataEntryResponse = {
       validation_results: {
         errors: [],
         warnings: [],
@@ -304,14 +304,14 @@ export const PollingStationDataEntryHandler = http.post<
 
 // delete data entry handler
 export const PollingStationDataEntryDeleteHandler = http.delete<
-  ParamsToString<POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS>
+  ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
 >("/api/polling_stations/:polling_station_id/data_entries/:entry_number", () => {
   return HttpResponse.text(null, { status: 204 });
 });
 
 // finalise data entry handler
 export const PollingStationDataEntryFinaliseHandler = http.post<
-  ParamsToString<POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS>
+  ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
 >("/api/polling_stations/:polling_station_id/data_entries/:entry_number/finalise", () => {
   return HttpResponse.text(null, { status: 200 });
 });

--- a/frontend/lib/api-mocks/RequestHandlers.ts
+++ b/frontend/lib/api-mocks/RequestHandlers.ts
@@ -21,6 +21,7 @@ type PingResponseBody = {
   pong: string;
 };
 
+// ping handler for testing
 const pingHandler = http.post<PingParams, PingRequestBody, PingResponseBody>("/ping", async ({ request }) => {
   const data = await request.json();
 
@@ -31,10 +32,12 @@ const pingHandler = http.post<PingParams, PingRequestBody, PingResponseBody>("/p
   });
 });
 
+// get election list handler
 export const ElectionListRequestHandler = http.get("/api/elections", () => {
   return HttpResponse.json(electionListMockResponse, { status: 200 });
 });
 
+// get election details handler
 export const ElectionRequestHandler = http.get<ParamsToString<{ election_id: number }>>(
   "/api/elections/:election_id",
   ({ params }) => {
@@ -47,6 +50,7 @@ export const ElectionRequestHandler = http.get<ParamsToString<{ election_id: num
   },
 );
 
+// get election status handler
 export const ElectionStatusRequestHandler = http.get<ParamsToString<{ election_id: number }>>(
   "/api/elections/:election_id/status",
   ({ params }) => {
@@ -59,7 +63,8 @@ export const ElectionStatusRequestHandler = http.get<ParamsToString<{ election_i
   },
 );
 
-export const PollingStationDataEntryHandler = http.post<
+// save data entry handler
+export const PollingStationDataEntrySaveHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   SaveDataEntryResponse | ErrorResponse
@@ -302,6 +307,14 @@ export const PollingStationDataEntryHandler = http.post<
   }
 });
 
+// get data entry handler
+export const PollingStationDataEntryGetHandler = http.get<
+  ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
+>("/api/polling_stations/:polling_station_id/data_entries/:entry_number", () => {
+  // Currently we have no persistence in MSW, so always return 404
+  return HttpResponse.text(null, { status: 404 });
+});
+
 // delete data entry handler
 export const PollingStationDataEntryDeleteHandler = http.delete<
   ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
@@ -321,7 +334,8 @@ export const handlers: HttpHandler[] = [
   ElectionListRequestHandler,
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
-  PollingStationDataEntryHandler,
+  PollingStationDataEntrySaveHandler,
+  PollingStationDataEntryGetHandler,
   PollingStationDataEntryDeleteHandler,
   PollingStationDataEntryFinaliseHandler,
 ];

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
@@ -21,6 +21,11 @@ describe("PollingStationFormController", () => {
       wrapper: Wrapper,
     });
 
+    // wait for the controller to be initialised
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
+
     result.current.registerCurrentForm({
       id: "recounted",
       type: "recounted",
@@ -93,6 +98,11 @@ describe("PollingStationFormController", () => {
 
     const { result } = renderHook(() => usePollingStationFormController(), {
       wrapper: Wrapper,
+    });
+
+    // wait for the controller to be initialised
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
     });
 
     result.current.registerCurrentForm({

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -4,11 +4,11 @@ import {
   addValidationResultToFormState,
   ApiError,
   ApiResponseStatus,
-  DataEntryResponse,
   Election,
   isGlobalValidationResult,
-  POLLING_STATION_DATA_ENTRY_REQUEST_PATH,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH,
   PollingStationResults,
+  SaveDataEntryResponse,
   useApi,
   ValidationResult,
   VotersRecounts,
@@ -141,7 +141,7 @@ export function PollingStationFormController({
   defaultFormState = {},
   defaultCurrentForm = null,
 }: PollingStationFormControllerProps) {
-  const request_path: POLLING_STATION_DATA_ENTRY_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
+  const request_path: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
 
   const temporaryCache = React.useRef<TemporaryCache | null>(null);
 
@@ -372,7 +372,7 @@ export function PollingStationFormController({
       setApiError(response);
       throw new Error("Failed to save data entry");
     }
-    const data = response.data as DataEntryResponse;
+    const data = response.data as SaveDataEntryResponse;
     setApiError(null);
 
     // update form state based on response

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -1,15 +1,20 @@
 import * as React from "react";
+import { useEffect } from "react";
 
 import {
   addValidationResultToFormState,
   ApiError,
   ApiResponseStatus,
   Election,
+  GetDataEntryResponse,
+  getInitialFormState,
+  getInitialValues,
   isGlobalValidationResult,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH,
   PollingStationResults,
   SaveDataEntryResponse,
   useApi,
+  useApiGetRequest,
   ValidationResult,
   VotersRecounts,
 } from "@kiesraad/api";
@@ -126,7 +131,7 @@ export const PollingStationControllerContext = React.createContext<iPollingStati
   undefined,
 );
 
-const INITIAL_FORM_SECTION_ID: FormSectionID = "recounted";
+export const INITIAL_FORM_SECTION_ID: FormSectionID = "recounted";
 
 // Status of the form controller
 // This is a type instead of an enum because of https://github.com/ArnaudBarre/eslint-plugin-react-refresh/issues/36
@@ -137,131 +142,59 @@ export function PollingStationFormController({
   pollingStationId,
   entryNumber,
   children,
-  defaultValues = {},
-  defaultFormState = {},
+  defaultValues = undefined,
+  defaultFormState = undefined,
   defaultCurrentForm = null,
 }: PollingStationFormControllerProps) {
   const request_path: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
+  const { client } = useApi();
+
+  // TODO: #277 render custom error page instead of passing error down
+  const [apiError, setApiError] = React.useState<ApiError | null>(null);
+
+  const [values, setValues] = React.useState<PollingStationValues>();
+
+  const initialDataRequest = useApiGetRequest<GetDataEntryResponse>(request_path);
+  useEffect(() => {
+    if (initialDataRequest.data) {
+      const responseData = initialDataRequest.data;
+      setValues(responseData.data);
+      setFormState((old) => {
+        const newFormState = { ...old };
+        addValidationResultToFormState(newFormState, responseData.validation_results.errors, "errors");
+        addValidationResultToFormState(newFormState, responseData.validation_results.warnings, "warnings");
+        return newFormState;
+      });
+    } else if (initialDataRequest.error) {
+      if (initialDataRequest.error.code === 404) {
+        // data entry not found, set initial values
+        setValues(getInitialValues(election, defaultValues));
+      } else {
+        setApiError(initialDataRequest.error);
+        throw new Error("Failed to load data entry");
+      }
+    }
+  }, [initialDataRequest.data, initialDataRequest.error, defaultValues, election]);
+
+  const [formState, setFormState] = React.useState<FormState>(() => {
+    return getInitialFormState(election, defaultFormState);
+  });
+
+  // status as ref, because it needs to immediately propagate to the blocker function in `PollingStationFormNavigation`
+  const status = React.useRef<Status>("idle");
 
   const temporaryCache = React.useRef<TemporaryCache | null>(null);
+  const setTemporaryCache = React.useCallback((cache: TemporaryCache | null) => {
+    //OPTIONAL: allow only cache for unvalidated data
+    temporaryCache.current = cache;
+    return true;
+  }, []);
 
   //reference to the current form on screen
   const currentForm = React.useRef<AnyFormReference | null>(defaultCurrentForm);
 
   //where to navigate to next
   const [targetFormSection, setTargetFormSection] = React.useState<FormSectionID | null>(INITIAL_FORM_SECTION_ID);
-
-  // status as ref, because it needs to immediately propagate to the blocker function in `PollingStationFormNavigation`
-  const status = React.useRef<Status>("idle");
-
-  // TODO: #277 render custom error page instead of passing error down
-  const [apiError, setApiError] = React.useState<ApiError | null>(null);
-
-  const [formState, setFormState] = React.useState<FormState>(() => {
-    const result: FormState = {
-      active: INITIAL_FORM_SECTION_ID,
-      current: INITIAL_FORM_SECTION_ID,
-      sections: {
-        recounted: {
-          index: 0,
-          id: "recounted",
-          title: "Is er herteld?",
-          isSaved: false,
-          ignoreWarnings: false,
-          errors: [],
-          warnings: [],
-        },
-        voters_votes_counts: {
-          index: 1,
-          id: "voters_votes_counts",
-          title: "Toegelaten kiezers en uitgebrachte stemmen",
-          isSaved: false,
-          ignoreWarnings: false,
-          errors: [],
-          warnings: [],
-        },
-        differences_counts: {
-          index: 2,
-          id: "differences_counts",
-          title: "Verschillen",
-          isSaved: false,
-          ignoreWarnings: false,
-          errors: [],
-          warnings: [],
-        },
-        save: {
-          index: election.political_groups.length + 3,
-          id: "save",
-          title: "Controleren en opslaan",
-          isSaved: false,
-          ignoreWarnings: false,
-          errors: [],
-          warnings: [],
-        },
-      },
-      unknown: {
-        errors: [],
-        warnings: [],
-      },
-      isCompleted: false,
-    };
-
-    election.political_groups.forEach((pg, n) => {
-      result.sections[`political_group_votes_${pg.number}`] = {
-        index: n + 3,
-        id: `political_group_votes_${pg.number}`,
-        title: pg.name,
-        isSaved: false,
-        ignoreWarnings: false,
-        errors: [],
-        warnings: [],
-      };
-    });
-
-    return structuredClone({ ...result, ...defaultFormState });
-  });
-  const { client } = useApi();
-
-  const [values, setValues] = React.useState<PollingStationValues>(() => ({
-    recounted: undefined,
-    voters_counts: {
-      poll_card_count: 0,
-      proxy_certificate_count: 0,
-      voter_card_count: 0,
-      total_admitted_voters_count: 0,
-    },
-    votes_counts: {
-      votes_candidates_count: 0,
-      blank_votes_count: 0,
-      invalid_votes_count: 0,
-      total_votes_cast_count: 0,
-    },
-    voters_recounts: undefined,
-    differences_counts: {
-      more_ballots_count: 0,
-      fewer_ballots_count: 0,
-      unreturned_ballots_count: 0,
-      too_few_ballots_handed_out_count: 0,
-      too_many_ballots_handed_out_count: 0,
-      other_explanation_count: 0,
-      no_explanation_count: 0,
-    },
-    political_group_votes: election.political_groups.map((pg) => ({
-      number: pg.number,
-      total: 0,
-      candidate_votes: pg.candidates.map((c) => ({
-        number: c.number,
-        votes: 0,
-      })),
-    })),
-    ...defaultValues,
-  }));
-
-  const setTemporaryCache = React.useCallback((cache: TemporaryCache | null) => {
-    //OPTIONAL: allow only cache for unvalidated data
-    temporaryCache.current = cache;
-    return true;
-  }, []);
 
   //tell the "outside world" which form section to show next
   React.useEffect(() => {
@@ -297,6 +230,11 @@ export function PollingStationFormController({
     [currentForm, formState],
   );
 
+  if (values === undefined) {
+    // loading
+    return null;
+  }
+
   const submitCurrentForm = async (ignoreWarnings = false) => {
     // React state is fixed within one render, so we update our own copy instead of using setValues directly
     let newValues: PollingStationValues = values;
@@ -319,7 +257,7 @@ export function PollingStationFormController({
           const formValues = ref.getValues();
           let voters_recounts: VotersRecounts | undefined = undefined;
           if (formValues.recounted) {
-            if (values.voters_recounts !== undefined) {
+            if (values.voters_recounts) {
               voters_recounts = values.voters_recounts;
             } else {
               voters_recounts = {

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useEffect } from "react";
 
 import {
   addValidationResultToFormState,
@@ -155,7 +154,7 @@ export function PollingStationFormController({
   const [values, setValues] = React.useState<PollingStationValues>();
 
   const initialDataRequest = useApiGetRequest<GetDataEntryResponse>(request_path);
-  useEffect(() => {
+  React.useEffect(() => {
     if (initialDataRequest.data) {
       const responseData = initialDataRequest.data;
       setValues(responseData.data);

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
@@ -296,7 +296,10 @@ function sortFormSections(a: FormSection, b: FormSection): number {
   return 0;
 }
 
-export function getInitialValues(election: Required<Election>, defaultValues?: Partial<PollingStationValues>) {
+export function getInitialValues(
+  election: Required<Election>,
+  defaultValues?: Partial<PollingStationValues>,
+): PollingStationValues {
   return {
     recounted: undefined,
     voters_counts: {
@@ -333,7 +336,7 @@ export function getInitialValues(election: Required<Election>, defaultValues?: P
   };
 }
 
-export function getInitialFormState(election: Required<Election>, defaultFormState?: Partial<FormState>) {
+export function getInitialFormState(election: Required<Election>, defaultFormState?: Partial<FormState>): FormState {
   const result: FormState = {
     active: INITIAL_FORM_SECTION_ID,
     current: INITIAL_FORM_SECTION_ID,

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
@@ -1,6 +1,6 @@
 import { ErrorsAndWarnings, FieldValidationResult } from "lib/api/api";
 
-import { ValidationResult } from "@kiesraad/api";
+import { Election, ValidationResult } from "@kiesraad/api";
 import { ValidationResultType } from "@kiesraad/ui";
 import { deepEqual, fieldNameFromPath, FieldSection, objectHasOnlyEmptyValues, rootFieldSection } from "@kiesraad/util";
 
@@ -10,6 +10,7 @@ import {
   FormSection,
   FormSectionID,
   FormState,
+  INITIAL_FORM_SECTION_ID,
   PollingStationValues,
 } from "./PollingStationFormController";
 import { DifferencesValues } from "./useDifferences";
@@ -293,4 +294,105 @@ function sortFormSections(a: FormSection, b: FormSection): number {
   if (a.index < b.index) return -1;
   if (a.index > b.index) return 1;
   return 0;
+}
+
+export function getInitialValues(election: Required<Election>, defaultValues?: Partial<PollingStationValues>) {
+  return {
+    recounted: undefined,
+    voters_counts: {
+      poll_card_count: 0,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 0,
+    },
+    votes_counts: {
+      votes_candidates_count: 0,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 0,
+    },
+    voters_recounts: undefined,
+    differences_counts: {
+      more_ballots_count: 0,
+      fewer_ballots_count: 0,
+      unreturned_ballots_count: 0,
+      too_few_ballots_handed_out_count: 0,
+      too_many_ballots_handed_out_count: 0,
+      other_explanation_count: 0,
+      no_explanation_count: 0,
+    },
+    political_group_votes: election.political_groups.map((pg) => ({
+      number: pg.number,
+      total: 0,
+      candidate_votes: pg.candidates.map((c) => ({
+        number: c.number,
+        votes: 0,
+      })),
+    })),
+    ...defaultValues,
+  };
+}
+
+export function getInitialFormState(election: Required<Election>, defaultFormState?: Partial<FormState>) {
+  const result: FormState = {
+    active: INITIAL_FORM_SECTION_ID,
+    current: INITIAL_FORM_SECTION_ID,
+    sections: {
+      recounted: {
+        index: 0,
+        id: "recounted",
+        title: "Is er herteld?",
+        isSaved: false,
+        ignoreWarnings: false,
+        errors: [],
+        warnings: [],
+      },
+      voters_votes_counts: {
+        index: 1,
+        id: "voters_votes_counts",
+        title: "Toegelaten kiezers en uitgebrachte stemmen",
+        isSaved: false,
+        ignoreWarnings: false,
+        errors: [],
+        warnings: [],
+      },
+      differences_counts: {
+        index: 2,
+        id: "differences_counts",
+        title: "Verschillen",
+        isSaved: false,
+        ignoreWarnings: false,
+        errors: [],
+        warnings: [],
+      },
+      save: {
+        index: election.political_groups.length + 3,
+        id: "save",
+        title: "Controleren en opslaan",
+        isSaved: false,
+        ignoreWarnings: false,
+        errors: [],
+        warnings: [],
+      },
+    },
+    unknown: {
+      errors: [],
+      warnings: [],
+    },
+    isCompleted: false,
+  };
+
+  election.political_groups.forEach((pg, n) => {
+    result.sections[`political_group_votes_${pg.number}`] = {
+      index: n + 3,
+      id: `political_group_votes_${pg.number}`,
+      title: pg.name,
+      isSaved: false,
+      ignoreWarnings: false,
+      errors: [],
+      warnings: [],
+    };
+  });
+
+  return structuredClone({ ...result, ...defaultFormState });
 }

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -25,12 +25,12 @@ export interface ELECTION_STATUS_REQUEST_PARAMS {
 export type ELECTION_STATUS_REQUEST_PATH = `/api/elections/${number}/status`;
 
 // /api/polling_stations/{polling_station_id}/data_entries/{entry_number}
-export interface POLLING_STATION_DATA_ENTRY_REQUEST_PARAMS {
+export interface POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS {
   polling_station_id: number;
   entry_number: number;
 }
-export type POLLING_STATION_DATA_ENTRY_REQUEST_PATH = `/api/polling_stations/${number}/data_entries/${number}`;
-export type POLLING_STATION_DATA_ENTRY_REQUEST_BODY = DataEntryRequest;
+export type POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${number}/data_entries/${number}`;
+export type POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY = SaveDataEntryRequest;
 
 // /api/polling_stations/{polling_station_id}/data_entries/{entry_number}/finalise
 export interface POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PARAMS {
@@ -64,20 +64,6 @@ export type CandidateGender = "Male" | "Female" | "X";
 export interface CandidateVotes {
   number: number;
   votes: number;
-}
-
-/**
- * Request structure for data entry of polling station results
- */
-export interface DataEntryRequest {
-  data: PollingStationResults;
-}
-
-/**
- * Response structure for data entry of polling station results
- */
-export interface DataEntryResponse {
-  validation_results: ValidationResults;
 }
 
 /**
@@ -144,6 +130,14 @@ export interface ErrorResponse {
 }
 
 /**
+ * Response structure for getting data entry of polling station results
+ */
+export interface GetDataEntryResponse {
+  data: PollingStationResults;
+  validation_results: ValidationResults;
+}
+
+/**
  * Political group with its candidates
  */
 export interface PoliticalGroup {
@@ -204,6 +198,20 @@ export interface PollingStationStatusEntry {
  * Type of Polling station
  */
 export type PollingStationType = "VasteLocatie" | "Bijzonder" | "Mobiel";
+
+/**
+ * Request structure for saving data entry of polling station results
+ */
+export interface SaveDataEntryRequest {
+  data: PollingStationResults;
+}
+
+/**
+ * Response structure for saving data entry of polling station results
+ */
+export interface SaveDataEntryResponse {
+  validation_results: ValidationResults;
+}
 
 export interface ValidationResult {
   code: ValidationResultCode;


### PR DESCRIPTION
This PR is a minimal implementation of resuming data entry, without saving/recovering state like accepted warnings. This means that the data will be filled in, the form will start at the 'Recounted' page and the left side navigation will not show progress. Navigating to the next page will also show previous data on that page.

Saving and recovering the full form state is part of a future issue in #137.

Also note that the Mock Service Worker build does not currently support resuming a data entry, implementing this is also part of a future issue in #137.

Resolves #355.