### PR TITLE
Never block navigation because of aborting data entry

### DIFF
--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
@@ -45,6 +45,7 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
       if (
         status.current === "deleted" ||
         status.current === "finalised" ||
+        status.current === "aborted" ||
         currentLocation.pathname === nextLocation.pathname ||
         !currentForm
       ) {
@@ -52,7 +53,7 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
       }
 
       //check if nextLocation is outside the data entry flow
-      if (status.current !== "aborted" && !isPartOfDataEntryFlow(nextLocation.pathname)) {
+      if (!isPartOfDataEntryFlow(nextLocation.pathname)) {
         return true;
       }
 


### PR DESCRIPTION
This PR should fix one of the scenario's that @jschuurk-kr found exploring data entry:
- Produce a warning on 'voters and votes' section
- Accepting the warning and continue
- Go back to 'voters and votes'
- Deselect accept warnings
- Abort data entry
- Select 'save data' in the abort popup modal
Expected behaviour: data is saved and navigation to data entry overview page
Actual behaviour: data is saved and a new popup modal appears over the original modal, because of navigating away

The suggested fix is to always allow navigation because of the initial data entry abort, thanks @lkleuver for finding it!