### PR TITLE
revert PR512, i.e. remove on:workflow_dispatch for cla bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,7 +1,6 @@
 name: CLA Assistant
 
 on:
-  workflow_dispatch:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
A workflow dispatch does not have a pull request context, which is required by the cla bot.

PR that is reverted by this one: #512 