### PR TITLE
fix flakiness in test CheckAndSaveForm.test.tsx > Test CheckAndSaveForm > Shift+Enter submits form

### DIFF
--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
@@ -63,7 +63,7 @@ describe("Test CheckAndSaveForm", () => {
     renderForm();
 
     const formTitle = await screen.findByRole("heading", { level: 2, name: "Controleren en opslaan" });
-    expect(formTitle).toHaveFocus();
+    expect(formTitle).toBeVisible();
 
     overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, null);
 

--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.test.tsx
@@ -62,8 +62,7 @@ describe("Test CheckAndSaveForm", () => {
   test("Shift+Enter submits form", async () => {
     renderForm();
 
-    const formTitle = await screen.findByRole("heading", { level: 2, name: "Controleren en opslaan" });
-    expect(formTitle).toBeVisible();
+    expect(await screen.findByRole("group", { name: "Controleren en opslaan" }));
 
     overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, null);
 


### PR DESCRIPTION
The test for submitting the Check and Save form with Shift+Enter is flaky in checking if the title of the form has focus. Since this test has no need to check for focus, I changed the assert to checking for visibility.