### PR TITLE
Build on ubuntu-latest with musl

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -66,19 +66,19 @@ jobs:
             ./backend/target/
           key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
-      - name: Check rustfmt
-        run: cargo --verbose --locked fmt --all -- --check
-      - name: Check Clippy with all features
-        run: cargo --verbose --locked clippy --all-targets --all-features -- -D warnings
-      - name: Check Clippy without default features
-        run: cargo --verbose --locked clippy --all-targets --no-default-features -- -D warnings
-      - name: Run tests
-        run: cargo --verbose --locked test
       - name: Install musl
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Install target
         run: rustup target add ${{ matrix.target.name }}
+      - name: Check rustfmt
+        run: cargo --verbose --locked fmt --all -- --check
+      - name: Check Clippy with all features
+        run: cargo --verbose --locked clippy --target=${{ matrix.target.name }} --all-targets --all-features -- -D warnings
+      - name: Check Clippy without default features
+        run: cargo --verbose --locked clippy --target=${{ matrix.target.name }} --all-targets --no-default-features -- -D warnings
+      - name: Run tests
+        run: cargo --verbose --locked test --target=${{ matrix.target.name }}
       - name: Build
         run: cargo --verbose --locked build --features memory-serve --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Install musl
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
+      - name: Install target
+        run: rustup target add ${{ matrix.target.name }}
       - name: Build
         run: cargo --verbose --locked build --features memory-serve --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -19,8 +19,17 @@ jobs:
     name: Backend
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+        target: 
+          - os: ubuntu-latest
+            name: x86_64-unknown-linux-musl
+            binary: backend/target/x86_64-unknown-linux-musl/release/abacus
+          - os: macos-latest
+            name: aarch64-apple-darwin
+            binary: backend/target/aarch64-apple-darwin/release/abacus
+          - os: windows-latest
+            name: x86_64-pc-windows-msvc
+            binary: backend/target/x86_64-pc-windows-msvc/release/abacus.exe
+    runs-on: ${{ matrix.target.os }}
     defaults:
       run:
         working-directory: ./backend
@@ -65,12 +74,15 @@ jobs:
         run: cargo --verbose --locked clippy --all-targets --no-default-features -- -D warnings
       - name: Run tests
         run: cargo --verbose --locked test
+      - name: Install musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        if: matrix.target.os == 'ubuntu-latest'
       - name: Build
-        run: cargo --verbose --locked build --features memory-serve
+        run: cargo --verbose --locked build --features memory-serve --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4
         with:
-          name: backend-build-${{ matrix.os }}
-          path: ${{ runner.os == 'Windows' && 'backend/target/debug/abacus.exe' || 'backend/target/debug/abacus' }}
+          name: abacus-${{ matrix.target.os }}
+          path: ${{ matrix.target.binary }}
   
   frontend:
     name: Frontend
@@ -144,10 +156,10 @@ jobs:
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps --no-shell
-      - name: Download backend-build
+      - name: Download abacus
         uses: actions/download-artifact@v4
         with:
-          name: backend-build-${{ matrix.os }}
+          name: abacus-${{ matrix.os }}
           path: builds/backend
       - name: make backend build executable
         run: chmod a+x ../builds/backend/abacus
@@ -170,7 +182,7 @@ jobs:
       - name: Download abacus
         uses: actions/download-artifact@v4
         with:
-          name: backend-build-ubuntu-latest
+          name: abacus-ubuntu-latest
       - name: Upload binary to test server
         run: |
           curl -s \

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   backend:
-    name: Backend (${{ matrix.os }})
+    name: Backend (${{ matrix.target.os }})
     strategy:
       matrix:
         target: 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -22,13 +22,13 @@ jobs:
         target: 
           - os: ubuntu-latest
             name: x86_64-unknown-linux-musl
-            binary: backend/target/x86_64-unknown-linux-musl/release/abacus
+            binary: backend/target/x86_64-unknown-linux-musl/debug/abacus
           - os: macos-latest
             name: aarch64-apple-darwin
-            binary: backend/target/aarch64-apple-darwin/release/abacus
+            binary: backend/target/aarch64-apple-darwin/debug/abacus
           - os: windows-latest
             name: x86_64-pc-windows-msvc
-            binary: backend/target/x86_64-pc-windows-msvc/release/abacus.exe
+            binary: backend/target/x86_64-pc-windows-msvc/debug/abacus.exe
     runs-on: ${{ matrix.target.os }}
     defaults:
       run:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   backend:
-    name: Backend
+    name: Backend (${{ matrix.os }})
     strategy:
       matrix:
         target: 


### PR DESCRIPTION
Compiling for a specific libc version makes abacus less portable. The changes the target on ubuntu-latest to musl.