### PR TITLE
Save and resume data entry with form state

### DIFF
--- a/backend/migrations/3_polling_station_data_entries.sql
+++ b/backend/migrations/3_polling_station_data_entries.sql
@@ -3,6 +3,7 @@ CREATE TABLE polling_station_data_entries
     polling_station_id INTEGER NOT NULL,
     entry_number       INTEGER NOT NULL,
     data               BLOB,
+    client_state       BLOB,
 
     PRIMARY KEY (entry_number, polling_station_id),
     FOREIGN KEY (polling_station_id) REFERENCES polling_stations (id)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -757,9 +757,13 @@
         "description": "Response structure for getting data entry of polling station results",
         "required": [
           "data",
+          "client_state",
           "validation_results"
         ],
         "properties": {
+          "client_state": {
+            "type": "object"
+          },
           "data": {
             "$ref": "#/components/schemas/PollingStationResults"
           },
@@ -956,9 +960,14 @@
         "type": "object",
         "description": "Request structure for saving data entry of polling station results",
         "required": [
-          "data"
+          "data",
+          "client_state"
         ],
         "properties": {
+          "client_state": {
+            "type": "object",
+            "description": "Client state for the data entry (arbitrary JSON)"
+          },
           "data": {
             "$ref": "#/components/schemas/PollingStationResults"
           }

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -65,7 +65,8 @@ async fn test_polling_station_data_entry_validation(pool: SqlitePool) {
             ]
           }
         ]
-      }
+      },
+      "client_state": {"foo": "bar"}
     });
 
     let url = format!("http://{addr}/api/polling_stations/1/data_entries/1");
@@ -209,6 +210,7 @@ async fn test_polling_station_data_entry_get(pool: SqlitePool) {
     // check that the data entry is the same
     let get_response: GetDataEntryResponse = response.json().await.unwrap();
     assert_eq!(get_response.data, request_body.data);
+    assert_eq!(get_response.client_state, request_body.client_state);
     assert_eq!(
         get_response.validation_results,
         save_response.validation_results

--- a/backend/tests/shared.rs
+++ b/backend/tests/shared.rs
@@ -49,6 +49,7 @@ pub fn example_data_entry() -> SaveDataEntryRequest {
                 ],
             }],
         },
+        client_state: None,
     }
 }
 

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
@@ -8,7 +8,13 @@ import {
 import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit";
 import { emptyDataEntryRequest } from "app/test/unit/form";
 
-import { Election, PoliticalGroup, PollingStationFormController, PollingStationValues } from "@kiesraad/api";
+import {
+  Election,
+  PoliticalGroup,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
+  PollingStationFormController,
+  PollingStationValues,
+} from "@kiesraad/api";
 import { electionMockData, politicalGroupMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { CandidatesVotesForm } from "./CandidatesVotesForm";
@@ -268,7 +274,8 @@ describe("Test CandidatesVotesForm", () => {
       const { url, method, body } = getUrlMethodAndBody(spy.mock.calls);
       expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
-      expect(body).toEqual(expectedRequest);
+      const request_body = body as POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY;
+      expect(request_body.data).toEqual(expectedRequest.data);
     });
   });
 

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.tsx
@@ -107,7 +107,7 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
           setWarningsWarning(true);
         } else {
           try {
-            await submit(acceptWarnings);
+            await submit({ acceptWarnings });
           } catch (e) {
             console.error("Error saving data entry", e);
           }

--- a/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
@@ -10,7 +10,11 @@ import {
 import { getUrlMethodAndBody, overrideOnce, render, screen, userTypeInputs } from "app/test/unit";
 import { emptyDataEntryRequest } from "app/test/unit/form";
 
-import { PollingStationFormController, PollingStationValues } from "@kiesraad/api";
+import {
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
+  PollingStationFormController,
+  PollingStationValues,
+} from "@kiesraad/api";
 import { electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { DifferencesForm } from "./DifferencesForm";
@@ -165,6 +169,7 @@ describe("Test DifferencesForm", () => {
             no_explanation_count: 1,
           },
         },
+        client_state: {},
       };
 
       const user = userEvent.setup();
@@ -184,7 +189,8 @@ describe("Test DifferencesForm", () => {
       const { url, method, body } = getUrlMethodAndBody(spy.mock.calls);
       expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
-      expect(body).toEqual(expectedRequest);
+      const request_body = body as POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY;
+      expect(request_body.data).toEqual(expectedRequest.data);
     });
   });
 

--- a/frontend/app/component/form/data_entry/differences/DifferencesForm.tsx
+++ b/frontend/app/component/form/data_entry/differences/DifferencesForm.tsx
@@ -66,7 +66,7 @@ export function DifferencesForm() {
     };
   }, [formRef]);
 
-  const getIgnoreWarnings = React.useCallback(() => {
+  const getAcceptWarnings = React.useCallback(() => {
     const checkbox = acceptWarningsRef.current;
     if (checkbox) {
       return checkbox.checked;
@@ -76,7 +76,7 @@ export function DifferencesForm() {
 
   const { status, sectionValues, errors, warnings, isSaved, submit, acceptWarnings } = useDifferences(
     getValues,
-    getIgnoreWarnings,
+    getAcceptWarnings,
   );
 
   const shouldWatch = warnings.length > 0 && isSaved;
@@ -102,7 +102,7 @@ export function DifferencesForm() {
           setWarningsWarning(true);
         } else {
           try {
-            await submit(acceptWarnings);
+            await submit({ acceptWarnings });
           } catch (e) {
             console.error("Error saving data entry", e);
           }
@@ -129,7 +129,7 @@ export function DifferencesForm() {
 
   const defaultProps = {
     errorsAndWarnings: isSaved ? errorsAndWarnings : undefined,
-    warningsAccepted: getIgnoreWarnings(),
+    warningsAccepted: getAcceptWarnings(),
   };
 
   return (

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationsList.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationsList.tsx
@@ -13,7 +13,7 @@ export function PollingStationsList({ pollingStations }: PollingStationsListProp
   const navigate = useNavigate();
 
   const handleRowClick = (pollingStationId: number) => () => {
-    navigate(`./${pollingStationId}/recounted`);
+    navigate(`./${pollingStationId}`);
   };
 
   return (

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, test, vi } from "vitest";
 import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit";
 import { emptyDataEntryRequest } from "app/test/unit/form";
 
-import { PollingStationFormController } from "@kiesraad/api";
+import { POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY, PollingStationFormController } from "@kiesraad/api";
 import { electionMockData } from "@kiesraad/api-mocks";
 
 import { RecountedForm } from "./RecountedForm";
@@ -87,6 +87,7 @@ describe("Test RecountedForm", () => {
             total_admitted_voters_recount: 0,
           },
         },
+        client_state: {},
       };
 
       render(Component);
@@ -105,7 +106,8 @@ describe("Test RecountedForm", () => {
 
       expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
-      expect(body).toEqual(expectedRequest);
+      const request_body = body as POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY;
+      expect(request_body.data).toEqual(expectedRequest.data);
     });
   });
 

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -57,7 +57,6 @@ const defaultFormState: FormState = {
       warnings: [],
     },
   },
-  isCompleted: false,
 };
 
 function renderForm(defaultValues: Partial<PollingStationValues> = {}) {

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -10,14 +10,19 @@ import {
 import { getUrlMethodAndBody, overrideOnce, render, screen, userTypeInputs, waitFor } from "app/test/unit";
 import { emptyDataEntryRequest } from "app/test/unit/form";
 
-import { FormState, PollingStationFormController, PollingStationValues } from "@kiesraad/api";
+import {
+  FormState,
+  POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
+  PollingStationFormController,
+  PollingStationValues,
+} from "@kiesraad/api";
 import { electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { VotersAndVotesForm } from "./VotersAndVotesForm";
 
 const defaultFormState: FormState = {
-  active: "recounted",
   current: "recounted",
+  furthest: "recounted",
   sections: {
     recounted: {
       index: 0,
@@ -51,10 +56,6 @@ const defaultFormState: FormState = {
       errors: [],
       warnings: [],
     },
-  },
-  unknown: {
-    errors: [],
-    warnings: [],
   },
   isCompleted: false,
 };
@@ -213,6 +214,7 @@ describe("Test VotersAndVotesForm", () => {
             total_votes_cast_count: 15,
           },
         },
+        client_state: {},
       };
 
       const user = userEvent.setup();
@@ -234,7 +236,8 @@ describe("Test VotersAndVotesForm", () => {
 
       expect(url).toEqual("/api/polling_stations/1/data_entries/1");
       expect(method).toEqual("POST");
-      expect(body).toEqual(expectedRequest);
+      const request_body = body as POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY;
+      expect(request_body.data).toEqual(expectedRequest.data);
     });
   });
 

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.tsx
@@ -127,7 +127,7 @@ export function VotersAndVotesForm() {
           setWarningsWarning(true);
         } else {
           try {
-            await submit(acceptWarnings);
+            await submit({ acceptWarnings });
           } catch (e) {
             console.error("Error saving data entry", e);
           }

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
@@ -3,6 +3,8 @@ import { useBlocker, useNavigate } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
 import { afterAll, beforeAll, describe, expect, Mock, test, vi } from "vitest";
 
+import { defaultFormState, emptyDataEntryRequest } from "app/test/unit/form.ts";
+
 import { usePollingStationFormController } from "@kiesraad/api";
 import { electionMockData } from "@kiesraad/api-mocks";
 
@@ -23,48 +25,7 @@ vi.mock("@kiesraad/api", async () => {
 });
 
 describe("PollingStationFormNavigation", () => {
-  const mockFormState = {
-    current: "recounted",
-    active: "recounted",
-    sections: {
-      recounted: {
-        index: 0,
-        id: "recounted",
-        errors: [],
-        warnings: [],
-        acceptWarnings: false,
-        isSaved: false,
-      },
-      voters_votes_counts: {
-        index: 1,
-        id: "voters_votes_counts",
-        errors: [],
-        warnings: [],
-        acceptWarnings: false,
-        isSaved: false,
-      },
-    },
-    isCompleted: false,
-  };
-
-  const mockCurrentForm = {
-    id: "section1",
-    getValues: vi.fn().mockReturnValue({}),
-  };
-
   const mockNavigate = vi.fn();
-
-  const mockController = {
-    status: { current: "idle" },
-    formState: mockFormState,
-    currentForm: mockCurrentForm,
-    error: null,
-    targetFormSection: "voters_votes_counts",
-    apiError: null,
-    values: {},
-    setTemporaryCache: vi.fn(),
-    submitCurrentForm: vi.fn(),
-  };
 
   beforeAll(() => {
     (useBlocker as Mock).mockReturnValue(vi.fn());
@@ -75,19 +36,11 @@ describe("PollingStationFormNavigation", () => {
     vi.clearAllMocks();
   });
 
-  test("It Navigates to targetFormSection", () => {
-    (usePollingStationFormController as Mock).mockReturnValue(mockController);
-
-    render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
-
-    expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry/1/voters-and-votes");
-  });
-
   test("It blocks navigation when form has changes", () => {
     (usePollingStationFormController as Mock).mockReturnValue({
       status: { current: "idle" },
       formState: {
-        ...mockFormState,
+        ...defaultFormState,
         current: "voters_votes_counts",
       },
       error: null,
@@ -123,11 +76,11 @@ describe("PollingStationFormNavigation", () => {
     (usePollingStationFormController as Mock).mockReturnValue({
       status: { current: "idle" },
       formState: {
-        ...mockFormState,
+        ...defaultFormState,
         sections: {
-          ...mockFormState.sections,
+          ...defaultFormState.sections,
           recounted: {
-            ...mockFormState.sections.recounted,
+            ...defaultFormState.sections.recounted,
             errors: ["error"],
           },
         },
@@ -144,7 +97,6 @@ describe("PollingStationFormNavigation", () => {
         }),
       },
       setTemporaryCache: vi.fn(),
-      targetFormSection: "recounted",
       values: {
         recounted: true,
       },
@@ -182,9 +134,7 @@ describe("PollingStationFormNavigation", () => {
   test("422 response results in display of error message", async () => {
     (usePollingStationFormController as Mock).mockReturnValue({
       status: { current: "idle" },
-      formState: {
-        ...mockFormState,
-      },
+      formState: defaultFormState,
       apiError: {
         code: 422,
         error: "JSON error or invalid data (Unprocessable Content)",
@@ -197,7 +147,6 @@ describe("PollingStationFormNavigation", () => {
         }),
       },
       setTemporaryCache: vi.fn(),
-      targetFormSection: "recounted",
       values: {
         recounted: true,
       },
@@ -214,9 +163,7 @@ describe("PollingStationFormNavigation", () => {
   test("500 response results in display of error message", async () => {
     (usePollingStationFormController as Mock).mockReturnValue({
       status: { current: "idle" },
-      formState: {
-        ...mockFormState,
-      },
+      formState: defaultFormState,
       apiError: {
         code: 500,
         error: "Internal server error",
@@ -229,10 +176,7 @@ describe("PollingStationFormNavigation", () => {
         }),
       },
       setTemporaryCache: vi.fn(),
-      targetFormSection: "recounted",
-      values: {
-        recounted: true,
-      },
+      values: emptyDataEntryRequest.data,
     });
 
     render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
@@ -22,13 +22,10 @@ export interface PollingStationFormNavigationProps {
 }
 
 export function PollingStationFormNavigation({ pollingStationId, election }: PollingStationFormNavigationProps) {
-  const _lastKnownSection = React.useRef<FormSectionID | null>(null);
-  const { status, formState, apiError, currentForm, targetFormSection, values, setTemporaryCache, submitCurrentForm } =
+  const { status, formState, apiError, currentForm, values, setTemporaryCache, submitCurrentForm } =
     usePollingStationFormController();
 
   const navigate = useNavigate();
-  //one time flag to prioritize user navigation over controller navigation
-  const overrideControllerNavigation = React.useRef<string | null>(null);
 
   const isPartOfDataEntryFlow = React.useCallback(
     (pathname: string) => pathname.startsWith(`/elections/${election.id}/data-entry/${pollingStationId}/`),
@@ -59,9 +56,10 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
       }
 
       const reasons = reasonsBlocked(formState, currentForm, values);
+
       //currently only block on changes
       if (reasons.includes("changes")) {
-        if (formState.active === formState.current) {
+        if (formState.current === formState.furthest) {
           setTemporaryCache({
             key: currentForm.id,
             data: currentForm.getValues(),
@@ -80,32 +78,15 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
 
   //prevent navigating to sections that are not yet active
   React.useEffect(() => {
-    const activeSection = formState.sections[formState.active];
     const currentSection = formState.sections[formState.current];
-    if (activeSection && currentSection) {
-      if (activeSection.index > currentSection.index) {
-        const url = getUrlForFormSection(currentSection.id);
+    const furthestSection = formState.sections[formState.furthest];
+    if (currentSection && furthestSection) {
+      if (currentSection.index > furthestSection.index) {
+        const url = getUrlForFormSection(furthestSection.id);
         navigate(url);
       }
     }
-    _lastKnownSection.current = formState.active;
   }, [formState, navigate, getUrlForFormSection]);
-
-  //check if the targetFormSection has changed and navigate to the correct url
-  React.useEffect(() => {
-    if (!targetFormSection) return;
-    if (overrideControllerNavigation.current) {
-      const url = overrideControllerNavigation.current;
-      overrideControllerNavigation.current = null;
-      navigate(url);
-      return;
-    }
-    if (targetFormSection !== _lastKnownSection.current) {
-      _lastKnownSection.current = targetFormSection;
-      const url = getUrlForFormSection(targetFormSection);
-      navigate(url);
-    }
-  }, [targetFormSection, getUrlForFormSection, navigate]);
 
   // scroll up when an error occurs
   React.useEffect(() => {
@@ -116,8 +97,8 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
 
   const onSave = () =>
     void (async () => {
-      if (blocker.location) overrideControllerNavigation.current = blocker.location.pathname;
-      await submitCurrentForm();
+      await submitCurrentForm({ continueToNextSection: false });
+      if (blocker.location) navigate(blocker.location.pathname);
       if (blocker.reset) blocker.reset();
     })();
 
@@ -145,7 +126,7 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
             >
               <h2 id="modal-blocker-title">Let op: niet opgeslagen wijzigingen</h2>
               <p>
-                Je hebt in <strong>{formState.sections[formState.active]?.title || "het huidige formulier"}</strong>{" "}
+                Je hebt in <strong>{formState.sections[formState.current]?.title || "het huidige formulier"}</strong>{" "}
                 wijzigingen gemaakt die nog niet zijn opgeslagen.
               </p>
               <p>Wil je deze wijzigingen bewaren?</p>
@@ -192,7 +173,7 @@ function reasonsBlocked(
     }
 
     if (
-      (currentForm.getIgnoreWarnings && formSection.acceptWarnings !== currentForm.getIgnoreWarnings()) ||
+      (currentForm.getAcceptWarnings && formSection.acceptWarnings !== currentForm.getAcceptWarnings()) ||
       currentFormHasChanges(currentForm, values)
     ) {
       result.push("changes");

--- a/frontend/app/component/pollingstation/PollingStationProgress.tsx
+++ b/frontend/app/component/pollingstation/PollingStationProgress.tsx
@@ -131,9 +131,9 @@ export function PollingStationProgress() {
         id="list-item-save"
         status={menuStatusForFormSection(formState.sections.save)}
         active={formState.current === "save"}
-        disabled={!formState.isCompleted}
+        disabled={formState.furthest !== "save"}
       >
-        {formState.current !== "save" && formState.isCompleted ? (
+        {formState.current !== "save" && formState.furthest === "save" ? (
           <Link to={`/elections/${election.id}/data-entry/${pollingStationId}/save`}>
             <span>Controleren en opslaan</span>
           </Link>

--- a/frontend/app/component/pollingstation/PollingStationProgress.tsx
+++ b/frontend/app/component/pollingstation/PollingStationProgress.tsx
@@ -27,10 +27,10 @@ export function PollingStationProgress() {
         return "warning";
       }
 
-      if (formSection.id === formState.current) {
+      if (formSection.id === formState.furthest) {
         return "unsaved";
       }
-      const currentSection = formState.sections[formState.current];
+      const currentSection = formState.sections[formState.furthest];
       if (currentSection) {
         //check if section has been left empty
         if (formSection.index < currentSection.index) {
@@ -50,7 +50,7 @@ export function PollingStationProgress() {
   );
 
   const lists = election.political_groups;
-  const currentIndex = formState.sections[formState.current]?.index || 0;
+  const currentIndex = formState.sections[formState.furthest]?.index || 0;
 
   return (
     <ProgressList>
@@ -58,9 +58,9 @@ export function PollingStationProgress() {
         id="list-item-recounted"
         key="recounted"
         status="accept"
-        active={formState.active === "recounted"}
+        active={formState.current === "recounted"}
       >
-        {formState.active !== "recounted" ? (
+        {formState.current !== "recounted" ? (
           <Link to={`/elections/${election.id}/data-entry/${pollingStationId}/recounted`}>
             <span>Is er herteld?</span>
           </Link>
@@ -73,9 +73,9 @@ export function PollingStationProgress() {
         id="list-item-voters-and-votes"
         status={menuStatusForFormSection(formState.sections.voters_votes_counts)}
         disabled={formState.sections.voters_votes_counts.index > currentIndex}
-        active={formState.active === "voters_votes_counts"}
+        active={formState.current === "voters_votes_counts"}
       >
-        {formState.active !== "voters_votes_counts" && formState.sections.voters_votes_counts.index <= currentIndex ? (
+        {formState.current !== "voters_votes_counts" && formState.sections.voters_votes_counts.index <= currentIndex ? (
           <Link to={`/elections/${election.id}/data-entry/${pollingStationId}/voters-and-votes`}>
             <span>Aantal kiezers en stemmen</span>
           </Link>
@@ -88,9 +88,9 @@ export function PollingStationProgress() {
         id="list-item-differences"
         disabled={formState.sections.differences_counts.index > currentIndex}
         status={menuStatusForFormSection(formState.sections.differences_counts)}
-        active={formState.active === "differences_counts"}
+        active={formState.current === "differences_counts"}
       >
-        {formState.active !== "differences_counts" && formState.sections.differences_counts.index <= currentIndex ? (
+        {formState.current !== "differences_counts" && formState.sections.differences_counts.index <= currentIndex ? (
           <Link to={`/elections/${election.id}/data-entry/${pollingStationId}/differences`}>
             <span>Verschillen</span>
           </Link>
@@ -109,9 +109,9 @@ export function PollingStationProgress() {
             id={`list-item-pg-${listId}`}
             disabled={formSection.index > currentIndex}
             status={menuStatusForFormSection(formSection)}
-            active={formState.active === formSection.id}
+            active={formState.current === formSection.id}
           >
-            {formState.active !== formSection.id && formSection.index <= currentIndex ? (
+            {formState.current !== formSection.id && formSection.index <= currentIndex ? (
               <Link to={`/elections/${election.id}/data-entry/${pollingStationId}/list/${listId}`}>
                 <span>
                   Lijst {list.number} - {list.name}
@@ -130,10 +130,10 @@ export function PollingStationProgress() {
         key="save"
         id="list-item-save"
         status={menuStatusForFormSection(formState.sections.save)}
-        active={formState.active === "save"}
+        active={formState.current === "save"}
         disabled={!formState.isCompleted}
       >
-        {formState.active !== "save" && formState.isCompleted ? (
+        {formState.current !== "save" && formState.isCompleted ? (
           <Link to={`/elections/${election.id}/data-entry/${pollingStationId}/save`}>
             <span>Controleren en opslaan</span>
           </Link>

--- a/frontend/app/component/pollingstation/utils.ts
+++ b/frontend/app/component/pollingstation/utils.ts
@@ -1,4 +1,6 @@
-export function getUrlForFormSectionID(electionId: number, pollingStationId: number, sectionId: string) {
+import { FormSectionID } from "@kiesraad/api";
+
+export function getUrlForFormSectionID(electionId: number, pollingStationId: number, sectionId: FormSectionID) {
   const baseUrl = `/elections/${electionId}/data-entry/${pollingStationId}`;
 
   let url: string = "";

--- a/frontend/app/module/data_entry/PollingStation/AbortDataEntryControl.test.tsx
+++ b/frontend/app/module/data_entry/PollingStation/AbortDataEntryControl.test.tsx
@@ -85,16 +85,13 @@ describe("Test AbortDataEntryControl", () => {
     await user.click(screen.getByRole("button", { name: "Invoer bewaren" }));
 
     // check that the save request was made with the correct data
-    expect(request_body).toEqual({
-      data: {
-        ...emptyDataEntryRequest.data,
-        voters_counts: {
-          ...emptyDataEntryRequest.data.voters_counts,
-          poll_card_count: 42,
-        },
+    expect(request_body?.data).toEqual({
+      ...emptyDataEntryRequest.data,
+      voters_counts: {
+        ...emptyDataEntryRequest.data.voters_counts,
+        poll_card_count: 42,
       },
     });
-    // }
 
     // check that the user is navigated back to the data entry page
     expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry");

--- a/frontend/app/module/data_entry/PollingStation/AbortDataEntryModal.tsx
+++ b/frontend/app/module/data_entry/PollingStation/AbortDataEntryModal.tsx
@@ -19,7 +19,7 @@ export function AbortDataEntryModal({ onCancel, onSave, onDelete }: AbortDataEnt
     void (async () => {
       try {
         setSaving(true);
-        await controller.submitCurrentForm(false, true);
+        await controller.submitCurrentForm({ aborting: true, continueToNextSection: false });
         onSave();
       } finally {
         setSaving(false);

--- a/frontend/app/routes.tsx
+++ b/frontend/app/routes.tsx
@@ -36,7 +36,7 @@ export const routes = createRoutesFromElements(
       <Route path="data-entry" element={<DataEntryLayout />}>
         <Route index element={<DataEntryHomePage />} />
         <Route path=":pollingStationId" element={<PollingStationLayout />}>
-          <Route index element={<Navigate to="./recounted" replace />} />
+          <Route index element={null} />
           <Route path="recounted" element={<RecountedPage />} />
           <Route path="voters-and-votes" element={<VotersAndVotesPage />} />
           <Route path="differences" element={<DifferencesPage />} />

--- a/frontend/app/test/unit/form.ts
+++ b/frontend/app/test/unit/form.ts
@@ -34,6 +34,9 @@ export const emptyDataEntryRequest: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY
       })),
     })),
   },
+  client_state: {
+    test: "test",
+  },
 };
 
 type ErrorMap = {

--- a/frontend/app/test/unit/form.ts
+++ b/frontend/app/test/unit/form.ts
@@ -80,8 +80,8 @@ export const errorWarningMocks: ErrorMap = {
 };
 
 export const defaultFormState: FormState = {
-  active: "recounted",
   current: "recounted",
+  furthest: "recounted",
   sections: {
     recounted: {
       index: 0,
@@ -131,10 +131,6 @@ export const defaultFormState: FormState = {
       errors: [],
       warnings: [],
     },
-  },
-  unknown: {
-    errors: [],
-    warnings: [],
   },
   isCompleted: false,
 };

--- a/frontend/app/test/unit/form.ts
+++ b/frontend/app/test/unit/form.ts
@@ -132,5 +132,4 @@ export const defaultFormState: FormState = {
       warnings: [],
     },
   },
-  isCompleted: false,
 };

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -143,7 +143,9 @@ test.describe("full data entry flow", () => {
     const checkAndSavePage = new CheckAndSavePage(page);
     await expect(checkAndSavePage.heading).toBeVisible();
 
-    // TODO: extend as part of epic #95: data entry check and finalisation
+    await checkAndSavePage.save.click();
+
+    await pollingStationChoicePage.dataEntrySuccess.waitFor();
   });
 
   test("no recount, difference of more ballots counted", async ({ page }) => {
@@ -206,7 +208,9 @@ test.describe("full data entry flow", () => {
     const checkAndSavePage = new CheckAndSavePage(page);
     await expect(checkAndSavePage.heading).toBeVisible();
 
-    // TODO: extend as part of epic #95: data entry check and finalisation
+    await checkAndSavePage.save.click();
+
+    await pollingStationChoicePage.dataEntrySuccess.waitFor();
   });
 
   test("recount, difference of fewer ballots counted", async ({ page }) => {
@@ -281,8 +285,7 @@ test.describe("full data entry flow", () => {
     await checkAndSavePage.heading.waitFor();
     await checkAndSavePage.save.click();
 
-    // TODO: #318 reset database to allow polling station to be finalised in multiple tests
-    // await inputPage.dataEntrySuccess.waitFor();
+    await pollingStationChoicePage.dataEntrySuccess.waitFor();
   });
 
   test("submit with accepted warning on voters and votes page", async ({ page }) => {
@@ -454,9 +457,8 @@ test.describe("errors and warnings", () => {
     await checkAndSavePage.heading.waitFor();
     await checkAndSavePage.save.click();
 
-    // TODO: #318 reset database to allow polling station to be finalised in multiple tests
-    // const inputPage = new InputPage(page);
-    // await inputPage.dataEntrySuccess.waitFor();
+    const pollingStationChoicePage = new PollingStationChoicePage(page);
+    await pollingStationChoicePage.dataEntrySuccess.waitFor();
   });
 
   test("correct warning on voters and votes page", async ({ page }) => {
@@ -658,7 +660,7 @@ test.describe("navigation", () => {
     // save changes
     await votersAndVotesPage.unsavedChangesModal.saveInput.click();
 
-    await expect(recountedPage.heading).toBeVisible(); // fails here because navigated to next page, i.e. Differences
+    await expect(recountedPage.heading).toBeVisible();
     await expect(recountedPage.navPanel.votersAndVotesIcon).toHaveAccessibleName("opgeslagen");
 
     // return to VotersAndVotes page and verify change is saved

--- a/frontend/e2e-tests/dom-to-db-tests/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/resume-data-entry.e2e.ts
@@ -53,6 +53,10 @@ test.describe("resume data entry flow", () => {
 
       await page.goto("/elections/1/data-entry/1/recounted");
 
+      const differencesPage = new DifferencesPage(page);
+      await expect(differencesPage.heading).toBeVisible();
+      await differencesPage.navPanel.recounted.click();
+
       const recountedPage = new RecountedPage(page);
       await expect(recountedPage.no).toBeChecked();
       await recountedPage.next.click();
@@ -95,6 +99,7 @@ test.describe("resume data entry flow", () => {
 
       const pollingStationChoicePage = new PollingStationChoicePage(page);
       await expect(pollingStationChoicePage.heading).toBeVisible();
+      await expect(pollingStationChoicePage.resumeDataEntry).toBeVisible();
 
       const dataEntryResponse = await request.get(`/api/polling_stations/1/data_entries/1`);
       expect(dataEntryResponse.status()).toBe(200);
@@ -129,7 +134,8 @@ test.describe("resume data entry flow", () => {
         },
       });
 
-      // TODO: extend test as part of epic #137 resume data entry
+      await pollingStationChoicePage.selectPollingStationAndClickStart(33);
+      await votersAndVotesPage.heading.waitFor();
     });
 
     test("save input from voters and votes page with warning", async ({ page, request }) => {
@@ -201,7 +207,9 @@ test.describe("resume data entry flow", () => {
           ],
         },
       });
-      // TODO: extend test as part of epic #137 resume data entry
+
+      await pollingStationChoicePage.selectPollingStationAndClickStart(33);
+      await votersAndVotesPage.heading.waitFor();
     });
   });
 

--- a/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
@@ -9,6 +9,7 @@ export class PollingStationChoicePage {
   readonly pollingStationFeedback: Locator;
   protected readonly start: Locator; // use clickStart() instead
   readonly dataEntrySuccess: Locator;
+  readonly resumeDataEntry: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -31,6 +32,7 @@ export class PollingStationChoicePage {
       level: 2,
       name: "Je invoer is opgeslagen",
     });
+    this.resumeDataEntry = page.getByRole("heading", { level: 2, name: "Je hebt nog een openstaande invoer" });
   }
 
   async clickStart() {

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
@@ -2,22 +2,22 @@ import * as React from "react";
 
 import { describe, expect, test } from "vitest";
 
-import { overrideOnce, renderHook, waitFor } from "app/test/unit";
+import { overrideOnce, Providers, renderHook, waitFor } from "app/test/unit";
 
-import { ApiProvider, PollingStationFormController, usePollingStationFormController } from "@kiesraad/api";
+import { PollingStationFormController, usePollingStationFormController } from "@kiesraad/api";
 import { electionMockData } from "@kiesraad/api-mocks";
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <ApiProvider>
+  <Providers>
     <PollingStationFormController election={electionMockData} pollingStationId={1} entryNumber={1}>
       {children}
     </PollingStationFormController>
-  </ApiProvider>
+  </Providers>
 );
 
 describe("PollingStationFormController", () => {
   test("PollingStationFormController renderHook", async () => {
-    const { result, rerender } = renderHook(() => usePollingStationFormController(), {
+    const { result } = renderHook(() => usePollingStationFormController(), {
       wrapper: Wrapper,
     });
 
@@ -35,21 +35,14 @@ describe("PollingStationFormController", () => {
         };
       },
     });
-
     expect(result.current.values.recounted).toEqual(undefined);
-
-    rerender();
 
     await result.current.submitCurrentForm();
 
-    rerender();
-    expect(result.current.values.recounted).toEqual(true);
-
     await waitFor(() => {
-      expect(result.current.formState.current).toBe("voters_votes_counts");
+      expect(result.current.values.recounted).toEqual(true);
+      expect(result.current.formState.furthest).toBe("voters_votes_counts");
     });
-
-    expect(result.current.targetFormSection).toBe("voters_votes_counts");
 
     result.current.registerCurrentForm({
       id: "voters_votes_counts",
@@ -72,9 +65,12 @@ describe("PollingStationFormController", () => {
         };
       },
     });
-    rerender();
+    await waitFor(() => {
+      // wait for the form state to be updated after registering the form
+      expect(result.current.formState.current).toBe("voters_votes_counts");
+    });
+
     await result.current.submitCurrentForm();
-    rerender();
 
     await waitFor(() => {
       expect(result.current.formState.sections.voters_votes_counts.errors.length).toBe(1);
@@ -125,6 +121,10 @@ describe("PollingStationFormController", () => {
           voters_recounts: undefined,
         };
       },
+    });
+    await waitFor(() => {
+      // wait for the form state to be updated after registering the form
+      expect(result.current.formState.current).toBe("voters_votes_counts");
     });
 
     await result.current.submitCurrentForm();

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -1,24 +1,27 @@
 import * as React from "react";
+import { useNavigate } from "react-router-dom";
+
+import { getUrlForFormSectionID } from "app/component/pollingstation/utils";
 
 import {
-  addValidationResultToFormState,
   ApiError,
   ApiResponseStatus,
   Election,
+  getClientState,
   GetDataEntryResponse,
   getInitialFormState,
   getInitialValues,
-  isGlobalValidationResult,
+  getNextSectionID,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH,
   PollingStationResults,
+  SaveDataEntryRequest,
   SaveDataEntryResponse,
+  updateFormStateAfterSubmit,
   useApi,
   useApiGetRequest,
   ValidationResult,
   VotersRecounts,
 } from "@kiesraad/api";
-
-import { formSectionComplete, getNextSection, resetFormSectionState } from "./pollingStationUtils";
 
 export interface PollingStationValues extends Omit<PollingStationResults, "recounted"> {
   recounted: boolean | undefined;
@@ -38,7 +41,7 @@ export interface FormReference<T> {
   type: string;
   id: FormSectionID;
   getValues: () => T;
-  getIgnoreWarnings?: () => boolean;
+  getAcceptWarnings?: () => boolean;
 }
 
 export interface FormReferenceRecounted extends FormReference<Pick<PollingStationValues, "recounted">> {
@@ -71,16 +74,21 @@ export type AnyFormReference =
   | FormReferencePoliticalGroupVotes
   | FormReferenceSave;
 
+interface SubmitCurrentFormOptions {
+  acceptWarnings?: boolean;
+  aborting?: boolean;
+  continueToNextSection?: boolean;
+}
+
 export interface iPollingStationControllerContext {
   status: React.RefObject<Status>;
   apiError: ApiError | null;
   formState: FormState;
-  targetFormSection: FormSectionID | null;
   values: PollingStationValues;
   setTemporaryCache: (cache: TemporaryCache | null) => boolean;
   cache: TemporaryCache | null;
   currentForm: AnyFormReference | null;
-  submitCurrentForm: (acceptWarnings?: boolean, aborting?: boolean) => Promise<void>;
+  submitCurrentForm: (params?: SubmitCurrentFormOptions) => Promise<void>;
   registerCurrentForm: (form: AnyFormReference) => void;
   deleteDataEntry: () => Promise<void>;
   finaliseDataEntry: () => Promise<void>;
@@ -98,8 +106,8 @@ export type FormSection = {
   index: number; //fixate the order of filling in sections
   id: FormSectionID;
   title?: string;
-  isSaved: boolean; //has this section been sent to the server
-  isSubmitted?: boolean; //has this section been submitted in the latest request
+  isSaved: boolean; //whether this section has been sent to the server
+  isSubmitted?: boolean; //whether this section has been submitted in the latest request
   acceptWarnings: boolean;
   errors: ValidationResult[];
   warnings: ValidationResult[];
@@ -110,14 +118,19 @@ export interface ClientValidationResult extends ValidationResult {
 }
 
 export interface FormState {
-  current: FormSectionID; //the current step that needs completion
-  active: FormSectionID; //the form that is currently active
+  // the furthest form section that the user has reached
+  furthest: FormSectionID;
+  // the form section that the user is currently working on
+  current: FormSectionID;
   sections: Record<FormSectionID, FormSection>;
-  unknown: {
-    errors: ClientValidationResult[];
-    warnings: ClientValidationResult[];
-  };
   isCompleted: boolean;
+}
+
+export interface ClientState {
+  furthest: FormSectionID;
+  current: FormSectionID;
+  acceptedWarnings: FormSectionID[];
+  continue: boolean;
 }
 
 //store unvalidated data
@@ -147,40 +160,22 @@ export function PollingStationFormController({
 }: PollingStationFormControllerProps) {
   const request_path: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
   const { client } = useApi();
+  const navigate = useNavigate();
+
+  const [values, setValues] = React.useState<PollingStationValues>();
+  const [formState, setFormState] = React.useState<FormState>();
 
   // TODO: #277 render custom error page instead of passing error down
   const [apiError, setApiError] = React.useState<ApiError | null>(null);
 
-  const [values, setValues] = React.useState<PollingStationValues>();
-
-  const initialDataRequest = useApiGetRequest<GetDataEntryResponse>(request_path);
-  React.useEffect(() => {
-    if (initialDataRequest.data) {
-      const responseData = initialDataRequest.data;
-      setValues(responseData.data);
-      setFormState((old) => {
-        const newFormState = { ...old };
-        addValidationResultToFormState(newFormState, responseData.validation_results.errors, "errors");
-        addValidationResultToFormState(newFormState, responseData.validation_results.warnings, "warnings");
-        return newFormState;
-      });
-    } else if (initialDataRequest.error) {
-      if (initialDataRequest.error.code === 404) {
-        // data entry not found, set initial values
-        setValues(getInitialValues(election, defaultValues));
-      } else {
-        setApiError(initialDataRequest.error);
-        throw new Error("Failed to load data entry");
-      }
-    }
-  }, [initialDataRequest.data, initialDataRequest.error, defaultValues, election]);
-
-  const [formState, setFormState] = React.useState<FormState>(() => {
-    return getInitialFormState(election, defaultFormState);
-  });
+  // the form section to navigate to next
+  const [targetFormSectionID, setTargetFormSectionID] = React.useState<FormSectionID | null>(null);
 
   // status as ref, because it needs to immediately propagate to the blocker function in `PollingStationFormNavigation`
   const status = React.useRef<Status>("idle");
+
+  // reference to the current form on screen
+  const currentForm = React.useRef<AnyFormReference | null>(defaultCurrentForm);
 
   const temporaryCache = React.useRef<TemporaryCache | null>(null);
   const setTemporaryCache = React.useCallback((cache: TemporaryCache | null) => {
@@ -189,54 +184,112 @@ export function PollingStationFormController({
     return true;
   }, []);
 
-  //reference to the current form on screen
-  const currentForm = React.useRef<AnyFormReference | null>(defaultCurrentForm);
-
-  //where to navigate to next
-  const [targetFormSection, setTargetFormSection] = React.useState<FormSectionID | null>(INITIAL_FORM_SECTION_ID);
-
-  //tell the "outside world" which form section to show next
+  const initialDataRequest = useApiGetRequest<GetDataEntryResponse>(request_path);
   React.useEffect(() => {
-    const activeSection = formState.sections[formState.active];
-    if (activeSection) {
-      if (activeSection.isSubmitted) {
-        if (formSectionComplete(activeSection)) {
-          const nextSectionID = getNextSection(formState, activeSection);
-          setTargetFormSection(nextSectionID);
+    if (initialDataRequest.data) {
+      const responseData = initialDataRequest.data;
+      setValues(responseData.data);
+
+      if (responseData.client_state) {
+        const newFormState = getInitialFormState(election);
+
+        const clientState = responseData.client_state as ClientState;
+
+        // set the furthest and current section
+        newFormState.furthest = clientState.furthest;
+        newFormState.current = clientState.current;
+
+        // set accepted warnings
+        clientState.acceptedWarnings.forEach((sectionID: FormSectionID) => {
+          const section = newFormState.sections[sectionID];
+          if (section) {
+            section.acceptWarnings = true;
+          }
+        });
+
+        // set saved sections to all sections before the current section
+        const currentIndex = newFormState.sections[newFormState.current]?.index ?? 0;
+        for (const section of Object.values(newFormState.sections)) {
+          if (section.index < currentIndex) {
+            section.isSaved = true;
+          }
         }
+
+        const acceptWarnings = clientState.acceptedWarnings.some(
+          (sectionID: FormSectionID) => sectionID === newFormState.current,
+        );
+
+        updateFormStateAfterSubmit(newFormState, responseData.validation_results, acceptWarnings, clientState.continue);
+
+        if (clientState.continue) {
+          setTargetFormSectionID(getNextSectionID(newFormState) ?? newFormState.current);
+        } else {
+          setTargetFormSectionID(newFormState.current);
+        }
+
+        setFormState(newFormState);
+      } else {
+        setFormState(getInitialFormState(election));
+        setTargetFormSectionID(INITIAL_FORM_SECTION_ID);
+      }
+    } else if (initialDataRequest.error) {
+      if (initialDataRequest.error.code === 404) {
+        // data entry not found, set initial values
+        setValues(getInitialValues(election, defaultValues));
+        setFormState(getInitialFormState(election, defaultFormState));
+        setTargetFormSectionID(INITIAL_FORM_SECTION_ID);
+      } else {
+        setApiError(initialDataRequest.error);
+        throw new Error("Failed to load data entry");
       }
     }
-  }, [formState]);
+  }, [defaultValues, defaultFormState, election, pollingStationId, initialDataRequest.data, initialDataRequest.error]);
+
+  // check if the targetFormSectionID has changed and navigate to the url for that section
+  React.useEffect(() => {
+    if (!targetFormSectionID) return;
+    const url = getUrlForFormSectionID(election.id, pollingStationId, targetFormSectionID);
+    navigate(url);
+  }, [targetFormSectionID, navigate, election.id, pollingStationId]);
 
   const registerCurrentForm = React.useCallback(
     (form: AnyFormReference) => {
+      if (formState === undefined) {
+        throw new Error("Form state is undefined, cannot register form");
+      }
       if (currentForm.current === null || form.id !== currentForm.current.id) {
         currentForm.current = form;
-        if (form.id !== formState.active) {
-          setFormState((old) => {
-            const newFormState = { ...old };
-            const oldActive = old.sections[old.active];
-            if (oldActive) {
-              oldActive.isSubmitted = false;
-            }
-            newFormState.active = form.id;
-            return newFormState;
-          });
-          setTargetFormSection(null);
-        }
+      }
+      if (form.id !== formState.current) {
+        setFormState((old) => {
+          if (old === undefined) {
+            throw new Error("Form state is undefined, cannot register form");
+          }
+          const newFormState = structuredClone(old);
+          const currentSection = newFormState.sections[newFormState.current];
+          if (currentSection) {
+            currentSection.isSubmitted = false;
+          }
+          newFormState.current = form.id;
+          return newFormState;
+        });
       }
     },
     [currentForm, formState],
   );
 
-  if (values === undefined) {
-    // loading
+  if (values === undefined || formState === undefined) {
+    // do not continue while loading initial data
     return null;
   }
 
-  const submitCurrentForm = async (acceptWarnings = false, aborting?: boolean) => {
+  const submitCurrentForm = async ({
+    acceptWarnings = false,
+    aborting = false,
+    continueToNextSection = true,
+  }: SubmitCurrentFormOptions = {}) => {
     // React state is fixed within one render, so we update our own copy instead of using setValues directly
-    let newValues: PollingStationValues = values;
+    let newValues: PollingStationValues = structuredClone(values);
     if (currentForm.current) {
       const ref: AnyFormReference = currentForm.current;
 
@@ -284,24 +337,22 @@ export function PollingStationFormController({
           break;
       }
       setValues(newValues);
-      //when submitting, all previous errors and warnings are invalid
-      setFormState((old) => {
-        const newFormState = { ...old };
-        resetFormSectionState(newFormState);
-        return newFormState;
-      });
     }
 
-    // prepare data
+    // prepare data to send to server
     const pollingStationResults: PollingStationResults = {
       ...newValues,
       recounted: newValues.recounted !== undefined ? newValues.recounted : false,
       voters_recounts: newValues.recounted ? newValues.voters_recounts : undefined,
     };
+    const clientState = getClientState(formState, acceptWarnings, continueToNextSection);
 
     // send data to server
     status.current = "saving";
-    const response = await client.postRequest(request_path, { data: pollingStationResults });
+    const response = await client.postRequest(request_path, {
+      data: pollingStationResults,
+      client_state: clientState,
+    } satisfies SaveDataEntryRequest);
     status.current = aborting ? "aborted" : "idle";
     if (response.status !== ApiResponseStatus.Success) {
       // TODO: #277 render custom error page
@@ -312,59 +363,13 @@ export function PollingStationFormController({
     const data = response.data as SaveDataEntryResponse;
     setApiError(null);
 
-    // update form state based on response
-    setFormState((old) => {
-      const newFormState = { ...old };
-      //reset all errors/warnings, and submitted, the server validates the entire request each time.
-      //a reset is done before submitting the form to the server.
+    const newFormState = structuredClone(formState);
+    updateFormStateAfterSubmit(newFormState, data.validation_results, acceptWarnings, !aborting);
+    setFormState(newFormState);
 
-      const activeFormSection = newFormState.sections[newFormState.active];
-
-      if (activeFormSection) {
-        //store that this section has been sent to the server
-        activeFormSection.isSaved = true;
-        //store that this section has been submitted, this resets on each request
-        activeFormSection.isSubmitted = true;
-        //flag ignore warnings
-        activeFormSection.acceptWarnings = acceptWarnings;
-      }
-
-      //distribute errors to sections
-      addValidationResultToFormState(newFormState, data.validation_results.errors, "errors");
-      //distribute warnings to sections
-      addValidationResultToFormState(newFormState, data.validation_results.warnings, "warnings");
-
-      //what form section is active
-      if (activeFormSection) {
-        //determine new current if applicable
-        if (newFormState.current === activeFormSection.id) {
-          if (
-            activeFormSection.errors.length === 0 ||
-            activeFormSection.errors.every((vr) => isGlobalValidationResult(vr))
-          ) {
-            if (activeFormSection.warnings.length === 0 || activeFormSection.acceptWarnings) {
-              const nextSectionID = getNextSection(newFormState, activeFormSection);
-              if (nextSectionID) {
-                newFormState.current = nextSectionID;
-              }
-              if (nextSectionID === "save") {
-                newFormState.isCompleted = true;
-              }
-            }
-          }
-        }
-      }
-
-      //if the entire form is not completed yet, filter out global validation results since they don't have meaning yet.
-      if (!newFormState.isCompleted) {
-        Object.values(newFormState.sections).forEach((section) => {
-          section.errors = section.errors.filter((err) => !isGlobalValidationResult(err));
-          section.warnings = section.warnings.filter((err) => !isGlobalValidationResult(err));
-        });
-      }
-
-      return newFormState;
-    });
+    if (continueToNextSection) {
+      setTargetFormSectionID(getNextSectionID(newFormState));
+    }
   };
 
   const deleteDataEntry = async () => {
@@ -405,7 +410,6 @@ export function PollingStationFormController({
         currentForm: currentForm.current,
         registerCurrentForm,
         submitCurrentForm,
-        targetFormSection,
         deleteDataEntry,
         finaliseDataEntry,
         pollingStationId,

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -123,7 +123,6 @@ export interface FormState {
   // the form section that the user is currently working on
   current: FormSectionID;
   sections: Record<FormSectionID, FormSection>;
-  isCompleted: boolean;
 }
 
 export interface ClientState {

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.test.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.test.ts
@@ -10,7 +10,7 @@ import {
   FormSection,
   formSectionComplete,
   getErrorsAndWarnings,
-  getNextSection,
+  getNextSectionID,
   getPollingStationSummary,
   hasOnlyGlobalValidationResults,
   isFormSectionEmpty,
@@ -98,17 +98,12 @@ describe("PollingStationUtils", () => {
     ).toBe(true);
   });
 
-  test("getNextSection", () => {
+  test("getNextSectionID", () => {
     const formState = structuredClone(defaultFormState);
+    formState.sections.recounted.isSaved = true;
+    formState.sections.recounted.isSubmitted = true;
 
-    const nextSection = getNextSection(formState, {
-      index: 0,
-      id: "recounted",
-      isSaved: false,
-      acceptWarnings: false,
-      errors: [],
-      warnings: [],
-    });
+    const nextSection = getNextSectionID(formState);
 
     expect(nextSection).toBe("voters_votes_counts");
   });

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
@@ -106,7 +106,7 @@ export function getNextSectionID(formState: FormState) {
   const currentSection = formState.sections[formState.current];
   if (currentSection && currentSection.isSubmitted && formSectionComplete(currentSection)) {
     for (const section of Object.values(formState.sections)) {
-      if ((formState.isCompleted && section.errors.length > 0) || section.index === currentSection.index + 1) {
+      if ((formState.furthest === "save" && section.errors.length > 0) || section.index === currentSection.index + 1) {
         return section.id;
       }
     }
@@ -362,7 +362,6 @@ export function getInitialFormState(election: Required<Election>, defaultFormSta
         warnings: [],
       },
     },
-    isCompleted: false,
   };
 
   election.political_groups.forEach((pg, n) => {
@@ -425,9 +424,7 @@ export function updateFormStateAfterSubmit(
     formState.furthest = getNextSectionID(formState) ?? formState.furthest;
   }
 
-  if (formState.furthest === "save") {
-    formState.isCompleted = true;
-  } else {
+  if (formState.furthest !== "save") {
     //if the entire form is not completed yet, filter out global validation results since they don't have meaning yet.
     Object.values(formState.sections).forEach((section) => {
       section.errors = section.errors.filter((err) => !isGlobalValidationResult(err));

--- a/frontend/lib/api/form/pollingstation/useDifferences.ts
+++ b/frontend/lib/api/form/pollingstation/useDifferences.ts
@@ -4,7 +4,7 @@ import { PollingStationResults, usePollingStationFormController } from "@kiesraa
 
 export type DifferencesValues = Pick<PollingStationResults, "differences_counts">;
 
-export function useDifferences(getValues: () => DifferencesValues, getIgnoreWarnings?: () => boolean) {
+export function useDifferences(getValues: () => DifferencesValues, getAcceptWarnings?: () => boolean) {
   const { status, values, formState, submitCurrentForm, setTemporaryCache, registerCurrentForm, cache } =
     usePollingStationFormController();
 
@@ -33,9 +33,9 @@ export function useDifferences(getValues: () => DifferencesValues, getIgnoreWarn
       id: "differences_counts",
       type: "differences",
       getValues,
-      getIgnoreWarnings,
+      getAcceptWarnings: getAcceptWarnings,
     });
-  }, [registerCurrentForm, getValues, getIgnoreWarnings]);
+  }, [registerCurrentForm, getValues, getAcceptWarnings]);
 
   return {
     status,

--- a/frontend/lib/api/form/pollingstation/useDifferences.ts
+++ b/frontend/lib/api/form/pollingstation/useDifferences.ts
@@ -44,7 +44,6 @@ export function useDifferences(getValues: () => DifferencesValues, getAcceptWarn
     warnings,
     isSaved: formState.sections.differences_counts.isSaved,
     submit: submitCurrentForm,
-    isCompleted: formState.isCompleted,
     acceptWarnings: formState.sections.differences_counts.acceptWarnings,
   };
 }

--- a/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
+++ b/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
@@ -46,7 +46,6 @@ export function usePoliticalGroup(
     isSaved: formState.sections[`political_group_votes_${political_group_number}`]?.isSaved || false,
     setTemporaryCache,
     submit: submitCurrentForm,
-    isCompleted: formState.isCompleted,
     acceptWarnings: formState.sections[`political_group_votes_${political_group_number}`]?.acceptWarnings || false,
   };
 }

--- a/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
+++ b/frontend/lib/api/form/pollingstation/usePoliticalGroups.ts
@@ -5,7 +5,7 @@ import { PoliticalGroupVotes, usePollingStationFormController } from "@kiesraad/
 export function usePoliticalGroup(
   political_group_number: number,
   getValues: () => PoliticalGroupVotes,
-  getIgnoreWarnings?: () => boolean,
+  getAcceptWarnings?: () => boolean,
 ) {
   const { status, values, formState, setTemporaryCache, cache, registerCurrentForm, submitCurrentForm } =
     usePollingStationFormController();
@@ -34,9 +34,9 @@ export function usePoliticalGroup(
       id: `political_group_votes_${political_group_number}`,
       number: political_group_number,
       getValues,
-      getIgnoreWarnings,
+      getAcceptWarnings: getAcceptWarnings,
     });
-  }, [registerCurrentForm, getValues, political_group_number, getIgnoreWarnings]);
+  }, [registerCurrentForm, getValues, political_group_number, getAcceptWarnings]);
 
   return {
     status,

--- a/frontend/lib/api/form/pollingstation/useVotersAndVotes.ts
+++ b/frontend/lib/api/form/pollingstation/useVotersAndVotes.ts
@@ -4,7 +4,7 @@ import { PollingStationResults, usePollingStationFormController } from "@kiesraa
 
 export type VotersAndVotesValues = Pick<PollingStationResults, "voters_counts" | "votes_counts" | "voters_recounts">;
 
-export function useVotersAndVotes(getValues: () => VotersAndVotesValues, getIgnoreWarnings?: () => boolean) {
+export function useVotersAndVotes(getValues: () => VotersAndVotesValues, getAcceptWarnings?: () => boolean) {
   const { status, values, formState, setTemporaryCache, cache, registerCurrentForm, submitCurrentForm } =
     usePollingStationFormController();
 
@@ -33,9 +33,9 @@ export function useVotersAndVotes(getValues: () => VotersAndVotesValues, getIgno
       id: "voters_votes_counts",
       type: "voters_and_votes",
       getValues,
-      getIgnoreWarnings,
+      getAcceptWarnings: getAcceptWarnings,
     });
-  }, [registerCurrentForm, getValues, getIgnoreWarnings]);
+  }, [registerCurrentForm, getValues, getAcceptWarnings]);
 
   const errors = React.useMemo(() => {
     return formState.sections.voters_votes_counts.errors;

--- a/frontend/lib/api/form/pollingstation/useVotersAndVotes.ts
+++ b/frontend/lib/api/form/pollingstation/useVotersAndVotes.ts
@@ -54,6 +54,5 @@ export function useVotersAndVotes(getValues: () => VotersAndVotesValues, getAcce
     acceptWarnings: formState.sections.voters_votes_counts.acceptWarnings,
     submit: submitCurrentForm,
     recounted: values.recounted,
-    isCompleted: formState.isCompleted,
   };
 }

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -133,6 +133,7 @@ export interface ErrorResponse {
  * Response structure for getting data entry of polling station results
  */
 export interface GetDataEntryResponse {
+  client_state: unknown;
   data: PollingStationResults;
   validation_results: ValidationResults;
 }
@@ -203,6 +204,7 @@ export type PollingStationType = "VasteLocatie" | "Bijzonder" | "Mobiel";
  * Request structure for saving data entry of polling station results
  */
 export interface SaveDataEntryRequest {
+  client_state: unknown;
   data: PollingStationResults;
 }
 

--- a/frontend/scripts/gen_openapi_types.ts
+++ b/frontend/scripts/gen_openapi_types.ts
@@ -155,8 +155,7 @@ function tsType(s: ReferenceObject | SchemaObject | undefined): string {
     case "array":
       return `${tsType(s.items)}[]`;
     default:
-      //TODO: catch all types, any is not allowed
-      return "any";
+      return "unknown";
   }
 }
 


### PR DESCRIPTION
* Add client state to data entry API
* Resume form progress with client state: save client state on each save to backend, and resume by loading client state. To achieve resuming using the state, some of the controller functionality is refactored.

Resolves #381 

What to test:
* Does saving or aborting data entry and resuming later always get back to the same point?
* Is the current behaviour with regards to showing errors and warnings when resuming ok? These are shown when coming back after clicking next ("Volgende"), but not when coming back after aborting ("Invoer afbreken") or navigating away.