### PR TITLE
Add `axum` to Dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
     groups:
       cargo:
         patterns: ["*"]
+    ignore:
+      # New axum major and minor versions usually have breaking changes, see #790 for axum 0.8
+      - dependency-name: "axum"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "axum-extra"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
New `axum` major and minor versions usually have breaking changes, e.g. #790 for `axum` 0.8. This means we don't want to have Dependabot propose upgrades for `axum`, so this PR creates an ignore rule for new major and minor versions.