### PR TITLE
Fix flaky header focus test

### DIFF
--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/dom";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
@@ -61,7 +62,7 @@ describe("Test RecountedForm", () => {
         level: 2,
         name: "Is het selectievakje op de eerste pagina aangevinkt?",
       });
-      expect(formTitle).toHaveFocus();
+      await waitFor(() => expect(formTitle).toHaveFocus());
       await user.keyboard("{tab}");
 
       const yes = await screen.findByTestId("yes");


### PR DESCRIPTION
Focus is changed using a `useEffect` hook after the initial render. If
the test checks whether the header has focus before the hook is fired,
the test will fail. This is fixed by wrapping the check in `waitFor`.

Fixes #550.