### PR TITLE
Add persistence to Mock Service Worker implementation

### DIFF
--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
@@ -42,7 +42,7 @@ describe("Test CheckAndSaveForm", () => {
 
     // set up a listener to check if the finalisation request is made
     let request_method, request_url;
-    overrideOnce("delete", "/api/polling_stations/1/data_entries/1/finalise", 200, null);
+    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, null);
     server.events.on("request:start", ({ request }) => {
       request_method = request.method;
       request_url = request.url;
@@ -61,6 +61,8 @@ describe("Test CheckAndSaveForm", () => {
 
   test("Shift+Enter submits form", async () => {
     renderForm();
+
+    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, null);
 
     const user = userEvent.setup();
     const spy = vi.spyOn(global, "fetch");

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -5,7 +5,7 @@ import { PollingStationChoiceForm } from "app/component/form/data_entry/polling_
 import { overrideOnce, render, screen, within } from "app/test/unit";
 
 import { ElectionProvider, ElectionStatusProvider } from "@kiesraad/api";
-import { electionDetailsMockResponse } from "@kiesraad/api-mocks";
+import { electionDetailsMockResponse, electionStatusMockResponse } from "@kiesraad/api-mocks";
 
 function renderPollingStationChoicePage() {
   render(
@@ -128,6 +128,7 @@ describe("Test PollingStationChoiceForm", () => {
 
     test("Selecting a valid, but finalised polling station shows alert", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
+      overrideOnce("get", "/api/elections/1/status", 200, electionStatusMockResponse);
       const user = userEvent.setup();
       render(
         <ElectionProvider electionId={1}>
@@ -169,6 +170,8 @@ describe("Test PollingStationChoiceForm", () => {
   describe("Polling station list", () => {
     test("Display polling station list", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
+      overrideOnce("get", "/api/elections/1/status", 200, electionStatusMockResponse);
+
       const user = userEvent.setup();
       renderPollingStationChoicePage();
 

--- a/frontend/app/component/navbar/NavBar.module.css
+++ b/frontend/app/component/navbar/NavBar.module.css
@@ -43,5 +43,6 @@
   svg {
     width: 1.5rem;
     color: var(--base-white);
+    fill: var(--base-white);
   }
 }

--- a/frontend/app/module/NotAvailableInMock.tsx
+++ b/frontend/app/module/NotAvailableInMock.tsx
@@ -2,13 +2,19 @@ import { Link } from "react-router-dom";
 
 import { NavBar } from "app/component/navbar/NavBar";
 
-export function NotAvailableInMock() {
+import { PageTitle } from "@kiesraad/ui";
+
+interface NotAvailableInMockProps {
+  title?: string;
+}
+
+export function NotAvailableInMock({ title }: NotAvailableInMockProps) {
   return (
     <>
+      {title && <PageTitle title={title} />}
       <NavBar>
         <Link to={"/overview"}>Overzicht</Link>
       </NavBar>
-
       <main>
         <article>
           Deze pagina is helaas niet beschikbaar in deze demo-versie. Ga naar het{" "}

--- a/frontend/app/module/NotAvailableInMock.tsx
+++ b/frontend/app/module/NotAvailableInMock.tsx
@@ -1,0 +1,20 @@
+import { Link } from "react-router-dom";
+
+import { NavBar } from "app/component/navbar/NavBar";
+
+export function NotAvailableInMock() {
+  return (
+    <>
+      <NavBar>
+        <Link to={"/overview"}>Overzicht</Link>
+      </NavBar>
+
+      <main>
+        <article>
+          Deze pagina is helaas niet beschikbaar in deze demo-versie. Ga naar het{" "}
+          <a href={"/overview"}>overzicht met verkiezingen</a> om andere functionaliteit uit te proberen.
+        </article>
+      </main>
+    </>
+  );
+}

--- a/frontend/app/module/data_entry/PollingStation/PollingStationLayout.tsx
+++ b/frontend/app/module/data_entry/PollingStation/PollingStationLayout.tsx
@@ -28,7 +28,7 @@ export function PollingStationLayout() {
       <PageTitle title={`Invoeren ${pollingStation.number} ${pollingStation.name} - Abacus`} />
       <NavBar>
         <Link to={"/overview"}>Overzicht</Link>
-        <IconChevronRight style={{ fill: "white" }} />
+        <IconChevronRight />
         <Link to={`/elections/${election.id}/data-entry`}>{election.name}</Link>
       </NavBar>
       <header>

--- a/frontend/app/module/data_entry/page/FinaliseElectionPage.tsx
+++ b/frontend/app/module/data_entry/page/FinaliseElectionPage.tsx
@@ -58,7 +58,7 @@ export function FinaliseElectionPage() {
       <PageTitle title="Invoerfase afronden - Abacus" />
       <NavBar>
         <Link to={"/overview"}>Overzicht</Link>
-        <IconChevronRight style={{ fill: "white" }} />
+        <IconChevronRight />
         <Link to={`/elections/${election.id}/data-entry`}>{election.name}</Link>
       </NavBar>
       <header>

--- a/frontend/app/module/data_entry/page/FinaliseElectionPage.tsx
+++ b/frontend/app/module/data_entry/page/FinaliseElectionPage.tsx
@@ -58,7 +58,7 @@ export function FinaliseElectionPage() {
       <PageTitle title="Invoerfase afronden - Abacus" />
       <NavBar>
         <Link to={"/overview"}>Overzicht</Link>
-        <IconChevronRight />
+        <IconChevronRight style={{ fill: "white" }} />
         <Link to={`/elections/${election.id}/data-entry`}>{election.name}</Link>
       </NavBar>
       <header>

--- a/frontend/app/routes.test.tsx
+++ b/frontend/app/routes.test.tsx
@@ -1,7 +1,9 @@
 import { render as rtlRender } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { expectNotFound, Providers, setupTestRouter } from "app/test/unit";
+import { expectNotFound, overrideOnce, Providers, setupTestRouter } from "app/test/unit";
+
+import { electionStatusMockResponse } from "@kiesraad/api-mocks";
 
 // NOTE: We're not using the wrapped render function here,
 // since we want control over our own memory router.
@@ -52,6 +54,8 @@ describe("routes", () => {
   });
 
   test("Not found page when polling station is finalised", async () => {
+    overrideOnce("get", "/api/elections/1/status", 200, electionStatusMockResponse);
+
     await router.navigate("/elections/1/data-entry/2");
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry/2");
     render();

--- a/frontend/app/routes.tsx
+++ b/frontend/app/routes.tsx
@@ -45,7 +45,10 @@ export const routes = createRoutesFromElements(
           <Route path="list/:listNumber" element={<CandidatesVotesPage />} />
           <Route path="save" element={<CheckAndSaveForm />} />
         </Route>
-        <Route path="finalise" element={__API_MSW__ ? <NotAvailableInMock /> : <FinaliseElectionPage />} />
+        <Route
+          path="finalise"
+          element={__API_MSW__ ? <NotAvailableInMock title="Invoerfase afronden - Abacus" /> : <FinaliseElectionPage />}
+        />
       </Route>
     </Route>
   </Route>,

--- a/frontend/app/routes.tsx
+++ b/frontend/app/routes.tsx
@@ -2,6 +2,7 @@ import { createRoutesFromElements, Navigate, Route } from "react-router-dom";
 
 import { CheckAndSaveForm } from "app/component/form/data_entry/check_and_save/CheckAndSaveForm";
 import { FinaliseElectionPage } from "app/module/data_entry/page/FinaliseElectionPage";
+import { NotAvailableInMock } from "app/module/NotAvailableInMock.tsx";
 
 import {
   CandidatesVotesPage,
@@ -44,7 +45,7 @@ export const routes = createRoutesFromElements(
           <Route path="list/:listNumber" element={<CandidatesVotesPage />} />
           <Route path="save" element={<CheckAndSaveForm />} />
         </Route>
-        <Route path="finalise" element={<FinaliseElectionPage />} />
+        <Route path="finalise" element={__API_MSW__ ? <NotAvailableInMock /> : <FinaliseElectionPage />} />
       </Route>
     </Route>
   </Route>,

--- a/frontend/app/test/unit/setup.ts
+++ b/frontend/app/test/unit/setup.ts
@@ -3,7 +3,8 @@ import { cleanup, configure } from "@testing-library/react";
 import { afterEach, beforeAll, vi } from "vitest";
 import failOnConsole from "vitest-fail-on-console";
 
-import { resetDatabase } from "../../../lib/api-mocks/Database.ts";
+import { resetDatabase } from "@kiesraad/api-mocks";
+
 import { server } from "./server";
 
 window.scrollTo = () => {};

--- a/frontend/app/test/unit/setup.ts
+++ b/frontend/app/test/unit/setup.ts
@@ -3,6 +3,7 @@ import { cleanup, configure } from "@testing-library/react";
 import { afterEach, beforeAll, vi } from "vitest";
 import failOnConsole from "vitest-fail-on-console";
 
+import { resetDatabase } from "../../../lib/api-mocks/Database.ts";
 import { server } from "./server";
 
 window.scrollTo = () => {};
@@ -24,4 +25,5 @@ afterEach(() => {
   vi.clearAllMocks();
   server.resetHandlers();
   server.events.removeAllListeners();
+  resetDatabase();
 });

--- a/frontend/lib/api-mocks/DataEntry.ts
+++ b/frontend/lib/api-mocks/DataEntry.ts
@@ -1,0 +1,216 @@
+import { PollingStationResults, ValidationResults } from "@kiesraad/api";
+
+export function validate(data: PollingStationResults): ValidationResults {
+  const validation_results: ValidationResults = {
+    errors: [],
+    warnings: [],
+  };
+
+  const { voters_counts, votes_counts, voters_recounts, differences_counts, political_group_votes } = data;
+
+  // Rules and checks implemented in this mock api:
+  // F.201-204, F.301-305, F.401, W.301-302
+  // Rules and checks not implemented in this mock api:
+  // W.201-210
+
+  const total_votes_counts = votes_counts.total_votes_cast_count;
+  let total_voters_counts;
+
+  //SECTION votes_counts
+  // F.202 E + F + G = H
+  if (
+    votes_counts.votes_candidates_count + votes_counts.blank_votes_count + votes_counts.invalid_votes_count !==
+    votes_counts.total_votes_cast_count
+  ) {
+    validation_results.errors.push({
+      fields: [
+        "data.votes_counts.total_votes_cast_count",
+        "data.votes_counts.votes_candidates_count",
+        "data.votes_counts.blank_votes_count",
+        "data.votes_counts.invalid_votes_count",
+      ],
+      code: "F202",
+    });
+  }
+
+  if (voters_recounts) {
+    // if recounted = true
+    //SECTION voters_recounts
+    total_voters_counts = voters_recounts.total_admitted_voters_recount;
+
+    // F.203 A.2 + B.2 + C.2 = D.2
+    if (
+      voters_recounts.poll_card_recount +
+        voters_recounts.proxy_certificate_recount +
+        voters_recounts.voter_card_recount !==
+      voters_recounts.total_admitted_voters_recount
+    ) {
+      validation_results.errors.push({
+        fields: [
+          "data.voters_recounts.poll_card_recount",
+          "data.voters_recounts.proxy_certificate_recount",
+          "data.voters_recounts.voter_card_recount",
+          "data.voters_recounts.total_admitted_voters_recount",
+        ],
+        code: "F203",
+      });
+    }
+  } else {
+    // if recounted = false
+    //SECTION voters_counts
+    total_voters_counts = voters_counts.total_admitted_voters_count;
+
+    // F.201 A + B + C = D
+    if (
+      voters_counts.poll_card_count + voters_counts.proxy_certificate_count + voters_counts.voter_card_count !==
+      voters_counts.total_admitted_voters_count
+    ) {
+      validation_results.errors.push({
+        fields: [
+          "data.voters_counts.poll_card_count",
+          "data.voters_counts.proxy_certificate_count",
+          "data.voters_counts.voter_card_count",
+          "data.voters_counts.total_admitted_voters_count",
+        ],
+        code: "F201",
+      });
+    }
+  }
+
+  //SECTION differences_counts
+  if (total_voters_counts < total_votes_counts) {
+    // F.301 validate that the difference for more ballots counted is correct
+    if (total_votes_counts - total_voters_counts != differences_counts.more_ballots_count) {
+      validation_results.errors.push({
+        fields: ["data.differences_counts.more_ballots_count"],
+        code: "F301",
+      });
+    }
+    // F.302 validate that fewer ballots counted is empty
+    if (differences_counts.fewer_ballots_count !== 0) {
+      validation_results.errors.push({
+        fields: ["data.differences_counts.fewer_ballots_count"],
+        code: "F302",
+      });
+    }
+  }
+
+  if (total_voters_counts > total_votes_counts) {
+    // F.303 validate that the difference for fewer ballots counted is correct
+    if (total_voters_counts - total_votes_counts != differences_counts.fewer_ballots_count) {
+      validation_results.errors.push({
+        fields: ["data.differences_counts.fewer_ballots_count"],
+        code: "F303",
+      });
+    }
+    // F.304 validate that more ballots counted is empty
+    if (differences_counts.more_ballots_count !== 0) {
+      validation_results.errors.push({
+        fields: ["data.differences_counts.more_ballots_count"],
+        code: "F304",
+      });
+    }
+  }
+
+  // F.305 validate that no differences should be filled in when there is no difference in the totals
+  if (total_voters_counts == total_votes_counts) {
+    const fields: string[] = [];
+    if (differences_counts.more_ballots_count != 0) {
+      fields.push("data.differences_counts.more_ballots_count");
+    }
+    if (differences_counts.fewer_ballots_count != 0) {
+      fields.push("data.differences_counts.fewer_ballots_count");
+    }
+    if (differences_counts.unreturned_ballots_count != 0) {
+      fields.push("data.differences_counts.unreturned_ballots_count");
+    }
+    if (differences_counts.too_few_ballots_handed_out_count != 0) {
+      fields.push("data.differences_counts.too_few_ballots_handed_out_count");
+    }
+    if (differences_counts.too_many_ballots_handed_out_count != 0) {
+      fields.push("data.differences_counts.too_many_ballots_handed_out_count");
+    }
+    if (differences_counts.other_explanation_count != 0) {
+      fields.push("data.differences_counts.other_explanation_count");
+    }
+    if (differences_counts.no_explanation_count != 0) {
+      fields.push("data.differences_counts.no_explanation_count");
+    }
+    if (fields.length > 0) {
+      validation_results.errors.push({
+        fields: fields,
+        code: "F305",
+      });
+    }
+  }
+
+  // W.301 if I: M + N + O - K - L = I
+  if (
+    differences_counts.more_ballots_count !== 0 &&
+    differences_counts.too_many_ballots_handed_out_count +
+      differences_counts.other_explanation_count +
+      differences_counts.no_explanation_count -
+      differences_counts.unreturned_ballots_count -
+      differences_counts.too_few_ballots_handed_out_count !==
+      differences_counts.more_ballots_count
+  ) {
+    validation_results.warnings.push({
+      fields: [
+        "data.differences_counts.more_ballots_count",
+        "data.differences_counts.too_many_ballots_handed_out_count",
+        "data.differences_counts.unreturned_ballots_count",
+        "data.differences_counts.too_few_ballots_handed_out_count",
+        "data.differences_counts.other_explanation_count",
+        "data.differences_counts.no_explanation_count",
+      ],
+      code: "W301",
+    });
+  }
+
+  // W.302 if J: K + L + N + O - M = J
+  if (
+    differences_counts.fewer_ballots_count !== 0 &&
+    differences_counts.unreturned_ballots_count +
+      differences_counts.too_few_ballots_handed_out_count +
+      differences_counts.other_explanation_count +
+      differences_counts.no_explanation_count -
+      differences_counts.too_many_ballots_handed_out_count !==
+      differences_counts.fewer_ballots_count
+  ) {
+    validation_results.warnings.push({
+      fields: [
+        "data.differences_counts.fewer_ballots_count",
+        "data.differences_counts.unreturned_ballots_count",
+        "data.differences_counts.too_few_ballots_handed_out_count",
+        "data.differences_counts.too_many_ballots_handed_out_count",
+        "data.differences_counts.other_explanation_count",
+        "data.differences_counts.no_explanation_count",
+      ],
+      code: "W302",
+    });
+  }
+
+  //SECTION political_group_votes
+  let candidateVotesSum = 0;
+  political_group_votes.forEach((pg) => {
+    // F.401
+    const sum = pg.candidate_votes.reduce((acc, cv) => acc + cv.votes, 0);
+    candidateVotesSum += sum;
+    if (sum !== pg.total) {
+      validation_results.errors.push({
+        fields: [`data.political_group_votes[${pg.number - 1}]`],
+        code: "F401",
+      });
+    }
+  });
+
+  // F.204
+  if (votes_counts.votes_candidates_count !== candidateVotesSum) {
+    validation_results.errors.push({
+      fields: ["data.votes_counts.votes_candidates_count", "data.political_group_votes"],
+      code: "F204",
+    });
+  }
+
+  return validation_results;
+}

--- a/frontend/lib/api-mocks/Database.ts
+++ b/frontend/lib/api-mocks/Database.ts
@@ -1,0 +1,33 @@
+import { ClientState, Election, PollingStation, PollingStationResults } from "@kiesraad/api";
+
+import { getElectionMockData } from "./ElectionMockData.ts";
+
+export interface ResultRecord {
+  pollingStationId: number;
+  entryNumber: number;
+  data: PollingStationResults;
+}
+
+export interface DataEntryRecord extends ResultRecord {
+  clientState: ClientState;
+}
+
+interface Database {
+  elections: Election[];
+  pollingStations: PollingStation[];
+  results: ResultRecord[];
+  dataEntries: DataEntryRecord[];
+}
+
+const initialData: Database = {
+  elections: [getElectionMockData(1).election, getElectionMockData(2).election],
+  pollingStations: [...getElectionMockData(1).polling_stations, ...getElectionMockData(2).polling_stations],
+  results: [],
+  dataEntries: [],
+};
+
+export let Database: Database = structuredClone(initialData);
+
+export function resetDatabase(): void {
+  Database = structuredClone(initialData);
+}

--- a/frontend/lib/api-mocks/PollingStationMockData.ts
+++ b/frontend/lib/api-mocks/PollingStationMockData.ts
@@ -15,10 +15,11 @@ export const pollingStationMockData: PollingStation = {
 };
 
 export const getPollingStationMockData = (election_id: number): PollingStation[] => {
+  const offset = (election_id - 1) * 10;
   return [
-    { ...pollingStationMockData, election_id },
+    { ...pollingStationMockData, id: offset + 1, election_id },
     {
-      id: 2,
+      id: offset + 2,
       election_id,
       name: "Testplek",
       number: 34,

--- a/frontend/lib/api-mocks/RequestHandlers.ts
+++ b/frontend/lib/api-mocks/RequestHandlers.ts
@@ -1,13 +1,20 @@
 import { http, type HttpHandler, HttpResponse } from "msw";
 
 import {
+  ClientState,
+  ElectionDetailsResponse,
+  ElectionListResponse,
+  ElectionStatusResponse,
   ErrorResponse,
+  GetDataEntryResponse,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS,
   SaveDataEntryResponse,
 } from "@kiesraad/api";
 
-import { electionListMockResponse, electionStatusMockResponse, getElectionMockData } from "./ElectionMockData";
+import { Database, DataEntryRecord } from "./Database.ts";
+import { validate } from "./DataEntry.ts";
+import { getElectionMockData } from "./ElectionMockData";
 
 type ParamsToString<T> = {
   [P in keyof T]: string;
@@ -34,19 +41,26 @@ const pingHandler = http.post<PingParams, PingRequestBody, PingResponseBody>("/p
 
 // get election list handler
 export const ElectionListRequestHandler = http.get("/api/elections", () => {
-  return HttpResponse.json(electionListMockResponse, { status: 200 });
+  const response: ElectionListResponse = {
+    elections: Database.elections.map((e) => ({ ...e, political_groups: undefined })),
+  };
+  return HttpResponse.json(response, { status: 200 });
 });
 
 // get election details handler
 export const ElectionRequestHandler = http.get<ParamsToString<{ election_id: number }>>(
   "/api/elections/:election_id",
   ({ params }) => {
-    try {
-      const election = getElectionMockData(Number(params.election_id));
-      return HttpResponse.json(election, { status: 200 });
-    } catch {
-      return HttpResponse.json({}, { status: 404 });
+    const election = Database.elections.find((e) => e.id === Number(params.election_id));
+    if (!election) {
+      return HttpResponse.text(null, { status: 404 });
     }
+    const pollingStations = Database.pollingStations.filter((ps) => ps.election_id === Number(params.election_id));
+    const response: ElectionDetailsResponse = {
+      election,
+      polling_stations: pollingStations,
+    };
+    return HttpResponse.json(response, { status: 200 });
   },
 );
 
@@ -56,9 +70,27 @@ export const ElectionStatusRequestHandler = http.get<ParamsToString<{ election_i
   ({ params }) => {
     try {
       getElectionMockData(Number(params.election_id));
-      return HttpResponse.json(electionStatusMockResponse, { status: 200 });
+
+      const response: ElectionStatusResponse = {
+        statuses: [],
+      };
+
+      const pollingStationIds = Database.pollingStations
+        .filter((ps) => ps.election_id === Number(params.election_id))
+        .map((ps) => ps.id);
+      for (const pollingStationId of pollingStationIds) {
+        if (Database.results.some((r) => r.pollingStationId === pollingStationId)) {
+          response.statuses.push({ id: pollingStationId, status: "definitive" });
+        } else if (Database.dataEntries.some((d) => d.pollingStationId === pollingStationId)) {
+          response.statuses.push({ id: pollingStationId, status: "first_entry_in_progress" });
+        } else {
+          response.statuses.push({ id: pollingStationId, status: "first_entry" });
+        }
+      }
+
+      return HttpResponse.json(response, { status: 200 });
     } catch {
-      return HttpResponse.json({}, { status: 404 });
+      return HttpResponse.text(null, { status: 404 });
     }
   },
 );
@@ -68,241 +100,43 @@ export const PollingStationDataEntrySaveHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   SaveDataEntryResponse | ErrorResponse
->("/api/polling_stations/:polling_station_id/data_entries/:entry_number", async ({ request }) => {
+>("/api/polling_stations/:polling_station_id/data_entries/:entry_number", async ({ request, params }) => {
   let json: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY;
 
   try {
     json = await request.json();
-    const response: SaveDataEntryResponse = {
-      validation_results: {
-        errors: [],
-        warnings: [],
-      },
+
+    if (Database.results.some((r) => r.pollingStationId === Number(params.polling_station_id))) {
+      return HttpResponse.json(
+        {
+          error: "Cannot save data entry for a polling station that has already been finalised",
+        } satisfies ErrorResponse,
+        { status: 409 },
+      );
+    }
+
+    const dataEntry: DataEntryRecord = {
+      pollingStationId: Number(params.polling_station_id),
+      entryNumber: Number(params.entry_number),
+      data: json.data,
+      clientState: json.client_state as ClientState,
     };
 
-    const { voters_counts, votes_counts, voters_recounts, differences_counts, political_group_votes } = json.data;
+    Database.dataEntries = Database.dataEntries.filter(
+      (d) => d.pollingStationId !== dataEntry.pollingStationId || d.entryNumber !== dataEntry.entryNumber,
+    );
+    Database.dataEntries.push(dataEntry);
 
-    // Rules and checks implemented in this mock api:
-    // F.201-204, F.301-305, F.401, W.301-302
-    // Rules and checks not implemented in this mock api:
-    // W.201-210
-
-    const total_votes_counts = votes_counts.total_votes_cast_count;
-    let total_voters_counts;
-
-    //SECTION votes_counts
-    // F.202 E + F + G = H
-    if (
-      votes_counts.votes_candidates_count + votes_counts.blank_votes_count + votes_counts.invalid_votes_count !==
-      votes_counts.total_votes_cast_count
-    ) {
-      response.validation_results.errors.push({
-        fields: [
-          "data.votes_counts.total_votes_cast_count",
-          "data.votes_counts.votes_candidates_count",
-          "data.votes_counts.blank_votes_count",
-          "data.votes_counts.invalid_votes_count",
-        ],
-        code: "F202",
-      });
-    }
-
-    if (voters_recounts) {
-      // if recounted = true
-      //SECTION voters_recounts
-      total_voters_counts = voters_recounts.total_admitted_voters_recount;
-
-      // F.203 A.2 + B.2 + C.2 = D.2
-      if (
-        voters_recounts.poll_card_recount +
-          voters_recounts.proxy_certificate_recount +
-          voters_recounts.voter_card_recount !==
-        voters_recounts.total_admitted_voters_recount
-      ) {
-        response.validation_results.errors.push({
-          fields: [
-            "data.voters_recounts.poll_card_recount",
-            "data.voters_recounts.proxy_certificate_recount",
-            "data.voters_recounts.voter_card_recount",
-            "data.voters_recounts.total_admitted_voters_recount",
-          ],
-          code: "F203",
-        });
-      }
-    } else {
-      // if recounted = false
-      //SECTION voters_counts
-      total_voters_counts = voters_counts.total_admitted_voters_count;
-
-      // F.201 A + B + C = D
-      if (
-        voters_counts.poll_card_count + voters_counts.proxy_certificate_count + voters_counts.voter_card_count !==
-        voters_counts.total_admitted_voters_count
-      ) {
-        response.validation_results.errors.push({
-          fields: [
-            "data.voters_counts.poll_card_count",
-            "data.voters_counts.proxy_certificate_count",
-            "data.voters_counts.voter_card_count",
-            "data.voters_counts.total_admitted_voters_count",
-          ],
-          code: "F201",
-        });
-      }
-    }
-
-    //SECTION differences_counts
-    if (total_voters_counts < total_votes_counts) {
-      // F.301 validate that the difference for more ballots counted is correct
-      if (total_votes_counts - total_voters_counts != differences_counts.more_ballots_count) {
-        response.validation_results.errors.push({
-          fields: ["data.differences_counts.more_ballots_count"],
-          code: "F301",
-        });
-      }
-      // F.302 validate that fewer ballots counted is empty
-      if (differences_counts.fewer_ballots_count !== 0) {
-        response.validation_results.errors.push({
-          fields: ["data.differences_counts.fewer_ballots_count"],
-          code: "F302",
-        });
-      }
-    }
-
-    if (total_voters_counts > total_votes_counts) {
-      // F.303 validate that the difference for fewer ballots counted is correct
-      if (total_voters_counts - total_votes_counts != differences_counts.fewer_ballots_count) {
-        response.validation_results.errors.push({
-          fields: ["data.differences_counts.fewer_ballots_count"],
-          code: "F303",
-        });
-      }
-      // F.304 validate that more ballots counted is empty
-      if (differences_counts.more_ballots_count !== 0) {
-        response.validation_results.errors.push({
-          fields: ["data.differences_counts.more_ballots_count"],
-          code: "F304",
-        });
-      }
-    }
-
-    // F.305 validate that no differences should be filled in when there is no difference in the totals
-    if (total_voters_counts == total_votes_counts) {
-      const fields: string[] = [];
-      if (differences_counts.more_ballots_count != 0) {
-        fields.push("data.differences_counts.more_ballots_count");
-      }
-      if (differences_counts.fewer_ballots_count != 0) {
-        fields.push("data.differences_counts.fewer_ballots_count");
-      }
-      if (differences_counts.unreturned_ballots_count != 0) {
-        fields.push("data.differences_counts.unreturned_ballots_count");
-      }
-      if (differences_counts.too_few_ballots_handed_out_count != 0) {
-        fields.push("data.differences_counts.too_few_ballots_handed_out_count");
-      }
-      if (differences_counts.too_many_ballots_handed_out_count != 0) {
-        fields.push("data.differences_counts.too_many_ballots_handed_out_count");
-      }
-      if (differences_counts.other_explanation_count != 0) {
-        fields.push("data.differences_counts.other_explanation_count");
-      }
-      if (differences_counts.no_explanation_count != 0) {
-        fields.push("data.differences_counts.no_explanation_count");
-      }
-      if (fields.length > 0) {
-        response.validation_results.errors.push({
-          fields: fields,
-          code: "F305",
-        });
-      }
-    }
-
-    // W.301 if I: M + N + O - K - L = I
-    if (
-      differences_counts.more_ballots_count !== 0 &&
-      differences_counts.too_many_ballots_handed_out_count +
-        differences_counts.other_explanation_count +
-        differences_counts.no_explanation_count -
-        differences_counts.unreturned_ballots_count -
-        differences_counts.too_few_ballots_handed_out_count !==
-        differences_counts.more_ballots_count
-    ) {
-      response.validation_results.warnings.push({
-        fields: [
-          "data.differences_counts.more_ballots_count",
-          "data.differences_counts.too_many_ballots_handed_out_count",
-          "data.differences_counts.unreturned_ballots_count",
-          "data.differences_counts.too_few_ballots_handed_out_count",
-          "data.differences_counts.other_explanation_count",
-          "data.differences_counts.no_explanation_count",
-        ],
-        code: "W301",
-      });
-    }
-
-    // W.302 if J: K + L + N + O - M = J
-    if (
-      differences_counts.fewer_ballots_count !== 0 &&
-      differences_counts.unreturned_ballots_count +
-        differences_counts.too_few_ballots_handed_out_count +
-        differences_counts.other_explanation_count +
-        differences_counts.no_explanation_count -
-        differences_counts.too_many_ballots_handed_out_count !==
-        differences_counts.fewer_ballots_count
-    ) {
-      response.validation_results.warnings.push({
-        fields: [
-          "data.differences_counts.fewer_ballots_count",
-          "data.differences_counts.unreturned_ballots_count",
-          "data.differences_counts.too_few_ballots_handed_out_count",
-          "data.differences_counts.too_many_ballots_handed_out_count",
-          "data.differences_counts.other_explanation_count",
-          "data.differences_counts.no_explanation_count",
-        ],
-        code: "W302",
-      });
-    }
-
-    //SECTION political_group_votes
-    let candidateVotesSum = 0;
-    political_group_votes.forEach((pg) => {
-      // F.401
-      const sum = pg.candidate_votes.reduce((acc, cv) => acc + cv.votes, 0);
-      candidateVotesSum += sum;
-      if (sum !== pg.total) {
-        response.validation_results.errors.push({
-          fields: [`data.political_group_votes[${pg.number - 1}]`],
-          code: "F401",
-        });
-      }
-    });
-
-    // F.204
-    if (votes_counts.votes_candidates_count !== candidateVotesSum) {
-      response.validation_results.errors.push({
-        fields: ["data.votes_counts.votes_candidates_count", "data.political_group_votes"],
-        code: "F204",
-      });
-    }
-
+    const response: SaveDataEntryResponse = {
+      validation_results: validate(json.data),
+    };
     return HttpResponse.json(response, { status: 200 });
   } catch (e) {
     if (e instanceof SyntaxError) {
-      return HttpResponse.json(
-        {
-          error: "Invalid JSON",
-        },
-        { status: 422 },
-      );
+      return HttpResponse.json({ error: "Invalid JSON" } satisfies ErrorResponse, { status: 422 });
     } else {
       console.error("Mock request error:", e);
-      return HttpResponse.json(
-        {
-          error: "Internal Server Error",
-        },
-        { status: 500 },
-      );
+      return HttpResponse.json({ error: "Internal Server Error" } satisfies ErrorResponse, { status: 500 });
     }
   }
 });
@@ -310,22 +144,50 @@ export const PollingStationDataEntrySaveHandler = http.post<
 // get data entry handler
 export const PollingStationDataEntryGetHandler = http.get<
   ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
->("/api/polling_stations/:polling_station_id/data_entries/:entry_number", () => {
-  // Currently we have no persistence in MSW, so always return 404
-  return HttpResponse.text(null, { status: 404 });
+>("/api/polling_stations/:polling_station_id/data_entries/:entry_number", ({ params }) => {
+  const pollingStationId = Number(params.polling_station_id);
+  const entryNumber = Number(params.entry_number);
+  const dataEntryRecord = Database.dataEntries.find(
+    (d) => d.pollingStationId === pollingStationId && d.entryNumber === entryNumber,
+  );
+  if (!dataEntryRecord) return HttpResponse.text(null, { status: 404 });
+
+  const response: GetDataEntryResponse = {
+    data: dataEntryRecord.data,
+    client_state: dataEntryRecord.clientState,
+    validation_results: validate(dataEntryRecord.data),
+  };
+  return HttpResponse.json(response, { status: 200 });
 });
 
 // delete data entry handler
 export const PollingStationDataEntryDeleteHandler = http.delete<
   ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
->("/api/polling_stations/:polling_station_id/data_entries/:entry_number", () => {
+>("/api/polling_stations/:polling_station_id/data_entries/:entry_number", ({ params }) => {
+  Database.dataEntries = Database.dataEntries.filter(
+    (d) => d.pollingStationId !== Number(params.polling_station_id) || d.entryNumber !== Number(params.entry_number),
+  );
   return HttpResponse.text(null, { status: 204 });
 });
 
 // finalise data entry handler
 export const PollingStationDataEntryFinaliseHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS>
->("/api/polling_stations/:polling_station_id/data_entries/:entry_number/finalise", () => {
+>("/api/polling_stations/:polling_station_id/data_entries/:entry_number/finalise", ({ params }) => {
+  const idx = Database.dataEntries.findIndex(
+    (d) => d.pollingStationId === Number(params.polling_station_id) && d.entryNumber === Number(params.entry_number),
+  );
+  if (idx === -1) return HttpResponse.text(null, { status: 404 });
+
+  const dataEntry = Database.dataEntries.splice(idx, 1)[0];
+  if (!dataEntry) return HttpResponse.text(null, { status: 404 });
+
+  Database.results.push({
+    pollingStationId: dataEntry.pollingStationId,
+    entryNumber: dataEntry.entryNumber,
+    data: dataEntry.data,
+  });
+
   return HttpResponse.text(null, { status: 200 });
 });
 

--- a/frontend/lib/api-mocks/index.ts
+++ b/frontend/lib/api-mocks/index.ts
@@ -1,3 +1,4 @@
 export * from "./ElectionMockData";
 export * from "./PollingStationMockData";
 export * from "./RequestHandlers";
+export { validate } from "./DataEntry.ts";

--- a/frontend/lib/api-mocks/index.ts
+++ b/frontend/lib/api-mocks/index.ts
@@ -1,4 +1,4 @@
 export * from "./ElectionMockData";
 export * from "./PollingStationMockData";
 export * from "./RequestHandlers";
-export { validate } from "./DataEntry.ts";
+export { resetDatabase } from "./Database";


### PR DESCRIPTION
Supports data entry resume, abort, and status.

Also add a new 'not available in mock' page that used to hide the finalisation page, because PDF creation doesn't work in the mock version.