### PR TITLE
632 use new chromium headless for playwright

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps  --no-shell
       - name: Run UI e2e tests
         run: npm run e2e:lib-ui
   playwright-app:
@@ -122,7 +122,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps --no-shell
       - name: Run app e2e tests
         run: npm run e2e:app
   playwright-d2d:
@@ -145,7 +145,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps --no-shell
       - name: Download backend-build
         uses: actions/download-artifact@v4
         with:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,7 +17,7 @@ npm install
 Install Playwright dependencies:
 
 ```sh
-npx playwright install --with-deps
+npx playwright install --with-deps --no-shell
 ```
 
 ### Running

--- a/frontend/playwright.common.config.ts
+++ b/frontend/playwright.common.config.ts
@@ -26,6 +26,7 @@ const commonConfig: PlaywrightTestConfig = defineConfig({
           permissions: ["clipboard-read", "clipboard-write"],
         },
         ...devices["Desktop Chrome"],
+        channel: "chromium",
       },
     },
     {


### PR DESCRIPTION
As mentioned in [this Playwirght issue](https://github.com/microsoft/playwright/issues/33566), until recently Chromium headless was basically a different browser from non-headless Chromium. Now that's no longer the case, Playwright lets you switch to the new headless Chromium which matches the non-headless one.

This entails two changes:
- adding `channel: "chromium",` to our Playwright config to use the new headless Chromium instead of the old shell
- adding ` --no-shell` to Playwright installation commands, so we don't install the old headless shell which we no longer use

The one difference between old and new Chromium headless that might affect us is that *"PDF documents are now rendered in the page, instead of being downloaded. We recommend to update your tests accordingly."* We have a Playwright test that downloads the Na31-2 and that still passes locally. I assume because it still downloads the pdf in the same way before rendering it.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc)
-->