### PR TITLE
Renamed binary to Abacus

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: backend-build
-          path: backend/target/debug/api
+          path: backend/target/debug/abacus
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
@@ -115,6 +115,6 @@ jobs:
           name: backend-build
           path: builds/backend
       - name: make backend build executable
-        run: chmod a+x ../builds/backend/api
+        run: chmod a+x ../builds/backend/abacus
       - name: Run DOM to Database e2e tests
         run: npm run e2e:d2d

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN useradd --no-log-init -r -g abacus --uid=999 abacus
 RUN install -o abacus -g abacus -d  /abacus
 
 # Copy the binary
-COPY ./backend/target/release/api /usr/local/bin/abacus
+COPY ./backend/target/release/abacus /usr/local/bin/abacus
 
 USER 999
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "EUPL-1.2"
 rust-version = "1.75"
 
-default-run = "api"
+default-run = "abacus"
 
 [features]
 default = ["openapi", "dev-database"]

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -12,7 +12,7 @@ use tokio::net::TcpListener;
 use tokio::signal;
 use tracing::info;
 
-/// Abacus API server
+/// Abacus API and asset server
 #[derive(Parser, Debug)]
 struct Args {
     /// Server port, optional

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  api:
+  backend:
     image: ghcr.io/tweedegolf/rust-dev:stable
     ports:
       - "8080:8080"
@@ -14,7 +14,7 @@ services:
     command: ["cargo", "watch", "--why", "--ignore", ".cargo", "--ignore", "db.sqlite*", "--ignore", "target-docker", "-x", "run --"]
 
   frontend:
-    depends_on: [api]
+    depends_on: [backend]
     image: node:20
     ports:
       - 3000:3000
@@ -24,6 +24,6 @@ services:
     user: "${USER_ID:?USER_ID not set}:${GROUP_ID:?GROUP_ID not set}"
     environment:
       TZ: "Europe/Amsterdam"
-      API_HOST: http://api:8080
+      API_HOST: http://backend:8080
       VITE_HOST: "0.0.0.0"
     command: ["npm", "run", "dev:server", "--", "--host"]

--- a/frontend/playwright.d2d.config.ts
+++ b/frontend/playwright.d2d.config.ts
@@ -5,7 +5,7 @@ import commonConfig from "./playwright.common.config";
 function returnWebserverCommand(): string {
   if (process.env.CI) {
     // CI: use existing backend build, reset and seed database
-    return `../builds/backend/api --reset-database --seed-data --port 8081`;
+    return `../builds/backend/abacus --reset-database --seed-data --port 8081`;
   } else if (process.env.LOCAL_CI) {
     // LOCAL CI: build frontend, then build and run backend with database reset and seed playwright-specific database
     return `npm run build &&


### PR DESCRIPTION
The current binary name is "api", but since the binary will be the thing that will be run by end users, I think "abacus" is a more appropriate name.

While reviewing, please check that I didn't miss any renames in the scripts/CI pipelines/etc.