### PR TITLE
Update election report page to include download button for zip

### DIFF
--- a/frontend/app/module/election/page/ElectionReportPage.test.tsx
+++ b/frontend/app/module/election/page/ElectionReportPage.test.tsx
@@ -47,6 +47,7 @@ describe("ElectionReportPage", () => {
     // Wait for the page to be loaded
     expect(await screen.findByRole("heading", { level: 1, name: "Steminvoer eerste zitting afronden" }));
     expect(await screen.findByRole("heading", { level: 2, name: "Invoerfase afronden?" }));
-    expect(await screen.findByRole("button", { name: "Download proces-verbaal" })).toBeVisible();
+    expect(await screen.findByRole("button", { name: "Download los proces-verbaal" })).toBeVisible();
+    expect(await screen.findByRole("button", { name: "Download proces-verbaal met telbestand" })).toBeVisible();
   });
 });

--- a/frontend/e2e-tests/dom-to-db-tests/zip-download.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/zip-download.e2e.ts
@@ -19,7 +19,7 @@ test.describe("election results zip", () => {
 
     const response = await responsePromise;
     expect(response.status()).toBe(200);
-    expect(await response.headerValue("content-type")).toBe("application/x-zip");
+    expect(await response.headerValue("content-type")).toBe("application/zip");
 
     const download = await downloadPromise;
 

--- a/frontend/e2e-tests/dom-to-db-tests/zip-download.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/zip-download.e2e.ts
@@ -5,25 +5,25 @@ import { stat } from "node:fs/promises";
 
 import { test } from "./fixtures";
 
-test.describe("pdf rendering", () => {
-  test("it downloads a pdf", async ({ page }) => {
+test.describe("election results zip", () => {
+  test("it downloads a zip", async ({ page }) => {
     await page.goto("/elections/4/status#coordinator");
 
     const electionStatusPage = new ElectionStatus(page);
     await electionStatusPage.finish.click();
 
     const electionReportPage = new ElectionReport(page);
-    const responsePromise = page.waitForResponse("/api/elections/4/download_pdf_results");
+    const responsePromise = page.waitForResponse("/api/elections/4/download_zip_results");
     const downloadPromise = page.waitForEvent("download");
-    await electionReportPage.downloadPdf.click();
+    await electionReportPage.downloadZip.click();
 
     const response = await responsePromise;
     expect(response.status()).toBe(200);
-    expect(await response.headerValue("content-type")).toBe("application/pdf");
+    expect(await response.headerValue("content-type")).toBe("application/x-zip");
 
     const download = await downloadPromise;
 
-    expect(download.suggestedFilename()).toBe("Model_Na31-2_GR2024_Heemdamseburg.pdf");
+    expect(download.suggestedFilename()).toBe("election_result_GR2024_Heemdamseburg.zip");
     expect((await stat(await download.path())).size).toBeGreaterThan(1024);
   });
 });

--- a/frontend/e2e-tests/page-objects/status/ElectionReportPgObj.ts
+++ b/frontend/e2e-tests/page-objects/status/ElectionReportPgObj.ts
@@ -3,11 +3,14 @@ import { Locator, Page } from "@playwright/test";
 export class ElectionReport {
   protected readonly page: Page;
 
-  readonly download: Locator;
+  readonly downloadPdf: Locator;
+
+  readonly downloadZip: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    this.download = page.getByRole("button", { name: "Download proces-verbaal" });
+    this.downloadPdf = page.getByRole("button", { name: "Download los proces-verbaal" });
+    this.downloadZip = page.getByRole("button", { name: "Download proces-verbaal met telbestand" });
   }
 }

--- a/frontend/lib/i18n/locales/nl/election_report.json
+++ b/frontend/lib/i18n/locales/nl/election_report.json
@@ -3,5 +3,6 @@
   "about_to_stop_data_entry": "Je staat op het punt het invoeren van stemmen te stoppen.",
   "data_entry_finish_steps_explanation": "<ul><li>In de volgende stap kan je het proces-verbaal van deze zitting opmaken en de officiële telbestanden downloaden.</li><li>Zolang het concept proces-verbaal nog niet is ondertekend en gedeeld met het centraal stembureau, kan je nog terug naar de steminvoer.</li></ul>",
   "for_recount_new_session_needed": "Als er na het afronden van de zitting nog stemmen herteld worden, moet dan in een nieuwe zitting van het gemeentelijke stembureau.",
-  "download_report": "Download proces-verbaal"
+  "download_report": "Download los proces-verbaal",
+  "download_zip": "Download proces-verbaal met telbestand"
 }


### PR DESCRIPTION
- This builds on top of #730
- I've updated the page to include one additional button for the combined output as a zip (and made that the primary button) while also keeping the original pdf-only download button. I've not included an xml-only download. This page is temporary anyway and will be removed as we move forward with this part of the application.
- Added an e2e test to test the download of the zip from the frontend as well
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->