### PR TITLE
Dependabot should ignore react-router-dom minor version 6.28

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,6 @@ updates:
       - dependency-name: "eslint"
         # ESLint major upgrades usually have breaking changes, #213 for ESLint 9
         update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router-dom"
+        # Update to 6.28 needs feature flags to be set and a potential problem to be solved, see issue #621
+        update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
Ignore minor versions for react-router-dom for now, see issue https://github.com/kiesraad/abacus/issues/621