### PR TITLE
Fix single progress bar

### DIFF
--- a/frontend/lib/ui/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/lib/ui/ProgressBar/ProgressBar.test.tsx
@@ -11,6 +11,13 @@ describe("UI Component: ProgressBar", () => {
     );
     expect(getByText("Progress")).toBeInTheDocument();
     expect(getByText("50%")).toBeInTheDocument();
+
+    const innerBars = screen.getByRole("progressbar").children;
+    expect(innerBars.length).toEqual(1);
+    for (const bar of innerBars) {
+      expect(bar.getAttribute("style")).toEqual("width: 50%;");
+      expect(bar.classList.contains("default")).toBeTruthy();
+    }
   });
 
   test("renders a progress bar without a title and percentage", () => {

--- a/frontend/lib/ui/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/lib/ui/ProgressBar/ProgressBar.test.tsx
@@ -6,13 +6,14 @@ import { PercentageAndColorClass, ProgressBar } from "@kiesraad/ui";
 
 describe("UI Component: ProgressBar", () => {
   test("renders a progress bar with a title and percentage", () => {
-    const { getByText } = render(
+    const { getByLabelText, getByRole } = render(
       <ProgressBar id="test" data={{ percentage: 50, class: "default" }} title="Progress" showPercentage />,
     );
-    expect(getByText("Progress")).toBeInTheDocument();
-    expect(getByText("50%")).toBeInTheDocument();
 
-    const innerBars = screen.getByRole("progressbar").children;
+    expect(getByLabelText("Progress")).toBeInTheDocument();
+    expect(getByRole("complementary")).toHaveTextContent("50%");
+
+    const innerBars = getByRole("progressbar").children;
     expect(innerBars.length).toEqual(1);
     for (const bar of innerBars) {
       expect(bar.getAttribute("style")).toEqual("width: 50%;");
@@ -21,10 +22,13 @@ describe("UI Component: ProgressBar", () => {
   });
 
   test("renders a progress bar without a title and percentage", () => {
-    const { queryByRole } = render(<ProgressBar id="test" data={{ percentage: 50, class: "default" }} />);
+    const { queryByRole, queryByTestId, queryByText } = render(
+      <ProgressBar id="test" data={{ percentage: 50, class: "default" }} />,
+    );
 
-    expect(queryByRole("label")).not.toBeInTheDocument();
-    expect(screen.queryByText("50%")).not.toBeInTheDocument();
+    expect(queryByTestId("progressbar-label")).not.toBeInTheDocument();
+    expect(queryByRole("complementary")).not.toBeInTheDocument();
+    expect(queryByText("50%")).not.toBeInTheDocument();
   });
 
   test("renders a progress bar with multiple bars", () => {
@@ -36,10 +40,11 @@ describe("UI Component: ProgressBar", () => {
       { percentage: 5, class: "errors-and-warnings" },
       { percentage: 2, class: "not-started" },
     ];
-    const { queryByRole } = render(<ProgressBar id="test" data={data} />);
+    const { queryByRole, queryByTestId } = render(<ProgressBar id="test" data={data} />);
 
-    expect(queryByRole("label")).not.toBeInTheDocument();
-    expect(screen.queryByText("50%")).not.toBeInTheDocument();
+    expect(queryByTestId("progressbar-label")).not.toBeInTheDocument();
+    expect(queryByRole("complementary")).not.toBeInTheDocument();
+
     const bars = [...screen.getByTestId("multi-outer-bar").children];
     bars.forEach((bar, index) => {
       expect(bar.getAttribute("style")).toEqual(`width: ${data[index]?.percentage}%;`);

--- a/frontend/lib/ui/ProgressBar/ProgressBar.tsx
+++ b/frontend/lib/ui/ProgressBar/ProgressBar.tsx
@@ -26,12 +26,13 @@ export interface ProgressBarProps {
 export function ProgressBar({ id, data, title, spacing, showPercentage = false }: ProgressBarProps) {
   return (
     <div className={cn(cls["progressbar-container"], spacing)} id={`progressbar-${id}`}>
-      {title && <label>{title}</label>}
+      {title && <label id="progressbar-label">{title}</label>}
       {!Array.isArray(data) ? (
         <section>
           <div
             className={cls["progressbar-outer"]}
             role="progressbar"
+            aria-labelledby="progressbar-label"
             aria-valuenow={data["percentage"]}
             aria-valuemin={0}
             aria-valuemax={100}

--- a/frontend/lib/ui/ProgressBar/ProgressBar.tsx
+++ b/frontend/lib/ui/ProgressBar/ProgressBar.tsx
@@ -36,10 +36,7 @@ export function ProgressBar({ id, data, title, spacing, showPercentage = false }
             aria-valuemin={0}
             aria-valuemax={100}
           >
-            <div
-              className={cn(cls["progressbar-inner"], cls[data["class"]])}
-              style={{ width: `${data["percentage"]}%` }}
-            />
+            <div className={cn(cls["progressbar-inner"], data["class"])} style={{ width: `${data["percentage"]}%` }} />
           </div>
           {showPercentage && <aside>{data["percentage"]}%</aside>}
         </section>


### PR DESCRIPTION
This PR addresses two issues:

1. The `default` class was not being set for the progress bar on the data entry page ("Voortang - Alles samen") due to the `cls`. This caused the progress bar to have no background-color, basically becoming invisible. (Fix by @oliver3, I just did the typing.)
2. The ProgressBar tests were checking for elements with role "label". However, that's not an ARIA role. Unfortunately the paramater for `*ByRole()` has type `ByRoleMatcher`, which means either an `ARIARole` or a `string`, so no help there.