### PR TITLE
fix CandidatesVotesForm showing (null) if candidates have no first name field

### DIFF
--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.test.tsx
@@ -5,7 +5,7 @@ import {
   expectFieldsToBeValidAndToNotHaveAccessibleErrorMessage,
   expectFieldsToNotHaveIcon,
 } from "app/component/form/testHelperFunctions";
-import { getUrlMethodAndBody, overrideOnce, render, screen } from "app/test/unit";
+import { getUrlMethodAndBody, overrideOnce, render, screen, within } from "app/test/unit";
 import { emptyDataEntryRequest } from "app/test/unit/form";
 
 import {
@@ -39,6 +39,75 @@ const candidatesFieldIds = {
 };
 
 describe("Test CandidatesVotesForm", () => {
+  describe("CandidatesVotesForm renders correctly", () => {
+    test("Candidates with first name", async () => {
+      const politicalGroupMockData: PoliticalGroup = {
+        number: 1,
+        name: "Lijst 1 - Vurige Vleugels Partij",
+        candidates: [
+          {
+            number: 1,
+            initials: "E.",
+            first_name: "Eldor",
+            last_name: "Zilverlicht",
+            locality: "Amsterdam",
+          },
+        ],
+      };
+
+      const politicalGroupMock = politicalGroupMockData as Required<PoliticalGroup>;
+
+      const Component = (
+        <PollingStationFormController
+          election={electionMockData}
+          pollingStationId={pollingStationMockData.id}
+          entryNumber={1}
+        >
+          <CandidatesVotesForm group={politicalGroupMock} />
+        </PollingStationFormController>
+      );
+
+      render(Component);
+
+      const candidateRow = await screen.findByTestId("row-candidate_votes[0].votes");
+      const candidateName = within(candidateRow).getAllByRole("cell")[2];
+      expect(candidateName).toHaveTextContent(/^Zilverlicht, E\. \(Eldor\)$/);
+    });
+
+    test("Candidates without first names", async () => {
+      const politicalGroupMockData: PoliticalGroup = {
+        number: 1,
+        name: "Lijst 1 - Vurige Vleugels Partij",
+        candidates: [
+          {
+            number: 1,
+            initials: "E.",
+            last_name: "Zilverlicht",
+            locality: "Amsterdam",
+          },
+        ],
+      };
+
+      const politicalGroupMock = politicalGroupMockData as Required<PoliticalGroup>;
+
+      const Component = (
+        <PollingStationFormController
+          election={electionMockData}
+          pollingStationId={pollingStationMockData.id}
+          entryNumber={1}
+        >
+          <CandidatesVotesForm group={politicalGroupMock} />
+        </PollingStationFormController>
+      );
+
+      render(Component);
+
+      const candidateRow = await screen.findByTestId("row-candidate_votes[0].votes");
+      const candidateName = within(candidateRow).getAllByRole("cell")[2];
+      expect(candidateName).toHaveTextContent(/^Zilverlicht, E\.$/);
+    });
+  });
+
   describe("CandidatesVotesForm user interactions", () => {
     test("hitting enter key does not result in api call", async () => {
       const user = userEvent.setup();

--- a/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.tsx
+++ b/frontend/app/component/form/data_entry/candidates_votes/CandidatesVotesForm.tsx
@@ -143,13 +143,16 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
           {group.candidates.map((candidate, index) => {
             const addSeparator = (index + 1) % 25 === 0 && index + 1 !== group.candidates.length;
             const defaultValue = sectionValues?.candidate_votes[index]?.votes || "";
+            const candidateFullName = candidate.first_name
+              ? `${candidate.last_name}, ${candidate.initials} (${candidate.first_name})`
+              : `${candidate.last_name}, ${candidate.initials}`;
             return (
               <InputGridRow
                 key={`list${group.number}-candidate${index + 1}`}
                 field={`${index + 1}`}
                 name="candidatevotes[]"
                 id={`candidate_votes[${candidate.number - 1}].votes`}
-                title={`${candidate.last_name}, ${candidate.initials} (${candidate.first_name})`}
+                title={candidateFullName}
                 addSeparator={addSeparator}
                 defaultValue={defaultValue}
                 {...defaultProps}


### PR DESCRIPTION
Candidates without `first_name` were shown as e.g. "Zilverlicht, E. (null)" on the CandidatesVotesForm.

This PR changes CandidatesVotesForm to only display the first name when it's available.