### PR TITLE
Dependabot should ignore react-router-dom versions 6.28 and 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,5 +29,6 @@ updates:
         # ESLint major upgrades usually have breaking changes, #213 for ESLint 9
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-router-dom"
+        # Update to 6.28 needs feature flags to be set to opt-in for version 7 features, to avoid warnings.
         # Update to 7 has a potential problem to be solved, see issue #621
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,5 +29,5 @@ updates:
         # ESLint major upgrades usually have breaking changes, #213 for ESLint 9
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-router-dom"
-        # Update to 6.28 needs feature flags to be set and a potential problem to be solved, see issue #621
-        update-types: ["version-update:semver-minor"]
+        # Update to 7 has a potential problem to be solved, see issue #621
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Updating react-router-dom needs code changes, see also #621 

This PR is to let dependabot ignore minor and major updates for react-router-dom