### PR TITLE
fixes test-tooling doc wrt UI elements / Ladle

### DIFF
--- a/documentatie/ontwikkelproces/test-tooling.md
+++ b/documentatie/ontwikkelproces/test-tooling.md
@@ -24,15 +24,19 @@ Tests uitgevoerd door externe partijen (pen test, wettelijke toets) zijn niet op
 title: Ladle Stories
 ---
 flowchart LR
-    ladle-story(Ladle Story)
+    rtl([React Testing Library])
+    ladle-story-1(Ladle Story)
+    ladle-story-2(Ladle Story)
 
     playwright([Playwright])
     browser([Browser])
-    msw([Mock Service Worker])
+    ladle-dev-server([Ladle dev server])
 
-    playwright --> ladle-story
-    browser --> ladle-story
-    ladle-story ---> msw
+    rtl --> ladle-story-1
+
+    playwright --> ladle-story-2
+    browser --> ladle-story-2
+    ladle-story-2 ---> ladle-dev-server
 ```
 
 ---


### PR DESCRIPTION
Our test tooling doc claimed we were testing Ladle stories with Playwright and MSW. This is incorrect.

We test Ladle stories with React Testing Library and with Playwright while served by the Ladle dev server.