### PR TITLE
Remove sharding from Playwright d2d tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -136,14 +136,12 @@ jobs:
         run: npm run e2e:lib-ui
 
   playwright-d2d:
-    name: Playwright d2d tests (${{ matrix.os }}, ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: Playwright d2d tests (${{ matrix.os }})
     needs:
       - backend # frontend is included in backend build
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -167,7 +165,7 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
         if: runner.os != 'Windows'
       - name: Run DOM to Database e2e tests
-        run: npm run e2e:d2d -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: npm run e2e:d2d
 
   deploy:
     name: Deploy to abacus-test.nl


### PR DESCRIPTION
Remove sharding from Playwright d2d tests so that we need fewer CI jobs.

This PR: Total duration [16m 46s](https://github.com/kiesraad/abacus/actions/runs/12766849827/usage)
`main`: Total duration [15m 1s](https://github.com/kiesraad/abacus/actions/runs/12765169639/usage)