### PR TITLE
Serve fallback pages with status OK

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -69,6 +69,7 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
             MemoryServe::new()
                 .index_file(Some("/index.html"))
                 .fallback(Some("/index.html"))
+                .fallback_status(axum::http::StatusCode::OK)
                 .into_router(),
         )
     };


### PR DESCRIPTION
Without this, visiting `/elections` served the app with a 404 Not Found status code.