### PR TITLE
Disable autocomplete for inputs

### DIFF
--- a/frontend/lib/ui/InputField/InputField.tsx
+++ b/frontend/lib/ui/InputField/InputField.tsx
@@ -39,6 +39,7 @@ export function InputField({
           <textarea
             name={name}
             value={value}
+            autoComplete="off"
             aria-invalid={error ? "true" : "false"}
             aria-errormessage={error ? `${name}-hint_or_error` : undefined}
             rows={7}
@@ -48,6 +49,7 @@ export function InputField({
             name={name}
             value={value}
             type={type}
+            autoComplete="off"
             aria-invalid={error ? "true" : "false"}
             aria-errormessage={error ? `${name}-hint_or_error` : undefined}
             {...InputFieldProps}

--- a/frontend/lib/ui/NumberInput/NumberInput.tsx
+++ b/frontend/lib/ui/NumberInput/NumberInput.tsx
@@ -10,6 +10,7 @@ export interface NumberInputProps
 export function NumberInput({ id, ...inputProps }: NumberInputProps) {
   const props = {
     maxLength: 9,
+    autocomplete: "off",
     ...inputProps,
     defaultValue: inputProps.defaultValue ? formatNumber(inputProps.defaultValue) : "",
     type: "text",

--- a/frontend/lib/ui/NumberInput/NumberInput.tsx
+++ b/frontend/lib/ui/NumberInput/NumberInput.tsx
@@ -10,7 +10,7 @@ export interface NumberInputProps
 export function NumberInput({ id, ...inputProps }: NumberInputProps) {
   const props = {
     maxLength: 9,
-    autocomplete: "off",
+    autoComplete: "off",
     ...inputProps,
     defaultValue: inputProps.defaultValue ? formatNumber(inputProps.defaultValue) : "",
     type: "text",


### PR DESCRIPTION
On the laptops we use for demo-ing (ubuntu/firefox), browsers are in their default config, which means autocomplete for input's is switched on.

We should make sure we never show autocomplete/auto populate on the inputs in our application.

closes #394 