### PR TITLE
adds imports to review checklist in pull request doc

### DIFF
--- a/documentatie/ontwikkelproces/pull-requests.md
+++ b/documentatie/ontwikkelproces/pull-requests.md
@@ -26,6 +26,7 @@ Let minstens op:
 - scope van de wijzigingen
 - kwaliteit van de code
 - consistentie met omliggende code
+- imports en de resulterende afhankelijkheden
 - edge cases
 - test coverage
 - documentatie (README, diagrammen, use cases)


### PR DESCRIPTION
We have/had some `import`s in our code that shouldn't be there, creating unwanted dependencies.

So as @rnijveld suggested yesterday, let's add this to the checklist for reviews in our pull requests document.

If there's a better way to phrase this, please leave a comment!