### PR TITLE
823 Polling station number should allow leading zeros

### DIFF
--- a/frontend/app/component/form/polling_station/PollingStationForm.tsx
+++ b/frontend/app/component/form/polling_station/PollingStationForm.tsx
@@ -21,7 +21,7 @@ interface Form extends HTMLFormElement {
 }
 
 const formFields: FormFields<PollingStationRequest> = {
-  number: { required: true, type: "number" },
+  number: { required: true, type: "number", isPollingStationNumber: true },
   name: { required: true, type: "string" },
   polling_station_type: { type: "string", mapUndefined: true },
   number_of_voters: { type: "number", isFormatted: true },

--- a/frontend/lib/util/form.test.ts
+++ b/frontend/lib/util/form.test.ts
@@ -37,7 +37,7 @@ describe("Form", () => {
 
     // Number required
     [{ type: "number", required: true }, "", "FORM_VALIDATION_RESULT_REQUIRED", undefined],
-    // FIXME [{ type: "number", required: false }, "", undefined, undefined],
+    // FIXME in issue #824 [{ type: "number", required: false }, "", undefined, undefined],
 
     // Number min/max
     [{ type: "number", min: 3 }, "2", "FORM_VALIDATION_RESULT_MIN", undefined],
@@ -50,11 +50,11 @@ describe("Form", () => {
     [{ type: "number", isFormatted: true }, "-5", undefined, -5],
     [{ type: "number", isFormatted: true }, "005", undefined, 5],
     [{ type: "number", isFormatted: true }, "5.005", undefined, 5005],
-    // FIXME [{ type: "number", isFormatted: true  }, "x", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+    [{ type: "number", isFormatted: true }, "x", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
 
     // Number isFormatted required
     [{ type: "number", isFormatted: true, required: true }, "", "FORM_VALIDATION_RESULT_REQUIRED", undefined],
-    // FIXME [{ type: "number", isFormatted: true , required: false }, "", undefined, undefined],
+    // FIXME in issue #824 [{ type: "number", isFormatted: true , required: false }, "", undefined, undefined],
 
     // Number isPollingStationNumber valid
     [{ type: "number", isPollingStationNumber: true }, "5", undefined, 5],
@@ -70,8 +70,8 @@ describe("Form", () => {
       "FORM_VALIDATION_RESULT_REQUIRED",
       undefined,
     ],
-    // FIXME [{ type: "number", isPollingStationNumber: true , required: false }, "", undefined, undefined],
-  ])("processForm for field type %j with input '%s' should return %j / %s", (field, inputValue, error, value) => {
+    // FIXME in issue #824 [{ type: "number", isPollingStationNumber: true , required: false }, "", undefined, undefined],
+  ])("processForm for field type %j with input %j should return %j, %j", (field, inputValue, error, value) => {
     type RequestObject = { field: FieldValue<typeof field> };
     const formFields: FormFields<RequestObject> = { field };
 

--- a/frontend/lib/util/form.test.ts
+++ b/frontend/lib/util/form.test.ts
@@ -1,19 +1,89 @@
 import { describe, expect, test } from "vitest";
 
-import { AnyFormField, FormFields, processForm, validateFormValue, ValidationError } from "@kiesraad/util";
+import { AnyFormField, FieldValue, FormFields, processForm, ValidationError } from "@kiesraad/util";
 
-describe("Form Utils", () => {
-  test.each<[AnyFormField, string | number, ValidationError | null]>([
-    [{ type: "string" }, "test", null],
-    [{ type: "string", minLength: 10 }, "test", "FORM_VALIDATION_RESULT_MIN_LENGTH"],
-    [{ type: "string", maxLength: 3 }, "test", "FORM_VALIDATION_RESULT_MAX_LENGTH"],
-    [{ type: "number" }, 5, null],
-    [{ type: "number" }, "x", "FORM_VALIDATION_RESULT_INVALID_TYPE"],
-    [{ type: "number", min: 3 }, 2, "FORM_VALIDATION_RESULT_MIN"],
-    [{ type: "number", max: 3 }, 4, "FORM_VALIDATION_RESULT_MAX"],
-  ])("validateFormValue for field type %j with input '%s' should return %j", (field, value, expected) => {
-    const result = validateFormValue(field, value);
-    expect(result).toBe(expected);
+type ExpectedError = ValidationError | undefined;
+type ExpectedValue = string | number | undefined;
+
+describe("Form", () => {
+  test.each<[AnyFormField, string, ExpectedError, ExpectedValue]>([
+    // String valid
+    [{ type: "string" }, "test", undefined, "test"],
+
+    // String required
+    [{ type: "string", required: true }, "", "FORM_VALIDATION_RESULT_REQUIRED", undefined],
+    [{ type: "string", required: false }, "", undefined, ""],
+
+    // String minLength/maxLength
+    [{ type: "string", minLength: 10 }, "test", "FORM_VALIDATION_RESULT_MIN_LENGTH", undefined],
+    [{ type: "string", minLength: 2 }, "test", undefined, "test"],
+    [{ type: "string", maxLength: 3 }, "test", "FORM_VALIDATION_RESULT_MAX_LENGTH", undefined],
+    [{ type: "string", maxLength: 255 }, "test", undefined, "test"],
+
+    // String Undefined
+    [{ type: "string", mapUndefined: true }, "test", undefined, "test"],
+    [{ type: "string", mapUndefined: true }, "Undefined", undefined, undefined],
+    [{ type: "string", mapUndefined: false }, "Undefined", undefined, "Undefined"],
+    [{ type: "string", mapUndefined: true }, "", undefined, ""],
+
+    // Number valid
+    [{ type: "number" }, "5", undefined, 5],
+    [{ type: "number" }, "-5", undefined, -5],
+    [{ type: "number" }, "005", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+    [{ type: "number" }, "5.005", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+    [{ type: "number" }, "x", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+    [{ type: "number" }, "12a", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+    [{ type: "number" }, "12,3", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+
+    // Number required
+    [{ type: "number", required: true }, "", "FORM_VALIDATION_RESULT_REQUIRED", undefined],
+    // FIXME [{ type: "number", required: false }, "", undefined, undefined],
+
+    // Number min/max
+    [{ type: "number", min: 3 }, "2", "FORM_VALIDATION_RESULT_MIN", undefined],
+    [{ type: "number", min: 1 }, "2", undefined, 2],
+    [{ type: "number", max: 3 }, "4", "FORM_VALIDATION_RESULT_MAX", undefined],
+    [{ type: "number", max: 5 }, "4", undefined, 4],
+
+    // Number isFormatted valid
+    [{ type: "number", isFormatted: true }, "5", undefined, 5],
+    [{ type: "number", isFormatted: true }, "-5", undefined, -5],
+    [{ type: "number", isFormatted: true }, "005", undefined, 5],
+    [{ type: "number", isFormatted: true }, "5.005", undefined, 5005],
+    // FIXME [{ type: "number", isFormatted: true  }, "x", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+
+    // Number isFormatted required
+    [{ type: "number", isFormatted: true, required: true }, "", "FORM_VALIDATION_RESULT_REQUIRED", undefined],
+    // FIXME [{ type: "number", isFormatted: true , required: false }, "", undefined, undefined],
+
+    // Number isPollingStationNumber valid
+    [{ type: "number", isPollingStationNumber: true }, "5", undefined, 5],
+    [{ type: "number", isPollingStationNumber: true }, "-5", undefined, -5],
+    [{ type: "number", isPollingStationNumber: true }, "005", undefined, 5],
+    [{ type: "number", isPollingStationNumber: true }, "5.005", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+    [{ type: "number", isPollingStationNumber: true }, "x", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
+
+    // Number isPollingStationNumber required
+    [
+      { type: "number", isPollingStationNumber: true, required: true },
+      "",
+      "FORM_VALIDATION_RESULT_REQUIRED",
+      undefined,
+    ],
+    // FIXME [{ type: "number", isPollingStationNumber: true , required: false }, "", undefined, undefined],
+  ])("processForm for field type %j with input '%s' should return %j / %s", (field, inputValue, error, value) => {
+    type RequestObject = { field: FieldValue<typeof field> };
+    const formFields: FormFields<RequestObject> = { field };
+
+    const input = document.createElement("input");
+    input.name = "field";
+    input.value = inputValue;
+
+    const { isValid, validationResult, requestObject } = processForm<RequestObject>(formFields, { field: input });
+
+    expect(validationResult.field, "validationResult").toBe(error);
+    expect(requestObject.field, "requestObject").toBe(value);
+    expect(isValid, "isValid").toBe(!error);
   });
 
   test("Process form, success", () => {

--- a/frontend/lib/util/form.ts
+++ b/frontend/lib/util/form.ts
@@ -36,7 +36,7 @@ export type FormFieldNumber = FormFieldBase & {
   max?: number;
 };
 
-type FieldValue<F extends AnyFormField> = F extends FormFieldNumber
+export type FieldValue<F extends AnyFormField> = F extends FormFieldNumber
   ? number
   : F extends FormFieldString
     ? string

--- a/frontend/lib/util/form.ts
+++ b/frontend/lib/util/form.ts
@@ -1,4 +1,4 @@
-import { deformatNumber, parseIntStrict } from "@kiesraad/util";
+import { deformatNumber, parseIntStrict, parsePollingStationNumber } from "@kiesraad/util";
 
 export type ValidationError =
   | "FORM_VALIDATION_RESULT_REQUIRED"
@@ -31,6 +31,7 @@ export type FormFieldStringUndefined = FormFieldBase & {
 export type FormFieldNumber = FormFieldBase & {
   type: "number";
   isFormatted?: boolean;
+  isPollingStationNumber?: boolean;
   min?: number;
   max?: number;
 };
@@ -67,7 +68,11 @@ export function processForm<RequestObject>(
 
     switch (field.type) {
       case "number": {
-        const parsedValue = field.isFormatted ? deformatNumber(value) : parseIntStrict(value);
+        const parsedValue = field.isFormatted
+          ? deformatNumber(value)
+          : field.isPollingStationNumber
+            ? parsePollingStationNumber(value)
+            : parseIntStrict(value);
         //parseIntStrict is used in deformatNumber as well, the result is a number or undefined.
         if (parsedValue === undefined) {
           validationResult[fieldName] = "FORM_VALIDATION_RESULT_INVALID_NUMBER";

--- a/frontend/lib/util/form.ts
+++ b/frontend/lib/util/form.ts
@@ -73,8 +73,8 @@ export function processForm<RequestObject>(
           : field.isPollingStationNumber
             ? parsePollingStationNumber(value)
             : parseIntStrict(value);
-        //parseIntStrict is used in deformatNumber as well, the result is a number or undefined.
-        if (parsedValue === undefined) {
+        //parseInt is used in deformatNumber, the result is a number or NaN.
+        if (parsedValue === undefined || Number.isNaN(parsedValue)) {
           validationResult[fieldName] = "FORM_VALIDATION_RESULT_INVALID_NUMBER";
           continue;
         } else {

--- a/frontend/lib/util/format.test.ts
+++ b/frontend/lib/util/format.test.ts
@@ -14,9 +14,17 @@ describe("Format util", () => {
     ["123456", "123.456"],
     ["1000000", "1.000.000"],
   ])("Number format string %s as %s", (input: string, expected: string) => {
-    expect(validateNumberString(input)).equals(true);
-    expect(formatNumber(input)).equals(expected);
-    expect(deformatNumber(expected)).equals(parseInt(input, 10));
+    expect(validateNumberString(input)).toBe(true);
+    expect(formatNumber(input)).toBe(expected);
+    expect(deformatNumber(expected)).toBe(parseInt(input, 10));
+  });
+
+  test.each([
+    ["000", 0],
+    ["", 0],
+    ["x", NaN],
+  ])("Deformat number %s as %s", (input: string, expected: number) => {
+    expect(deformatNumber(input)).toBe(expected);
   });
 
   const today = new Date();
@@ -30,6 +38,6 @@ describe("Format util", () => {
     [yesterday, `${yesterday.toLocaleString(t("date_locale"), { weekday: "long" })} 10:20`],
     [one_week_ago, `${one_week_ago.toLocaleString(t("date_locale"), { day: "numeric", month: "short" })} 10:20`],
   ])("Date format string %s as %s", (input: Date, expected: string) => {
-    expect(formatDateTime(input)).equals(expected);
+    expect(formatDateTime(input)).toEqual(expected);
   });
 });


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->
Closes https://github.com/kiesraad/abacus/issues/823

- `FormFieldNumber` now has a `isPollingStationNumber` boolean to use `parsePollingStationNumber()` instead of `parseIntStrict()`, which allows for leading zeros.
- Add test scenarios for `processForm()`, including commented out FIXME's that should be fixed in https://github.com/kiesraad/abacus/issues/824

