### PR TITLE
Button tertiary

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,6 +36,8 @@ jobs:
         run: npm ci
       - name: Build with MSW
         run: npm run build:msw
+      - name: Build Ladle
+        run: npm run build:ladle
       - name: Deploy
         id: deploy
         uses: cloudflare/wrangler-action@v3

--- a/frontend/.ladle/config.mjs
+++ b/frontend/.ladle/config.mjs
@@ -1,3 +1,6 @@
 export default {
   stories: "lib/ui/**/*.stories.tsx",
+  outDir: "dist/ladle",
+  base: "/ladle/",
+  viteConfig: "./.ladle/vite.config.ts",
 };

--- a/frontend/.ladle/vite.config.ts
+++ b/frontend/.ladle/vite.config.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/frontend/lib/ui/Button/Button.module.css
+++ b/frontend/lib/ui/Button/Button.module.css
@@ -78,6 +78,46 @@
     }
   }
 
+  &.tertiary {
+    --button-border-width: 0px;
+    border: none;
+    background: transparent;
+    color: var(--color-error-darkest);
+
+    &:not(:hover, :active) {
+      box-shadow: none;
+    }
+
+    &:hover {
+      background: #fef9fa;
+    }
+
+    &:focus,
+    &:focus-visible {
+      box-shadow: none;
+      outline: none;
+      --button-border-width: 2px;
+      border: var(--button-border-width) solid var(--border-color-focus);
+    }
+
+    &:active {
+      background-color: var(--color-error-bg);
+    }
+
+    &:disabled {
+      box-shadow: none;
+      background: var(--button-color-bg-disabled);
+      border-color: var(--button-color-bg-disabled);
+      color: var(--button-color-disabled);
+    }
+  }
+
+  &:disabled {
+    background: var(--button-color-bg-disabled);
+    border-color: var(--button-color-bg-disabled);
+    color: var(--button-color-disabled);
+  }
+
   &.alert {
     border-color: var(--color-error);
     background: var(--color-error);

--- a/frontend/lib/ui/Button/Button.stories.tsx
+++ b/frontend/lib/ui/Button/Button.stories.tsx
@@ -1,65 +1,44 @@
-import type { Story } from "@ladle/react";
+import type { Story, StoryDefault } from "@ladle/react";
 
-import { Size, Variant } from "@kiesraad/ui";
+import { ButtonVariant, Size } from "@kiesraad/ui";
 
 import { Button } from "./Button";
 
 type Props = {
-  label: string;
   text: string;
-  variant: Variant;
   size: Size;
-};
-
-export const DefaultButton: Story<Props> = ({ label, text, variant, size }) => (
-  <Button size={size} variant={variant} aria-label={label}>
-    {text}
-  </Button>
-);
-
-export const EnabledButton: Story<{
-  text: string;
-  label: string;
-}> = ({ label, text }) => (
-  <Button type="button" aria-label={label}>
-    {text}
-  </Button>
-);
-
-EnabledButton.args = {
-  text: "Click me!",
-  label: "enabled-button",
-};
-
-export const DisabledButton: Story<{
-  text: string;
-  label: string;
   disabled: boolean;
-}> = ({ label, disabled, text }) => (
-  <Button type="button" aria-label={label} disabled={disabled}>
-    {text}
-  </Button>
-);
-
-DisabledButton.args = {
-  text: "I'm disabled!",
-  label: "disabled-button",
-  disabled: true,
 };
+
+const buttonVariants: ButtonVariant[] = ["default", "secondary", "tertiary", "alert", "ghost"];
+
+export const Buttons: Story<Props> = ({ text, size, disabled }) => (
+  <>
+    {buttonVariants.map((variant) => (
+      <div key={variant} className="mb-lg">
+        <h2>{variant}</h2>
+        <Button id={"button-variant-" + variant} size={size} variant={variant} disabled={disabled}>
+          {text}
+        </Button>
+      </div>
+    ))}
+    <aside>
+      <i>Disabled and different sizes can be seen using the Controls below</i>
+    </aside>
+  </>
+);
 
 export default {
   args: {
-    label: "Invoer",
     text: "Invoer",
   },
   argTypes: {
-    variant: {
-      options: ["default", "secondary", "ghost", "alert"],
+    size: {
+      options: ["xs", "sm", "md", "lg", "xl"],
       control: { type: "radio" },
     },
-    size: {
-      options: ["xs", "sm", "md", "lg"],
-      control: { type: "radio" },
+    disabled: {
+      control: { type: "boolean" },
     },
   },
-};
+} satisfies StoryDefault<Props>;

--- a/frontend/lib/ui/Button/Button.test.tsx
+++ b/frontend/lib/ui/Button/Button.test.tsx
@@ -2,35 +2,29 @@ import { expect, test } from "vitest";
 
 import { render, screen } from "app/test/unit";
 
-import { DefaultButton, DisabledButton, EnabledButton } from "./Button.stories";
+import { Buttons } from "./Button.stories";
 
-test("The default button is enabled", () => {
-  render(<DefaultButton label="Click me" variant="default" size="md" text="Click me" />);
+test("The default button is enabled", async () => {
+  render(<Buttons size="md" text="Click me" disabled={false} />);
 
-  const buttonElement = screen.getByRole("button", {
+  const buttons = await screen.findAllByRole("button", {
     name: "Click me",
   });
 
-  buttonElement.click();
-  expect(buttonElement).toBeEnabled();
+  for (const button of buttons) {
+    button.click();
+    expect(button).toBeEnabled();
+  }
 });
 
-test("The enabled button is enabled", () => {
-  render(<EnabledButton text="Click me!" label="enabled-button" />);
+test("The disabled button is disabled", async () => {
+  render(<Buttons size="md" text="Click me" disabled={true} />);
 
-  const buttonElement = screen.getByRole("button", {
-    name: "enabled-button",
+  const buttons = await screen.findAllByRole("button", {
+    name: "Click me",
   });
 
-  expect(buttonElement).toBeEnabled();
-});
-
-test("The disabled button is disabled", () => {
-  render(<DisabledButton text="Try and click me!" label="disabled-button" disabled={true} />);
-
-  const buttonElement = screen.getByRole("button", {
-    name: "disabled-button",
-  });
-
-  expect(buttonElement).toBeDisabled();
+  for (const button of buttons) {
+    expect(button).toBeDisabled();
+  }
 });

--- a/frontend/lib/ui/Button/Button.tsx
+++ b/frontend/lib/ui/Button/Button.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 
-import { Size, Variant } from "@kiesraad/ui";
+import { ButtonVariant, Size } from "@kiesraad/ui";
 
 import cls from "./Button.module.css";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isDisabled?: boolean;
   isLoading?: boolean;
-  variant?: Variant;
+  variant?: ButtonVariant;
   size?: Size;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;

--- a/frontend/lib/ui/IconButton/IconButton.stories.tsx
+++ b/frontend/lib/ui/IconButton/IconButton.stories.tsx
@@ -1,13 +1,13 @@
 import type { Story } from "@ladle/react";
 
 import { IconCross } from "@kiesraad/icon";
-import { Size, Variant } from "@kiesraad/ui";
+import { ButtonVariant, Size } from "@kiesraad/ui";
 
 import { IconButton } from "./IconButton";
 
 type Props = {
   label: string;
-  variant: Variant;
+  variant: ButtonVariant;
   size: Size;
   isRound: boolean;
 };

--- a/frontend/lib/ui/IconButton/IconButton.tsx
+++ b/frontend/lib/ui/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Size, Variant } from "@kiesraad/ui";
+import { ButtonVariant, Size } from "@kiesraad/ui";
 import { cn } from "@kiesraad/util";
 
 import cls from "./IconButton.module.css";
@@ -10,7 +10,7 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   title: string;
   isDisabled?: boolean;
   isLoading?: boolean;
-  variant?: Variant;
+  variant?: ButtonVariant;
   isRound?: boolean;
   size?: Size;
 }

--- a/frontend/lib/ui/ui.types.d.ts
+++ b/frontend/lib/ui/ui.types.d.ts
@@ -1,5 +1,5 @@
 export type Size = "xs" | "sm" | "md" | "lg" | "xl";
-export type Variant = "alert" | "default" | "ghost" | "secondary";
+export type ButtonVariant = "alert" | "default" | "ghost" | "secondary" | "tertiary";
 export type AlertType = "error" | "notify" | "success" | "warning";
 export type FeedbackId = "feedback-error" | "feedback-warning" | "feedback-server-error";
 export type MenuStatus = "accept" | "active" | "empty" | "error" | "idle" | "unsaved" | "warning";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "e2e:d2d": "cross-env LOCAL_CI=true playwright test -c playwright.d2d.config.ts",
     "e2e:d2d-dev": "playwright test -c playwright.d2d.config.ts",
     "ladle": "ladle serve",
+    "build:ladle": "ladle build",
     "start:msw": "cross-env API_MODE=mock vite",
     "gen:icons": "node scripts/gen_icons.js",
     "gen:openapi": "vite-node ./scripts/gen_openapi_types.ts",


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc)
-->
Added tertiary button variant for delete polling station.

Button can be seen in the (hopefully) now deployed preview ladle pages at `/ladle`.

It should have all the proper states and behave as expected.