### PR TITLE
Show election in the navbar

### DIFF
--- a/frontend/app/component/navbar/NavBar.module.css
+++ b/frontend/app/component/navbar/NavBar.module.css
@@ -15,7 +15,7 @@
       gap: 0.5rem;
     }
 
-    a {
+    > a {
       text-decoration: none;
       color: inherit;
 
@@ -25,21 +25,22 @@
       }
     }
 
-    a,
-    span {
+    > a,
+    > span {
       display: flex;
       height: 3rem;
       padding: 0.5rem 0.75rem;
       justify-content: center;
       align-items: center;
+      gap: 0.25rem;
     }
 
-    a:first-of-type:not(:global(.active)),
-    span:first-of-type:not(:global(.active)) {
+    > a:first-of-type:not(:global(.active)),
+    > span:first-of-type:not(:global(.active)) {
       padding-left: 0;
     }
 
-    span:global(.active) {
+    > span:global(.active) {
       border-bottom: 4px solid var(--accent-orange);
       padding-bottom: calc(0.5rem - 4px);
       font-weight: bold;

--- a/frontend/app/component/navbar/NavBar.module.css
+++ b/frontend/app/component/navbar/NavBar.module.css
@@ -10,6 +10,7 @@
 
   .links {
     display: flex;
+
     &:not(:has(svg)) {
       gap: 0.5rem;
     }
@@ -17,6 +18,7 @@
     a {
       text-decoration: none;
       color: inherit;
+
       &:hover,
       &:active {
         color: inherit !important;
@@ -32,6 +34,7 @@
       align-items: center;
     }
 
+    a:first-of-type:not(:global(.active)),
     span:first-of-type:not(:global(.active)) {
       padding-left: 0;
     }

--- a/frontend/app/module/data_entry/polling_station/PollingStationLayout.test.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStationLayout.test.tsx
@@ -50,7 +50,7 @@ describe("PollingStationLayout", () => {
     // Check if the navigation bar displays the correct information
     const nav = await screen.findByRole("navigation", { name: /primary-navigation/i });
     expect(within(nav).getByRole("link", { name: "Overzicht" })).toHaveAttribute("href", "/elections");
-    expect(within(nav).getByRole("link", { name: election.name })).toHaveAttribute(
+    expect(within(nav).getByRole("link", { name: new RegExp(election.name) })).toHaveAttribute(
       "href",
       `/elections/${election.id}/data-entry`,
     );

--- a/frontend/app/module/data_entry/polling_station/PollingStationLayout.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStationLayout.tsx
@@ -30,7 +30,11 @@ export function PollingStationLayout() {
       <NavBar>
         <Link to={"/elections"}>Overzicht</Link>
         <IconChevronRight />
-        <Link to={`/elections/${election.id}/data-entry`}>{election.name}</Link>
+        <Link to={`/elections/${election.id}/data-entry`}>
+          <span className="bold">{election.location}</span>
+          <span>&mdash;</span>
+          <span>{election.name}</span>
+        </Link>
       </NavBar>
       <header>
         <section>

--- a/frontend/app/module/election/page/ElectionHomePage.tsx
+++ b/frontend/app/module/election/page/ElectionHomePage.tsx
@@ -12,7 +12,9 @@ export function ElectionHomePage() {
   return (
     <>
       <PageTitle title="Details verkiezing - Abacus" />
-      <NavBar />
+      <NavBar>
+        <span>{election.name}</span>
+      </NavBar>
       <header>
         <section>
           <h1>{election.name}</h1>

--- a/frontend/app/module/election/page/ElectionHomePage.tsx
+++ b/frontend/app/module/election/page/ElectionHomePage.tsx
@@ -13,7 +13,11 @@ export function ElectionHomePage() {
     <>
       <PageTitle title="Details verkiezing - Abacus" />
       <NavBar>
-        <span>{election.name}</span>
+        <span>
+          <span className="bold">{election.location}</span>
+          <span>&mdash;</span>
+          <span>{election.name}</span>
+        </span>
       </NavBar>
       <header>
         <section>

--- a/frontend/app/module/election/page/ElectionReportPage.tsx
+++ b/frontend/app/module/election/page/ElectionReportPage.tsx
@@ -55,7 +55,11 @@ export function ElectionReportPage() {
     <>
       <PageTitle title="Invoerfase afronden - Abacus" />
       <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>{election.name}</Link>
+        <Link to={`/elections/${election.id}#coordinator`}>
+          <span className="bold">{election.location}</span>
+          <span>&mdash;</span>
+          <span>{election.name}</span>
+        </Link>
       </NavBar>
       <header>
         <section>

--- a/frontend/app/module/election/page/ElectionStatusPage.tsx
+++ b/frontend/app/module/election/page/ElectionStatusPage.tsx
@@ -18,7 +18,11 @@ export function ElectionStatusPage() {
     <>
       <PageTitle title="Status verkiezing - Abacus" />
       <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>{election.name}</Link>
+        <Link to={`/elections/${election.id}#coordinator`}>
+          <span className="bold">{election.location}</span>
+          <span>&mdash;</span>
+          <span>{election.name}</span>
+        </Link>
       </NavBar>
       <header>
         <section>

--- a/frontend/app/module/polling_stations/PollingStationsLayout.tsx
+++ b/frontend/app/module/polling_stations/PollingStationsLayout.tsx
@@ -10,7 +10,11 @@ export function PollingStationsLayout() {
   return (
     <div className="app-layout">
       <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>{election.name}</Link>
+        <Link to={`/elections/${election.id}#coordinator`}>
+          <span className="bold">{election.location}</span>
+          <span>&mdash;</span>
+          <span>{election.name}</span>
+        </Link>
       </NavBar>
       <Outlet />
     </div>

--- a/frontend/app/module/polling_stations/PollingStationsLayout.tsx
+++ b/frontend/app/module/polling_stations/PollingStationsLayout.tsx
@@ -1,11 +1,17 @@
-import { Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 
 import { NavBar } from "app/component/navbar/NavBar";
 
+import { useElection } from "@kiesraad/api";
+
 export function PollingStationsLayout() {
+  const { election } = useElection();
+
   return (
     <div className="app-layout">
-      <NavBar />
+      <NavBar>
+        <Link to={`/elections/${election.id}#coordinator`}>{election.name}</Link>
+      </NavBar>
       <Outlet />
     </div>
   );


### PR DESCRIPTION
Fixes https://github.com/kiesraad/abacus/pull/453#discussion_r1804747108
- Added clickable election name on `/elections/1/polling-stations`
- Added election name on `/elections/1`
- Remove padding on first link in the navbar to align left with the rest of the page
<img width="452" alt="image" src="https://github.com/user-attachments/assets/13b74113-1871-4121-8be0-f08b866491b1">
