### PR TITLE
Remove unused tower-http dependency

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -273,7 +273,6 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "typst",
@@ -1252,12 +1251,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -3404,31 +3397,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
-dependencies = [
- "bitflags 2.6.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,7 +33,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono"] }
 tower = "0.5"
-tower-http = { version = "0.6.2", features = ["fs"] }
 tracing-subscriber = "0.3.19"
 tracing = "0.1.41"
 typst = "0.12.0"

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,7 +61,6 @@ The following dependencies (crates) are used:
 - `sqlx`: async SQL library featuring compile-time checked queries.
 - `tokio`: runtime for writing asynchronous applications.
 - `tower`: a library of modular and reusable components for building robust networking clients and servers.
-- `tower-http`: Tower middleware and utilities for HTTP clients and servers.
 - `tracing`: a framework for instrumenting Rust programs to collect structured, event-based diagnostic information.
 - `tracing-subscriber`: utilities for implementing and composing `tracing` subscribers.
 - `typst`: a new markup-based typesetting system that is powerful and easy to learn.


### PR DESCRIPTION
The tower-http dependency was added in #175 but is no longer needed since we started using memory-serve in #429.