### PR TITLE
Ladle vite config should convert CSS module dashes into camelCase too  

### DIFF
--- a/frontend/.ladle/vite.config.ts
+++ b/frontend/.ladle/vite.config.ts
@@ -1,1 +1,9 @@
-export default {};
+export default {
+  css: {
+    modules: {
+      // Only dashes in class names will be converted to camelCase,
+      // the original class name will not to be removed from the locals
+      localsConvention: "dashes",
+    },
+  },
+};


### PR DESCRIPTION
In Ladle, the dashes to camelCase was not working anymore because of a separate vite config that did not include the `localsConventions: dashes`, which resulted in e.g. the Table Link rows to not have the correct class anymore with on hover styling and a chevron.

Related PR's
- Implemented the possibility to use dashes in CSS modules and camelCase in components in https://github.com/kiesraad/abacus/pull/570
- Implemented a separate vite config for Ladle to make build and deploy possible in https://github.com/kiesraad/abacus/pull/655