### PR TITLE
Rename h1, h2 classes to heading-xl, heading-lg

### DIFF
--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
@@ -93,7 +93,7 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
         </div>
       )}
       <fieldset>
-        <legend className="h2 mb-lg">
+        <legend className="heading-lg mb-lg">
           {anotherEntry ? t("polling_station_choice.insert_another") : t("polling_station_choice.insert_title")}
         </legend>
         <PollingStationSelector

--- a/frontend/app/module/election/page/ElectionStatusPage.tsx
+++ b/frontend/app/module/election/page/ElectionStatusPage.tsx
@@ -219,7 +219,7 @@ export function ElectionStatusPage() {
         <div className={cls.statusSection}>
           <Progress>
             <div id="polling-stations-per-status" className="column">
-              <h3 className="mb-0 h2">{t("election_status.polling_stations_per_status")}</h3>
+              <h3 className="mb-0 heading-lg">{t("election_status.polling_stations_per_status")}</h3>
               {statusCategories.map((cat) => {
                 return (
                   <span
@@ -234,7 +234,7 @@ export function ElectionStatusPage() {
               })}
             </div>
             <div id="progress" className="column">
-              <h3 className="mb-0 h2">{t("progress")}</h3>
+              <h3 className="mb-0 heading-lg">{t("progress")}</h3>
               <ProgressBar key="all" id="all" data={progressBarData} spacing="small" />
             </div>
           </Progress>
@@ -247,7 +247,7 @@ export function ElectionStatusPage() {
                   <div key={`item-table-${categoryColorClass[cat]}`}>
                     <span className="item">
                       <Circle size="xs" color={categoryColorClass[cat]} />
-                      <h3 className="mb-0 h2">
+                      <h3 className="mb-0 heading-lg">
                         {t(`status.${cat}`)} <span className="normal">({categoryCounts[cat]})</span>
                       </h3>
                     </span>

--- a/frontend/lib/ui/Form/Form.tsx
+++ b/frontend/lib/ui/Form/Form.tsx
@@ -106,7 +106,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(({ title, child
       {...formProps}
     >
       <fieldset>
-        <legend className="h2">{title}</legend>
+        <legend className="heading-lg">{title}</legend>
         {children}
       </fieldset>
     </form>

--- a/frontend/lib/ui/style/typography.css
+++ b/frontend/lib/ui/style/typography.css
@@ -15,12 +15,8 @@ h3,
 h4,
 h5,
 h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
+.heading-xl,
+.heading-lg {
   margin-top: 0;
   font-family: var(--font-header-body), sans-serif;
   color: var(--text-color-header);
@@ -31,38 +27,34 @@ h6,
 }
 
 h1,
-.h1 {
+.heading-xl {
   font-family: var(--font-header), sans-serif;
-  font-size: 2.25em;
+  font-size: 2.25rem;
 }
 
 h2,
-.h2 {
+.heading-lg {
   font-size: 1.25rem;
   font-weight: bold;
   line-height: 1.875rem;
   margin-bottom: 1rem;
 }
 
-h3,
-.h3 {
+h3 {
   font-size: 1.125em;
   margin-bottom: 0.4rem;
   font-weight: bold;
 }
 
-h4,
-.h4 {
+h4 {
   font-size: 1.25rem;
 }
 
-h5,
-.h5 {
+h5 {
   font-size: 1.125rem;
 }
 
-h6,
-.h6 {
+h6 {
   font-weight: bold;
   font-size: 1rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc)
-->
Fixes https://github.com/kiesraad/abacus/issues/594 about `<h3 className="h2">`.

The idea is to have type scale css classes such as `heading-xl`, `heading-lg` (name to be finalized) and also h1 etc tags with good default styling, that can be overridden with the aforementioned heading classes.

To test:
Header styling on the polling station status page should still be the same, but classnames for the headers should be less awkward. 

Also the form headings for the data entry pages (that are actually fieldset legends) should still look the same.
