### PR TITLE
adds contents write permission to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,9 @@ jobs:
       - build
       - playwright-d2d
     runs-on: ubuntu-latest
+    permissions:
+      # contents write permission is needed to push the tag
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Determine release tag


### PR DESCRIPTION
The release job in our release workflpw needs `write` permission for `contents` so it can push a tag. This PR grants that permission to the job (not the whole workflow).

I tested this in [my fork](https://github.com/jschuurk-kr/abacus), where I made sure the have the same _Workflow permissions_ as this repo, i.e. "Read repository contents and packages permissions " and not "Read and write permissions ". There are [three releases](https://github.com/jschuurk-kr/abacus/releases) built by the [release workflow](https://github.com/jschuurk-kr/abacus/actions/workflows/release.yml).