### PR TITLE
Save data entry immediately after beginning

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -878,7 +878,6 @@
         "type": "object",
         "description": "PollingStationResults, following the fields in Model Na 31-2 Bijage 2.\n\nSee \"Model Na 31-2. Proces-verbaal van een gemeentelijk stembureau/stembureau voor het openbaar\nlichaam in een gemeente/openbaar lichaam waar een centrale stemopneming wordt verricht,\nBijlage 2: uitkomsten per stembureau\" from the\n[Kiesregeling](https://wetten.overheid.nl/BWBR0034180/2024-04-01#Bijlage1_DivisieNa31.2) or\n[Verkiezingstoolbox](https://www.rijksoverheid.nl/onderwerpen/verkiezingen/verkiezingentoolkit/modellen).",
         "required": [
-          "recounted",
           "voters_counts",
           "votes_counts",
           "differences_counts",
@@ -897,7 +896,8 @@
           },
           "recounted": {
             "type": "boolean",
-            "description": "Recounted (\"Is er herteld? - See form for official long description of the checkbox\")"
+            "description": "Recounted (\"Is er herteld? - See form for official long description of the checkbox\")",
+            "nullable": true
           },
           "voters_counts": {
             "$ref": "#/components/schemas/VotersCounts"
@@ -998,6 +998,7 @@
       "ValidationResultCode": {
         "type": "string",
         "enum": [
+          "F101",
           "F201",
           "F202",
           "F203",

--- a/backend/src/data_entry/mod.rs
+++ b/backend/src/data_entry/mod.rs
@@ -263,7 +263,7 @@ mod tests {
     fn example_data_entry() -> SaveDataEntryRequest {
         SaveDataEntryRequest {
             data: PollingStationResults {
-                recounted: false,
+                recounted: Some(false),
                 voters_counts: VotersCounts {
                     poll_card_count: 100, // incorrect
                     proxy_certificate_count: 1,

--- a/backend/src/pdf_gen/models/model_na_31_2.rs
+++ b/backend/src/pdf_gen/models/model_na_31_2.rs
@@ -101,7 +101,7 @@ impl ModelNa31_2Summary {
                 .add_polling_station_results(polling_station, &result.differences_counts);
 
             // if this polling station was recounted, add it to the list
-            if result.recounted {
+            if result.recounted == Some(true) {
                 totals
                     .recounted_polling_stations
                     .push(polling_station.number);
@@ -238,7 +238,7 @@ mod tests {
     fn polling_station_results_fixture() -> (PollingStationResults, PollingStationResults) {
         (
             PollingStationResults {
-                recounted: false,
+                recounted: Some(false),
                 voters_counts: VotersCounts {
                     poll_card_count: 20,
                     proxy_certificate_count: 5,
@@ -297,7 +297,7 @@ mod tests {
                 ],
             },
             PollingStationResults {
-                recounted: false,
+                recounted: Some(false),
                 voters_counts: VotersCounts {
                     poll_card_count: 39,
                     proxy_certificate_count: 1,
@@ -468,7 +468,7 @@ mod tests {
         let (ps1, ps2) = polling_station_fixture(&election);
         let (ps1_results, mut ps2_results) = polling_station_results_fixture();
 
-        ps2_results.recounted = true;
+        ps2_results.recounted = Some(true);
         ps2_results.voters_counts = VotersCounts {
             poll_card_count: 50,
             proxy_certificate_count: 0,

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -30,6 +30,7 @@ pub struct ValidationResult {
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ValidationResultCode {
+    F101,
     F201,
     F202,
     F203,

--- a/backend/tests/shared.rs
+++ b/backend/tests/shared.rs
@@ -11,7 +11,7 @@ use hyper::StatusCode;
 pub fn example_data_entry() -> SaveDataEntryRequest {
     SaveDataEntryRequest {
         data: PollingStationResults {
-            recounted: false,
+            recounted: Some(false),
             voters_counts: VotersCounts {
                 poll_card_count: 100,
                 proxy_certificate_count: 2,

--- a/documentatie/use-cases/GSB-validatieregels-plausibiliteitschecks.md
+++ b/documentatie/use-cases/GSB-validatieregels-plausibiliteitschecks.md
@@ -33,6 +33,8 @@ Er zijn geen regels omdat het niet mogelijk is om foute aantallen in te vullen i
 
 Velden markeren: geen (laat alleen error zien op de pagina)
 
+Bij deze foutmelding wordt het standaard handelingsperspectief niet getoond.
+
 ### Regels voor totalen (reeks F.2xx)
 
 #### F.201: (Als niet herteld) `stempassen + volmachten + kiezerspassen = totaal toegelaten kiezers`

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
@@ -13,13 +13,13 @@ import {
   PoliticalGroup,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   PollingStationFormController,
-  PollingStationValues,
+  PollingStationResults,
 } from "@kiesraad/api";
 import { electionMockData, politicalGroupMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { CandidatesVotesForm } from "./CandidatesVotesForm";
 
-function renderForm(defaultValues: Partial<PollingStationValues> = {}) {
+function renderForm(defaultValues: Partial<PollingStationResults> = {}) {
   return render(
     <PollingStationFormController
       election={electionMockData}

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
@@ -44,11 +44,12 @@ describe("Test CandidatesVotesForm", () => {
       const user = userEvent.setup();
 
       renderForm({ recounted: false });
-      const spy = vi.spyOn(global, "fetch");
 
       const candidate1 = await screen.findByTestId("candidate_votes[0].votes");
       await user.type(candidate1, "12345");
       expect(candidate1).toHaveValue("12345");
+
+      const spy = vi.spyOn(global, "fetch");
 
       await user.keyboard("{enter}");
 
@@ -281,16 +282,17 @@ describe("Test CandidatesVotesForm", () => {
 
   describe("CandidatesVotesForm errors", () => {
     test("F.401 IncorrectTotal group total", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("candidates_form_1");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [{ fields: ["data.political_group_votes[0]"], code: "F401" }],
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -312,16 +314,17 @@ describe("Test CandidatesVotesForm", () => {
 
   describe("CandidatesVotesForm warnings", () => {
     test("Imagined warning on this form", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("candidates_form_1");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
           warnings: [{ fields: ["data.political_group_votes[0]"], code: "F401" }],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);

--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
@@ -7,14 +7,14 @@ import { CheckAndSaveForm } from "app/component/form/data_entry/check_and_save/C
 import { overrideOnce, render, screen, server, within } from "app/test/unit";
 import { defaultFormState, emptyDataEntryRequest, errorWarningMocks } from "app/test/unit/form";
 
-import { ElectionProvider, FormState, PollingStationFormController, PollingStationValues } from "@kiesraad/api";
+import { ElectionProvider, FormState, PollingStationFormController, PollingStationResults } from "@kiesraad/api";
 import { electionDetailsMockResponse, electionMockData } from "@kiesraad/api-mocks";
 
 const mockNavigate = vi.fn();
 
 const defaultValues = emptyDataEntryRequest.data;
 
-function renderForm(defaultFormState: Partial<FormState> = {}, defaultValues?: Partial<PollingStationValues>) {
+function renderForm(defaultFormState: Partial<FormState> = {}, defaultValues?: Partial<PollingStationResults>) {
   return render(
     <ElectionProvider electionId={1}>
       <PollingStationFormController

--- a/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
@@ -48,11 +48,12 @@ describe("Test DifferencesForm", () => {
       const user = userEvent.setup();
 
       renderForm({ recounted: false });
-      const spy = vi.spyOn(global, "fetch");
 
       const moreBallotsCount = await screen.findByTestId("more_ballots_count");
       await user.type(moreBallotsCount, "12345");
       expect(moreBallotsCount).toHaveValue("12345");
+
+      const spy = vi.spyOn(global, "fetch");
 
       await user.keyboard("{enter}");
 
@@ -176,6 +177,7 @@ describe("Test DifferencesForm", () => {
 
       renderForm({ ...votersAndVotesValues });
 
+      await screen.findByTestId("differences_form");
       const spy = vi.spyOn(global, "fetch");
 
       await userTypeInputs(user, {
@@ -196,16 +198,17 @@ describe("Test DifferencesForm", () => {
 
   describe("DifferencesForm errors", () => {
     test("F.301 IncorrectDifference", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [{ fields: ["data.differences_counts.more_ballots_count"], code: "F301" }],
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -230,16 +233,17 @@ describe("Test DifferencesForm", () => {
     });
 
     test("F.302 Should be empty", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: true });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [{ fields: ["data.differences_counts.fewer_ballots_count"], code: "F302" }],
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: true });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -264,16 +268,17 @@ describe("Test DifferencesForm", () => {
     });
 
     test("F.303 IncorrectDifference", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [{ fields: ["data.differences_counts.fewer_ballots_count"], code: "F303" }],
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -298,16 +303,17 @@ describe("Test DifferencesForm", () => {
     });
 
     test("F.304 Should be empty", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: true });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [{ fields: ["data.differences_counts.more_ballots_count"], code: "F304" }],
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: true });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -332,6 +338,11 @@ describe("Test DifferencesForm", () => {
     });
 
     test("F.305 No difference expected", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [
@@ -350,10 +361,6 @@ describe("Test DifferencesForm", () => {
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -380,6 +387,11 @@ describe("Test DifferencesForm", () => {
 
   describe("DifferencesForm warnings", () => {
     test("clicking next without accepting warning results in alert shown and then accept warning", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -398,10 +410,6 @@ describe("Test DifferencesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -447,6 +455,11 @@ describe("Test DifferencesForm", () => {
     });
 
     test("W.301 Incorrect total", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -465,10 +478,6 @@ describe("Test DifferencesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -493,6 +502,11 @@ describe("Test DifferencesForm", () => {
     });
 
     test("W.302 Incorrect total", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("differences_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -511,10 +525,6 @@ describe("Test DifferencesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);

--- a/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/differences/DifferencesForm.test.tsx
@@ -13,13 +13,13 @@ import { emptyDataEntryRequest } from "app/test/unit/form";
 import {
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   PollingStationFormController,
-  PollingStationValues,
+  PollingStationResults,
 } from "@kiesraad/api";
 import { electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
 import { DifferencesForm } from "./DifferencesForm";
 
-function renderForm(defaultValues: Partial<PollingStationValues> = {}) {
+function renderForm(defaultValues: Partial<PollingStationResults> = {}) {
   return render(
     <PollingStationFormController
       election={electionMockData}

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
@@ -114,7 +114,15 @@ describe("Test RecountedForm", () => {
   describe("RecountedForm errors", () => {
     test("F.101 No radio selected", async () => {
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
-        validation_results: { errors: [], warnings: [] },
+        validation_results: {
+          errors: [
+            {
+              code: "F101",
+              fields: ["data.recounted"],
+            },
+          ],
+          warnings: [],
+        },
       });
 
       const user = userEvent.setup();

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
@@ -21,11 +21,12 @@ describe("Test RecountedForm", () => {
       render(Component);
 
       const user = userEvent.setup();
-      const spy = vi.spyOn(global, "fetch");
 
       const yes = await screen.findByTestId("yes");
       await user.click(yes);
       expect(yes).toBeChecked();
+
+      const spy = vi.spyOn(global, "fetch");
 
       await user.keyboard("{enter}");
 
@@ -92,11 +93,12 @@ describe("Test RecountedForm", () => {
 
       render(Component);
 
-      const spy = vi.spyOn(global, "fetch");
       const user = userEvent.setup();
 
       const yes = await screen.findByTestId("yes");
       await user.click(yes);
+
+      const spy = vi.spyOn(global, "fetch");
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.tsx
@@ -13,7 +13,6 @@ interface RecountedFormElement extends HTMLFormElement {
 }
 
 export function RecountedForm() {
-  const [hasValidationError, setHasValidationError] = React.useState(false);
   const formRef = React.useRef<RecountedFormElement>(null);
 
   const getValues = React.useCallback(() => {
@@ -25,22 +24,16 @@ export function RecountedForm() {
     return { recounted: elements.yes.checked ? true : elements.no.checked ? false : undefined };
   }, []);
 
-  const { status, sectionValues, isSaved, submit } = useRecounted(getValues);
+  const { status, sectionValues, errors, isSaved, submit } = useRecounted(getValues);
 
   const handleSubmit = (event: React.FormEvent<RecountedFormElement>) =>
     void (async (event: React.FormEvent<RecountedFormElement>) => {
       event.preventDefault();
-      const elements = event.currentTarget.elements;
 
-      if (!elements.yes.checked && !elements.no.checked) {
-        setHasValidationError(true);
-      } else {
-        setHasValidationError(false);
-        try {
-          await submit();
-        } catch (e) {
-          console.error("Error saving data entry", e);
-        }
+      try {
+        await submit();
+      } catch (e) {
+        console.error("Error saving data entry", e);
       }
     })(event);
 
@@ -48,19 +41,15 @@ export function RecountedForm() {
     if (isSaved) {
       window.scrollTo(0, 0);
     }
-  }, [isSaved]);
+  }, [isSaved, errors]);
+
+  const hasValidationError = errors.length > 0;
 
   return (
     <Form onSubmit={handleSubmit} ref={formRef} id="recounted_form">
       <h2>Is er herteld?</h2>
-      {hasValidationError && (
-        <Feedback id="feedback-error" type="error" data={["F101"]}>
-          <ul>
-            <li>Controleer of rubriek 3 is ingevuld. Is dat zo? Kies hieronder 'ja'</li>
-            <li>Wel een vinkje, maar rubriek 3 niet ingevuld? Overleg met de coördinator</li>
-            <li>Geen vinkje? Kies dan 'nee'.</li>
-          </ul>
-        </Feedback>
+      {isSaved && hasValidationError && (
+        <Feedback id="feedback-error" type="error" data={errors.map((error) => error.code)} />
       )}
       <p className="form-paragraph md">
         Was er een onverklaard verschil tussen het aantal toegelaten kiezers en het aantal uitgebrachte stemmen? Is er

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -14,7 +14,7 @@ import {
   FormState,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   PollingStationFormController,
-  PollingStationValues,
+  PollingStationResults,
 } from "@kiesraad/api";
 import { electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
 
@@ -59,7 +59,7 @@ const defaultFormState: FormState = {
   },
 };
 
-function renderForm(defaultValues: Partial<PollingStationValues> = {}) {
+function renderForm(defaultValues: Partial<PollingStationResults> = {}) {
   return render(
     <PollingStationFormController
       election={electionMockData}
@@ -200,6 +200,7 @@ describe("Test VotersAndVotesForm", () => {
       const expectedRequest = {
         data: {
           ...emptyDataEntryRequest.data,
+          recounted: false,
           voters_counts: {
             poll_card_count: 1,
             proxy_certificate_count: 2,

--- a/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -100,11 +100,12 @@ describe("Test VotersAndVotesForm", () => {
       const user = userEvent.setup();
 
       renderForm({ recounted: false });
-      const spy = vi.spyOn(global, "fetch");
 
       const pollCards = await screen.findByTestId("poll_card_count");
       await user.type(pollCards, "12345");
       expect(pollCards).toHaveValue("12345");
+
+      const spy = vi.spyOn(global, "fetch");
 
       await user.keyboard("{enter}");
 
@@ -221,12 +222,12 @@ describe("Test VotersAndVotesForm", () => {
 
       renderForm({ recounted: false });
 
-      const spy = vi.spyOn(global, "fetch");
-
       await userTypeInputs(user, {
         ...expectedRequest.data.voters_counts,
         ...expectedRequest.data.votes_counts,
       });
+
+      const spy = vi.spyOn(global, "fetch");
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -243,6 +244,11 @@ describe("Test VotersAndVotesForm", () => {
 
   describe("VotersAndVotesForm errors", () => {
     test("F.201 IncorrectTotal Voters counts", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [
@@ -259,10 +265,6 @@ describe("Test VotersAndVotesForm", () => {
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -290,6 +292,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("F.202 IncorrectTotal Votes counts", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [
@@ -306,10 +313,6 @@ describe("Test VotersAndVotesForm", () => {
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -337,6 +340,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("F.203 IncorrectTotal Voters recounts", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: true });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [
@@ -353,10 +361,6 @@ describe("Test VotersAndVotesForm", () => {
           warnings: [],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: true });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -391,16 +395,17 @@ describe("Test VotersAndVotesForm", () => {
 
   describe("VotersAndVotesForm warnings", () => {
     test("clicking next without accepting warning results in alert shown and then accept warning", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
           warnings: [{ fields: ["data.votes_counts.blank_votes_count"], code: "W201" }],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -476,16 +481,17 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.201 high number of blank votes", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
           warnings: [{ fields: ["data.votes_counts.blank_votes_count"], code: "W201" }],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -511,16 +517,17 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.202 high number of invalid votes", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
           warnings: [{ fields: ["data.votes_counts.invalid_votes_count"], code: "W202" }],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -546,6 +553,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.203 voters counts and votes counts difference above threshold", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -557,10 +569,6 @@ describe("Test VotersAndVotesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -585,6 +593,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.204 votes counts and voters recounts difference above threshold", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: true });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -599,10 +612,6 @@ describe("Test VotersAndVotesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: true });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -632,16 +641,17 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.205 total votes cast should not be zero", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
           warnings: [{ fields: ["data.votes_counts.total_votes_cast_count"], code: "W205" }],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -667,6 +677,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.206 total admitted voters and total votes cast should not exceed polling stations number of eligible voters", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -678,10 +693,6 @@ describe("Test VotersAndVotesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -706,6 +717,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.207 total votes cast and total admitted voters recount should not exceed polling stations number of eligible voters", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: true });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -720,10 +736,6 @@ describe("Test VotersAndVotesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: true });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -752,6 +764,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.208 EqualInput voters counts and votes counts", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: false });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -763,10 +780,6 @@ describe("Test VotersAndVotesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: false });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);
@@ -791,6 +804,11 @@ describe("Test VotersAndVotesForm", () => {
     });
 
     test("W.209 EqualInput voters recounts and votes counts", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ recounted: true });
+
+      await screen.findByTestId("voters_and_votes_form");
       overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
         validation_results: {
           errors: [],
@@ -811,10 +829,6 @@ describe("Test VotersAndVotesForm", () => {
           ],
         },
       });
-
-      const user = userEvent.setup();
-
-      renderForm({ recounted: true });
 
       const submitButton = await screen.findByRole("button", { name: "Volgende" });
       await user.click(submitButton);

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
@@ -9,7 +9,7 @@ import {
   Election,
   FormSectionID,
   FormState,
-  PollingStationValues,
+  PollingStationResults,
   usePollingStationFormController,
 } from "@kiesraad/api";
 import { Button, Feedback, Modal } from "@kiesraad/ui";
@@ -159,7 +159,7 @@ type BlockReason = "errors" | "warnings" | "changes";
 function reasonsBlocked(
   formState: FormState,
   currentForm: AnyFormReference,
-  values: PollingStationValues,
+  values: PollingStationResults,
 ): BlockReason[] {
   const result: BlockReason[] = [];
 

--- a/frontend/app/component/pollingstation/utils.ts
+++ b/frontend/app/component/pollingstation/utils.ts
@@ -1,7 +1,11 @@
 import { FormSectionID } from "@kiesraad/api";
 
+export function getBaseUrl(electionId: number, pollingStationId: number) {
+  return `/elections/${electionId}/data-entry/${pollingStationId}`;
+}
+
 export function getUrlForFormSectionID(electionId: number, pollingStationId: number, sectionId: FormSectionID) {
-  const baseUrl = `/elections/${electionId}/data-entry/${pollingStationId}`;
+  const baseUrl = getBaseUrl(electionId, pollingStationId);
 
   let url: string = "";
   if (sectionId.startsWith("political_group_votes_")) {

--- a/frontend/app/test/unit/form.ts
+++ b/frontend/app/test/unit/form.ts
@@ -3,7 +3,6 @@ import { electionMockData } from "@kiesraad/api-mocks";
 
 export const emptyDataEntryRequest: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY = {
   data: {
-    recounted: false,
     voters_counts: {
       poll_card_count: 0,
       proxy_certificate_count: 0,

--- a/frontend/lib/api-mocks/DataEntry.ts
+++ b/frontend/lib/api-mocks/DataEntry.ts
@@ -6,12 +6,21 @@ export function validate(data: PollingStationResults): ValidationResults {
     warnings: [],
   };
 
-  const { voters_counts, votes_counts, voters_recounts, differences_counts, political_group_votes } = data;
+  const { recounted, voters_counts, votes_counts, voters_recounts, differences_counts, political_group_votes } = data;
 
   // Rules and checks implemented in this mock api:
-  // F.201-204, F.301-305, F.401, W.301-302
+  // F.101, F.201-204, F.301-305, F.401, W.301-302
   // Rules and checks not implemented in this mock api:
   // W.201-210
+
+  // SECTION recounted
+  //  F.101
+  if (recounted === undefined) {
+    validation_results.errors.push({
+      fields: ["data.recounted"],
+      code: "F101",
+    });
+  }
 
   const total_votes_counts = votes_counts.total_votes_cast_count;
   let total_voters_counts;

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.test.tsx
@@ -80,18 +80,6 @@ describe("PollingStationFormController", () => {
   });
 
   test("It filters out global errors", async () => {
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
-      validation_results: {
-        errors: [
-          {
-            fields: ["data.votes_counts.votes_candidates_count", "data.political_group_votes"],
-            code: "F204",
-          },
-        ],
-        warnings: [],
-      },
-    });
-
     const { result } = renderHook(() => usePollingStationFormController(), {
       wrapper: Wrapper,
     });
@@ -125,6 +113,18 @@ describe("PollingStationFormController", () => {
     await waitFor(() => {
       // wait for the form state to be updated after registering the form
       expect(result.current.formState.current).toBe("voters_votes_counts");
+    });
+
+    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
+      validation_results: {
+        errors: [
+          {
+            fields: ["data.votes_counts.votes_candidates_count", "data.political_group_votes"],
+            code: "F204",
+          },
+        ],
+        warnings: [],
+      },
     });
 
     await result.current.submitCurrentForm();

--- a/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
+++ b/frontend/lib/api/form/pollingstation/PollingStationFormController.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
-import { getUrlForFormSectionID } from "app/component/pollingstation/utils";
+import { getBaseUrl, getUrlForFormSectionID } from "app/component/pollingstation/utils";
 
 import {
   ApiError,
@@ -161,6 +161,7 @@ export function PollingStationFormController({
   const request_path: POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
   const { client } = useApi();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [values, setValues] = React.useState<PollingStationValues>();
   const [formState, setFormState] = React.useState<FormState>();
@@ -219,9 +220,13 @@ export function PollingStationFormController({
   React.useEffect(() => {
     if (!targetFormSectionID) return;
     const url = getUrlForFormSectionID(election.id, pollingStationId, targetFormSectionID);
-    navigate(url);
+    if (location.pathname === getBaseUrl(election.id, pollingStationId)) {
+      navigate(url, { replace: true });
+    } else if (location.pathname !== url) {
+      navigate(url);
+    }
     setTargetFormSectionID(null);
-  }, [targetFormSectionID, navigate, election.id, pollingStationId]);
+  }, [targetFormSectionID, navigate, election.id, pollingStationId, location.pathname]);
 
   const registerCurrentForm = React.useCallback(
     (form: AnyFormReference) => {

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.test.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.test.ts
@@ -15,12 +15,12 @@ import {
   hasOnlyGlobalValidationResults,
   isFormSectionEmpty,
   isGlobalValidationResult,
-  PollingStationValues,
+  PollingStationResults,
   resetFormSectionState,
   ValidationResult,
 } from "@kiesraad/api";
 
-const defaultValues: PollingStationValues = emptyDataEntryRequest.data;
+const defaultValues: PollingStationResults = emptyDataEntryRequest.data;
 
 describe("PollingStationUtils", () => {
   test("addValidationResultToFormState adds result to correct section", () => {

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
@@ -42,6 +42,9 @@ export function addValidationResultToFormState(
     uniqueRootSections.forEach((fieldSection) => {
       const { name: rootSection, index } = fieldSection;
       switch (rootSection) {
+        case "recounted":
+          checkAndAddValidationResult(formState.sections.recounted, target, validationResult);
+          break;
         case "votes_counts":
         case "voters_counts":
         case "voters_recounts":

--- a/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
+++ b/frontend/lib/api/form/pollingstation/pollingStationUtils.ts
@@ -1,6 +1,6 @@
 import { ErrorsAndWarnings } from "lib/api/api";
 
-import { Election, ValidationResult, ValidationResults } from "@kiesraad/api";
+import { Election, PollingStationResults, ValidationResult, ValidationResults } from "@kiesraad/api";
 import { ValidationResultType } from "@kiesraad/ui";
 import { deepEqual, fieldNameFromPath, FieldSection, objectHasOnlyEmptyValues, rootFieldSection } from "@kiesraad/util";
 
@@ -12,7 +12,6 @@ import {
   FormSectionID,
   FormState,
   INITIAL_FORM_SECTION_ID,
-  PollingStationValues,
 } from "./PollingStationFormController";
 import { DifferencesValues } from "./useDifferences";
 import { RecountedValue } from "./useRecounted";
@@ -114,7 +113,7 @@ export function getNextSectionID(formState: FormState) {
   return null;
 }
 
-export function currentFormHasChanges(currentForm: AnyFormReference, values: PollingStationValues): boolean {
+export function currentFormHasChanges(currentForm: AnyFormReference, values: PollingStationResults): boolean {
   if (currentForm.type === "recounted") {
     const valA: RecountedValue = { recounted: values.recounted };
     const valB = currentForm.getValues();
@@ -197,7 +196,7 @@ export function getErrorsAndWarnings(
   return result;
 }
 
-export function isFormSectionEmpty(section: FormSection, values: PollingStationValues): boolean {
+export function isFormSectionEmpty(section: FormSection, values: PollingStationResults): boolean {
   if (section.id.startsWith("political_group_votes_")) {
     const index = parseInt(section.id.replace("political_group_votes_", "")) - 1;
     const g = values.political_group_votes[index];
@@ -236,7 +235,7 @@ export type PollingStationSummary = {
   }[];
 };
 
-export function getPollingStationSummary(formState: FormState, values: PollingStationValues): PollingStationSummary {
+export function getPollingStationSummary(formState: FormState, values: PollingStationResults): PollingStationSummary {
   const result: PollingStationSummary = {
     countsAddUp: true,
     hasBlocks: false,
@@ -282,8 +281,8 @@ function sortFormSections(a: FormSection, b: FormSection): number {
 
 export function getInitialValues(
   election: Required<Election>,
-  defaultValues?: Partial<PollingStationValues>,
-): PollingStationValues {
+  defaultValues?: Partial<PollingStationResults>,
+): PollingStationResults {
   return {
     recounted: undefined,
     voters_counts: {

--- a/frontend/lib/api/form/pollingstation/useRecounted.ts
+++ b/frontend/lib/api/form/pollingstation/useRecounted.ts
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import { PollingStationValues, usePollingStationFormController } from "@kiesraad/api";
+import { PollingStationResults, usePollingStationFormController } from "@kiesraad/api";
 
-export type RecountedValue = Pick<PollingStationValues, "recounted">;
+export type RecountedValue = Pick<PollingStationResults, "recounted">;
 
 export function useRecounted(getValues: () => RecountedValue) {
   const { status, values, formState, submitCurrentForm, setTemporaryCache, registerCurrentForm, cache } =

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -182,7 +182,7 @@ Bijlage 2: uitkomsten per stembureau" from the
 export interface PollingStationResults {
   differences_counts: DifferencesCounts;
   political_group_votes: PoliticalGroupVotes[];
-  recounted: boolean;
+  recounted?: boolean;
   voters_counts: VotersCounts;
   voters_recounts?: VotersRecounts;
   votes_counts: VotesCounts;
@@ -221,6 +221,7 @@ export interface ValidationResult {
 }
 
 export type ValidationResultCode =
+  | "F101"
   | "F201"
   | "F202"
   | "F203"

--- a/frontend/lib/ui/Feedback/Feedback.stories.tsx
+++ b/frontend/lib/ui/Feedback/Feedback.stories.tsx
@@ -15,16 +15,8 @@ export const SingleError: Story = () => {
   return <Feedback id="feedback-error" type="error" data={["F202"]} />;
 };
 
-export const SingleErrorWithCustomAction: Story = () => {
-  return (
-    <Feedback id="feedback-error" type="error" data={["F101"]}>
-      <ul>
-        <li>Controleer of rubriek 3 is ingevuld. Is dat zo? Kies hieronder 'ja'</li>
-        <li>Wel een vinkje, maar rubriek 3 niet ingevuld? Overleg met de coördinator</li>
-        <li>Geen vinkje? Kies dan 'nee'.</li>
-      </ul>
-    </Feedback>
-  );
+export const SingleErrorCustomAction: Story = () => {
+  return <Feedback id="feedback-error" type="error" data={["F101"]} />;
 };
 
 export const MultipleErrors: Story = () => {

--- a/frontend/lib/ui/Feedback/Feedback.test.tsx
+++ b/frontend/lib/ui/Feedback/Feedback.test.tsx
@@ -6,7 +6,7 @@ import {
   MultipleErrors,
   MultipleWarnings,
   SingleError,
-  SingleErrorWithCustomAction,
+  SingleErrorCustomAction,
   SingleServerError,
   SingleWarning,
 } from "./Feedback.stories";
@@ -25,14 +25,12 @@ describe("UI component: Feedback", () => {
     ).toBeInTheDocument();
   });
 
-  test("Single Error With Custom Action has expected children", () => {
-    const { getByText } = render(<SingleErrorWithCustomAction />);
+  test("Single error with custom action does not have default action text", () => {
+    const { getByText, queryByText } = render(<SingleErrorCustomAction />);
 
     expect(getByText("Controleer het papieren proces-verbaal")).toBeInTheDocument();
     expect(getByText("F.101")).toBeInTheDocument();
-    expect(getByText("Controleer of rubriek 3 is ingevuld. Is dat zo? Kies hieronder 'ja'")).toBeInTheDocument();
-    expect(getByText("Wel een vinkje, maar rubriek 3 niet ingevuld? Overleg met de coördinator")).toBeInTheDocument();
-    expect(getByText("Geen vinkje? Kies dan 'nee'.")).toBeInTheDocument();
+    expect(queryByText("Heb je iets niet goed overgenomen? Herstel de fout en ga verder.")).not.toBeInTheDocument();
   });
 
   test("Multiple errors has expected children", () => {

--- a/frontend/lib/ui/Feedback/Feedback.tsx
+++ b/frontend/lib/ui/Feedback/Feedback.tsx
@@ -1,5 +1,3 @@
-import { ReactNode } from "react";
-
 import { ApiError } from "@kiesraad/api";
 import { AlertType, FeedbackId, renderIconForType } from "@kiesraad/ui";
 import { cn } from "@kiesraad/util";
@@ -13,10 +11,9 @@ export interface FeedbackProps {
   data?: ClientValidationResultCode[];
   // TODO: #277 move to error page or modal
   apiError?: ApiError;
-  children?: ReactNode;
 }
 
-export function Feedback({ id, type, data, apiError, children }: FeedbackProps) {
+export function Feedback({ id, type, data, apiError }: FeedbackProps) {
   const feedbackList: FeedbackItem[] = [];
   if (data) {
     for (const code of data) {
@@ -47,29 +44,26 @@ export function Feedback({ id, type, data, apiError, children }: FeedbackProps) 
           <div className="content">{feedback.content}</div>
         </div>
       ))}
-      {(children || feedbackList.length > 0) && (
+      {feedbackList.length > 0 && (
         <div className="feedback-action">
-          {children ? (
-            children
+          {feedbackList.length > 1 ? (
+            <h3>Voor alle {type === "error" ? "foutmeldingen" : "waarschuwingen"} geldt het volgende:</h3>
           ) : (
-            <>
-              {feedbackList.length > 1 ? (
-                <h3>Voor alle {type === "error" ? "foutmeldingen" : "waarschuwingen"} geldt het volgende:</h3>
+            <></>
+          )}
+          {feedbackList.length > 1 || !feedbackList[0]?.action ? (
+            <ul>
+              <li>Heb je iets niet goed overgenomen? Herstel de fout en ga verder.</li>
+              {type === "error" ? (
+                <li>
+                  Heb je alles goed overgenomen, en blijft de fout? Dan mag je niet verder. Overleg met de coördinator.
+                </li>
               ) : (
-                <></>
+                <li>Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.</li>
               )}
-              <ul>
-                <li>Heb je iets niet goed overgenomen? Herstel de fout en ga verder.</li>
-                {type === "error" ? (
-                  <li>
-                    Heb je alles goed overgenomen, en blijft de fout? Dan mag je niet verder. Overleg met de
-                    coördinator.
-                  </li>
-                ) : (
-                  <li>Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.</li>
-                )}
-              </ul>
-            </>
+            </ul>
+          ) : (
+            feedbackList[0].action
           )}
         </div>
       )}

--- a/frontend/lib/ui/Feedback/Feedback.types.tsx
+++ b/frontend/lib/ui/Feedback/Feedback.types.tsx
@@ -9,6 +9,7 @@ export interface FeedbackItem {
   title: string;
   code?: string;
   content: ReactNode;
+  action?: ReactNode;
 }
 
 export const feedbackTypes: { [feedbackCode in ClientValidationResultCode]: FeedbackItem } = {
@@ -16,6 +17,13 @@ export const feedbackTypes: { [feedbackCode in ClientValidationResultCode]: Feed
     title: "Controleer het papieren proces-verbaal",
     code: "F.101",
     content: <span>Is op pagina 1 aangegeven dat er in opdracht van het Gemeentelijk Stembureau is herteld?</span>,
+    action: (
+      <ul>
+        <li>Controleer of rubriek 3 is ingevuld. Is dat zo? Kies hieronder 'ja'</li>
+        <li>Wel een vinkje, maar rubriek 3 niet ingevuld? Overleg met de coördinator</li>
+        <li>Geen vinkje? Kies dan 'nee'.</li>
+      </ul>
+    ),
   },
   F201: {
     title: "Controleer toegelaten kiezers",


### PR DESCRIPTION
- **Fix back button after beginning data entry**
  Initially, navigate by replacing the current entry in the history
  stack. This prevents the initial page that redirects from being loaded
  when the back button is clicked. The back button now goes back to the
  polling station choice page instead.
  

- **Make the `recounted` field optional**
  If the data entry form is saved on the first step and later resumed, the
  `recounted` radio button is now unchecked instead of defaulting to 'No'.
  

- **Render F.101 using server validation result**
  

- **Save data entry immediately after beginning**
  And fix form tests to not override POST before the new initial save.
  
Closes #411 