### PR TITLE
adds epic template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -6,7 +6,6 @@ type: epic
 labels: ''
 assignees: ''
 projects: ["kiesraad/1"]
-area: epic
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -1,0 +1,27 @@
+---
+name: Epic template
+about: template for epics
+title: 'Epic: '
+labels: ''
+assignees: ''
+
+---
+
+# Context
+<!--
+Describe the context of the epic. Where does it fit into the process? Which related features have been built already? Which will be built at a later time?
+-->
+
+# Architecture
+<!--
+What architectural considerations are relevant to this epic? Does this epic require significant architectural changes? What's the basic structure of what's going to be built?*
+-->
+
+# Scope
+<!--
+- functionality to be implemented (include a link to the design)
+- refactorings
+- documentation: use cases, dev documentation, user documentation
+- knowledge sharing
+- anything else?
+-->

--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -1,9 +1,12 @@
 ---
 name: Epic template
-about: template for epics
+about: Template for epics
 title: 'Epic: '
+type: epic
 labels: ''
 assignees: ''
+projects: ["kiesraad/1"]
+area: epic
 
 ---
 


### PR DESCRIPTION
relates to #764 

This PR adds en epic template. It looks like this:
![image](https://github.com/user-attachments/assets/b9504c88-65cf-4ebd-9b2f-1ffcd5eef75e)

---

When you create an issue, you will either be presented by a modal to choose a template:
![image](https://github.com/user-attachments/assets/aa9836ed-4f8e-4ec8-a059-8ad92f6256dd)

Or when you create an item on the board, you can open the modal by clicking the button:
![image](https://github.com/user-attachments/assets/8e1e7dfd-d7d8-4274-87d9-5e139010c4bf)
