### PR TITLE
Add API endpoint to retrieve zip with xml and pdf combined

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4470,6 +4470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
 dependencies = [
  "arbitrary",
+ "chrono",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
@@ -4477,7 +4478,6 @@ dependencies = [
  "indexmap",
  "memchr",
  "thiserror 2.0.4",
- "time",
  "zopfli",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "typst-pdf",
  "utoipa",
  "utoipa-swagger-ui",
+ "zip",
 ]
 
 [[package]]
@@ -4476,6 +4477,7 @@ dependencies = [
  "indexmap",
  "memchr",
  "thiserror 2.0.4",
+ "time",
  "zopfli",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,7 +42,7 @@ argon2 = "0.5.3"
 password-hash = { version = "0.5.0", features = ["getrandom"] }
 rand = "0.8.5"
 cookie = "0.18.1"
-zip = { version = "2.2.1", default-features = false, features = ["deflate", "time"] }
+zip = { version = "2.2.1", default-features = false, features = ["deflate", "chrono"] }
 
 [dev-dependencies]
 http-body-util = "0.1.2"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,6 +42,7 @@ argon2 = "0.5.3"
 password-hash = { version = "0.5.0", features = ["getrandom"] }
 rand = "0.8.5"
 cookie = "0.18.1"
+zip = { version = "2.2.1", default-features = false, features = ["deflate", "time"] }
 
 [dev-dependencies]
 http-body-util = "0.1.2"

--- a/backend/README.md
+++ b/backend/README.md
@@ -62,6 +62,7 @@ The following dependencies (crates) are used:
 - `rand`: create a random session key.
 - `password_hash`: password hashing interfaces.
 - `argon2`: password hashing implementation (Argon2id).
+- `zip`: creating a zip of the EML_NL and PDF PV.
 
 Additionally, the following development dependencies are used:
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -234,7 +234,7 @@
               }
             },
             "content": {
-              "application/x-zip": {}
+              "application/zip": {}
             }
           },
           "404": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -94,13 +94,13 @@
         }
       }
     },
-    "/api/elections/{election_id}/download_results": {
+    "/api/elections/{election_id}/download_pdf_results": {
       "get": {
         "tags": [
           "election"
         ],
         "summary": "Download a generated PDF with election results",
-        "operationId": "election_download_results",
+        "operationId": "election_download_pdf_results",
         "parameters": [
           {
             "name": "election_id",
@@ -123,12 +123,6 @@
                   "type": "string"
                 },
                 "description": "attachment; filename=\"filename.pdf\""
-              },
-              "Content-Type": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "application/pdf"
               }
             },
             "content": {
@@ -181,16 +175,66 @@
         "responses": {
           "200": {
             "description": "XML",
+            "content": {
+              "text/xml": {}
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/elections/{election_id}/download_zip_results": {
+      "get": {
+        "tags": [
+          "election"
+        ],
+        "summary": "Download a zip containing a PDF for the PV and the EML with election results",
+        "operationId": "election_download_zip_results",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP",
             "headers": {
-              "Content-Type": {
+              "Content-Disposition": {
                 "schema": {
                   "type": "string"
                 },
-                "description": "text/xml"
+                "description": "attachment; filename=\"filename.zip\""
               }
             },
             "content": {
-              "text/xml": {}
+              "application/x-zip": {}
             }
           },
           "404": {

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -148,7 +148,7 @@ impl ResultsInput {
     fn xml_filename(&self) -> String {
         use chrono::Datelike;
         format!(
-            "Telling_{}{}_{}.xml",
+            "Telling_{}{}_{}.eml.xml",
             self.election.category.to_eml_code(),
             self.election.election_date.year(),
             self.election.location.replace(" ", "_"),
@@ -158,7 +158,7 @@ impl ResultsInput {
     fn pdf_filename(&self) -> String {
         use chrono::Datelike;
         format!(
-            "PV_{}{}_{}.pdf",
+            "Model_Na31-2_{}{}_{}.pdf",
             self.election.category.to_eml_code(),
             self.election.election_date.year(),
             self.election.location.replace(" ", "_"),
@@ -239,7 +239,7 @@ pub async fn election_download_zip_results(
             chrono::Local::now()
                 .naive_local()
                 .try_into()
-                .expect("Timestamp outside of zip range"),
+                .expect("Timestamp should be inside zip timestamp range"),
         )
         .unix_permissions(0o644);
     zip.start_file(xml_filename, options)?;

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -3,10 +3,13 @@ use axum::Json;
 use axum_extra::response::Attachment;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use zip::result::ZipError;
+use zip::write::SimpleFileOptions;
 
 use self::repository::Elections;
 pub use self::structs::*;
 use crate::data_entry::repository::PollingStationResultsEntries;
+use crate::data_entry::PollingStationResults;
 use crate::eml::axum::Eml;
 use crate::eml::{eml_document_hash, EMLDocument, EML510};
 use crate::pdf_gen::generate_pdf;
@@ -103,17 +106,156 @@ pub async fn election_status(
     Ok(Json(ElectionStatusResponse { statuses }))
 }
 
+struct ResultsInput {
+    election: Election,
+    polling_stations: Vec<PollingStation>,
+    results: Vec<(PollingStation, PollingStationResults)>,
+    summary: ElectionSummary,
+    creation_date_time: chrono::DateTime<chrono::Local>,
+}
+
+impl ResultsInput {
+    async fn new(
+        election_id: u32,
+        elections_repo: Elections,
+        polling_stations_repo: PollingStations,
+        polling_station_results_entries_repo: PollingStationResultsEntries,
+    ) -> Result<ResultsInput, APIError> {
+        let election = elections_repo.get(election_id).await?;
+        let polling_stations = polling_stations_repo.list(election.id).await?;
+        let results = polling_station_results_entries_repo
+            .list_with_polling_stations(polling_stations_repo, election.id)
+            .await?;
+
+        Ok(ResultsInput {
+            summary: ElectionSummary::from_results(&election, &results)?,
+            creation_date_time: chrono::Local::now(),
+            election,
+            polling_stations,
+            results,
+        })
+    }
+
+    fn as_xml(&self) -> EML510 {
+        EML510::from_results(
+            &self.election,
+            &self.results,
+            &self.summary,
+            &self.creation_date_time,
+        )
+    }
+
+    fn xml_filename(&self) -> String {
+        use chrono::Datelike;
+        format!(
+            "Telling_{}{}_{}.xml",
+            self.election.category.to_eml_code(),
+            self.election.election_date.year(),
+            self.election.location.replace(" ", "_"),
+        )
+    }
+
+    fn pdf_filename(&self) -> String {
+        use chrono::Datelike;
+        format!(
+            "PV_{}{}_{}.pdf",
+            self.election.category.to_eml_code(),
+            self.election.election_date.year(),
+            self.election.location.replace(" ", "_"),
+        )
+    }
+
+    fn zip_filename(&self) -> String {
+        use chrono::Datelike;
+        format!(
+            "election_result_{}{}_{}.zip",
+            self.election.category.to_eml_code(),
+            self.election.election_date.year(),
+            self.election.location.replace(" ", "_"),
+        )
+    }
+
+    fn into_pdf_model(self, xml_hash: impl Into<String>) -> PdfModel {
+        PdfModel::ModelNa31_2(ModelNa31_2Input {
+            polling_stations: self.polling_stations,
+            summary: self.summary,
+            election: self.election,
+            hash: xml_hash.into(),
+            creation_date_time: self.creation_date_time.format("%d-%m-%Y %H:%M").to_string(),
+        })
+    }
+}
+
+/// Download a zip containing a PDF for the PV and the EML with election results
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/download_zip_results",
+    responses(
+        (
+            status = 200,
+            description = "ZIP",
+            content_type = "application/x-zip",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.zip\"")
+            )
+        ),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = u32, description = "Election database id"),
+    ),
+)]
+pub async fn election_download_zip_results(
+    State(elections_repo): State<Elections>,
+    State(polling_stations_repo): State<PollingStations>,
+    State(polling_station_results_entries_repo): State<PollingStationResultsEntries>,
+    Path(id): Path<u32>,
+) -> Result<Attachment<Vec<u8>>, APIError> {
+    use std::io::Write;
+
+    let input = ResultsInput::new(
+        id,
+        elections_repo,
+        polling_stations_repo,
+        polling_station_results_entries_repo,
+    )
+    .await?;
+    let xml = input.as_xml();
+    let xml_string = xml.to_xml_string()?;
+    let pdf_filename = input.pdf_filename();
+    let xml_filename = input.xml_filename();
+    let zip_filename = input.zip_filename();
+    let model = input.into_pdf_model(eml_document_hash(&xml_string, true));
+    let content = generate_pdf(model)?;
+
+    let mut buf = vec![];
+    let mut cursor = std::io::Cursor::new(&mut buf);
+    let mut zip = zip::ZipWriter::new(&mut cursor);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::DEFLATE)
+        .unix_permissions(0o644);
+    zip.start_file(xml_filename, options)?;
+    zip.write_all(xml_string.as_bytes()).map_err(ZipError::Io)?;
+    zip.start_file(pdf_filename, options)?;
+    zip.write_all(&content.buffer).map_err(ZipError::Io)?;
+    zip.finish()?;
+
+    Ok(Attachment::new(buf)
+        .filename(zip_filename)
+        .content_type("application/x-zip"))
+}
+
 /// Download a generated PDF with election results
 #[utoipa::path(
     get,
-    path = "/api/elections/{election_id}/download_results",
+    path = "/api/elections/{election_id}/download_pdf_results",
     responses(
         (
             status = 200,
             description = "PDF",
-            content_type="application/pdf",
+            content_type = "application/pdf",
             headers(
-                ("Content-Type", description = "application/pdf"),
                 ("Content-Disposition", description = "attachment; filename=\"filename.pdf\"")
             )
         ),
@@ -124,36 +266,27 @@ pub async fn election_status(
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn election_download_results(
+pub async fn election_download_pdf_results(
     State(elections_repo): State<Elections>,
     State(polling_stations_repo): State<PollingStations>,
     State(polling_station_results_entries_repo): State<PollingStationResultsEntries>,
     Path(id): Path<u32>,
 ) -> Result<Attachment<Vec<u8>>, APIError> {
-    let election = elections_repo.get(id).await?;
-    let polling_stations = polling_stations_repo.list(election.id).await?;
-    let results = polling_station_results_entries_repo
-        .list_with_polling_stations(polling_stations_repo, election.id)
-        .await?;
-    let summary = ElectionSummary::from_results(&election, &results)?;
-    let creation_date_time = chrono::Local::now();
-    let xml = EML510::from_results(&election, &results, &summary, &creation_date_time);
+    let input = ResultsInput::new(
+        id,
+        elections_repo,
+        polling_stations_repo,
+        polling_station_results_entries_repo,
+    )
+    .await?;
+    let xml = input.as_xml();
     let xml_string = xml.to_xml_string()?;
-    let hash = eml_document_hash(&xml_string, true);
-
-    let model = PdfModel::ModelNa31_2(ModelNa31_2Input {
-        polling_stations,
-        summary,
-        election,
-        hash,
-        creation_date_time: creation_date_time.format("%d-%m-%Y %H:%M").to_string(),
-    });
-    let mut filename: String = model.as_filename().to_string();
-    filename.push_str(".pdf");
+    let pdf_filename = input.pdf_filename();
+    let model = input.into_pdf_model(eml_document_hash(&xml_string, true));
     let content = generate_pdf(model)?;
 
     Ok(Attachment::new(content.buffer)
-        .filename(filename)
+        .filename(pdf_filename)
         .content_type("application/pdf"))
 }
 
@@ -165,10 +298,7 @@ pub async fn election_download_results(
         (
             status = 200,
             description = "XML",
-            content_type="text/xml",
-            headers(
-                ("Content-Type", description = "text/xml"),
-            )
+            content_type = "text/xml",
         ),
         (status = 404, description = "Not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
@@ -183,11 +313,13 @@ pub async fn election_download_xml_results(
     State(polling_station_results_entries_repo): State<PollingStationResultsEntries>,
     Path(id): Path<u32>,
 ) -> Result<Eml<EML510>, APIError> {
-    let election = elections_repo.get(id).await?;
-    let results = polling_station_results_entries_repo
-        .list_with_polling_stations(polling_stations_repo, election.id)
-        .await?;
-    let summary = ElectionSummary::from_results(&election, &results)?;
-    let xml = EML510::from_results(&election, &results, &summary, &chrono::Local::now());
+    let input = ResultsInput::new(
+        id,
+        elections_repo,
+        polling_stations_repo,
+        polling_station_results_entries_repo,
+    )
+    .await?;
+    let xml = input.as_xml();
     Ok(Eml(xml))
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -58,8 +58,12 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
         .route("/", get(election::election_list))
         .route("/:election_id", get(election::election_details))
         .route(
-            "/:election_id/download_results",
-            get(election::election_download_results),
+            "/:election_id/download_zip_results",
+            get(election::election_download_zip_results),
+        )
+        .route(
+            "/:election_id/download_pdf_results",
+            get(election::election_download_pdf_results),
         )
         .route(
             "/:election_id/download_xml_results",
@@ -127,7 +131,8 @@ pub fn create_openapi() -> utoipa::openapi::OpenApi {
             election::election_list,
             election::election_details,
             election::election_status,
-            election::election_download_results,
+            election::election_download_zip_results,
+            election::election_download_pdf_results,
             election::election_download_xml_results,
             data_entry::polling_station_data_entry_save,
             data_entry::polling_station_data_entry_get,

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -249,7 +249,7 @@ async fn test_election_zip_download(pool: SqlitePool) {
     let content_type = response.headers().get("Content-Type");
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(content_type.unwrap(), "application/x-zip");
+    assert_eq!(content_type.unwrap(), "application/zip");
 
     let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
     assert_eq!(&content_disposition_string[..21], "attachment; filename=");

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -257,4 +257,16 @@ async fn test_election_zip_download(pool: SqlitePool) {
         &content_disposition_string[21..],
         "\"election_result_GR2024_Heemdamseburg.zip\""
     );
+
+    let bytes = response.bytes().await.unwrap();
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    {
+        let xml_file = archive.by_name("Telling_GR2024_Heemdamseburg.xml").unwrap();
+        assert!(xml_file.size() > 0);
+    }
+
+    {
+        let pdf_file = archive.by_name("PV_GR2024_Heemdamseburg.pdf").unwrap();
+        assert!(pdf_file.size() > 0);
+    }
 }

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -193,7 +193,7 @@ async fn test_election_details_status_no_other_election_statuses(pool: SqlitePoo
 async fn test_election_pdf_download(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
-    let url = format!("http://{addr}/api/elections/1/download_results");
+    let url = format!("http://{addr}/api/elections/1/download_pdf_results");
     let response = reqwest::Client::new().get(&url).send().await.unwrap();
     let status = response.status();
     let content_disposition = response.headers().get("Content-Disposition");
@@ -233,4 +233,28 @@ async fn test_election_xml_download(pool: SqlitePool) {
     let body = response.text().await.unwrap();
     assert!(body.contains("<Election>"));
     assert!(body.contains("<ValidVotes>125</ValidVotes>"));
+}
+
+#[sqlx::test(fixtures(
+    path = "../fixtures",
+    scripts("elections", "polling_stations", "polling_station_results")
+))]
+async fn test_election_zip_download(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    let url = format!("http://{addr}/api/elections/4/download_zip_results");
+    let response = reqwest::Client::new().get(&url).send().await.unwrap();
+    let status = response.status();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/x-zip");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    assert_eq!(
+        &content_disposition_string[21..],
+        "\"election_result_GR2024_Heemdamseburg.zip\""
+    );
 }

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -261,12 +261,16 @@ async fn test_election_zip_download(pool: SqlitePool) {
     let bytes = response.bytes().await.unwrap();
     let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
     {
-        let xml_file = archive.by_name("Telling_GR2024_Heemdamseburg.xml").unwrap();
+        let xml_file = archive
+            .by_name("Telling_GR2024_Heemdamseburg.eml.xml")
+            .unwrap();
         assert!(xml_file.size() > 0);
     }
 
     {
-        let pdf_file = archive.by_name("PV_GR2024_Heemdamseburg.pdf").unwrap();
+        let pdf_file = archive
+            .by_name("Model_Na31-2_GR2024_Heemdamseburg.pdf")
+            .unwrap();
         assert!(pdf_file.size() > 0);
     }
 }

--- a/frontend/app/module/election/page/ElectionReportPage.tsx
+++ b/frontend/app/module/election/page/ElectionReportPage.tsx
@@ -19,7 +19,7 @@ export function ElectionReportPage() {
 
   function downloadResults() {
     let filename: string;
-    fetch(`/api/elections/${election.id}/download_results`)
+    fetch(`/api/elections/${election.id}/download_pdf_results`)
       .then((result) => {
         if (result.status !== 200) {
           const message = `Failed to download PDF: status code ${result.status}`;

--- a/frontend/e2e-tests/dom-to-db-tests/pdf-rendering.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/pdf-rendering.e2e.ts
@@ -13,7 +13,7 @@ test.describe("pdf rendering", () => {
     await electionStatusPage.finish.click();
 
     const electionReportPage = new ElectionReport(page);
-    const responsePromise = page.waitForResponse("/api/elections/4/download_results");
+    const responsePromise = page.waitForResponse("/api/elections/4/download_pdf_results");
     const downloadPromise = page.waitForEvent("download");
     await electionReportPage.download.click();
 

--- a/frontend/e2e-tests/dom-to-db-tests/pdf-rendering.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/pdf-rendering.e2e.ts
@@ -23,7 +23,7 @@ test.describe("pdf rendering", () => {
 
     const download = await downloadPromise;
 
-    expect(download.suggestedFilename()).toBe("model-na-31-2.pdf");
+    expect(download.suggestedFilename()).toBe("PV_GR2024_Heemdamseburg.pdf");
     expect((await stat(await download.path())).size).toBeGreaterThan(1024);
   });
 });

--- a/frontend/e2e-tests/dom-to-db-tests/pdf-rendering.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/pdf-rendering.e2e.ts
@@ -23,7 +23,7 @@ test.describe("pdf rendering", () => {
 
     const download = await downloadPromise;
 
-    expect(download.suggestedFilename()).toBe("PV_GR2024_Heemdamseburg.pdf");
+    expect(download.suggestedFilename()).toBe("Model_Na31-2_GR2024_Heemdamseburg.pdf");
     expect((await stat(await download.path())).size).toBeGreaterThan(1024);
   });
 });

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -12,17 +12,23 @@ export interface ELECTION_DETAILS_REQUEST_PARAMS {
 }
 export type ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${number}`;
 
-// /api/elections/{election_id}/download_results
-export interface ELECTION_DOWNLOAD_RESULTS_REQUEST_PARAMS {
+// /api/elections/{election_id}/download_pdf_results
+export interface ELECTION_DOWNLOAD_PDF_RESULTS_REQUEST_PARAMS {
   election_id: number;
 }
-export type ELECTION_DOWNLOAD_RESULTS_REQUEST_PATH = `/api/elections/${number}/download_results`;
+export type ELECTION_DOWNLOAD_PDF_RESULTS_REQUEST_PATH = `/api/elections/${number}/download_pdf_results`;
 
 // /api/elections/{election_id}/download_xml_results
 export interface ELECTION_DOWNLOAD_XML_RESULTS_REQUEST_PARAMS {
   election_id: number;
 }
 export type ELECTION_DOWNLOAD_XML_RESULTS_REQUEST_PATH = `/api/elections/${number}/download_xml_results`;
+
+// /api/elections/{election_id}/download_zip_results
+export interface ELECTION_DOWNLOAD_ZIP_RESULTS_REQUEST_PARAMS {
+  election_id: number;
+}
+export type ELECTION_DOWNLOAD_ZIP_RESULTS_REQUEST_PATH = `/api/elections/${number}/download_zip_results`;
 
 // /api/elections/{election_id}/polling_stations
 export interface POLLING_STATION_LIST_REQUEST_PARAMS {


### PR DESCRIPTION
- Added a new `zip` dependency to create the zip file (doing it without a dependency, especially with compression, is hard to do)
- Added a small struct `ResultsInput` to share some code between the xml, pdf and zip endpoints. 
- I'm extracing the zip in our test, but it does use the same library as the one that created it, might not say too much about the validity of the file
- Updated urls and filenames for the results endpoints
- Remove the unnecessary content-type duplication in these endpoints for openapi
- Can be tested by going to http://localhost:3000/api/elections/4/download_zip_results
- Good test: check the hash in the PDF against the sha256sum of the XML
