### PR TITLE
Add some additional tests for addition and pdf rendering

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,3 +42,6 @@ unsafe_code = "forbid"
 
 [lints.clippy]
 unwrap_used = "warn"
+
+[profile.release]
+overflow-checks = true

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -703,6 +703,21 @@ pub struct DifferencesCounts {
     pub no_explanation_count: Count,
 }
 
+#[cfg(test)]
+impl DifferencesCounts {
+    pub fn zero() -> DifferencesCounts {
+        DifferencesCounts {
+            more_ballots_count: 0,
+            fewer_ballots_count: 0,
+            unreturned_ballots_count: 0,
+            too_few_ballots_handed_out_count: 0,
+            too_many_ballots_handed_out_count: 0,
+            other_explanation_count: 0,
+            no_explanation_count: 0,
+        }
+    }
+}
+
 impl Validate for DifferencesCounts {
     fn validate(
         &self,
@@ -833,6 +848,36 @@ impl PoliticalGroupVotes {
         }
 
         Ok(())
+    }
+
+    /// Create `PoliticalGroupVotes` from test data.
+    #[cfg(test)]
+    pub fn from_test_data(number: u8, total_count: Count, candidate_votes: &[(u8, Count)]) -> Self {
+        PoliticalGroupVotes {
+            number,
+            total: total_count,
+            candidate_votes: candidate_votes
+                .iter()
+                .map(|(number, votes)| CandidateVotes {
+                    number: *number,
+                    votes: *votes,
+                })
+                .collect(),
+        }
+    }
+
+    /// Create `PoliticalGroupVotes` from test data with candidate numbers automatically generated starting from 1.
+    #[cfg(test)]
+    pub fn from_test_data_auto(number: u8, total_count: Count, candidate_votes: &[Count]) -> Self {
+        Self::from_test_data(
+            number,
+            total_count,
+            &candidate_votes
+                .iter()
+                .enumerate()
+                .map(|(i, votes)| (i as u8 + 1, *votes))
+                .collect::<Vec<_>>(),
+        )
     }
 }
 

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -53,9 +53,44 @@ mod tests {
     use chrono::Utc;
     use models::{ModelNa31_2Input, ModelNa31_2Summary};
 
-    use crate::election::{Election, ElectionCategory};
+    use crate::{
+        election::{tests::election_fixture, Election, ElectionCategory},
+        polling_station::{PollingStation, PollingStationType},
+    };
 
     use super::*;
+
+    pub fn polling_stations_fixture(
+        election: &Election,
+        polling_station_voter_count: &[i64],
+    ) -> Vec<PollingStation> {
+        let mut polling_stations = Vec::new();
+        for (i, voter_count) in polling_station_voter_count.iter().enumerate() {
+            let idx = i + 1;
+            polling_stations.push(PollingStation {
+                id: idx as u32,
+                election_id: election.id,
+                name: format!("Testplek {idx}"),
+                number: idx as i64 + 30,
+                number_of_voters: if *voter_count < 0 {
+                    None
+                } else {
+                    Some(*voter_count)
+                },
+                polling_station_type: PollingStationType::Bijzonder,
+                street: "Teststraat".to_string(),
+                house_number: format!("{idx}"),
+                house_number_addition: if idx % 2 == 0 {
+                    Some("b".to_string())
+                } else {
+                    None
+                },
+                postal_code: "1234 QY".to_string(),
+                locality: "Testdorp".to_string(),
+            });
+        }
+        polling_stations
+    }
 
     #[test]
     fn it_generates_a_pdf() {
@@ -71,6 +106,19 @@ mod tests {
                 political_groups: None,
             },
             polling_stations: vec![],
+            summary: ModelNa31_2Summary::zero(),
+        }))
+        .unwrap();
+
+        assert!(!content.buffer.is_empty());
+    }
+
+    #[test]
+    fn it_generates_a_pdf_with_polling_stations() {
+        let election = election_fixture(&[2, 3]);
+        let content = generate_pdf(PdfModel::ModelNa31_2(ModelNa31_2Input {
+            polling_stations: polling_stations_fixture(&election, &[100, 200, 300]),
+            election,
             summary: ModelNa31_2Summary::zero(),
         }))
         .unwrap();

--- a/backend/src/pdf_gen/models/mod.rs
+++ b/backend/src/pdf_gen/models/mod.rs
@@ -40,8 +40,6 @@ impl PdfModel {
             Self::ModelNa31_2(input) => serde_json::to_string(input),
         }?;
 
-        dbg!(&data);
-
         Ok(Bytes::from(data.as_bytes()))
     }
 

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -117,7 +117,7 @@ was. Indien er meerdere zittingslocaties waren, vermeld dan per lid de locatie.]
         #if polling_station.polling_station_type == "Mobiel" [
           _(Mobiel stembureau)_
         ] else [
-          #polling_station.street #polling_station.house_number #if polling_station.house_number_addition != none [
+          #polling_station.street #polling_station.house_number #if "house_number_addition" in polling_station and polling_station.house_number_addition != none [
             #polling_station.house_number_addition
           ] \
           #polling_station.postal_code #polling_station.locality


### PR DESCRIPTION
Fixes #335 

This also fixes a bug that caused a crash when no house number addition was given because the JSON serialization behavior was changed. I've added a test that checks for this as well.

One additional change that was made is that the release profile now always includes integer overflow checks. I don't think we need the performance for this, but I do think we need the correctness here. While I don't expect any overflow or underflows to occur with any regular input (and even if there are large enough numbers entered they should normally be captured by validation rules), if one does occur, we should really have the software crash instead of it continuing as if nothing bad happened.