### PR TITLE
Fix memory-serve documentation in backend README

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,7 +27,11 @@ In this version of `memory-serve`, the path must be absolute, since `build.rs`
 has no knowledge of the project it is currently built in. Example:
 
 ```shell
-ASSET_DIR=$PWD/frontend/dist cargo run --features memory-serve
+cd frontend
+npm run build
+cd ../backend
+sqlx database setup
+ASSET_DIR=$PWD/../frontend/dist cargo run --features memory-serve
 ```
 
 ### Linting


### PR DESCRIPTION
In the memory-serve documentation in backend README, the `ASSET_DIR` path was not correct (missing `../`). This PR fixes this and expands the shell code block to include all commands to build and run Abacus.