### PR TITLE
d2d tests: replace hard-coded pollingstation data with an api call fixture

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["*.e2e.ts", "*PgObj.ts"],
+      files: ["*.e2e.ts", "*PgObj.ts", "e2e-tests/**/fixtures.ts"],
       extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended-type-checked",
@@ -48,6 +48,7 @@ module.exports = {
       plugins: ["@typescript-eslint", "prettier"],
       rules: {
         "@typescript-eslint/no-floating-promises": "error",
+        "react-hooks/rules-of-hooks": "off",
       },
     },
   ],

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -14,11 +14,7 @@ import {
 } from "e2e-tests/page-objects/data_entry";
 
 import { test } from "./fixtures";
-import {
-  noErrorsWarningsResponse,
-  noRecountNoDifferencesRequest,
-  pollingStation33,
-} from "./test-data/PollingStationTestData";
+import { noErrorsWarningsResponse, noRecountNoDifferencesRequest } from "./test-data/PollingStationTestData";
 
 async function fillDataEntryNoRecountNoDifferences(page: Page) {
   const recountedPage = new RecountedPage(page);
@@ -90,14 +86,13 @@ async function fillDataEntryNoRecountNoDifferences(page: Page) {
 }
 
 test.describe("full data entry flow", () => {
-  test("no recount, no differences", async ({ page }) => {
+  test("no recount, no differences", async ({ page, pollingStation1 }) => {
     await page.goto("/elections/1/data-entry");
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    const pollingStation = pollingStation33;
-    await pollingStationChoicePage.pollingStationNumber.fill(pollingStation.number.toString());
-    await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(pollingStation.name);
+    await pollingStationChoicePage.pollingStationNumber.fill(pollingStation1.number.toString());
+    await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(pollingStation1.name);
     await pollingStationChoicePage.clickStart();
 
     await fillDataEntryNoRecountNoDifferences(page);
@@ -111,13 +106,12 @@ test.describe("full data entry flow", () => {
     );
   });
 
-  test("recount, no differences", async ({ page }) => {
+  test("recount, no differences", async ({ page, pollingStation1 }) => {
     await page.goto("/elections/1/data-entry");
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    const pollingStation = pollingStation33;
-    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation1.number);
 
     const recountedPage = new RecountedPage(page);
     await expect(recountedPage.fieldset).toBeVisible();
@@ -169,13 +163,12 @@ test.describe("full data entry flow", () => {
     await pollingStationChoicePage.dataEntrySuccess.waitFor();
   });
 
-  test("no recount, difference of more ballots counted", async ({ page }) => {
+  test("no recount, difference of more ballots counted", async ({ page, pollingStation1 }) => {
     await page.goto("/elections/1/data-entry");
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    const pollingStation = pollingStation33;
-    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation1.number);
 
     const recountedPage = new RecountedPage(page);
     await expect(recountedPage.fieldset).toBeVisible();
@@ -235,13 +228,12 @@ test.describe("full data entry flow", () => {
     await pollingStationChoicePage.dataEntrySuccess.waitFor();
   });
 
-  test("recount, difference of fewer ballots counted", async ({ page }) => {
+  test("recount, difference of fewer ballots counted", async ({ page, pollingStation1 }) => {
     await page.goto("/elections/1/data-entry");
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    const pollingStation = pollingStation33;
-    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation1.number);
 
     const recountedPage = new RecountedPage(page);
     await expect(recountedPage.fieldset).toBeVisible();
@@ -388,7 +380,7 @@ test.describe("full data entry flow", () => {
 });
 
 test.describe("second data entry", () => {
-  test("equal second data entry after first data entry", async ({ page, request }) => {
+  test("equal second data entry after first data entry", async ({ page, request, pollingStation1 }) => {
     const saveResponse = await request.post("/api/polling_stations/1/data_entries/1", {
       data: noRecountNoDifferencesRequest,
     });
@@ -400,9 +392,8 @@ test.describe("second data entry", () => {
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    const pollingStation = pollingStation33;
-    await pollingStationChoicePage.pollingStationNumber.fill(pollingStation.number.toString());
-    await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(pollingStation.name);
+    await pollingStationChoicePage.pollingStationNumber.fill(pollingStation1.number.toString());
+    await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(pollingStation1.name);
     await pollingStationChoicePage.clickStart();
 
     await expect(page).toHaveURL("/elections/1/data-entry/1/2/recounted");
@@ -416,7 +407,7 @@ test.describe("second data entry", () => {
     );
 
     await expect(pollingStationChoicePage.fieldsetNextPollingStation).toBeVisible();
-    await pollingStationChoicePage.pollingStationNumber.fill(pollingStation.number.toString());
+    await pollingStationChoicePage.pollingStationNumber.fill(pollingStation1.number.toString());
     await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(
       "Stembureau 33(Op Rolletjes)is al twee keer ingevoerd",
     );

--- a/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/data-entry.e2e.ts
@@ -14,7 +14,7 @@ import {
 } from "e2e-tests/page-objects/data_entry";
 
 import { test } from "./fixtures";
-import { noErrorsWarningsResponse, noRecountNoDifferencesRequest } from "./test-data/PollingStationTestData";
+import { noErrorsWarningsResponse, noRecountNoDifferencesRequest } from "./test-data/request-response-templates";
 
 async function fillDataEntryNoRecountNoDifferences(page: Page) {
   const recountedPage = new RecountedPage(page);

--- a/frontend/e2e-tests/dom-to-db-tests/fixtures.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/fixtures.ts
@@ -1,11 +1,19 @@
 import { test as base, expect } from "@playwright/test";
 
+import { PollingStation } from "@kiesraad/api";
+
 type AutoFixtures = {
+  // AutoFixtures contain { auto: true } and are called for each test automatically.
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   resetDatabase: void;
 };
 
-export const test = base.extend<AutoFixtures>({
+type Fixtures = {
+  // Regular fixtures need to be passed into the test's arguments.
+  pollingStation1: PollingStation;
+};
+
+export const test = base.extend<AutoFixtures & Fixtures>({
   resetDatabase: [
     async ({ request }, use) => {
       const response = await request.post(`/reset`);
@@ -14,4 +22,10 @@ export const test = base.extend<AutoFixtures>({
     },
     { auto: true },
   ],
+  pollingStation1: async ({ request }, use) => {
+    const response = await request.get(`/api/polling_stations/1`);
+    expect(response.ok()).toBeTruthy();
+    const pollingStation = (await response.json()) as PollingStation;
+    await use(pollingStation);
+  },
 });

--- a/frontend/e2e-tests/dom-to-db-tests/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/resume-data-entry.e2e.ts
@@ -11,7 +11,7 @@ import {
 } from "e2e-tests/page-objects/data_entry";
 
 import { test } from "./fixtures";
-import { emptyDataEntryResponse } from "./test-data/PollingStationTestData";
+import { emptyDataEntryResponse } from "./test-data/request-response-templates";
 
 test.describe("resume data entry flow", () => {
   const fillFirstTwoPagesAndAbort = async (page: Page) => {

--- a/frontend/e2e-tests/dom-to-db-tests/test-data/PollingStationTestData.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/test-data/PollingStationTestData.ts
@@ -1,20 +1,6 @@
-import { GetDataEntryResponse, PollingStation, SaveDataEntryRequest, SaveDataEntryResponse } from "@kiesraad/api";
+import { GetDataEntryResponse, SaveDataEntryRequest, SaveDataEntryResponse } from "@kiesraad/api";
 
-// should match backend/fixtures/polling_stations.sql
-
-export const pollingStation33: PollingStation = {
-  id: 1,
-  election_id: 1,
-  name: "Op Rolletjes",
-  number: 33,
-  number_of_voters: undefined,
-  polling_station_type: "Mobile",
-  street: "Rijksweg A12",
-  house_number: "1",
-  house_number_addition: undefined,
-  postal_code: "1234 YQ",
-  locality: "Den Haag",
-};
+//TODO: rename file to match purpose
 
 export const emptyDataEntryResponse: GetDataEntryResponse = {
   progress: 0,

--- a/frontend/e2e-tests/dom-to-db-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/dom-to-db-tests/test-data/request-response-templates.ts
@@ -1,7 +1,5 @@
 import { GetDataEntryResponse, SaveDataEntryRequest, SaveDataEntryResponse } from "@kiesraad/api";
 
-//TODO: rename file to match purpose
-
 export const emptyDataEntryResponse: GetDataEntryResponse = {
   progress: 0,
   data: {

--- a/frontend/lib/ui/InputGrid/InputGrid.e2e.ts
+++ b/frontend/lib/ui/InputGrid/InputGrid.e2e.ts
@@ -7,7 +7,6 @@ const test = base.extend<{ gridPage: Locator }>({
     const grid = main.locator("table");
     await grid.waitFor();
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     await use(grid);
   },
 });


### PR DESCRIPTION
partial #665

We had the data of a polling station hard-coded in `PollingStationTestData.ts`. I replaced it with a fixture that does an API call to retrieve the polling station data. This way we don't have to keep the hard-coded data in sync with the data in the backend seed data.

I had to update the eslint config, because it saw the Playwright `await use(pollingStation);` as a React hook `use()`.

I also renamed the `PollingStationTestData.ts` file to something that better matches its new contents. I will be making more changes to that file as part of the refactoring covered in #665.

Questions:
- Does the way I separated auto-fixtures and regular fixtures in `fixtures.ts` make sense? As in, is it conceptually clear? And is this a good way to do it syntax-wise?