### PR TITLE
Add Rust version to GitHub Actions cache key

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -39,7 +39,11 @@ jobs:
         working-directory: ./frontend
       # Compile and test backend
       - name: Setup Rust
-        run: rustup update stable && rustup default stable
+        shell: bash
+        run: >
+          rustup update stable &&
+          rustup default stable &&
+          echo RUST_VERSION=$(rustc --version | cut -d' ' -f2) >> $GITHUB_ENV
       - name: Cargo cache
         uses: actions/cache@v4
         with:
@@ -51,8 +55,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./backend/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
       - name: Check rustfmt
         run: cargo --verbose --locked fmt --all -- --check
       - name: Check Clippy with all features


### PR DESCRIPTION
Cargo rebuilds everything when Rust is updated, but GitHub Actions
does not always update the cache when there is a cache key hit. This
causes workflow runs after a Rust update to use a stale cache.

By adding the Rust version number to the GitHub Actions cache key, a
fresh cache is created that can then be used in later workflow runs.