### PR TITLE
EntryNumber enum

### DIFF
--- a/backend/src/data_entry/entry_number.rs
+++ b/backend/src/data_entry/entry_number.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+use sqlx::Sqlite;
+use std::fmt::Display;
+
+#[derive(Debug, Copy, Clone, Serialize)]
+pub enum EntryNumber {
+    FirstEntry,
+    SecondEntry,
+}
+#[derive(Debug)]
+pub struct InvalidEntryNumberError(u8);
+impl Display for InvalidEntryNumberError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid entry number `{}`", self.0)
+    }
+}
+impl TryFrom<u8> for EntryNumber {
+    type Error = InvalidEntryNumberError;
+    fn try_from(n: u8) -> Result<Self, Self::Error> {
+        match n {
+            1 => Ok(Self::FirstEntry),
+            2 => Ok(Self::SecondEntry),
+            _ => Err(InvalidEntryNumberError(n)),
+        }
+    }
+}
+impl<'de> Deserialize<'de> for EntryNumber {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let n = u8::deserialize(deserializer)?;
+        Self::try_from(n).map_err(serde::de::Error::custom)
+    }
+}
+impl<'q> sqlx::Encode<'q, Sqlite> for EntryNumber {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Sqlite as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        let n: u8 = match self {
+            EntryNumber::FirstEntry => 1,
+            EntryNumber::SecondEntry => 2,
+        };
+        n.encode(buf)
+    }
+}
+impl sqlx::Type<Sqlite> for EntryNumber {
+    fn type_info() -> <Sqlite as sqlx::Database>::TypeInfo {
+        u8::type_info()
+    }
+}

--- a/backend/src/data_entry/repository.rs
+++ b/backend/src/data_entry/repository.rs
@@ -1,6 +1,7 @@
 use axum::extract::FromRef;
 use sqlx::{query, Sqlite, SqlitePool, Transaction};
 
+use super::entry_number::EntryNumber;
 use super::{PollingStation, PollingStationResults, PollingStationResultsEntry};
 use crate::polling_station::repository::PollingStations;
 use crate::AppState;
@@ -17,7 +18,7 @@ impl PollingStationDataEntries {
     pub async fn upsert(
         &self,
         id: u32,
-        entry_number: u8,
+        entry_number: EntryNumber,
         progress: u8,
         data: String,
         client_state: String,
@@ -50,7 +51,7 @@ impl PollingStationDataEntries {
         &self,
         tx: &mut Transaction<'_, Sqlite>,
         id: u32,
-        entry_number: u8,
+        entry_number: EntryNumber,
     ) -> Result<(u8, Vec<u8>, Vec<u8>, i64), sqlx::Error> {
         let res = query!(
             r#"SELECT progress AS "progress: u8", data, client_state, updated_at FROM polling_station_data_entries WHERE polling_station_id = ? AND entry_number = ?"#,
@@ -68,7 +69,7 @@ impl PollingStationDataEntries {
         }
     }
 
-    pub async fn delete(&self, id: u32, entry_number: u8) -> Result<(), sqlx::Error> {
+    pub async fn delete(&self, id: u32, entry_number: EntryNumber) -> Result<(), sqlx::Error> {
         let res = query!(
             "DELETE FROM polling_station_data_entries WHERE polling_station_id = ? AND entry_number = ? AND finalised_at IS NULL",
             id,


### PR DESCRIPTION
Adds an enum for `entry_number`s. The goal is to parse the entry number once at serialization, so you when you use the `EntryNumber` type, you'll be guaranteed it represents a valid entry number.
It mitigates the need for a lot of checks throughout the API code and it offloads logic from the State Machine that will be introduced in a future PR.

- I chose an enum instead of a newtype around a `u8`, because it is harder to (accidentally) circumvent the type system.
- I haven't updated the `utoipa` attributes, as I'm not sure it makes sense to do so in this case
- I've updated the test code to use `try_from()` + `unwrap()` instead of enum variants directly, so we don't skip on testing the validation

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->