### PR TITLE
Build on push to `main` for GitHub Actions cache

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   merge_group:
     types: [checks_requested]
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
For building pull requests, GitHub Actions uses the cache from the base branch (e.g. `main`) if available: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

However, because the merge queue builds commits as if they were already merged to `main`, we disabled builds for pushes to `main` to avoid double work. Unfortunately this also means that GitHub Actions never has any available cache for building pull requests. 

We can fix this by letting GitHub Actions also build pushes to `main`, which will fill the cache in such a way that pull request builds can also use this cache.

Related discussion in the GitHub Community: https://github.com/orgs/community/discussions/66430