### PR TITLE
adds on:workflow_dispatch to cla action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,6 +1,7 @@
 name: CLA Assistant
 
 on:
+  workflow_dispatch:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
This allows us to trigger the workflow from https://github.com/kiesraad/abacus/actions/workflows/cla.yml, allowing us to re-run the action using the latest commit on main of our cla-bot. (Re-run action does not pull in the latest commit(s).)