### PR TITLE
Polling station status behavior

### DIFF
--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -126,6 +126,33 @@ describe("Test PollingStationChoiceForm", () => {
       ).toBeVisible();
     });
 
+    test("Selecting a valid, but finalised polling station show alert", async () => {
+      overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
+      const user = userEvent.setup();
+      render(
+        <ElectionProvider electionId={1}>
+          <ElectionStatusProvider electionId={1}>
+            <PollingStationChoiceForm anotherEntry />
+          </ElectionStatusProvider>
+        </ElectionProvider>,
+      );
+
+      const submitButton = await screen.findByRole("button", { name: "Beginnen" });
+      const pollingStation = screen.getByTestId("pollingStation");
+
+      // Test if the polling station name is shown
+      await user.type(pollingStation, "34");
+
+      // Click submit again and see that the alert appeared again
+      await user.click(submitButton);
+
+      expect(
+        within(screen.getByTestId("pollingStationSubmitFeedback")).getByText(
+          "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
+        ),
+      ).toBeVisible();
+    });
+
     test("Form displays message when searching", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -126,7 +126,7 @@ describe("Test PollingStationChoiceForm", () => {
       ).toBeVisible();
     });
 
-    test("Selecting a valid, but finalised polling station show alert", async () => {
+    test("Selecting a valid, but finalised polling station shows alert", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
       render(

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -155,8 +155,10 @@ describe("Test PollingStationChoiceForm", () => {
       const pollingStationList = screen.getByTestId("polling_station_list");
       expect(within(pollingStationList).getByText("33")).toBeVisible();
       expect(within(pollingStationList).getByText("Op Rolletjes")).toBeVisible();
-      expect(within(pollingStationList).getByText("34")).toBeVisible();
-      expect(within(pollingStationList).getByText("Testplek")).toBeVisible();
+
+      // These should not exist, as they are finalised
+      expect(within(pollingStationList).queryByText("34")).toBe(null);
+      expect(within(pollingStationList).queryByText("Testplek")).toBe(null);
     });
 
     test("Polling station list no stations", async () => {

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
@@ -49,9 +49,9 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
 
     const parsedStationNumber = parsePollingStationNumber(pollingStationNumber);
     const pollingStation = pollingStations.find((pollingStation) => pollingStation.number === parsedStationNumber);
-    const pollingStationStatus = electionStatuses.statuses.find((status) => status.id === pollingStation?.id);
+    const pollingStationStatusEntry = electionStatuses.statuses.find((status) => status.id === pollingStation?.id);
 
-    if (pollingStationStatus?.status === "definitive") {
+    if (pollingStationStatusEntry?.status === "definitive") {
       setAlert(DEFINITIVE_POLLING_STATION_ALERT);
       setLoading(false);
       return;

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationSelector.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationSelector.tsx
@@ -14,7 +14,7 @@ export interface PollingStationSelectorProps {
   setLoading: Dispatch<SetStateAction<boolean>>;
   currentPollingStation: PollingStation | undefined;
   setCurrentPollingStation: Dispatch<SetStateAction<PollingStation | undefined>>;
-  setShowAlert: Dispatch<SetStateAction<boolean>>;
+  setAlert: Dispatch<SetStateAction<string | undefined>>;
   handleSubmit: () => void;
 }
 
@@ -23,7 +23,7 @@ export function PollingStationSelector({
   setPollingStationNumber,
   loading,
   currentPollingStation,
-  setShowAlert,
+  setAlert,
   handleSubmit,
 }: PollingStationSelectorProps) {
   const currentPollingStationStatus = usePollingStationStatus(currentPollingStation?.id);
@@ -40,7 +40,7 @@ export function PollingStationSelector({
         margin={false}
         maxLength={6}
         onChange={(e) => {
-          setShowAlert(false);
+          setAlert(undefined);
           setPollingStationNumber(e.target.value);
         }}
         onKeyDown={(e) => {

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationsList.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationsList.tsx
@@ -28,6 +28,10 @@ export function PollingStationsList({ pollingStations }: PollingStationsListProp
       <tbody>
         {pollingStations.map((pollingStation: PollingStation) => {
           const pollingStationStatus = electionStatus.statuses.find((status) => status.id === pollingStation.id);
+          if (pollingStationStatus?.status === "definitive") {
+            return null;
+          }
+
           return (
             <tr onClick={handleRowClick(pollingStation.id)} key={pollingStation.number}>
               <td width="6.5rem" className="number">

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationsList.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationsList.tsx
@@ -27,8 +27,8 @@ export function PollingStationsList({ pollingStations }: PollingStationsListProp
       </thead>
       <tbody>
         {pollingStations.map((pollingStation: PollingStation) => {
-          const pollingStationStatus = electionStatus.statuses.find((status) => status.id === pollingStation.id);
-          if (pollingStationStatus?.status === "definitive") {
+          const pollingStationStatusEntry = electionStatus.statuses.find((status) => status.id === pollingStation.id);
+          if (pollingStationStatusEntry?.status === "definitive") {
             return null;
           }
 
@@ -39,7 +39,7 @@ export function PollingStationsList({ pollingStations }: PollingStationsListProp
               </td>
               <td>
                 <span>{pollingStation.name}</span>
-                {pollingStationStatus && <Badge type={pollingStationStatus.status} />}
+                {pollingStationStatusEntry && <Badge type={pollingStationStatusEntry.status} />}
               </td>
               <td width="5rem">
                 <div className="link">

--- a/frontend/app/module/data_entry/PollingStation/PollingStationLayout.tsx
+++ b/frontend/app/module/data_entry/PollingStation/PollingStationLayout.tsx
@@ -19,6 +19,10 @@ export function PollingStationLayout() {
     throw Error("Polling station not found");
   }
 
+  if (pollingStationStatus === "definitive") {
+    throw Error("Polling station already finalised");
+  }
+
   return (
     <PollingStationFormController election={election} pollingStationId={pollingStation.id} entryNumber={1}>
       <PageTitle title={`Invoeren ${pollingStation.number} ${pollingStation.name} - Abacus`} />

--- a/frontend/app/routes.test.tsx
+++ b/frontend/app/routes.test.tsx
@@ -90,4 +90,22 @@ describe("routes", () => {
     // Test that we get the Not Found page
     await expectNotFound();
   });
+
+  test("Not found page when polling station is finalised", async () => {
+    const router = setupTestRouter();
+
+    // Navigate to a non-existing page
+    await router.navigate("/elections/1/data-entry/2");
+    expect(router.state.location.pathname).toEqual("/elections/1/data-entry/2");
+
+    // NOTE: We're not using the wrapped render function here,
+    // since we want control over our own memory router.
+    rtlRender(
+      <ApiProvider>
+        <RouterProvider router={router} />
+      </ApiProvider>,
+    );
+
+    await expectNotFound();
+  });
 });

--- a/frontend/app/routes.test.tsx
+++ b/frontend/app/routes.test.tsx
@@ -1,11 +1,12 @@
-import { RouterProvider } from "react-router-dom";
-
 import { render as rtlRender } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { expectNotFound, setupTestRouter } from "app/test/unit";
+import { expectNotFound, Providers, setupTestRouter } from "app/test/unit";
 
-import { ApiProvider } from "@kiesraad/api";
+// NOTE: We're not using the wrapped render function here,
+// since we want control over our own memory router.
+const router = setupTestRouter();
+const render = () => rtlRender(<Providers router={router} />);
 
 describe("routes", () => {
   beforeEach(() => {
@@ -16,8 +17,6 @@ describe("routes", () => {
   });
 
   test("Non existing route results in not found page", async () => {
-    const router = setupTestRouter();
-
     // Router sanity checks
     expect(router.state.location.pathname).toEqual("/");
     await router.navigate("/elections/1/data-entry");
@@ -26,86 +25,36 @@ describe("routes", () => {
     // Navigate to a non existing route
     await router.navigate("/thisroutedoesnotexist");
     expect(router.state.location.pathname).toEqual("/thisroutedoesnotexist");
-
-    // NOTE: We're not using the wrapped render function here,
-    // since we want control over our own memory router.
-    rtlRender(
-      <ApiProvider>
-        <RouterProvider router={router} />
-      </ApiProvider>,
-    );
-
+    render();
     await expectNotFound();
   });
 
   test("Malformed election ID should result in not found page", async () => {
-    const router = setupTestRouter();
     await router.navigate("/elections/1asd/data-entry/");
-
-    // NOTE: We're not using the wrapped render function here,
-    // since we want control over our own memory router.
-    rtlRender(
-      <ApiProvider>
-        <RouterProvider router={router} />
-      </ApiProvider>,
-    );
-
+    render();
     await expectNotFound();
   });
 
   test("Non existing election id results in not found page", async () => {
-    const router = setupTestRouter();
-
     // Navigate to a non-existing page
     await router.navigate("/elections/9876/data-entry");
     expect(router.state.location.pathname).toEqual("/elections/9876/data-entry");
-
-    // NOTE: We're not using the wrapped render function here,
-    // since we want control over our own memory router.
-    rtlRender(
-      <ApiProvider>
-        <RouterProvider router={router} />
-      </ApiProvider>,
-    );
-
-    // Test that we get the Not Found page
+    render();
     await expectNotFound();
   });
 
   test("Non existing polling station id results in not found page", async () => {
-    const router = setupTestRouter();
-
+    render();
     // Navigate to a non-existing page
     await router.navigate("/elections/1/data-entry/9876");
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry/9876");
-
-    // NOTE: We're not using the wrapped render function here,
-    // since we want control over our own memory router.
-    rtlRender(
-      <ApiProvider>
-        <RouterProvider router={router} />
-      </ApiProvider>,
-    );
-
-    // Test that we get the Not Found page
     await expectNotFound();
   });
 
   test("Not found page when polling station is finalised", async () => {
-    const router = setupTestRouter();
-
-    // Navigate to a non-existing page
     await router.navigate("/elections/1/data-entry/2");
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry/2");
-
-    // NOTE: We're not using the wrapped render function here,
-    // since we want control over our own memory router.
-    rtlRender(
-      <ApiProvider>
-        <RouterProvider router={router} />
-      </ApiProvider>,
-    );
-
+    render();
     await expectNotFound();
   });
 });


### PR DESCRIPTION
- Adds an alert when the users enters a valid polling station number, but it's in the "Definitief" state
- Filters polling stations from the list with a "Definitief" state
- Throws an error and send the user to the "Er is iets mis" page, in case the user tries to reach a finalised polling station through the URL bar or browser history

@jorisleker When the user tries to select a finalised polling station, it will get an alert, but at the same time the polling station message will appear green. Perhaps we want the polling station message to be a different color? Yellow or red? What do you think?