### PR TITLE
Memory serve

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
       - name: Create frontend asset directory
-        run: mkdir -p frontend/dist
+        run: mkdir -p ../frontend/dist
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features sqlite
       - name: Create database and run migrations

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -33,6 +33,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+      - name: Create frontend asset directory
+        run: mkdir -p frontend/dist
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features sqlite
       - name: Create database and run migrations

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  ASSET_DIR: ${{ GITHUB_WORKSPACE }}/frontend/dist
+  ASSET_DIR: ${{ github.workspace }}/frontend/dist
 jobs:
   backend:
     name: Backend

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-
+  ASSET_DIR: ${{ GITHUB_WORKSPACE }}/frontend/dist
 jobs:
   backend:
     name: Backend

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   backend:
     name: Backend
+    needs:
+        - frontend
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -33,12 +35,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - name: Create frontend asset directory
-        run: mkdir -p ../frontend/dist
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features sqlite
       - name: Create database and run migrations
         run: sqlx database setup
+      - name: Download frontend-build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: ../frontend/dist
       - name: Check rustfmt
         run: cargo --verbose --locked fmt --all -- --check
       - name: Check Clippy with all features


### PR DESCRIPTION
Updated GitHub action to set the `ASSET_DIR` env variable. Note that at this moment, `memory-serve` does not support relative paths, so we use `${{ github.workspace }}` to construct an absolute path