### PR TITLE
add default selection color

### DIFF
--- a/frontend/lib/ui/style/core.css
+++ b/frontend/lib/ui/style/core.css
@@ -11,3 +11,7 @@ div.radio-form {
 .hidden {
   display: none;
 }
+
+::selection {
+  background-color: var(--shadow-color-focus);
+}


### PR DESCRIPTION
Override the OS/Browser default selection color to avoid some confusing vendor color choices.

closes #393 