### PR TITLE
No migration files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,9 @@ RUN groupadd -r abacus --gid=999
 RUN useradd --no-log-init -r -g abacus --uid=999 abacus
 USER 999
 
-# Copy the binary, database and migrations
+# Copy the binary and database
 COPY --chown=abacus:abacus ./backend/target/release/api /abacus/backend
 COPY --chown=abacus:abacus ./backend/db.sqlite /abacus/db.sqlite
-COPY --chown=abacus:abacus ./backend/migrations /abacus/migrations
 
 # Run
 CMD ["/abacus/backend"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,19 @@ FROM debian:bookworm-slim
 
 WORKDIR /abacus
 
+
 RUN groupadd -r abacus --gid=999 
 RUN useradd --no-log-init -r -g abacus --uid=999 abacus
+
+# Creates the /abacus folder owned by the abacus user
+RUN install -o abacus -g abacus -d  /abacus
+
 USER 999
 
-# Copy the binary and database
+# Copy the binary
 COPY --chown=abacus:abacus ./backend/target/release/api /abacus/backend
-COPY --chown=abacus:abacus ./backend/db.sqlite /abacus/db.sqlite
 
 # Run
-CMD ["/abacus/backend"]
+ENTRYPOINT ["/abacus/backend"]
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,18 @@ FROM debian:bookworm-slim
 
 WORKDIR /abacus
 
-
 RUN groupadd -r abacus --gid=999 
 RUN useradd --no-log-init -r -g abacus --uid=999 abacus
 
 # Creates the /abacus folder owned by the abacus user
 RUN install -o abacus -g abacus -d  /abacus
 
+# Copy the binary
+COPY ./backend/target/release/api /usr/local/bin/abacus
+
 USER 999
 
-# Copy the binary
-COPY --chown=abacus:abacus ./backend/target/release/api /abacus/backend
-
 # Run
-ENTRYPOINT ["/abacus/backend"]
+ENTRYPOINT ["/usr/local/bin/abacus"]
 
 EXPOSE 8080


### PR DESCRIPTION
Because we use the `migrate!()` macro, the migrations files are embedded in the binary. Copying them into the Docker container is therefore not needed.

See https://docs.rs/sqlx/latest/sqlx/macro.migrate.html for more information