### PR TITLE
Upgrade to React Router 7.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,9 @@ updates:
       # ESLint major upgrades usually have breaking changes
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
-      # React Router 7 has breaking changes, see #621
-      # Update to 6.28 needs feature flags to be set to opt-in for version 7 features, to avoid warnings.
-      - dependency-name: "react-router-dom"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      # React Router major upgrades usually have breaking changes
+      - dependency-name: "react-router"
+        update-types: ["version-update:semver-major"]
       # React major upgrades usually have breaking changes, see #716 for React 19
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]

--- a/frontend/.ladle/components.tsx
+++ b/frontend/.ladle/components.tsx
@@ -1,4 +1,4 @@
-import { StaticRouter } from "react-router-dom/server";
+import { StaticRouter } from "react-router-dom";
 
 import type { GlobalProvider } from "@ladle/react";
 

--- a/frontend/.ladle/components.tsx
+++ b/frontend/.ladle/components.tsx
@@ -1,4 +1,4 @@
-import { StaticRouter } from "react-router-dom";
+import { StaticRouter } from "react-router";
 
 import type { GlobalProvider } from "@ladle/react";
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,7 @@ The application uses the following dependencies:
 
 - `react`: creating efficient, declarative, and component-based web applications.
 - `react-dom`: DOM implementation for rendering UI
-- `react-dom-router`: Handling browser routing for React applications
+- `react-router`: Handling browser routing for React applications
 
 #### Development dependencies
 

--- a/frontend/app/component/error/Error.tsx
+++ b/frontend/app/component/error/Error.tsx
@@ -31,7 +31,7 @@ export function Error({ title, error, children }: ErrorProps) {
                 variant="secondary"
                 leftIcon={<IconArrowLeft />}
                 onClick={() => {
-                  navigate(-1);
+                  void navigate(-1);
                 }}
               >
                 {t("history_back")}

--- a/frontend/app/component/error/Error.tsx
+++ b/frontend/app/component/error/Error.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { t } from "@kiesraad/i18n";
 import { IconArrowLeft } from "@kiesraad/icon";

--- a/frontend/app/component/error/ErrorBoundary.tsx
+++ b/frontend/app/component/error/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { useRouteError } from "react-router-dom";
+import { useRouteError } from "react-router";
 
 import { FatalErrorPage } from "app/module/FatalErrorPage";
 import { NotFoundPage } from "app/module/NotFoundPage";

--- a/frontend/app/component/form/data_entry/PollingStationFormController.tsx
+++ b/frontend/app/component/form/data_entry/PollingStationFormController.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 import { getBaseUrl, getUrlForFormSectionID } from "app/component/pollingstation/utils";
 

--- a/frontend/app/component/form/data_entry/PollingStationFormController.tsx
+++ b/frontend/app/component/form/data_entry/PollingStationFormController.tsx
@@ -231,9 +231,9 @@ export function PollingStationFormController({
     if (!targetFormSectionID) return;
     const url = getUrlForFormSectionID(election.id, pollingStationId, entryNumber, targetFormSectionID);
     if (location.pathname === getBaseUrl(election.id, pollingStationId, entryNumber)) {
-      navigate(url, { replace: true });
+      void navigate(url, { replace: true });
     } else if (location.pathname !== url) {
-      navigate(url);
+      void navigate(url);
     }
     setTargetFormSectionID(null);
   }, [targetFormSectionID, navigate, election.id, pollingStationId, entryNumber, location.pathname]);

--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ReactElement } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { useElection } from "@kiesraad/api";
 import { t, tx } from "@kiesraad/i18n";

--- a/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/app/component/form/data_entry/check_and_save/CheckAndSaveForm.tsx
@@ -58,7 +58,7 @@ export function CheckAndSaveForm() {
       if (!finalisationAllowed) return;
 
       await finaliseDataEntry();
-      navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
+      await navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
     })(event);
 
   return (

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.test.tsx
@@ -1,17 +1,15 @@
-import * as router from "react-router";
-
 import { waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { PollingStationChoiceForm } from "app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm";
 
 import { ElectionProvider, ElectionStatusProvider, ElectionStatusResponse } from "@kiesraad/api";
 import { electionDetailsMockResponse, electionStatusMockResponse } from "@kiesraad/api-mocks";
-import { overrideOnce, render, screen, within } from "@kiesraad/test";
+import { overrideOnce, render, renderReturningRouter, screen, within } from "@kiesraad/test";
 
 function renderPollingStationChoicePage() {
-  render(
+  return renderReturningRouter(
     <ElectionProvider electionId={1}>
       <ElectionStatusProvider electionId={1}>
         <PollingStationChoiceForm />
@@ -227,16 +225,14 @@ describe("Test PollingStationChoiceForm", () => {
         ],
       } satisfies ElectionStatusResponse);
 
-      const mockNavigate = vi.fn();
-      vi.spyOn(router, "useNavigate").mockImplementation(() => mockNavigate);
-
-      renderPollingStationChoicePage();
+      const router = renderPollingStationChoicePage();
 
       const user = userEvent.setup();
       const pollingStation = await screen.findByTestId("pollingStation");
       await user.type(pollingStation, "33");
       await user.click(screen.getByRole("button", { name: "Beginnen" }));
-      expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry/1/2");
+
+      expect(router.state.location.pathname).toEqual("/elections/1/data-entry/1/2");
     });
   });
 
@@ -292,10 +288,7 @@ describe("Test PollingStationChoiceForm", () => {
         ],
       } satisfies ElectionStatusResponse);
 
-      const mockNavigate = vi.fn();
-      vi.spyOn(router, "useNavigate").mockImplementation(() => mockNavigate);
-
-      renderPollingStationChoicePage();
+      const router = renderPollingStationChoicePage();
 
       // Open the polling station list
       const user = userEvent.setup();
@@ -305,7 +298,8 @@ describe("Test PollingStationChoiceForm", () => {
       // Click polling station 33 and check if the link is correct
       const pollingStationList = await screen.findByTestId("polling_station_list");
       await user.click(within(pollingStationList).getByText("33"));
-      expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry/1/2");
+
+      expect(router.state.location.pathname).toEqual("/elections/1/data-entry/1/2");
     });
   });
 

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { DataEntryStatusName, PollingStation, useElection, useElectionStatus } from "@kiesraad/api";
 import { t, tx } from "@kiesraad/i18n";

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm.tsx
@@ -62,7 +62,7 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
     }
 
     if (pollingStation) {
-      navigate(getUrlForDataEntry(election.id, pollingStation.id, pollingStationStatus));
+      void navigate(getUrlForDataEntry(election.id, pollingStation.id, pollingStationStatus));
     } else {
       setAlert(INVALID_POLLING_STATION_ALERT);
       setLoading(false);

--- a/frontend/app/component/form/data_entry/polling_station_choice/PollingStationLink.tsx
+++ b/frontend/app/component/form/data_entry/polling_station_choice/PollingStationLink.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { DataEntryStatusName, PollingStation } from "@kiesraad/api";
 import { IconArrowNarrowRight } from "@kiesraad/icon";

--- a/frontend/app/component/form/user/account_setup/AccountSetupForm.tsx
+++ b/frontend/app/component/form/user/account_setup/AccountSetupForm.tsx
@@ -1,5 +1,5 @@
 import { FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { t } from "@kiesraad/i18n";
 import { BottomBar, Button, InputField } from "@kiesraad/ui";

--- a/frontend/app/component/form/user/account_setup/AccountSetupForm.tsx
+++ b/frontend/app/component/form/user/account_setup/AccountSetupForm.tsx
@@ -17,7 +17,7 @@ export function AccountSetupForm() {
   const navigate = useNavigate();
   function handleSubmit(event: FormEvent<AccountSetupFormElement>) {
     event.preventDefault();
-    navigate("/elections#new-account");
+    void navigate("/elections#new-account");
   }
 
   return (

--- a/frontend/app/component/form/user/login/LoginForm.tsx
+++ b/frontend/app/component/form/user/login/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { t } from "@kiesraad/i18n";
 import { BottomBar, Button, InputField } from "@kiesraad/ui";

--- a/frontend/app/component/form/user/login/LoginForm.tsx
+++ b/frontend/app/component/form/user/login/LoginForm.tsx
@@ -18,7 +18,7 @@ export function LoginForm() {
 
   function handleSubmit(event: FormEvent<LoginFormElement>) {
     event.preventDefault();
-    navigate("../account/setup");
+    void navigate("../account/setup");
   }
 
   return (

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   usePollingStationFormController: vi.fn(),
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useNavigate: mocks.useNavigate,
   useBlocker: mocks.useBlocker,
   Navigate: vi.fn(),

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
@@ -82,7 +82,7 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
     if (currentSection && furthestSection) {
       if (currentSection.index > furthestSection.index) {
         const url = getUrlForFormSection(furthestSection.id);
-        navigate(url);
+        void navigate(url);
       }
     }
   }, [formState, navigate, getUrlForFormSection]);
@@ -97,7 +97,7 @@ export function PollingStationFormNavigation({ pollingStationId, election }: Pol
   const onSave = () =>
     void (async () => {
       await submitCurrentForm({ continueToNextSection: false });
-      if (blocker.location) navigate(blocker.location.pathname);
+      if (blocker.location) void navigate(blocker.location.pathname);
       if (blocker.reset) blocker.reset();
     })();
 

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { BlockerFunction, useBlocker, useNavigate } from "react-router-dom";
+import { BlockerFunction, useBlocker, useNavigate } from "react-router";
 
 import { AbortDataEntryModal } from "app/module/data_entry";
 

--- a/frontend/app/component/pollingstation/PollingStationProgress.tsx
+++ b/frontend/app/component/pollingstation/PollingStationProgress.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 
 import { useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";

--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router";
 
 import { ApiProvider } from "@kiesraad/api";
 

--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -17,11 +17,7 @@ if (!rootDiv) {
 const root = createRoot(rootDiv);
 
 function render() {
-  const router = createBrowserRouter(routes, {
-    future: {
-      v7_normalizeFormMethod: true,
-    },
-  });
+  const router = createBrowserRouter(routes);
 
   root.render(
     <StrictMode>

--- a/frontend/app/module/AdministratorLayout.tsx
+++ b/frontend/app/module/AdministratorLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 
 import { Footer } from "app/component/footer/Footer";
 

--- a/frontend/app/module/DevHomePage.tsx
+++ b/frontend/app/module/DevHomePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { MockTest } from "app/component/MockTest";
 import { NavBar } from "app/component/navbar/NavBar";

--- a/frontend/app/module/NotAvailableInMock.tsx
+++ b/frontend/app/module/NotAvailableInMock.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/module/RootLayout.tsx
+++ b/frontend/app/module/RootLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, ScrollRestoration } from "react-router-dom";
+import { Outlet, ScrollRestoration } from "react-router";
 
 import { AppFrame } from "@kiesraad/ui";
 

--- a/frontend/app/module/account/LoginLayout.tsx
+++ b/frontend/app/module/account/LoginLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/module/account/page/UserHomePage.tsx
+++ b/frontend/app/module/account/page/UserHomePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { t } from "@kiesraad/i18n";
 import { PageTitle } from "@kiesraad/ui";

--- a/frontend/app/module/data_entry/page/CandidatesVotesPage.tsx
+++ b/frontend/app/module/data_entry/page/CandidatesVotesPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 import { CandidatesVotesForm } from "app/component/form/data_entry/candidates_votes/CandidatesVotesForm";
 

--- a/frontend/app/module/data_entry/page/DataEntryHomePage.tsx
+++ b/frontend/app/module/data_entry/page/DataEntryHomePage.tsx
@@ -32,7 +32,7 @@ export function DataEntryHomePage() {
   const dataEntryDone = showFirstDataEntrySavedAlert || showSecondDataEntrySavedAlert;
 
   function closeDataEntrySavedAlert() {
-    navigate(location.pathname);
+    void navigate(location.pathname);
   }
 
   return (

--- a/frontend/app/module/data_entry/page/DataEntryHomePage.tsx
+++ b/frontend/app/module/data_entry/page/DataEntryHomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router";
 
 import { ElectionProgress } from "app/component/election/ElectionProgress";
 import { Footer } from "app/component/footer/Footer";

--- a/frontend/app/module/data_entry/polling_station/AbortDataEntryControl.test.tsx
+++ b/frontend/app/module/data_entry/polling_station/AbortDataEntryControl.test.tsx
@@ -1,8 +1,6 @@
-import * as router from "react-router";
-
 import { userEvent } from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import {
   ElectionProvider,
@@ -11,17 +9,15 @@ import {
   SaveDataEntryResponse,
 } from "@kiesraad/api";
 import { electionDetailsMockResponse, electionMockData, pollingStationMockData } from "@kiesraad/api-mocks";
-import { overrideOnce, render, screen, server } from "@kiesraad/test";
+import { overrideOnce, renderReturningRouter, screen, server } from "@kiesraad/test";
 
 import { PollingStationFormController } from "../../../component/form/data_entry/PollingStationFormController";
 import { VotersAndVotesForm } from "../../../component/form/data_entry/voters_and_votes/VotersAndVotesForm";
 import { emptyDataEntryRequest } from "../../../component/form/testHelperFunctions";
 import { AbortDataEntryControl } from "./AbortDataEntryControl";
 
-const mockNavigate = vi.fn();
-
 const renderAbortDataEntryControl = () => {
-  render(
+  return renderReturningRouter(
     <ElectionProvider electionId={1}>
       <PollingStationFormController
         election={electionMockData}
@@ -38,7 +34,6 @@ const renderAbortDataEntryControl = () => {
 describe("Test AbortDataEntryControl", () => {
   beforeEach(() => {
     overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
-    vi.spyOn(router, "useNavigate").mockImplementation(() => mockNavigate);
   });
 
   test("renders and toggles the modal", async () => {
@@ -56,7 +51,7 @@ describe("Test AbortDataEntryControl", () => {
 
   test("saves the form state and navigates on save", async () => {
     // render the abort button
-    renderAbortDataEntryControl();
+    const router = renderAbortDataEntryControl();
     const user = userEvent.setup();
 
     // click the abort button to open the modal
@@ -93,12 +88,12 @@ describe("Test AbortDataEntryControl", () => {
     });
 
     // check that the user is navigated back to the data entry page
-    expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry");
+    expect(router.state.location.pathname).toBe("/elections/1/data-entry");
   });
 
   test("deletes the data entry and navigates on delete", async () => {
     // render the abort button, then click it to open the modal
-    renderAbortDataEntryControl();
+    const router = renderAbortDataEntryControl();
     const user = userEvent.setup();
 
     // click the abort button to open the modal
@@ -121,6 +116,6 @@ describe("Test AbortDataEntryControl", () => {
     expect(request_url).toBe("http://localhost:3000/api/polling_stations/1/data_entries/1");
 
     // check that the user is navigated back to the data entry page
-    expect(mockNavigate).toHaveBeenCalledWith("/elections/1/data-entry");
+    expect(router.state.location.pathname).toBe("/elections/1/data-entry");
   });
 });

--- a/frontend/app/module/data_entry/polling_station/AbortDataEntryControl.tsx
+++ b/frontend/app/module/data_entry/polling_station/AbortDataEntryControl.tsx
@@ -26,10 +26,10 @@ export function AbortDataEntryControl() {
         <AbortDataEntryModal
           onCancel={toggleAbortModal}
           onSave={() => {
-            navigate(`/elections/${election.id}/data-entry`);
+            void navigate(`/elections/${election.id}/data-entry`);
           }}
           onDelete={() => {
-            navigate(`/elections/${election.id}/data-entry`);
+            void navigate(`/elections/${election.id}/data-entry`);
           }}
         />
       )}

--- a/frontend/app/module/data_entry/polling_station/AbortDataEntryControl.tsx
+++ b/frontend/app/module/data_entry/polling_station/AbortDataEntryControl.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";

--- a/frontend/app/module/data_entry/polling_station/PollingStation.test.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStation.test.tsx
@@ -5,23 +5,35 @@ import { describe, expect, test, vi } from "vitest";
 import { routes } from "app/routes";
 
 import { electionMockData } from "@kiesraad/api-mocks";
-import { overrideOnce, Providers, screen, setupTestRouter, userTypeInputs, waitFor, within } from "@kiesraad/test";
+import {
+  overrideOnce,
+  Providers,
+  Router,
+  screen,
+  setupTestRouter,
+  userTypeInputs,
+  waitFor,
+  within,
+} from "@kiesraad/test";
 
-const router = setupTestRouter(routes);
-const render = () => rtlRender(<Providers router={router} />);
+function renderWithRouter() {
+  const router = setupTestRouter(routes);
+  rtlRender(<Providers router={router} />);
+  return router;
+}
 
 const user = userEvent.setup();
 
-const submit = async () => {
+async function submit() {
   await user.click(screen.getByRole("button", { name: "Volgende" }));
-};
+}
 
-const startPollingStationInput = async () => {
+async function startPollingStationInput(router: Router) {
   await router.navigate("/elections/1/data-entry/1/1");
   expect(router.state.location.pathname).toEqual("/elections/1/data-entry/1/1");
-};
+}
 
-const expectRecountedForm = async (inputShouldHaveFocus = true) => {
+async function expectRecountedForm(inputShouldHaveFocus = true) {
   await waitFor(() => {
     expect(screen.getByTestId("recounted_form")).toBeInTheDocument();
   });
@@ -30,23 +42,23 @@ const expectRecountedForm = async (inputShouldHaveFocus = true) => {
       expect(screen.getByTestId("yes")).toHaveFocus();
     });
   }
-};
+}
 
-const fillRecountedFormNo = async () => {
+async function fillRecountedFormNo() {
   await user.click(await screen.findByLabelText("Nee, er was geen hertelling"));
   await waitFor(() => {
     expect(screen.getByLabelText("Nee, er was geen hertelling")).toBeChecked();
   });
-};
+}
 
-const fillRecountedFormYes = async () => {
+async function fillRecountedFormYes() {
   await user.click(await screen.findByLabelText("Ja, er was een hertelling"));
   await waitFor(() => {
     expect(screen.getByLabelText("Ja, er was een hertelling")).toBeChecked();
   });
-};
+}
 
-const expectVotersAndVotesForm = async (inputShouldHaveFocus = true) => {
+async function expectVotersAndVotesForm(inputShouldHaveFocus = true) {
   await waitFor(() => {
     expect(screen.getByTestId("voters_and_votes_form")).toBeInTheDocument();
   });
@@ -55,11 +67,11 @@ const expectVotersAndVotesForm = async (inputShouldHaveFocus = true) => {
       expect(screen.getByRole("textbox", { name: "A Stempassen" })).toHaveFocus();
     });
   }
-};
+}
 
 const total_votes = electionMockData.political_groups.length * 10;
 
-const fillVotersAndVotesForm = async (values?: Record<string, number>) => {
+async function fillVotersAndVotesForm(values?: Record<string, number>) {
   const userValues = values ?? {
     poll_card_count: total_votes,
     proxy_certificate_count: 0,
@@ -72,9 +84,9 @@ const fillVotersAndVotesForm = async (values?: Record<string, number>) => {
   };
 
   await userTypeInputs(user, userValues);
-};
+}
 
-const expectDifferencesForm = async (inputShouldHaveFocus = true) => {
+async function expectDifferencesForm(inputShouldHaveFocus = true) {
   await waitFor(() => {
     expect(screen.getByTestId("differences_form")).toBeInTheDocument();
   });
@@ -83,9 +95,9 @@ const expectDifferencesForm = async (inputShouldHaveFocus = true) => {
       expect(screen.getByRole("textbox", { name: "I Stembiljetten méér geteld" })).toHaveFocus();
     });
   }
-};
+}
 
-const fillDifferencesForm = async (values?: Record<string, number>) => {
+async function fillDifferencesForm(values?: Record<string, number>) {
   const userValues = values ?? {
     more_ballots_count: 0,
     fewer_ballots_count: 0,
@@ -97,9 +109,9 @@ const fillDifferencesForm = async (values?: Record<string, number>) => {
   };
 
   await userTypeInputs(user, userValues);
-};
+}
 
-const expectPoliticalGroupCandidatesForm = async (pgNumber: number, inputShouldHaveFocus = true) => {
+async function expectPoliticalGroupCandidatesForm(pgNumber: number, inputShouldHaveFocus = true) {
   await waitFor(() => {
     expect(screen.getByTestId(`candidates_form_${pgNumber}`)).toBeInTheDocument();
   });
@@ -108,17 +120,17 @@ const expectPoliticalGroupCandidatesForm = async (pgNumber: number, inputShouldH
       expect(screen.getByTestId(`candidate_votes[0].votes`)).toHaveFocus();
     });
   }
-};
+}
 
-const fillPoliticalGroupCandidatesVotesForm = async () => {
+async function fillPoliticalGroupCandidatesVotesForm() {
   await userTypeInputs(user, {
     "candidate_votes[0].votes": 5,
     "candidate_votes[1].votes": 5,
     total: 10,
   });
-};
+}
 
-const expectCheckAndSavePage = async (bodyShouldHaveFocus = true) => {
+async function expectCheckAndSavePage(router: Router, bodyShouldHaveFocus = true) {
   await waitFor(() => {
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry/1/1/save");
   });
@@ -127,9 +139,9 @@ const expectCheckAndSavePage = async (bodyShouldHaveFocus = true) => {
       expect(document.body).toHaveFocus();
     });
   }
-};
+}
 
-const expectFeedbackError = async (code?: string) => {
+async function expectFeedbackError(code?: string) {
   await waitFor(() => {
     expect(screen.getByTestId("feedback-error")).toBeInTheDocument();
   });
@@ -139,9 +151,9 @@ const expectFeedbackError = async (code?: string) => {
   await waitFor(() => {
     expect(screen.getByRole("heading", { level: 3 })).toHaveFocus();
   });
-};
+}
 
-const expectFeedbackWarning = async (code?: string) => {
+async function expectFeedbackWarning(code?: string) {
   await waitFor(() => {
     expect(screen.getByTestId("feedback-warning")).toBeInTheDocument();
   });
@@ -151,78 +163,78 @@ const expectFeedbackWarning = async (code?: string) => {
   await waitFor(() => {
     expect(screen.getByRole("heading", { level: 3 })).toHaveFocus();
   });
-};
+}
 
-const acceptWarnings = async () => {
+async function acceptWarnings() {
   await user.click(screen.getByLabelText("Ik heb de aantallen gecontroleerd met het papier en correct overgenomen."));
   expect(
     screen.getByLabelText("Ik heb de aantallen gecontroleerd met het papier en correct overgenomen."),
   ).toBeChecked();
-};
+}
 
-const expectBlockerModal = async () => {
+async function expectBlockerModal() {
   expect(await screen.findByTestId("modal-title")).toHaveFocus();
   expect(await screen.findByTestId("modal-title")).toHaveTextContent("Let op: niet opgeslagen wijzigingen");
-};
+}
 
-const expectElementContainsIcon = async (id: string, ariaLabel: string) => {
+async function expectElementContainsIcon(id: string, ariaLabel: string) {
   const el = await screen.findByTestId(id);
   expect(el).toBeInTheDocument();
   expect(within(el).getByRole("img")).toHaveAccessibleName(ariaLabel);
-};
+}
 
-const abortDataEntry = async () => {
+async function abortDataEntry() {
   await user.click(screen.getByRole("button", { name: "Invoer afbreken" }));
-};
+}
 
-const abortSaveChanges = async () => {
+async function abortSaveChanges() {
   await user.click(screen.getByRole("button", { name: "Invoer bewaren" }));
-};
+}
 
-const abortDelete = async () => {
+async function abortDelete() {
   await user.click(screen.getByRole("button", { name: "Niet bewaren" }));
-};
+}
 
-const expectPollingStationChoicePage = async () => {
+async function expectPollingStationChoicePage(router: Router) {
   await waitFor(() => {
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry");
   });
   await waitFor(() => {
     expect(screen.getByTestId("polling-station-choice-form")).toBeInTheDocument();
   });
-};
+}
 
-const submitWith422Response = async () => {
+async function submitWith422Response() {
   overrideOnce("post", "/api/polling_stations/1/data_entries/1", 422, {
     error: "JSON error or invalid data (Unprocessable Content)",
     fatal: false,
     reference: "InvalidJson",
   });
   await submit();
-};
+}
 
-const expect422ClientError = async () => {
+async function expect422ClientError() {
   const feedbackServerError = await screen.findByTestId("error-modal");
   expect(feedbackServerError).toHaveTextContent("Foutcode: 422JSON error or invalid data (Unprocessable Content)");
-};
+}
 
-const submitWith500Response = async () => {
+async function submitWith500Response() {
   overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, {
     error: "Internal server error",
     fatal: false,
     reference: "InternalServerError",
   });
   await submit();
-};
+}
 
-const expect500ServerError = async () => {
+async function expect500ServerError() {
   const feedbackServerError = await screen.findByTestId("error-modal");
   expect(feedbackServerError).toHaveTextContent("Foutcode: 500Internal server error");
-};
+}
 
 type FormIdentifier = "recounted" | "voters_and_votes" | "differences" | `candidates_${number}`;
 
-const gotoForm = async (id: FormIdentifier, inputShouldHaveFocus = true) => {
+async function gotoForm(id: FormIdentifier, inputShouldHaveFocus = true) {
   if (id.startsWith("candidates_")) {
     const bits = id.split("_");
     if (bits.length === 2 && bits[1]) {
@@ -246,157 +258,122 @@ const gotoForm = async (id: FormIdentifier, inputShouldHaveFocus = true) => {
       await expectDifferencesForm(inputShouldHaveFocus);
       break;
   }
-};
+}
 
 // Steps to fill up to the 'voters and votes' form, submit, and leave pending changes
-const stepsForPendingChanges = [
-  startPollingStationInput,
-  expectRecountedForm,
-  fillRecountedFormNo,
-  submit,
-  expectVotersAndVotesForm,
-  fillVotersAndVotesForm,
-  submit,
-  expectDifferencesForm,
-  () => gotoForm("voters_and_votes"),
-  expectVotersAndVotesForm,
-  () =>
-    fillVotersAndVotesForm({
-      poll_card_count: 1,
-      proxy_certificate_count: 1,
-      voter_card_count: 1,
-      total_admitted_voters_count: 2,
-      votes_candidates_count: 1,
-      blank_votes_count: 1,
-      invalid_votes_count: 1,
-      total_votes_cast_count: 3,
-    }),
-  submit,
-  expectFeedbackError,
-  () =>
-    fillVotersAndVotesForm({
-      total_admitted_voters_count: 3,
-    }),
-];
+async function executeStepsForPendingChanges(router: Router) {
+  await startPollingStationInput(router);
+  await expectRecountedForm();
+  await fillRecountedFormNo();
+  await submit();
+  await expectVotersAndVotesForm();
+  await fillVotersAndVotesForm();
+  await submit();
+  await expectDifferencesForm();
+  await gotoForm("voters_and_votes");
+  await expectVotersAndVotesForm();
+  await fillVotersAndVotesForm({
+    poll_card_count: 1,
+    proxy_certificate_count: 1,
+    voter_card_count: 1,
+    total_admitted_voters_count: 2,
+    votes_candidates_count: 1,
+    blank_votes_count: 1,
+    invalid_votes_count: 1,
+    total_votes_cast_count: 3,
+  });
+  await submit();
+  await expectFeedbackError();
+  await fillVotersAndVotesForm({
+    total_admitted_voters_count: 3,
+  });
+}
 
 describe("Polling Station data entry integration tests", () => {
   describe("Navigation through the form", () => {
     test("Fill in complete form", async () => {
-      render();
-
-      const formFillingSteps = [
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        submit,
-        expectDifferencesForm,
-        fillDifferencesForm,
-        submit,
-        ...electionMockData.political_groups.flatMap((pg) => [
-          () => expectPoliticalGroupCandidatesForm(pg.number),
-          fillPoliticalGroupCandidatesVotesForm,
-          submit,
-        ]),
-        expectCheckAndSavePage,
-      ];
-
-      for (const step of formFillingSteps) {
-        await step();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await fillDifferencesForm();
+      await submit();
+      for (const pg of electionMockData.political_groups) {
+        await expectPoliticalGroupCandidatesForm(pg.number);
+        await fillPoliticalGroupCandidatesVotesForm();
+        await submit();
       }
+      await expectCheckAndSavePage(router);
     });
 
     test("Error F204 navigates back to voters and votes page", async () => {
-      render();
-
-      const formFillingSteps = [
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        () =>
-          fillVotersAndVotesForm({
-            poll_card_count: total_votes,
-            proxy_certificate_count: 1,
-            voter_card_count: 0,
-            total_admitted_voters_count: total_votes + 1,
-            // to get the F204 error, votes_candidates_count should not match total_votes
-            votes_candidates_count: total_votes + 1,
-            blank_votes_count: 0,
-            invalid_votes_count: 0,
-            total_votes_cast_count: total_votes + 1,
-          }),
-        submit,
-        expectDifferencesForm,
-        fillDifferencesForm,
-        submit,
-        ...electionMockData.political_groups.flatMap((pg) => [
-          () => expectPoliticalGroupCandidatesForm(pg.number),
-          fillPoliticalGroupCandidatesVotesForm,
-          submit,
-        ]),
-        () => expectVotersAndVotesForm(false),
-        () => expectFeedbackError("F.204"),
-      ];
-
-      for (const step of formFillingSteps) {
-        await step();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm({
+        poll_card_count: total_votes,
+        proxy_certificate_count: 1,
+        voter_card_count: 0,
+        total_admitted_voters_count: total_votes + 1,
+        // to get the F204 error, votes_candidates_count should not match total_votes
+        votes_candidates_count: total_votes + 1,
+        blank_votes_count: 0,
+        invalid_votes_count: 0,
+        total_votes_cast_count: total_votes + 1,
+      });
+      await submit();
+      await expectDifferencesForm();
+      await fillDifferencesForm();
+      await submit();
+      for (const pg of electionMockData.political_groups) {
+        await expectPoliticalGroupCandidatesForm(pg.number);
+        await fillPoliticalGroupCandidatesVotesForm();
+        await submit();
       }
+      await expectVotersAndVotesForm(false);
+      await expectFeedbackError("F.204");
     });
 
     test("Navigate back", async () => {
-      render();
-
-      const steps = [
-        // fill up to and including the differences form
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        submit,
-        expectDifferencesForm,
-        fillDifferencesForm,
-        submit,
-        // navigate back to the 'voters and votes' form
-        () => user.click(screen.getByRole("link", { name: "Aantal kiezers en stemmen" })),
-        expectVotersAndVotesForm,
-      ];
-
-      for (const step of steps) {
-        await step();
-      }
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await fillDifferencesForm();
+      await submit();
+      await user.click(screen.getByRole("link", { name: "Aantal kiezers en stemmen" }));
+      await expectVotersAndVotesForm();
     });
 
     test("Navigate back with dirty state", async () => {
-      render();
-
-      const steps = [
-        // fill up to and including the voters and votes form
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        // don't submit, and navigate back to the 'recounted' form
-        () => user.click(screen.getByRole("link", { name: "Is er herteld?" })),
-        expectRecountedForm,
-      ];
-
-      for (const step of steps) {
-        await step();
-      }
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await user.click(screen.getByRole("link", { name: "Is er herteld?" }));
+      await expectRecountedForm();
     });
 
     test("Navigate to next page after navigating back one page submitting", async () => {
       // https://github.com/kiesraad/abacus/issues/426
-      render();
-      await startPollingStationInput();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
       await expectRecountedForm();
       await fillRecountedFormNo();
       await submit();
@@ -411,216 +388,177 @@ describe("Polling Station data entry integration tests", () => {
     });
 
     test("Navigate to next page after navigating back two pages and submitting", async () => {
-      render();
+      const router = renderWithRouter();
 
-      const steps = [
-        // fill up to and including the differences form
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        submit,
-        expectDifferencesForm,
-        fillDifferencesForm,
-        submit,
-        // navigate back to the 'voters and votes' form and submit
-        () => user.click(screen.getByRole("link", { name: "Aantal kiezers en stemmen" })),
-        expectVotersAndVotesForm,
-        submit,
-        // expect to be on the 'differences' form
-        expectDifferencesForm,
-      ];
-
-      for (const step of steps) {
-        await step();
-      }
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await fillDifferencesForm();
+      await submit();
+      await user.click(screen.getByRole("link", { name: "Aantal kiezers en stemmen" }));
+      await expectVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
     });
 
     test("Navigating with changes triggers changes modal", async () => {
-      render();
-
-      const steps = [
-        ...stepsForPendingChanges,
-        () => user.click(screen.getByRole("link", { name: "Verschillen" })),
-        expectBlockerModal,
-      ];
-
-      for (const step of steps) {
-        await step();
-      }
+      const router = renderWithRouter();
+      await executeStepsForPendingChanges(router);
+      await user.click(screen.getByRole("link", { name: "Verschillen" }));
+      await expectBlockerModal();
     });
 
     test("Navigating with saved changes goes to correct form", async () => {
-      render();
-
-      const steps = [
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        submit,
-        expectDifferencesForm,
-        fillDifferencesForm,
-        submit,
-        ...electionMockData.political_groups.flatMap((pg) => [
-          () => expectPoliticalGroupCandidatesForm(pg.number),
-          fillPoliticalGroupCandidatesVotesForm,
-          submit,
-        ]),
-        expectCheckAndSavePage,
-
-        () => gotoForm("voters_and_votes"),
-        () =>
-          userTypeInputs(user, {
-            total_admitted_voters_count: 1,
-          }),
-        submit,
-        expectFeedbackError,
-        () =>
-          userTypeInputs(user, {
-            total_admitted_voters_count: total_votes,
-          }),
-        () => user.click(screen.getByRole("link", { name: "Is er herteld?" })),
-        expectBlockerModal,
-        () => user.click(screen.getByRole("button", { name: "Wijzigingen opslaan" })),
-        expectRecountedForm,
-      ];
-
-      for (const step of steps) {
-        await step();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await fillDifferencesForm();
+      await submit();
+      for (const pg of electionMockData.political_groups) {
+        await expectPoliticalGroupCandidatesForm(pg.number);
+        await fillPoliticalGroupCandidatesVotesForm();
+        await submit();
       }
+      await expectCheckAndSavePage(router);
+
+      await gotoForm("voters_and_votes");
+      await userTypeInputs(user, {
+        total_admitted_voters_count: 1,
+      });
+      await submit();
+      await expectFeedbackError();
+
+      await userTypeInputs(user, {
+        total_admitted_voters_count: total_votes,
+      });
+
+      await user.click(screen.getByRole("link", { name: "Is er herteld?" }));
+      await expectBlockerModal();
+
+      await user.click(screen.getByRole("button", { name: "Wijzigingen opslaan" }));
+      await expectRecountedForm();
     });
 
     test("Changing recount generates an error for differences page", async () => {
-      render();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await fillDifferencesForm();
+      await submit();
 
-      const steps = [
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        submit,
-        expectDifferencesForm,
-        fillDifferencesForm,
-        submit,
-        ...electionMockData.political_groups.flatMap((pg) => [
-          () => expectPoliticalGroupCandidatesForm(pg.number),
-          fillPoliticalGroupCandidatesVotesForm,
-          submit,
-        ]),
-        expectCheckAndSavePage,
-        () => expectElementContainsIcon("list-item-save", "je bent hier"),
-        () => gotoForm("recounted"),
-        () => expectElementContainsIcon("list-item-save", "nog niet afgerond"),
-        fillRecountedFormYes,
-        submit,
-        expectVotersAndVotesForm,
-        () => expectElementContainsIcon("list-item-differences", "bevat een fout"),
-      ];
-
-      for (const step of steps) {
-        await step();
+      for (const pg of electionMockData.political_groups) {
+        await expectPoliticalGroupCandidatesForm(pg.number);
+        await fillPoliticalGroupCandidatesVotesForm();
+        await submit();
       }
+
+      await expectCheckAndSavePage(router);
+      await expectElementContainsIcon("list-item-save", "je bent hier");
+      await gotoForm("recounted");
+      await expectElementContainsIcon("list-item-save", "nog niet afgerond");
+      await fillRecountedFormYes();
+      await submit();
+      await expectVotersAndVotesForm();
+      await expectElementContainsIcon("list-item-differences", "bevat een fout");
     });
 
     test("Progress list shows correct icons", async () => {
-      render();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
+      await expectRecountedForm();
+      await fillRecountedFormNo();
+      await submit();
+      await expectVotersAndVotesForm();
+      await fillVotersAndVotesForm();
+      await submit();
+      await expectDifferencesForm();
+      await gotoForm("voters_and_votes");
+      await expectElementContainsIcon("list-item-differences", "nog niet afgerond");
 
-      const steps = [
-        startPollingStationInput,
-        expectRecountedForm,
-        fillRecountedFormNo,
-        submit,
-        expectVotersAndVotesForm,
-        fillVotersAndVotesForm,
-        submit,
-        expectDifferencesForm,
-        () => gotoForm("voters_and_votes"),
-        () => expectElementContainsIcon("list-item-differences", "nog niet afgerond"),
+      await gotoForm("differences");
+      await fillDifferencesForm();
+      await submit();
 
-        () => gotoForm("differences"),
-        fillDifferencesForm,
-        submit,
-        ...electionMockData.political_groups.flatMap((pg) => [
-          () => expectPoliticalGroupCandidatesForm(pg.number),
-          fillPoliticalGroupCandidatesVotesForm,
-          submit,
-        ]),
-        expectCheckAndSavePage,
-        () => expectElementContainsIcon("list-item-recounted", "opgeslagen"),
-        () => expectElementContainsIcon("list-item-differences", "leeg"),
-
-        () => gotoForm("voters_and_votes"),
-        () => expectElementContainsIcon("list-item-voters-and-votes", "je bent hier"),
-        () =>
-          fillVotersAndVotesForm({
-            poll_card_count: total_votes + 1,
-            total_admitted_voters_count: total_votes + 1,
-            votes_candidates_count: total_votes,
-            total_votes_cast_count: total_votes,
-          }),
-        submit,
-        () => expectDifferencesForm(false),
-        () => fillDifferencesForm({ fewer_ballots_count: 1, no_explanation_count: 2 }),
-        submit,
-        () => expectFeedbackWarning("W.302"),
-        acceptWarnings,
-        submit,
-
-        () => expectPoliticalGroupCandidatesForm(1),
-        () => expectElementContainsIcon("list-item-differences", "opgeslagen"),
-
-        () => gotoForm("voters_and_votes"),
-        () =>
-          userTypeInputs(user, {
-            total_admitted_voters_count: 1,
-          }),
-        submit,
-        () => expectVotersAndVotesForm(false),
-        () => gotoForm("differences", false),
-        () => expectElementContainsIcon("list-item-voters-and-votes", "bevat een fout"),
-      ];
-
-      for (const step of steps) {
-        await step();
+      for (const pg of electionMockData.political_groups) {
+        await expectPoliticalGroupCandidatesForm(pg.number);
+        await fillPoliticalGroupCandidatesVotesForm();
+        await submit();
       }
+
+      await expectCheckAndSavePage(router);
+      await expectElementContainsIcon("list-item-recounted", "opgeslagen");
+      await expectElementContainsIcon("list-item-differences", "leeg");
+
+      await gotoForm("voters_and_votes");
+      await expectElementContainsIcon("list-item-voters-and-votes", "je bent hier");
+      await fillVotersAndVotesForm({
+        poll_card_count: total_votes + 1,
+        total_admitted_voters_count: total_votes + 1,
+        votes_candidates_count: total_votes,
+        total_votes_cast_count: total_votes,
+      });
+      await submit();
+      await expectDifferencesForm(false);
+      await fillDifferencesForm({ fewer_ballots_count: 1, no_explanation_count: 2 });
+      await submit();
+      await expectFeedbackWarning("W.302");
+      await acceptWarnings();
+      await submit();
+
+      await expectPoliticalGroupCandidatesForm(1);
+      await expectElementContainsIcon("list-item-differences", "opgeslagen");
+
+      await gotoForm("voters_and_votes");
+      await userTypeInputs(user, {
+        total_admitted_voters_count: 1,
+      });
+      await submit();
+      await expectVotersAndVotesForm(false);
+      await gotoForm("differences", false);
+      await expectElementContainsIcon("list-item-voters-and-votes", "bevat een fout");
     });
   });
 
   describe("Aborting data entry", () => {
     test("Aborting and save with pending changes is possible", async () => {
-      render();
-
-      const steps = [...stepsForPendingChanges, abortDataEntry, abortSaveChanges, expectPollingStationChoicePage];
-
-      for (const step of steps) {
-        await step();
-      }
+      const router = renderWithRouter();
+      await executeStepsForPendingChanges(router);
+      await abortDataEntry();
+      await abortSaveChanges();
+      await expectPollingStationChoicePage(router);
     });
 
     test("Abort and delete with pending changes is possible", async () => {
-      render();
-
-      const steps = [...stepsForPendingChanges, abortDataEntry, abortDelete, expectPollingStationChoicePage];
-
-      for (const step of steps) {
-        await step();
-      }
+      const router = renderWithRouter();
+      await executeStepsForPendingChanges(router);
+      await abortDataEntry();
+      await abortDelete();
+      await expectPollingStationChoicePage(router);
     });
   });
 
   describe("API error responses", () => {
     test("4xx response results in error shown", async () => {
       vi.spyOn(console, "error").mockImplementation(() => {});
-      render();
-
-      await startPollingStationInput();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
       await expectRecountedForm();
       await fillRecountedFormNo();
       await submitWith422Response();
@@ -629,9 +567,8 @@ describe("Polling Station data entry integration tests", () => {
 
     test("5xx response results in error shown", async () => {
       vi.spyOn(console, "error").mockImplementation(() => {});
-      render();
-
-      await startPollingStationInput();
+      const router = renderWithRouter();
+      await startPollingStationInput(router);
       await expectRecountedForm();
       await fillRecountedFormNo();
       await submitWith500Response();

--- a/frontend/app/module/data_entry/polling_station/PollingStationLayout.test.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStationLayout.test.tsx
@@ -1,5 +1,3 @@
-import * as Router from "react-router";
-
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { PollingStationLayout } from "app/module/data_entry";
@@ -10,17 +8,16 @@ import { overrideOnce, render, screen, within } from "@kiesraad/test";
 
 import { PollingStationFormController } from "../../../component/form/data_entry/PollingStationFormController";
 
+vi.mock(import("@kiesraad/util"), async (importOriginal) => ({
+  ...(await importOriginal()),
+  useNumericParam: vi.fn().mockReturnValue(1),
+}));
+
 describe("PollingStationLayout", () => {
   const election = electionDetailsMockResponse.election as Required<Election>;
 
   beforeEach(() => {
     overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
-
-    vi.spyOn(Router, "useParams").mockReturnValue({
-      electionId: election.id.toString(),
-      pollingStationId: pollingStationMockData.id.toString(),
-      entryNumber: "1",
-    });
   });
 
   test("Render", async () => {

--- a/frontend/app/module/data_entry/polling_station/PollingStationLayout.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStationLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 import { PollingStationFormNavigation } from "app/component/pollingstation/PollingStationFormNavigation";

--- a/frontend/app/module/election/ElectionLayout.tsx
+++ b/frontend/app/module/election/ElectionLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 
 import { ElectionProvider, ElectionStatusProvider } from "@kiesraad/api";
 import { useNumericParam } from "@kiesraad/util";

--- a/frontend/app/module/election/OverviewLayout.tsx
+++ b/frontend/app/module/election/OverviewLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 
 import { ElectionListProvider } from "@kiesraad/api";
 import { AppLayout } from "@kiesraad/ui";

--- a/frontend/app/module/election/page/ElectionHomePage.tsx
+++ b/frontend/app/module/election/page/ElectionHomePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { Footer } from "app/component/footer/Footer";
 import { MockTest } from "app/component/MockTest";

--- a/frontend/app/module/election/page/ElectionReportPage.tsx
+++ b/frontend/app/module/election/page/ElectionReportPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/module/election/page/ElectionStatusPage.tsx
+++ b/frontend/app/module/election/page/ElectionStatusPage.tsx
@@ -162,7 +162,7 @@ export function ElectionStatusPage() {
   }, [statuses, categoryCounts]);
 
   function finishInput() {
-    navigate("../report#coordinator");
+    void navigate("../report#coordinator");
   }
 
   const pollingStationsWithStatuses = pollingStations.map((ps) => {
@@ -212,7 +212,7 @@ export function ElectionStatusPage() {
               variant="secondary"
               leftIcon={<IconPlus />}
               onClick={() => {
-                navigate(`/elections/${election.id}/polling-stations`);
+                void navigate(`/elections/${election.id}/polling-stations`);
               }}
             >
               {t("election_status.add_polling_station")}

--- a/frontend/app/module/election/page/ElectionStatusPage.tsx
+++ b/frontend/app/module/election/page/ElectionStatusPage.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useMemo } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { HeaderElectionStatusWithIcon } from "app/component/election/ElectionStatusWithIcon";
 import { Footer } from "app/component/footer/Footer";

--- a/frontend/app/module/election/page/OverviewPage.tsx
+++ b/frontend/app/module/election/page/OverviewPage.tsx
@@ -1,4 +1,4 @@
-import { Link, To, useLocation, useNavigate } from "react-router-dom";
+import { Link, To, useLocation, useNavigate } from "react-router";
 
 import { ElectionStatusWithIcon } from "app/component/election/ElectionStatusWithIcon";
 import { Footer } from "app/component/footer/Footer";

--- a/frontend/app/module/election/page/OverviewPage.tsx
+++ b/frontend/app/module/election/page/OverviewPage.tsx
@@ -25,7 +25,7 @@ export function OverviewPage() {
   }
 
   function closeNewAccountAlert() {
-    navigate(location.pathname);
+    void navigate(location.pathname);
   }
 
   return (

--- a/frontend/app/module/logs/LogsHomePage.tsx
+++ b/frontend/app/module/logs/LogsHomePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/module/polling_stations/PollingStationsLayout.tsx
+++ b/frontend/app/module/polling_stations/PollingStationsLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 
 import { Footer } from "app/component/footer/Footer";
 

--- a/frontend/app/module/polling_stations/page/PollingStationCreatePage.test.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationCreatePage.test.tsx
@@ -1,7 +1,5 @@
-import * as Router from "react-router";
-
 import { screen } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { ElectionProvider } from "@kiesraad/api";
 import { render } from "@kiesraad/test";
@@ -10,8 +8,6 @@ import { PollingStationCreatePage } from "./PollingStationCreatePage";
 
 describe("PollingStationCreatePage", () => {
   test("Shows form", async () => {
-    vi.spyOn(Router, "useParams").mockReturnValue({ electionId: "1" });
-
     render(
       <ElectionProvider electionId={1}>
         <PollingStationCreatePage />

--- a/frontend/app/module/polling_stations/page/PollingStationCreatePage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationCreatePage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { PollingStationForm } from "app/component/form/polling_station/PollingStationForm";
 import { NavBar } from "app/component/navbar/NavBar";

--- a/frontend/app/module/polling_stations/page/PollingStationCreatePage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationCreatePage.tsx
@@ -7,16 +7,16 @@ import { PollingStation, useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { IconChevronRight } from "@kiesraad/icon";
 import { PageTitle } from "@kiesraad/ui";
-import { useNumericParam } from "@kiesraad/util";
 
 export function PollingStationCreatePage() {
-  const electionId = useNumericParam("electionId");
   const { election } = useElection();
   const navigate = useNavigate();
 
-  const handleSaved = (ps: PollingStation) => {
-    navigate(`../?created=${ps.id}`);
-  };
+  const parentUrl = `/elections/${election.id}/polling_stations`;
+
+  function handleSaved(ps: PollingStation) {
+    void navigate(`${parentUrl}?created=${ps.id}`);
+  }
 
   return (
     <>
@@ -39,7 +39,7 @@ export function PollingStationCreatePage() {
       </header>
       <main>
         <article>
-          <PollingStationForm electionId={electionId} onSaved={handleSaved} />
+          <PollingStationForm electionId={election.id} onSaved={handleSaved} />
         </article>
       </main>
     </>

--- a/frontend/app/module/polling_stations/page/PollingStationListPage.test.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationListPage.test.tsx
@@ -1,7 +1,5 @@
-import * as Router from "react-router";
-
 import { screen } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { PollingStationListPage } from "app/module/polling_stations";
 
@@ -10,8 +8,6 @@ import { overrideOnce, render } from "@kiesraad/test";
 
 describe("PollingStationListPage", () => {
   test("Show polling stations", async () => {
-    vi.spyOn(Router, "useParams").mockReturnValue({ electionId: "1" });
-
     render(
       <ElectionProvider electionId={1}>
         <PollingStationListPage />
@@ -48,8 +44,6 @@ describe("PollingStationListPage", () => {
     overrideOnce("get", "/api/elections/1/polling_stations", 200, {
       polling_stations: [],
     } satisfies PollingStationListResponse);
-
-    vi.spyOn(Router, "useParams").mockReturnValue({ electionId: "1" });
 
     render(
       <ElectionProvider electionId={1}>

--- a/frontend/app/module/polling_stations/page/PollingStationListPage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationListPage.tsx
@@ -6,14 +6,12 @@ import { useElection, usePollingStationListRequest } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { IconPlus } from "@kiesraad/icon";
 import { Alert, Button, Loader, PageTitle, Table, Toolbar } from "@kiesraad/ui";
-import { useNumericParam } from "@kiesraad/util";
 
 export function PollingStationListPage() {
-  const electionId = useNumericParam("electionId");
   const { election } = useElection();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { requestState } = usePollingStationListRequest(electionId);
+  const { requestState } = usePollingStationListRequest(election.id);
 
   if (requestState.status === "loading") {
     return <Loader />;
@@ -33,9 +31,9 @@ export function PollingStationListPage() {
 
   const deletedPollingStation = searchParams.get("deleted");
 
-  const closeAlert = () => {
+  function closeAlert() {
     setSearchParams("");
-  };
+  }
 
   const labelForPollingStationType = {
     FixedLocation: t("polling_station.type.FixedLocation"),
@@ -101,7 +99,7 @@ export function PollingStationListPage() {
                   size="sm"
                   leftIcon={<IconPlus />}
                   onClick={() => {
-                    navigate("create");
+                    void navigate("create");
                   }}
                 >
                   {t("manual_input")}
@@ -118,7 +116,7 @@ export function PollingStationListPage() {
                   size="sm"
                   leftIcon={<IconPlus />}
                   onClick={() => {
-                    navigate("create");
+                    void navigate("create");
                   }}
                 >
                   {t("polling_station.form.create")}

--- a/frontend/app/module/polling_stations/page/PollingStationListPage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/module/polling_stations/page/PollingStationUpdatePage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationUpdatePage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { PollingStationForm } from "app/component/form/polling_station/PollingStationForm";
 import { NavBar } from "app/component/navbar/NavBar";

--- a/frontend/app/module/polling_stations/page/PollingStationUpdatePage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationUpdatePage.tsx
@@ -12,7 +12,6 @@ import { Alert, Button, Loader, PageTitle } from "@kiesraad/ui";
 import { useNumericParam } from "@kiesraad/util";
 
 export function PollingStationUpdatePage() {
-  const electionId = useNumericParam("electionId");
   const pollingStationId = useNumericParam("pollingStationId");
   const { election } = useElection();
   const navigate = useNavigate();
@@ -26,22 +25,24 @@ export function PollingStationUpdatePage() {
 
   const [error, setError] = React.useState<[string, string] | undefined>(undefined);
 
+  const parentUrl = `/elections/${election.id}/polling_stations`;
+
   function closeError() {
     setError(undefined);
   }
 
-  const handleSaved = () => {
-    navigate(`../?updated=${pollingStationId}`);
-  };
+  function handleSaved() {
+    void navigate(`${parentUrl}?updated=${pollingStationId}`);
+  }
 
-  const handleCancel = () => {
-    navigate("..");
-  };
+  function handleCancel() {
+    void navigate(parentUrl);
+  }
 
   function handleDeleted() {
     toggleShowDeleteModal();
     const pollingStation = "data" in requestState ? `${requestState.data.number} (${requestState.data.name})` : "";
-    navigate(`../?deleted=${encodeURIComponent(pollingStation)}`);
+    void navigate(`${parentUrl}?deleted=${encodeURIComponent(pollingStation)}`);
   }
 
   function handleDeleteError() {
@@ -89,7 +90,7 @@ export function PollingStationUpdatePage() {
           {requestState.status === "success" && (
             <>
               <PollingStationForm
-                electionId={electionId}
+                electionId={election.id}
                 pollingStation={requestState.data}
                 onSaved={handleSaved}
                 onCancel={handleCancel}

--- a/frontend/app/module/users/UsersHomePage.tsx
+++ b/frontend/app/module/users/UsersHomePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/module/workstations/WorkstationsHomePage.tsx
+++ b/frontend/app/module/workstations/WorkstationsHomePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 

--- a/frontend/app/routes.test.tsx
+++ b/frontend/app/routes.test.tsx
@@ -1,15 +1,16 @@
 import { render as rtlRender } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { routes } from "app/routes";
-
 import { electionStatusMockResponse } from "@kiesraad/api-mocks";
 import { expectErrorPage, expectNotFound, overrideOnce, Providers, setupTestRouter } from "@kiesraad/test";
 
-// NOTE: We're not using the wrapped render function here,
-// since we want control over our own memory router.
-const router = setupTestRouter(routes);
-const render = () => rtlRender(<Providers router={router} />);
+import { routes } from "./routes";
+
+const renderWithRouter = () => {
+  const router = setupTestRouter(routes);
+  rtlRender(<Providers router={router} />);
+  return router;
+};
 
 describe("routes", () => {
   beforeEach(() => {
@@ -21,34 +22,34 @@ describe("routes", () => {
 
   test("Non existing route results in not found page", async () => {
     // Router sanity checks
-    expect(router.state.location.pathname).toEqual("/");
+    const router = renderWithRouter();
+    expect(router.state.location.pathname).toEqual("/elections");
     await router.navigate("/elections/1/data-entry");
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry");
 
     // Navigate to a non existing route
     await router.navigate("/thisroutedoesnotexist");
     expect(router.state.location.pathname).toEqual("/thisroutedoesnotexist");
-    render();
     await expectNotFound();
   });
 
   test("Malformed election ID should result in not found page", async () => {
+    const router = renderWithRouter();
     await router.navigate("/elections/1asd/data-entry/");
-    render();
     await expectErrorPage();
   });
 
   test("Non existing election id results in not found page", async () => {
     // Navigate to a non-existing page
+    const router = renderWithRouter();
     await router.navigate("/elections/9876/data-entry");
     expect(router.state.location.pathname).toEqual("/elections/9876/data-entry");
-    render();
     await expectNotFound("Verkiezing niet gevonden");
   });
 
   test("Non existing polling station id results in not found page", async () => {
-    render();
     // Navigate to a non-existing page
+    const router = renderWithRouter();
     await router.navigate("/elections/1/data-entry/9876/1");
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry/9876/1");
     await expectNotFound("Stembureau niet gevonden");
@@ -56,9 +57,9 @@ describe("routes", () => {
 
   test("Error page when polling station is finalised", async () => {
     overrideOnce("get", "/api/elections/1/status", 200, electionStatusMockResponse);
+    const router = renderWithRouter();
     await router.navigate("/elections/1/data-entry/2/1");
     expect(router.state.location.pathname).toEqual("/elections/1/data-entry/2/1");
-    render();
     await expectErrorPage();
   });
 });

--- a/frontend/app/routes.tsx
+++ b/frontend/app/routes.tsx
@@ -1,4 +1,4 @@
-import { createRoutesFromElements, Navigate, Route } from "react-router-dom";
+import { createRoutesFromElements, Navigate, Route } from "react-router";
 
 import { CheckAndSaveForm } from "app/component/form/data_entry/check_and_save/CheckAndSaveForm";
 import { AdministratorLayout } from "app/module/AdministratorLayout";

--- a/frontend/lib/test/Providers.tsx
+++ b/frontend/lib/test/Providers.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router";
 
 import { ApiProvider } from "@kiesraad/api";
 

--- a/frontend/lib/test/Providers.tsx
+++ b/frontend/lib/test/Providers.tsx
@@ -1,18 +1,16 @@
 import * as React from "react";
 import { RouterProvider } from "react-router-dom";
 
-import type { Router as RemixRouter } from "@remix-run/router/dist/router";
-
 import { ApiProvider } from "@kiesraad/api";
 
-import { getRouter } from "./router";
+import { getRouter, Router } from "./router";
 
 export const Providers = ({
   children,
   router = getRouter(children),
 }: {
   children?: React.ReactNode;
-  router?: RemixRouter;
+  router?: Router;
 }) => {
   return (
     <ApiProvider>

--- a/frontend/lib/test/index.ts
+++ b/frontend/lib/test/index.ts
@@ -1,3 +1,4 @@
+export * from "./Providers";
+export * from "./router";
 export * from "./server";
 export * from "./test-utils";
-export * from "./Providers";

--- a/frontend/lib/test/router.ts
+++ b/frontend/lib/test/router.ts
@@ -1,11 +1,8 @@
 import { ReactNode } from "react";
-import { createMemoryRouter } from "react-router-dom";
+import { createMemoryRouter } from "react-router";
 
-import { Router } from "@remix-run/router";
-
-export let router: Router;
+export type Router = ReturnType<typeof createMemoryRouter>;
 
 export function getRouter(children: ReactNode) {
-  router = createMemoryRouter([{ path: "*", element: children }]);
-  return router;
+  return createMemoryRouter([{ path: "*", element: children }]);
 }

--- a/frontend/lib/test/test-utils.ts
+++ b/frontend/lib/test/test-utils.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { createMemoryRouter, RouteObject } from "react-router-dom";
+import { createMemoryRouter, RouteObject } from "react-router";
 
 import { render, RenderOptions, screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";

--- a/frontend/lib/test/test-utils.ts
+++ b/frontend/lib/test/test-utils.ts
@@ -6,6 +6,7 @@ import { UserEvent } from "@testing-library/user-event";
 import { expect } from "vitest";
 
 import { Providers } from "./Providers";
+import { getRouter } from "./router";
 
 const customRender = (ui: ReactElement, options?: Omit<RenderOptions, "wrapper">) =>
   render(ui, { wrapper: Providers, ...options });
@@ -14,16 +15,26 @@ const customRender = (ui: ReactElement, options?: Omit<RenderOptions, "wrapper">
 // Re-export everything in RTL but shadow the original `render` with our custom implementation.
 export * from "@testing-library/react";
 export { customRender as render };
-export { router } from "./router";
 /* eslint-enable import/export */
 
 export const setupTestRouter = (routes: RouteObject[]) => {
-  return createMemoryRouter(routes, {
-    future: {
-      v7_normalizeFormMethod: true,
-    },
-  });
+  return createMemoryRouter(routes);
 };
+
+export function renderReturningRouter(ui: ReactElement) {
+  const router = getRouter(ui);
+  const providers = () => Providers({ router });
+  render(ui, { wrapper: providers });
+  return router;
+}
+
+export function renderReturningRouter2(ui: ReactElement) {
+  const router = getRouter(ui);
+  const providers = () => Providers({ router });
+  const result = render(ui, { wrapper: providers });
+  const rerender = result.rerender;
+  return { router, rerender };
+}
 
 export const expectErrorPage = async () => {
   expect(await screen.findByText(/Abacus is stuk/)).toBeVisible();

--- a/frontend/lib/test/test-utils.ts
+++ b/frontend/lib/test/test-utils.ts
@@ -28,14 +28,6 @@ export function renderReturningRouter(ui: ReactElement) {
   return router;
 }
 
-export function renderReturningRouter2(ui: ReactElement) {
-  const router = getRouter(ui);
-  const providers = () => Providers({ router });
-  const result = render(ui, { wrapper: providers });
-  const rerender = result.rerender;
-  return { router, rerender };
-}
-
 export const expectErrorPage = async () => {
   expect(await screen.findByText(/Abacus is stuk/)).toBeVisible();
 };

--- a/frontend/lib/ui/AppLayout/StickyNav.tsx
+++ b/frontend/lib/ui/AppLayout/StickyNav.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { domtoren } from "@kiesraad/util";
 

--- a/frontend/lib/ui/Feedback/Feedback.tsx
+++ b/frontend/lib/ui/Feedback/Feedback.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { t, tx } from "@kiesraad/i18n";
 import { AlertType, FeedbackId, renderIconForType } from "@kiesraad/ui";

--- a/frontend/lib/ui/Table/Table.test.tsx
+++ b/frontend/lib/ui/Table/Table.test.tsx
@@ -1,10 +1,8 @@
-import * as router from "react-router";
-
 import { within } from "@testing-library/dom";
 import { userEvent } from "@testing-library/user-event";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
-import { render, screen } from "@kiesraad/test";
+import { render, renderReturningRouter, screen } from "@kiesraad/test";
 
 import { BasicTable, LinkTable } from "./Table.stories";
 
@@ -29,10 +27,7 @@ describe("Table", () => {
   test("LinkRow navigates to url when clicked", async () => {
     const user = userEvent.setup();
 
-    const mockNavigate = vi.fn();
-    vi.spyOn(router, "useNavigate").mockImplementation(() => mockNavigate);
-
-    render(<LinkTable />);
+    const router = renderReturningRouter(<LinkTable />);
 
     const table = await screen.findByTestId("link_table");
     const rows = within(table).getAllByRole("row");
@@ -41,6 +36,6 @@ describe("Table", () => {
       await user.click(rows[1]);
     }
 
-    expect(mockNavigate).toHaveBeenCalledWith("#row1");
+    expect(router.state.location.hash).toEqual("#row1");
   });
 });

--- a/frontend/lib/ui/Table/Table.tsx
+++ b/frontend/lib/ui/Table/Table.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { To, useNavigate } from "react-router-dom";
+import { To, useNavigate } from "react-router";
 
 import { cn } from "@kiesraad/util";
 

--- a/frontend/lib/ui/Table/Table.tsx
+++ b/frontend/lib/ui/Table/Table.tsx
@@ -50,7 +50,7 @@ function LinkRow({ children, to }: { children: React.ReactNode[]; to: To }) {
   const navigate = useNavigate();
 
   function handleClick() {
-    navigate(to);
+    void navigate(to);
   }
 
   return (

--- a/frontend/lib/ui/util/PageTitle.tsx
+++ b/frontend/lib/ui/util/PageTitle.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 export const PageTitle = ({ title }: { title: string }) => {
   const location = useLocation();

--- a/frontend/lib/util/hook/useNumericParam.ts
+++ b/frontend/lib/util/hook/useNumericParam.ts
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 import { parseIntStrict } from "@kiesraad/util";
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^7.1.1"
       },
       "devDependencies": {
         "@ladle/react": "^5.0.1",
@@ -2057,15 +2057,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
-      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -2893,7 +2884,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -10862,35 +10852,52 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
-      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.1.tgz",
+      "integrity": "sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.20.0"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
-      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.1.tgz",
+      "integrity": "sha512-vSrQHWlJ5DCfyrhgo0k6zViOe9ToK8uT5XGSmnuC2R3/g261IdIMpZVqfjD6vWSXdnf5Czs4VA/V60oVR6/jnA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.20.0",
-        "react-router": "6.27.0"
+        "react-router": "7.1.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -11475,6 +11482,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -12295,6 +12308,12 @@
       "engines": {
         "node": ">=0.6.x"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.1.1"
+        "react-router": "^7.1.1"
       },
       "devDependencies": {
         "@ladle/react": "^5.0.1",
@@ -10873,22 +10873,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.1.tgz",
-      "integrity": "sha512-vSrQHWlJ5DCfyrhgo0k6zViOe9ToK8uT5XGSmnuC2R3/g261IdIMpZVqfjD6vWSXdnf5Czs4VA/V60oVR6/jnA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.1.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/cookie": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.1.1"
+    "react-router": "^7.1.1"
   },
   "devDependencies": {
     "@ladle/react": "^5.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^7.1.1"
   },
   "devDependencies": {
     "@ladle/react": "^5.0.1",


### PR DESCRIPTION
- Upgrade to React Router 7.1.1 and rewrite tests where needed to work around Vitest mocking/spying
issues.
- Replace react-router-dom with react-router as mentioned in [React Router upgrade docs](https://reactrouter.com/upgrading/v6#upgrade-to-v7).
- Update Dependabot react-router ignore rules

Resolves #621.