### PR TITLE
Add 'skip serialization' and 'nullable false' attributes to optional recounted field

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -896,8 +896,7 @@
           },
           "recounted": {
             "type": "boolean",
-            "description": "Recounted (\"Is er herteld? - See form for official long description of the checkbox\")",
-            "nullable": true
+            "description": "Recounted (\"Is er herteld? - See form for official long description of the checkbox\")"
           },
           "voters_counts": {
             "$ref": "#/components/schemas/VotersCounts"

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -65,6 +65,8 @@ pub struct PollingStationResultsEntry {
 #[cfg_attr(test, derive(Default))]
 pub struct PollingStationResults {
     /// Recounted ("Is er herteld? - See form for official long description of the checkbox")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
     pub recounted: Option<bool>,
     /// Voters counts ("1. Aantal toegelaten kiezers")
     pub voters_counts: VotersCounts,


### PR DESCRIPTION
The field was made optional in https://github.com/kiesraad/abacus/pull/446 but I believe the attributes as discussed in https://github.com/kiesraad/abacus/pull/406#discussion_r1793108126 were accidentally not added.
