### PR TITLE
`build-and-run`: fetch before checkout

### DIFF
--- a/build-and-run
+++ b/build-and-run
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-if [ -n "$1" ]
-then
-  git checkout "$1"
-fi
-
 # Exit on errors
 set -e
+
+if [ -n "$1" ]
+then
+  git fetch
+  git checkout "$1"
+fi
 
 # Print the commands as they are executed
 set -x


### PR DESCRIPTION
Note:
To make sure you're checkout a remote branche, use `./build-and-run origin/<branch-name>`.
This will be documented in https://github.com/kiesraad/abacus/issues/516

To test this PR:
- Run the script on a branch that does not exist, and see if it indeed fails, instead of building the current branch. Example: `./build-and-run foo`
- Run the script on a branch that exists, but is never checked out locally and see if it builds the right branch