### PR TITLE
Call login API endpoint

### DIFF
--- a/backend/fixtures/reset.sql
+++ b/backend/fixtures/reset.sql
@@ -3,3 +3,5 @@ DELETE FROM polling_station_results;
 DELETE FROM polling_station_data_entries;
 DELETE FROM polling_stations;
 DELETE FROM elections;
+DELETE FROM users;
+DELETE FROM sessions;

--- a/backend/migrations/5_users.sql
+++ b/backend/migrations/5_users.sql
@@ -4,5 +4,6 @@ CREATE TABLE users
     username           TEXT                 NOT NULL,
     password_hash      TEXT                 NOT NULL,
     updated_at         INTEGER              NOT NULL DEFAULT (unixepoch()),
-    created_at         INTEGER              NOT NULL DEFAULT (unixepoch())
+    created_at         INTEGER              NOT NULL DEFAULT (unixepoch()),
+    UNIQUE(username)
 );

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -121,28 +121,92 @@ pub async fn logout(
     Ok((updated_jar, StatusCode::OK))
 }
 
+/// Development endpoint: create a new user (unauthenticated)
+#[cfg(debug_assertions)]
+#[utoipa::path(
+  post,
+  path = "/api/user/development/create",
+  responses(
+      (status = 201, description = "User was successfully created"),
+      (status = 500, description = "Internal server error", body = ErrorResponse),
+  ),
+)]
+pub async fn development_create_user(
+    State(users): State<Users>,
+    Json(credentials): Json<Credentials>,
+) -> Result<impl IntoResponse, APIError> {
+    let Credentials { username, password } = credentials;
+
+    // Create a new user
+    users.create(&username, &password).await?;
+
+    Ok(StatusCode::CREATED)
+}
+
+/// Development endpoint: login as a user (unauthenticated)
+#[cfg(debug_assertions)]
+#[utoipa::path(
+  post,
+  path = "/api/user/development/login",
+  responses(
+    (status = 200, description = "The logged in user id and user name", body = LoginResponse),
+    (status = 500, description = "Internal server error", body = ErrorResponse),
+  ),
+)]
+pub async fn development_login(
+    State(users): State<Users>,
+    State(sessions): State<Sessions>,
+    jar: CookieJar,
+) -> Result<impl IntoResponse, APIError> {
+    // Get or create the test user
+    let user = match users.get_by_username("user").await? {
+        Some(u) => u,
+        None => users.create("user", "password").await?,
+    };
+
+    // Create a new session and cookie
+    let session = sessions.create(user.id(), SESSION_LIFE_TIME).await?;
+
+    // Add the session cookie to the response
+    let mut cookie = session.get_cookie();
+    set_default_cookie_properties(&mut cookie);
+    let updated_jar = jar.add(cookie);
+
+    Ok((updated_jar, Json(LoginResponse::from(&user))))
+}
+
 #[cfg(test)]
 mod tests {
-    use axum::{body::Body, http::Request, routing::post, Router};
+    use axum::{
+        body::Body,
+        http::Request,
+        routing::{get, post},
+        Router,
+    };
     use http_body_util::BodyExt;
     use hyper::{header::CONTENT_TYPE, Method};
     use sqlx::SqlitePool;
     use test_log::test;
     use tower::ServiceExt;
 
-    use super::{login, logout};
-    use crate::{
-        authentication::{Credentials, LoginResponse},
-        AppState,
-    };
+    use crate::{authentication::*, AppState};
 
     fn create_app(pool: SqlitePool) -> Router {
         let state = AppState { pool };
 
-        Router::new()
+        let router = Router::new()
             .route("/api/user/login", post(login))
-            .route("/api/user/logout", post(logout))
-            .with_state(state)
+            .route("/api/user/logout", post(logout));
+
+        #[cfg(debug_assertions)]
+        let router = router
+            .route(
+                "/api/user/development/create",
+                post(development_create_user),
+            )
+            .route("/api/user/development/login", get(development_login));
+
+        router.with_state(state)
     }
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
@@ -168,6 +232,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 200);
+        assert!(response.headers().get("set-cookie").is_some());
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let result: LoginResponse = serde_json::from_slice(&body).unwrap();
@@ -268,5 +333,80 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 200);
+    }
+
+    #[cfg(debug_assertions)]
+    #[sqlx::test]
+    async fn test_development_create_user(pool: SqlitePool) {
+        let app = create_app(pool);
+
+        // create a new user
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/user/development/create")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&Credentials {
+                            username: "user_test".to_string(),
+                            password: "password_test".to_string(),
+                        })
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 201);
+
+        // test login
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/user/login")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&Credentials {
+                            username: "user_test".to_string(),
+                            password: "password_test".to_string(),
+                        })
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+    }
+
+    #[cfg(debug_assertions)]
+    #[sqlx::test]
+    async fn test_development_login(pool: SqlitePool) {
+        let app = create_app(pool);
+
+        // test login
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/user/development/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+        assert!(response.headers().get("set-cookie").is_some());
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let result: LoginResponse = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(result.username, "user");
     }
 }

--- a/backend/src/fixtures.rs
+++ b/backend/src/fixtures.rs
@@ -23,7 +23,7 @@ macro_rules! load_fixtures {
 ///
 /// This list should be updated manually when a new fixture is added that
 /// needs to be loaded when seeding fixtures.
-const FIXTURES: &[Fixture] = load_fixtures!(["reset", "election_1"]);
+const FIXTURES: &[Fixture] = load_fixtures!(["reset", "election_3", "users"]);
 
 /// The data contained in a fixture file
 struct Fixture {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -81,6 +81,14 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
         .route("/login", post(authentication::login))
         .route("/logout", post(authentication::logout));
 
+    #[cfg(debug_assertions)]
+    let user_router = user_router
+        .route(
+            "/development/create",
+            post(authentication::development_create_user),
+        )
+        .route("/development/login", get(authentication::development_login));
+
     let app = Router::new()
         .nest("/api/user", user_router)
         .nest("/api/elections", election_routes)

--- a/frontend/app/component/error/ErrorModal.test.tsx
+++ b/frontend/app/component/error/ErrorModal.test.tsx
@@ -9,6 +9,5 @@ describe("Component: ErrorModal", () => {
     const { getByText } = render(<ServerErrorModal />);
 
     expect(getByText("Sorry, er ging iets mis")).toBeInTheDocument();
-    expect(getByText("500")).toBeInTheDocument();
   });
 });

--- a/frontend/app/component/error/ErrorModal.tsx
+++ b/frontend/app/component/error/ErrorModal.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 
-import { ApiError } from "@kiesraad/api";
-import { t } from "@kiesraad/i18n";
+import { AnyApiError, ApiError } from "@kiesraad/api";
+import { t, TranslationPath } from "@kiesraad/i18n";
 import { Button, Modal } from "@kiesraad/ui";
 
 import cls from "./ErrorModal.module.css";
 
 interface ErrorModalProps {
-  error: ApiError;
+  error: AnyApiError;
 }
 
 export function ErrorModal({ error }: ErrorModalProps) {
@@ -26,14 +26,35 @@ export function ErrorModal({ error }: ErrorModalProps) {
     return null;
   }
 
+  if (error instanceof ApiError) {
+    const key: TranslationPath = `error.api_error.${error.reference}`;
+
+    if (key !== t(key)) {
+      return (
+        <Modal title={t("something_went_wrong")} onClose={hideModal}>
+          <div id="error-modal" className={cls.error}>
+            <p>
+              <strong>{t(key)}</strong>
+            </p>
+            <nav>
+              <Button onClick={hideModal}>{t("close_message")}</Button>
+            </nav>
+          </div>
+        </Modal>
+      );
+    }
+  }
+
   return (
     <Modal title={t("something_went_wrong")} onClose={hideModal}>
       <div id="error-modal" className={cls.error}>
-        <p>
-          <strong>
-            {t("error_code")}: <code>{error.code}</code>
-          </strong>
-        </p>
+        {error instanceof ApiError && error.code && (
+          <p>
+            <strong>
+              {t("error_code")}: <code>{error.code}</code>
+            </strong>
+          </p>
+        )}
         <p>{error.message}</p>
         <nav>
           <Button onClick={hideModal}>{t("close_message")}</Button>

--- a/frontend/app/component/form/user/login/LoginForm.test.tsx
+++ b/frontend/app/component/form/user/login/LoginForm.test.tsx
@@ -1,0 +1,65 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+
+import { overrideOnce, render, screen, waitFor } from "@kiesraad/test";
+
+import { LoginForm } from "./LoginForm";
+
+describe("LoginForm", () => {
+  test("Successful login", async () => {
+    render(<LoginForm />);
+    let requestBody: object | null = null;
+
+    overrideOnce(
+      "post",
+      "/api/user/login",
+      200,
+      {
+        user_id: 1,
+        username: "user",
+      },
+      undefined,
+      async (request) => {
+        requestBody = (await request.json()) as object;
+      },
+    );
+
+    const user = userEvent.setup();
+
+    const username = screen.getByLabelText("Gebruikersnaam");
+    await user.type(username, "user");
+    const password = screen.getByLabelText("Wachtwoord");
+    await user.type(password, "password");
+
+    const submitButton = screen.getByRole("button", { name: "Inloggen" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(requestBody).toStrictEqual({ username: "user", password: "password" });
+    });
+  });
+
+  test("Unsuccessful login", async () => {
+    render(<LoginForm />);
+
+    overrideOnce("post", "/api/user/login", 401, {
+      error: "Invalid username and/or password",
+      fatal: false,
+      reference: "InvalidUsernamePassword",
+    });
+
+    const user = userEvent.setup();
+
+    const username = screen.getByLabelText("Gebruikersnaam");
+    await user.type(username, "user");
+    const password = screen.getByLabelText("Wachtwoord");
+    await user.type(password, "wrong");
+
+    const submitButton = screen.getByRole("button", { name: "Inloggen" });
+    await user.click(submitButton);
+
+    await waitFor(async () => {
+      expect(await screen.findByText("De gebruikersnaam of het wachtwoord is onjuist")).toBeVisible();
+    });
+  });
+});

--- a/frontend/app/component/form/user/login/LoginForm.tsx
+++ b/frontend/app/component/form/user/login/LoginForm.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 
 import { AnyApiError, FatalError, isError, LOGIN_REQUEST_BODY, LOGIN_REQUEST_PATH, useApi } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
-import { Alert, BottomBar, Button, InputField } from "@kiesraad/ui";
+import { Alert, BottomBar, Button, FormLayout, InputField } from "@kiesraad/ui";
 
 export function LoginForm() {
   const navigate = useNavigate();
@@ -41,23 +41,20 @@ export function LoginForm() {
 
   return (
     <>
-      {error && (
-        <Alert
-          type="error"
-          onClose={() => {
-            setError(null);
-          }}
-        >
-          {t(`error.api_error.${error.reference}`)}
-        </Alert>
-      )}
       <form
         className="no_footer"
         onSubmit={(e) => {
           void handleSubmit(e);
         }}
       >
-        <div>
+        <FormLayout>
+          {error && (
+            <FormLayout.Alert>
+              <Alert type="error" margin="mb-lg">
+                <h2>{t(`error.api_error.${error.reference}`)}</h2>
+              </Alert>
+            </FormLayout.Alert>
+          )}
           <InputField
             name="username"
             label={t("user.username")}
@@ -73,7 +70,7 @@ export function LoginForm() {
             readOnly={loading}
             required={true}
           />
-        </div>
+        </FormLayout>
         <BottomBar type="footer">
           <BottomBar.Row>
             <Button type="submit" size="lg" disabled={loading}>

--- a/frontend/app/component/form/user/login/LoginForm.tsx
+++ b/frontend/app/component/form/user/login/LoginForm.tsx
@@ -1,39 +1,87 @@
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import { useNavigate } from "react-router";
 
+import { AnyApiError, FatalError, isError, LOGIN_REQUEST_BODY, LOGIN_REQUEST_PATH, useApi } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
-import { BottomBar, Button, InputField } from "@kiesraad/ui";
-
-interface FormElements extends HTMLFormControlsCollection {
-  username: HTMLInputElement;
-  password: HTMLInputElement;
-}
-
-interface LoginFormElement extends HTMLFormElement {
-  readonly elements: FormElements;
-}
+import { Alert, BottomBar, Button, InputField } from "@kiesraad/ui";
 
 export function LoginForm() {
   const navigate = useNavigate();
+  const client = useApi();
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<AnyApiError | null>(null);
 
-  function handleSubmit(event: FormEvent<LoginFormElement>) {
+  // Handle form submission
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    void navigate("../setup");
+    setLoading(true);
+
+    // Submit the credentials to the API
+    const formData = new FormData(event.currentTarget);
+    const requestPath: LOGIN_REQUEST_PATH = `/api/user/login`;
+    const requestBody: LOGIN_REQUEST_BODY = {
+      username: formData.get("username") as string,
+      password: formData.get("password") as string,
+    };
+    const result = await client.postRequest(requestPath, requestBody);
+
+    // Handle the result
+    setLoading(false);
+    if (isError(result)) {
+      setError(result);
+    } else {
+      void navigate("../setup");
+    }
+  }
+
+  // Propagate fatal errors to the error boundary, which will render an error page
+  if (error instanceof FatalError) {
+    throw error;
   }
 
   return (
-    <form className="no_footer" onSubmit={handleSubmit}>
-      <div>
-        <InputField name="username" label={t("user.username")} hint={t("user.username_login_hint")} />
-        <InputField name="password" label={t("user.password")} hint={t("user.password_login_hint")} type="password" />
-      </div>
-      <BottomBar type="footer">
-        <BottomBar.Row>
-          <Button type="submit" size="lg">
-            {t("user.login")}
-          </Button>
-        </BottomBar.Row>
-      </BottomBar>
-    </form>
+    <>
+      {error && (
+        <Alert
+          type="error"
+          onClose={() => {
+            setError(null);
+          }}
+        >
+          {t(`error.api_error.${error.reference}`)}
+        </Alert>
+      )}
+      <form
+        className="no_footer"
+        onSubmit={(e) => {
+          void handleSubmit(e);
+        }}
+      >
+        <div>
+          <InputField
+            name="username"
+            label={t("user.username")}
+            hint={t("user.username_login_hint")}
+            readOnly={loading}
+            required={true}
+          />
+          <InputField
+            name="password"
+            label={t("user.password")}
+            hint={t("user.password_login_hint")}
+            type="password"
+            readOnly={loading}
+            required={true}
+          />
+        </div>
+        <BottomBar type="footer">
+          <BottomBar.Row>
+            <Button type="submit" size="lg" disabled={loading}>
+              {t("user.login")}
+            </Button>
+          </BottomBar.Row>
+        </BottomBar>
+      </form>
+    </>
   );
 }

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
@@ -137,7 +137,7 @@ describe("PollingStationFormNavigation", () => {
       formState: defaultFormState,
       apiError: {
         code: 422,
-        message: "JSON error or invalid data (Unprocessable Content)",
+        message: "De JSON is niet geldig",
       },
       currentForm: {
         id: "recounted",
@@ -157,7 +157,7 @@ describe("PollingStationFormNavigation", () => {
     render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
 
     const feedbackServerError = await screen.findByTestId("error-modal");
-    expect(feedbackServerError).toHaveTextContent("Foutcode: 422JSON error or invalid data (Unprocessable Content)");
+    expect(feedbackServerError).toHaveTextContent("De JSON is niet geldig");
   });
 
   test("500 response results in display of error message", async () => {
@@ -166,7 +166,7 @@ describe("PollingStationFormNavigation", () => {
       formState: defaultFormState,
       apiError: {
         code: 500,
-        message: "Internal server error",
+        message: "Er is een interne fout opgetreden",
       },
       currentForm: {
         id: "recounted",
@@ -185,6 +185,6 @@ describe("PollingStationFormNavigation", () => {
 
     const feedbackServerError = await screen.findByTestId("error-modal");
 
-    expect(feedbackServerError).toHaveTextContent("Foutcode: 500Internal server error");
+    expect(feedbackServerError).toHaveTextContent("Er is een interne fout opgetreden");
   });
 });

--- a/frontend/app/module/data_entry/polling_station/PollingStation.test.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStation.test.tsx
@@ -228,7 +228,7 @@ async function submitWith422Response() {
 
 async function expect422ClientError() {
   const feedbackServerError = await screen.findByTestId("error-modal");
-  expect(feedbackServerError).toHaveTextContent("Foutcode: 422JSON error or invalid data (Unprocessable Content)");
+  expect(feedbackServerError).toHaveTextContent("De JSON is niet geldig");
 }
 
 async function submitWith500Response() {
@@ -242,7 +242,7 @@ async function submitWith500Response() {
 
 async function expect500ServerError() {
   const feedbackServerError = await screen.findByTestId("error-modal");
-  expect(feedbackServerError).toHaveTextContent("Foutcode: 500Internal server error");
+  expect(feedbackServerError).toHaveTextContent("Er is een interne fout opgetreden");
 }
 
 type FormIdentifier = "recounted" | "voters_and_votes" | "differences" | `candidates_${number}`;

--- a/frontend/e2e-tests/authentication.e2e.ts
+++ b/frontend/e2e-tests/authentication.e2e.ts
@@ -7,6 +7,7 @@ test.describe("authentication", () => {
     crypto.getRandomValues(array);
     const random = array.toString();
     const username = `user_${random}`;
+    const password = "password_test";
     // create a test user
     const createUserResponse = await request.post("/api/user/development/create", {
       headers: {
@@ -14,7 +15,7 @@ test.describe("authentication", () => {
       },
       data: {
         username,
-        password: "password_test",
+        password,
       },
     });
     expect(createUserResponse.status()).toBe(201);
@@ -22,7 +23,7 @@ test.describe("authentication", () => {
     await page.goto("/account/login");
 
     await page.getByLabel("Gebruikersnaam").fill(username);
-    await page.getByLabel("Wachtwoord").fill("password_test");
+    await page.getByLabel("Wachtwoord").fill(password);
     await page.getByRole("button", { name: "Inloggen" }).click();
 
     // TODO: use new page object when we know which page to render

--- a/frontend/e2e-tests/authentication.e2e.ts
+++ b/frontend/e2e-tests/authentication.e2e.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+import { webcrypto as crypto } from "crypto";
+
+test.describe("authentication", () => {
+  test("login happy path", async ({ page, request }) => {
+    const array = new Uint32Array(1);
+    crypto.getRandomValues(array);
+    const random = array.toString();
+    const username = `user_${random}`;
+    // create a test user
+    const createUserResponse = await request.post("/api/user/development/create", {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      data: {
+        username,
+        password: "password_test",
+      },
+    });
+    expect(createUserResponse.status()).toBe(201);
+
+    await page.goto("/account/login");
+
+    await page.getByLabel("Gebruikersnaam").fill(username);
+    await page.getByLabel("Wachtwoord").fill("password_test");
+    await page.getByRole("button", { name: "Inloggen" }).click();
+
+    // TODO: use new page object when we know which page to render
+    await expect(page.getByRole("alert")).toContainText("Inloggen gelukt");
+  });
+
+  test("login unhappy path", async ({ page }) => {
+    await page.goto("/account/login");
+
+    await page.getByLabel("Gebruikersnaam").fill("user");
+    await page.getByLabel("Wachtwoord").fill("wrong-password");
+    await page.getByRole("button", { name: "Inloggen" }).click();
+
+    await expect(page.getByRole("alert")).toContainText("De gebruikersnaam of het wachtwoord is onjuist");
+  });
+});

--- a/frontend/lib/api/ApiError.ts
+++ b/frontend/lib/api/ApiError.ts
@@ -56,6 +56,15 @@ export class NotFoundError extends FatalError {
   }
 }
 
+export function isError<T>(result: ApiResult<T>): result is Error {
+  return (
+    result instanceof ApiError ||
+    result instanceof FatalApiError ||
+    result instanceof NotFoundError ||
+    result instanceof NetworkError
+  );
+}
+
 export function isSuccess<T>(result: ApiResult<T>): result is ApiResponse<T> {
   return !(
     result instanceof ApiError ||

--- a/frontend/lib/test/server.ts
+++ b/frontend/lib/test/server.ts
@@ -7,7 +7,7 @@
  *
  * https://github.com/oxidecomputer/console/blob/8dcddcef62b8d10dfcd3adb470439212b23b3d5e/test/unit/server.ts
  */
-import { delay, http, HttpResponse, JsonBodyType } from "msw";
+import { DefaultBodyType, delay, http, HttpResponse, JsonBodyType, StrictRequest } from "msw";
 import { setupServer } from "msw/node";
 
 export const server = setupServer();
@@ -19,11 +19,16 @@ export function overrideOnce(
   status: number,
   body: string | null | JsonBodyType,
   delayResponse?: "infinite" | number,
+  onRequest?: (request: StrictRequest<DefaultBodyType>) => Promise<void>,
 ) {
   server.use(
     http[method](
       path,
-      async () => {
+      async ({ request }) => {
+        if (onRequest) {
+          await onRequest(request);
+        }
+
         if (delayResponse) {
           await delay(delayResponse);
         }

--- a/frontend/lib/ui/Alert/Alert.tsx
+++ b/frontend/lib/ui/Alert/Alert.tsx
@@ -10,13 +10,14 @@ import cls from "./Alert.module.css";
 export interface AlertProps {
   type: AlertType;
   variant?: "default" | "small" | "no-icon";
+  margin?: "mb-md" | "mb-md-lg" | "mb-lg";
   children: React.ReactNode;
   onClose?: () => void;
 }
 
-export function Alert({ type, onClose, children, variant = "default" }: AlertProps) {
+export function Alert({ type, onClose, children, margin, variant = "default" }: AlertProps) {
   return (
-    <div className={cn(cls.alert, cls[type], variant)} role="alert">
+    <div className={`${cn(cls.alert, cls[type], variant)} ${margin}`} role="alert">
       {onClose && (
         <IconButton icon={<IconCross />} title={t("close_message")} variant="tertiary" size="lg" onClick={onClose} />
       )}


### PR DESCRIPTION
Fixes #710 and #711

The login form now actually calls the login API endpoint.
Also added development endpoints to create a user or to login (without any credentials).

To Test:

```sh
# run the backend
cd backend
sqlx database reset
cargo run -- --reset-database --seed-data

# run the frontend
cd frontend
npm run dev:server
```

Or visit: https://3dd96737538f666fcb09a792a1e760435de0414b.abacus-test.nl/

Go to `/account/login` and login using "user" and "password".