### PR TITLE
Configure Lefthook to commit SQLx metadata

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,8 +6,7 @@ pre-commit:
     backend-sqlx-prepare:
       root: "backend/"
       glob: "*.rs"
-      run: cargo sqlx prepare -- --all-targets --all-features
-      stage_fixed: true
+      run: cargo sqlx prepare -- --all-targets --all-features && git add .sqlx
     backend-formatter:
       root: "backend/"
       glob: "*.rs"


### PR DESCRIPTION
[`stage_fixed`](https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#stage_fixed) did not work because the SQLx command did not change any files matching the glob filter (`*.rs`), so execute `git add` manually.