### PR TITLE
Fix submit-navigate after navigating back one page

### DIFF
--- a/frontend/app/module/data_entry/PollingStation/PollingStation.test.tsx
+++ b/frontend/app/module/data_entry/PollingStation/PollingStation.test.tsx
@@ -350,7 +350,24 @@ describe("Polling Station data entry integration tests", () => {
       }
     });
 
-    test("Navigate to next page after navigating back and submitting", async () => {
+    test("Navigate to next page after navigating back one page submitting", async () => {
+      // https://github.com/kiesraad/abacus/issues/426
+      render();
+      await startPollingStationInput();
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await userEvent.click(screen.getByRole("link", { name: "Aantal kiezers en stemmen" }));
+      await expectVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+    });
+
+    test("Navigate to next page after navigating back two pages and submitting", async () => {
       render();
 
       const steps = [

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -220,6 +220,7 @@ export function PollingStationFormController({
     if (!targetFormSectionID) return;
     const url = getUrlForFormSectionID(election.id, pollingStationId, targetFormSectionID);
     navigate(url);
+    setTargetFormSectionID(null);
   }, [targetFormSectionID, navigate, election.id, pollingStationId]);
 
   const registerCurrentForm = React.useCallback(


### PR DESCRIPTION
This issue occurred whenever navigating back by one page. In that case, the 'next section after submit' did not change so the form did not navigate to the expected next section. The 'accept warnings' checkbox does not seem to matter.

Fixes #426.