### PR TITLE
--ff-only instead of --no-ff

### DIFF
--- a/pull-and-run
+++ b/pull-and-run
@@ -7,7 +7,7 @@ if [ -n "$1" ]
 then
   git fetch
   git checkout "$1"
-  git pull --no-ff
+  git pull --ff-only
 fi
 
 # Print the commands as they are executed


### PR DESCRIPTION
Mistakenly used `--no-ff`, we only want to pull when a fast forward is possible and never create a merge commit