### PR TITLE
First iteration of table component

### DIFF
--- a/frontend/lib/ui/Table/Table.module.css
+++ b/frontend/lib/ui/Table/Table.module.css
@@ -1,0 +1,44 @@
+.table {
+  width: 100%;
+  line-height: 1.5rem;
+  border-spacing: unset;
+  color: var(--color-help-text);
+
+  th,
+  td {
+    border-bottom: 1px solid var(--bg-gray-darkest);
+    padding: 1rem 1.5rem;
+  }
+
+  th {
+    text-align: left;
+    height: 2.75rem;
+  }
+
+  td {
+    height: 3.5rem;
+    font-size: 1.125rem;
+  }
+
+  td.number {
+    text-align: right;
+    font-weight: bold;
+    width: 6.5rem;
+  }
+
+  tr.row-link {
+    cursor: pointer;
+
+    &:hover {
+      background: var(--color-hover);
+    }
+
+    td:last-of-type {
+      padding-right: 2.75rem;
+      background-image: url("../../icon/svg/chevronRight.svg");
+      background-size: 1.25rem;
+      background-position: center right 1.5rem;
+      background-repeat: no-repeat;
+    }
+  }
+}

--- a/frontend/lib/ui/Table/Table.stories.tsx
+++ b/frontend/lib/ui/Table/Table.stories.tsx
@@ -1,0 +1,49 @@
+import { Story } from "@ladle/react";
+
+import { Table } from "./Table";
+
+const data: [number, string, string][] = [
+  [1, "some", "value"],
+  [2, "other", "value"],
+  [3, "another", "thing"],
+];
+
+export const BasicTable: Story = () => (
+  <Table id="basic_table">
+    <Table.Header>
+      <Table.Column number>Number</Table.Column>
+      <Table.Column width={"20rem"}>Fixed width</Table.Column>
+      <Table.Column>Some value</Table.Column>
+    </Table.Header>
+    <Table.Body>
+      {data.map((row) => (
+        <Table.Row key={row[0]}>
+          <Table.Cell number>{row[0]}</Table.Cell>
+          <Table.Cell>{row[1]}</Table.Cell>
+          <Table.Cell>{row[2]}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table>
+);
+
+export const LinkTable: Story = () => {
+  return (
+    <Table id="link_table">
+      <Table.Header>
+        <Table.Column number>Number</Table.Column>
+        <Table.Column>Click me</Table.Column>
+        <Table.Column>Look a chevron</Table.Column>
+      </Table.Header>
+      <Table.Body>
+        {data.map((row) => (
+          <Table.LinkRow key={row[0]} to={`#row${row[0]}`}>
+            <Table.Cell number>{row[0]}</Table.Cell>
+            <Table.Cell>{row[1]}</Table.Cell>
+            <Table.Cell>{row[2]}</Table.Cell>
+          </Table.LinkRow>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};

--- a/frontend/lib/ui/Table/Table.test.tsx
+++ b/frontend/lib/ui/Table/Table.test.tsx
@@ -1,0 +1,46 @@
+import * as router from "react-router";
+
+import { within } from "@testing-library/dom";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+import { render, screen } from "app/test/unit";
+
+import { BasicTable, LinkTable } from "./Table.stories";
+
+describe("Table", () => {
+  test("BasicTable renders", async () => {
+    render(<BasicTable />);
+
+    const table = await screen.findByTestId("basic_table");
+    const rows = within(table).getAllByRole("row");
+
+    expect(rows.length).toBe(4);
+
+    expect(rows[0]).toHaveTextContent(/Number/);
+    expect(rows[0]).toHaveTextContent(/Fixed width/);
+    expect(rows[0]).toHaveTextContent(/Some value/);
+
+    expect(rows[1]).toHaveTextContent(/1/);
+    expect(rows[1]).toHaveTextContent(/some/);
+    expect(rows[1]).toHaveTextContent(/value/);
+  });
+
+  test("LinkRow navigates to url when clicked", async () => {
+    const user = userEvent.setup();
+
+    const mockNavigate = vi.fn();
+    vi.spyOn(router, "useNavigate").mockImplementation(() => mockNavigate);
+
+    render(<LinkTable />);
+
+    const table = await screen.findByTestId("link_table");
+    const rows = within(table).getAllByRole("row");
+
+    if (rows[1]) {
+      await user.click(rows[1]);
+    }
+
+    expect(mockNavigate).toHaveBeenCalledWith("#row1");
+  });
+});

--- a/frontend/lib/ui/Table/Table.tsx
+++ b/frontend/lib/ui/Table/Table.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { useNavigate } from "react-router-dom";
+
+import cls from "./Table.module.css";
+
+export interface TableProps {
+  id?: string;
+  children?: React.ReactNode;
+}
+
+export function Table({ id, children }: TableProps) {
+  return (
+    <table id={id} className={cls["table"]}>
+      {children}
+    </table>
+  );
+}
+
+Table.Header = ({ children }: { children: React.ReactNode[] }) => (
+  <thead>
+    <tr>{children}</tr>
+  </thead>
+);
+
+Table.Column = ({ children, number, width }: { children: React.ReactNode; number?: boolean; width?: string }) => (
+  <th className={number ? cls["number"] : undefined} style={width ? { width } : undefined}>
+    {children}
+  </th>
+);
+
+Table.Body = ({ children }: { children: React.ReactNode[] }) => <tbody>{children}</tbody>;
+
+Table.Row = ({ children }: { children: React.ReactNode[] }) => <tr>{children}</tr>;
+
+Table.LinkRow = ({ children, to }: { children: React.ReactNode[]; to: string }) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const navigate = useNavigate();
+
+  function handleClick() {
+    navigate(to);
+  }
+
+  return (
+    <tr className={cls["row-link"]} onClick={handleClick}>
+      {children}
+    </tr>
+  );
+};
+
+Table.Cell = ({ children, number }: { children?: React.ReactNode; number?: boolean }) => (
+  <td className={number ? cls["number"] : undefined}>{children}</td>
+);

--- a/frontend/lib/ui/Table/Table.tsx
+++ b/frontend/lib/ui/Table/Table.tsx
@@ -16,24 +16,38 @@ export function Table({ id, children }: TableProps) {
   );
 }
 
-Table.Header = ({ children }: { children: React.ReactNode[] }) => (
-  <thead>
-    <tr>{children}</tr>
-  </thead>
-);
+Table.Header = Header;
+Table.Column = Column;
+Table.Body = Body;
+Table.Row = Row;
+Table.LinkRow = LinkRow;
+Table.Cell = Cell;
 
-Table.Column = ({ children, number, width }: { children: React.ReactNode; number?: boolean; width?: string }) => (
-  <th className={number ? cls["number"] : undefined} style={width ? { width } : undefined}>
-    {children}
-  </th>
-);
+function Header({ children }: { children: React.ReactNode[] }) {
+  return (
+    <thead>
+      <tr>{children}</tr>
+    </thead>
+  );
+}
 
-Table.Body = ({ children }: { children: React.ReactNode[] }) => <tbody>{children}</tbody>;
+function Column({ children, number, width }: { children: React.ReactNode; number?: boolean; width?: string }) {
+  return (
+    <th className={number ? cls["number"] : undefined} style={width ? { width } : undefined}>
+      {children}
+    </th>
+  );
+}
 
-Table.Row = ({ children }: { children: React.ReactNode[] }) => <tr>{children}</tr>;
+function Body({ children }: { children: React.ReactNode[] }) {
+  return <tbody>{children}</tbody>;
+}
 
-Table.LinkRow = ({ children, to }: { children: React.ReactNode[]; to: string }) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+function Row({ children }: { children: React.ReactNode[] }) {
+  return <tr>{children}</tr>;
+}
+
+function LinkRow({ children, to }: { children: React.ReactNode[]; to: string }) {
   const navigate = useNavigate();
 
   function handleClick() {
@@ -45,8 +59,8 @@ Table.LinkRow = ({ children, to }: { children: React.ReactNode[]; to: string }) 
       {children}
     </tr>
   );
-};
+}
 
-Table.Cell = ({ children, number }: { children?: React.ReactNode; number?: boolean }) => (
-  <td className={number ? cls["number"] : undefined}>{children}</td>
-);
+function Cell({ children, number }: { children?: React.ReactNode; number?: boolean }) {
+  return <td className={number ? cls["number"] : undefined}>{children}</td>;
+}


### PR DESCRIPTION
Implements the component/visual part of https://github.com/kiesraad/abacus/issues/433

This `Table` component and friends will render and style an HTML table, inspired by `InputGrid`.

The `Table.LinkRow` component handles a click event and navigates to the specified url. Keyboard support will be added later.

Behaviour such as sorting will be done in a separate hook, that will play nicely with this `Table`.

Please have a look at `Table.stories.tsx` to see how it can be used, and let me know:
- if this setup will work for us
- if we indeed want `Table.Row` instead of `TableRow`
- other implementation comments