### PR TITLE
Add XML hashcode to PDF

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "axum-extra",
  "chrono",
  "clap",
- "const-hex",
+ "hex",
  "hyper",
  "memory-serve",
  "quick-xml 0.37.1",
@@ -575,19 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "const-hex"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "hex",
- "proptest",
- "serde",
 ]
 
 [[package]]
@@ -2174,22 +2161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
-dependencies = [
- "bitflags 2.6.0",
- "lazy_static",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
 name = "psm"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,15 +2247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -3694,12 +3656,6 @@ dependencies = [
  "siphasher 1.0.1",
  "thin-vec",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unic-langid"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -245,12 +245,14 @@ dependencies = [
  "axum-extra",
  "chrono",
  "clap",
+ "const-hex",
  "hyper",
  "memory-serve",
  "quick-xml 0.37.1",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tokio",
  "tower",
@@ -573,6 +575,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -2159,6 +2174,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -3654,6 +3694,12 @@ dependencies = [
  "siphasher 1.0.1",
  "thin-vec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unic-langid"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -245,7 +245,6 @@ dependencies = [
  "axum-extra",
  "chrono",
  "clap",
- "hex",
  "hyper",
  "memory-serve",
  "quick-xml 0.37.1",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -37,6 +37,8 @@ tracing = "0.1.41"
 typst = "0.12.0"
 typst-pdf = "0.12.0"
 quick-xml = { version = "0.37.1", features = ["serialize"] }
+sha2 = "0.10.8"
+const-hex = "1.14.0"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,7 +38,7 @@ typst = "0.12.0"
 typst-pdf = "0.12.0"
 quick-xml = { version = "0.37.1", features = ["serialize"] }
 sha2 = "0.10.8"
-const-hex = "1.14.0"
+hex = "0.4.3"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,7 +38,6 @@ typst = "0.12.0"
 typst-pdf = "0.12.0"
 quick-xml = { version = "0.37.1", features = ["serialize"] }
 sha2 = "0.10.8"
-hex = "0.4.3"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -57,7 +57,6 @@ The following dependencies (crates) are used:
 - `clap`: library for command-line argument parsing.
 - `quick-xml`: reading and writing EML_NL XML files.
 - `sha2`: generating a hash of the EML_NL XML files for inclusion in the PDF.
-- `hex`: converting hash bytes to a string for inclusion in the PDF.
 
 Additionally, the following development dependencies are used:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -57,7 +57,7 @@ The following dependencies (crates) are used:
 - `clap`: library for command-line argument parsing.
 - `quick-xml`: reading and writing EML_NL XML files.
 - `sha2`: generating a hash of the EML_NL XML files for inclusion in the PDF.
-- `const-hex`: converting hash bytes to a string for inclusion in the PDF.
+- `hex`: converting hash bytes to a string for inclusion in the PDF.
 
 Additionally, the following development dependencies are used:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,8 @@ The following dependencies (crates) are used:
 - `chrono`: date and time library.
 - `clap`: library for command-line argument parsing.
 - `quick-xml`: reading and writing EML_NL XML files.
+- `sha2`: generating a hash of the EML_NL XML files for inclusion in the PDF.
+- `const-hex`: converting hash bytes to a string for inclusion in the PDF.
 
 Additionally, the following development dependencies are used:
 

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -8,7 +8,7 @@ use self::repository::Elections;
 pub use self::structs::*;
 use crate::data_entry::repository::PollingStationResultsEntries;
 use crate::eml::axum::Eml;
-use crate::eml::EML510;
+use crate::eml::{eml_document_hash, EMLDocument, EML510};
 use crate::pdf_gen::generate_pdf;
 use crate::pdf_gen::models::{ModelNa31_2Input, PdfModel};
 use crate::polling_station::repository::PollingStations;
@@ -136,11 +136,17 @@ pub async fn election_download_results(
         .list_with_polling_stations(polling_stations_repo, election.id)
         .await?;
     let summary = ElectionSummary::from_results(&election, &results)?;
+    let creation_date_time = chrono::Local::now();
+    let xml = EML510::from_results(&election, &results, &summary, &creation_date_time);
+    let xml_string = xml.to_xml_string()?;
+    let hash = eml_document_hash(&xml_string, true);
 
     let model = PdfModel::ModelNa31_2(ModelNa31_2Input {
         polling_stations,
         summary,
         election,
+        hash,
+        creation_date_time: creation_date_time.format("%d-%m-%Y %H:%M:%S").to_string(),
     });
     let mut filename: String = model.as_filename().to_string();
     filename.push_str(".pdf");
@@ -182,6 +188,6 @@ pub async fn election_download_xml_results(
         .list_with_polling_stations(polling_stations_repo, election.id)
         .await?;
     let summary = ElectionSummary::from_results(&election, &results)?;
-    let xml = EML510::from_results(&election, &results, &summary);
+    let xml = EML510::from_results(&election, &results, &summary, &chrono::Local::now());
     Ok(Eml(xml))
 }

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -146,7 +146,7 @@ pub async fn election_download_results(
         summary,
         election,
         hash,
-        creation_date_time: creation_date_time.format("%d-%m-%Y %H:%M:%S").to_string(),
+        creation_date_time: creation_date_time.format("%d-%m-%Y %H:%M").to_string(),
     });
     let mut filename: String = model.as_filename().to_string();
     filename.push_str(".pdf");

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -92,22 +92,26 @@ pub fn eml_document_hash(input: &str, chunked: bool) -> String {
     let digest = sha2::Sha256::digest(input.as_bytes());
 
     // This can never fail unless `Sha256::output_size()` would give a wrong value
-    const_hex::encode_to_slice_upper(digest, &mut bytes)
-        .expect("Hashing output has unexpected length");
+    hex::encode_to_slice(digest, &mut bytes).expect("Hashing output has unexpected length");
+
+    fn to_upper_char(c: u8) -> char {
+        let c = char::from(c);
+        c.to_ascii_uppercase()
+    }
 
     if chunked {
         let mut iter = bytes.into_iter();
         let chunks_iter = std::iter::from_fn(move || {
             let chunk = iter.by_ref().take(4);
             if chunk.len() > 0 {
-                Some(chunk.map(char::from).collect::<String>())
+                Some(chunk.map(to_upper_char).collect::<String>())
             } else {
                 None
             }
         });
         chunks_iter.collect::<Vec<_>>().join(" ")
     } else {
-        bytes.into_iter().map(char::from).collect::<String>()
+        bytes.into_iter().map(to_upper_char).collect::<String>()
     }
 }
 

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -94,24 +94,19 @@ pub fn eml_document_hash(input: &str, chunked: bool) -> String {
     // This can never fail unless `Sha256::output_size()` would give a wrong value
     hex::encode_to_slice(digest, &mut bytes).expect("Hashing output has unexpected length");
 
-    fn to_upper_char(c: u8) -> char {
-        let c = char::from(c);
-        c.to_ascii_uppercase()
-    }
-
     if chunked {
         let mut iter = bytes.into_iter();
         let chunks_iter = std::iter::from_fn(move || {
             let chunk = iter.by_ref().take(4);
             if chunk.len() > 0 {
-                Some(chunk.map(to_upper_char).collect::<String>())
+                Some(chunk.map(char::from).collect::<String>())
             } else {
                 None
             }
         });
         chunks_iter.collect::<Vec<_>>().join(" ")
     } else {
-        bytes.into_iter().map(to_upper_char).collect::<String>()
+        bytes.into_iter().map(char::from).collect::<String>()
     }
 }
 
@@ -154,12 +149,12 @@ mod tests {
         let hash = eml_document_hash(input, false);
         assert_eq!(
             hash,
-            "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08"
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
         );
         let hash = eml_document_hash(input, true);
         assert_eq!(
             hash,
-            "9F86 D081 884C 7D65 9A2F EAA0 C55A D015 A3BF 4F1B 2B0B 822C D15D 6C15 B0F0 0A08"
+            "9f86 d081 884c 7d65 9a2f eaa0 c55a d015 a3bf 4f1b 2b0b 822c d15d 6c15 b0f0 0a08"
         );
     }
 }

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -143,4 +143,19 @@ mod tests {
         assert_eq!(doc.base.id, "test-id");
         assert_eq!(doc.base.schema_version, "5");
     }
+
+    #[test]
+    fn test_eml_document_hash() {
+        let input = "test";
+        let hash = eml_document_hash(input, false);
+        assert_eq!(
+            hash,
+            "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08"
+        );
+        let hash = eml_document_hash(input, true);
+        assert_eq!(
+            hash,
+            "9F86 D081 884C 7D65 9A2F EAA0 C55A D015 A3BF 4F1B 2B0B 822C D15D 6C15 B0F0 0A08"
+        );
+    }
 }

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -88,16 +88,14 @@ pub trait EMLDocument: Sized + DeserializeOwned + Serialize {
 
 pub fn eml_document_hash(input: &str, chunked: bool) -> String {
     use sha2::Digest;
-    let digest = sha2::Sha256::digest(input.as_bytes())
-        .into_iter()
-        .map(|b| format!("{:02x}", b));
+    let digest = sha2::Sha256::digest(input.as_bytes());
 
     let mut res = String::new();
-    for (idx, b) in digest.enumerate() {
+    for (idx, b) in digest.into_iter().enumerate() {
         if chunked && idx > 0 && idx % 2 == 0 {
             res.push(' ');
         }
-        res.push_str(&b);
+        res.push_str(&format!("{:02x}", b));
     }
     res
 }

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -1,5 +1,5 @@
 pub use base::*;
-use chrono::{Datelike, Local};
+use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -32,6 +32,7 @@ impl EML510 {
         election: &crate::election::Election,
         results: &[(PollingStation, PollingStationResults)],
         summary: &ElectionSummary,
+        creation_date_time: &chrono::DateTime<chrono::Local>,
     ) -> EML510 {
         let authority_id = "0000".to_string(); // TODO: replace with actual authority id from election definition (i.e. data from election tree)
         let total_votes = TotalVotes::from_summary(election, summary);
@@ -79,7 +80,8 @@ impl EML510 {
                 },
                 authority_address: AuthorityAddress {},
             },
-            creation_date_time: Local::now().to_rfc3339(),
+            creation_date_time: creation_date_time
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             count,
         }
     }

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -113,9 +113,9 @@ pub(crate) mod tests {
             },
             polling_stations: vec![],
             summary: ElectionSummary::zero(),
-            hash: "ED36 60EB 017A 0D3A D3EF 72B1 6865 F991 A36A 9F92 72D9 1516 39CD 422B 4756 D161"
+            hash: "ed36 60eb 017a 0d3a d3ef 72b1 6865 f991 a36a 9f92 72d9 1516 39cd 422b 4756 d161"
                 .to_string(),
-            creation_date_time: "04-12-2024 12:08:55".to_string(),
+            creation_date_time: "04-12-2024 12:08".to_string(),
         }))
         .unwrap();
 
@@ -129,9 +129,9 @@ pub(crate) mod tests {
             polling_stations: polling_stations_fixture(&election, &[100, 200, 300]),
             election,
             summary: ElectionSummary::zero(),
-            hash: "ED36 60EB 017A 0D3A D3EF 72B1 6865 F991 A36A 9F92 72D9 1516 39CD 422B 4756 D161"
+            hash: "ed36 60eb 017a 0d3a d3ef 72b1 6865 f991 a36a 9f92 72d9 1516 39cd 422b 4756 d161"
                 .to_string(),
-            creation_date_time: "04-12-2024 12:08:55".to_string(),
+            creation_date_time: "04-12-2024 12:08".to_string(),
         }))
         .unwrap();
 

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -113,6 +113,9 @@ pub(crate) mod tests {
             },
             polling_stations: vec![],
             summary: ElectionSummary::zero(),
+            hash: "ED36 60EB 017A 0D3A D3EF 72B1 6865 F991 A36A 9F92 72D9 1516 39CD 422B 4756 D161"
+                .to_string(),
+            creation_date_time: "04-12-2024 12:08:55".to_string(),
         }))
         .unwrap();
 
@@ -126,6 +129,9 @@ pub(crate) mod tests {
             polling_stations: polling_stations_fixture(&election, &[100, 200, 300]),
             election,
             summary: ElectionSummary::zero(),
+            hash: "ED36 60EB 017A 0D3A D3EF 72B1 6865 F991 A36A 9F92 72D9 1516 39CD 422B 4756 D161"
+                .to_string(),
+            creation_date_time: "04-12-2024 12:08:55".to_string(),
         }))
         .unwrap();
 

--- a/backend/src/pdf_gen/models/model_na_31_2.rs
+++ b/backend/src/pdf_gen/models/model_na_31_2.rs
@@ -9,4 +9,6 @@ pub struct ModelNa31_2Input {
     pub election: Election,
     pub summary: ElectionSummary,
     pub polling_stations: Vec<PollingStation>,
+    pub hash: String,
+    pub creation_date_time: String,
 }

--- a/backend/templates/common/style.typ
+++ b/backend/templates/common/style.typ
@@ -1,4 +1,4 @@
-#let conf(input, doc) = [
+#let conf(input, doc, footer: none) = [
   #set text(
     font: "DM Sans",
     size: 9pt
@@ -7,6 +7,14 @@
     paper: "a4",
     margin: (x: 2.0cm, y: 1.5cm),
     numbering: "1 / 1",
+    footer: context(grid(
+      columns: (1fr, auto),
+      gutter: 3pt,
+      [#footer],
+      [
+        pagina #counter(page).display("1 / 1", both: true)
+      ]
+    )),
   )
 
   #set heading(numbering: "1a. ")

--- a/backend/templates/common/style.typ
+++ b/backend/templates/common/style.typ
@@ -11,9 +11,9 @@
       columns: (1fr, auto),
       gutter: 3pt,
       [#footer],
-      [
+      align(end + top, [
         pagina #counter(page).display("1 / 1", both: true)
-      ]
+      ]),
     )),
   )
 

--- a/backend/templates/inputs/model-na-31-2.json
+++ b/backend/templates/inputs/model-na-31-2.json
@@ -639,5 +639,7 @@
       "postal_code": "0123AB",
       "locality": "Heemdamseburg"
     }
-  ]
+  ],
+  "hash": "ED36 60EB 017A 0D3A D3EF 72B1 6865 F991 A36A 9F92 72D9 1516 39CD 422B 4756 D161",
+  "creation_date_time": "04-12-2024 12:08:55"
 }

--- a/backend/templates/inputs/model-na-31-2.json
+++ b/backend/templates/inputs/model-na-31-2.json
@@ -640,6 +640,6 @@
       "locality": "Heemdamseburg"
     }
   ],
-  "hash": "ED36 60EB 017A 0D3A D3EF 72B1 6865 F991 A36A 9F92 72D9 1516 39CD 422B 4756 D161",
-  "creation_date_time": "04-12-2024 12:08:55"
+  "hash": "ed36 60eb 017a 0d3a d3ef 72b1 6865 f991 a36a 9f92 72d9 1516 39cd 422b 4756 d161",
+  "creation_date_time": "04-12-2024 12:08"
 }

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -3,7 +3,7 @@
 #let input = json("inputs/model-na-31-2.json")
 
 #show: doc => conf(input, doc, footer: [
-  Datum: #input.creation_date_time, SHA-256-Hashcode: \
+  #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
   #input.hash
 ])
 

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -1,8 +1,11 @@
 #import "common/style.typ": conf, title, mono
-#import "common/scripts.typ": alertbox, block_with_checkbox, date_input, time_input, letterbox_main, summary_table, text_input, format_date, TODO
+#import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2.json")
 
-#show: doc => conf(input, doc)
+#show: doc => conf(input, doc, footer: [
+  Datum: #input.creation_date_time, SHA-256-Hashcode: \
+  #input.hash
+])
 
 #let is_municipality = (municipal, public_body) => if input.election.category == "Municipal" [#municipal] else [#public_body]
 


### PR DESCRIPTION
- ~~Note: #685 should probably be merged first~~
- Adds XML Hashcode to the PDF
- Changes indentation of XML to 2 spaces
- ~~Example output: [model-na-31-2.pdf](https://github.com/user-attachments/files/18021786/model-na-31-2.pdf)~~
- Example output: [model-na-31-2-22.pdf](https://github.com/user-attachments/files/18024332/model-na-31-2-22.pdf)
