### PR TITLE
Log tracing events in tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Check Clippy without default features
         run: cargo --verbose --locked clippy --target=${{ matrix.target.name }} --all-targets --no-default-features -- -D warnings
       - name: Run tests
-        run: cargo --verbose --locked test --target=${{ matrix.target.name }}
+        run: cargo --verbose --locked test --target=${{ matrix.target.name }} -- --nocapture
       - name: Build
         run: cargo --verbose --locked build --features memory-serve --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -75,10 +75,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "approx"
@@ -124,9 +168,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.84"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -270,6 +314,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "test-log",
  "tokio",
  "tower",
  "tower-http",
@@ -354,9 +399,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -392,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -438,9 +483,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -523,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -533,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -572,6 +617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "comemo"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,7 +631,7 @@ dependencies = [
  "comemo-macros",
  "once_cell",
  "parking_lot",
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
@@ -862,6 +913,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1576,9 +1648,9 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1593,9 +1665,15 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1605,9 +1683,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1672,9 +1750,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lipsum"
@@ -1713,9 +1791,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matchers"
@@ -1811,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2029,7 +2107,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be17f48d7fbbd22c6efedb58af5d409aa578e407f40b29a0bcb4e66ed84c5c98"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2052,9 +2130,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2062,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -2072,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2085,11 +2163,11 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
@@ -2198,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2320,7 +2398,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2507,11 +2585,11 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2530,7 +2608,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -2716,18 +2794,12 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simplecss"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -2831,7 +2903,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2885,7 +2957,7 @@ checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2915,7 +2987,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tracing",
  "whoami",
 ]
@@ -2928,7 +3000,7 @@ checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2953,7 +3025,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tracing",
  "whoami",
 ]
@@ -3079,7 +3151,7 @@ dependencies = [
  "once_cell",
  "pdf-writer",
  "resvg",
- "siphasher 1.0.1",
+ "siphasher",
  "subsetter",
  "tiny-skia",
  "ttf-parser",
@@ -3088,19 +3160,19 @@ dependencies = [
 
 [[package]]
 name = "svgtypes"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794de53cc48eaabeed0ab6a3404a65f40b3e38c067e4435883a65d2aa4ca000e"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo",
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,6 +3236,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thin-vec"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,11 +3274,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3200,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3411,7 +3505,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "http",
  "http-body",
@@ -3512,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "two-face"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccd4843ea031c609fe9c16cae00e9657bad8a9f735a3cc2e420955d802b4268"
+checksum = "bf7a7f2e469787d6242b2a8dba5d3bfafef2ce70e63f6e1cda5706b79d161fa5"
 dependencies = [
  "once_cell",
  "serde",
@@ -3541,7 +3635,7 @@ checksum = "87286a6b7e417426c425f35c42fb3d86e54ee99485b7eeb3662f4aeb569151c6"
 dependencies = [
  "arrayvec",
  "az",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bumpalo",
  "chinese-number",
  "ciborium",
@@ -3578,7 +3672,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "siphasher 1.0.1",
+ "siphasher",
  "smallvec",
  "stacker",
  "syntect",
@@ -3687,7 +3781,7 @@ dependencies = [
  "once_cell",
  "portable-atomic",
  "rayon",
- "siphasher 1.0.1",
+ "siphasher",
  "thin-vec",
 ]
 
@@ -3820,7 +3914,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher 1.0.1",
+ "siphasher",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -3841,6 +3935,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
@@ -3886,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3935,20 +4035,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -3960,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3973,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3983,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3996,9 +4097,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasmi"
@@ -4051,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4295,9 +4399,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -4456,7 +4560,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "zopfli",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -45,6 +45,7 @@ password-hash = { version = "0.5.0", features = ["getrandom"] }
 rand = "0.8.5"
 cookie = "0.18.1"
 zip = { version = "2.2.2", default-features = false, features = ["deflate", "chrono"] }
+test-log = "0.2.17"
 
 [dev-dependencies]
 http-body-util = "0.1.2"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 license = "EUPL-1.2"
 rust-version = "1.75"
-
 default-run = "abacus"
 
 [features]
@@ -45,9 +44,9 @@ password-hash = { version = "0.5.0", features = ["getrandom"] }
 rand = "0.8.5"
 cookie = "0.18.1"
 zip = { version = "2.2.2", default-features = false, features = ["deflate", "chrono"] }
-test-log = "0.2.17"
 
 [dev-dependencies]
+test-log = "0.2.17"
 http-body-util = "0.1.2"
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,7 +68,7 @@ The following dependencies (crates) are used:
 - `tower-http`: Tower middleware and utilities for HTTP clients and servers.
 - `tracing`: a framework for instrumenting Rust programs to collect structured, event-based diagnostic information.
 - `tracing-subscriber`: utilities for implementing and composing `tracing` subscribers.
-- `test-log`: show tracing messages while winning tests
+- `test-log`: show tracing messages while running tests
 - `typst`: a new markup-based typesetting system that is powerful and easy to learn.
 - `typst-pdf`: a PDF exporter for Typst.
 - `utoipa`: library for documenting REST APIs using OpenAPI.

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,6 +68,7 @@ The following dependencies (crates) are used:
 - `tower-http`: Tower middleware and utilities for HTTP clients and servers.
 - `tracing`: a framework for instrumenting Rust programs to collect structured, event-based diagnostic information.
 - `tracing-subscriber`: utilities for implementing and composing `tracing` subscribers.
+- `test-log`: show tracing messages while winning tests
 - `typst`: a new markup-based typesetting system that is powerful and easy to learn.
 - `typst-pdf`: a PDF exporter for Typst.
 - `utoipa`: library for documenting REST APIs using OpenAPI.

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,7 +68,6 @@ The following dependencies (crates) are used:
 - `tower-http`: Tower middleware and utilities for HTTP clients and servers.
 - `tracing`: a framework for instrumenting Rust programs to collect structured, event-based diagnostic information.
 - `tracing-subscriber`: utilities for implementing and composing `tracing` subscribers.
-- `test-log`: show tracing messages while running tests
 - `typst`: a new markup-based typesetting system that is powerful and easy to learn.
 - `typst-pdf`: a PDF exporter for Typst.
 - `utoipa`: library for documenting REST APIs using OpenAPI.
@@ -77,6 +76,7 @@ The following dependencies (crates) are used:
 
 Additionally, the following development dependencies are used:
 
+- `test-log`: show tracing messages while running tests
 - `reqwest`: HTTP client for testing the API.
 - `http-body-util`: trait used to extract a response body in some tests.
 

--- a/backend/src/apportionment/fraction.rs
+++ b/backend/src/apportionment/fraction.rs
@@ -1,7 +1,9 @@
 use crate::data_entry::Count;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-use std::ops::{Div, Mul};
+use std::{
+    fmt,
+    fmt::{Debug, Display, Formatter},
+    ops::{Div, Mul},
+};
 
 pub struct Fraction {
     numerator: u64,

--- a/backend/src/apportionment/fraction.rs
+++ b/backend/src/apportionment/fraction.rs
@@ -104,6 +104,7 @@ impl Debug for Fraction {
 mod tests {
     use super::*;
     use crate::apportionment::fraction::Fraction;
+    use test_log::test;
 
     #[test]
     fn test_from_count() {

--- a/backend/src/apportionment/mod.rs
+++ b/backend/src/apportionment/mod.rs
@@ -102,6 +102,7 @@ mod tests {
     use crate::apportionment::{seat_allocation, ApportionmentError};
     use crate::data_entry::{PoliticalGroupVotes, VotersCounts, VotesCounts};
     use crate::summary::{ElectionSummary, SummaryDifferencesCounts};
+    use test_log::test;
 
     #[test]
     fn test_seat_allocation_less_than_19_seats_with_remaining_seats() {

--- a/backend/src/apportionment/mod.rs
+++ b/backend/src/apportionment/mod.rs
@@ -1,5 +1,4 @@
-use crate::apportionment::fraction::Fraction;
-use crate::summary::ElectionSummary;
+use crate::{apportionment::fraction::Fraction, summary::ElectionSummary};
 use serde::{Deserialize, Serialize};
 
 mod fraction;
@@ -99,9 +98,11 @@ pub enum ApportionmentError {
 
 #[cfg(test)]
 mod tests {
-    use crate::apportionment::{seat_allocation, ApportionmentError};
-    use crate::data_entry::{PoliticalGroupVotes, VotersCounts, VotesCounts};
-    use crate::summary::{ElectionSummary, SummaryDifferencesCounts};
+    use crate::{
+        apportionment::{seat_allocation, ApportionmentError},
+        data_entry::{PoliticalGroupVotes, VotersCounts, VotesCounts},
+        summary::{ElectionSummary, SummaryDifferencesCounts},
+    };
     use test_log::test;
 
     #[test]

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -127,6 +127,7 @@ mod tests {
     use http_body_util::BodyExt;
     use hyper::{header::CONTENT_TYPE, Method};
     use sqlx::SqlitePool;
+    use test_log::test;
     use tower::ServiceExt;
 
     use super::{login, logout};
@@ -144,7 +145,7 @@ mod tests {
             .with_state(state)
     }
 
-    #[sqlx::test(fixtures("../../fixtures/users.sql"))]
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_login_success(pool: SqlitePool) {
         let app = create_app(pool);
 
@@ -175,7 +176,7 @@ mod tests {
         assert_eq!(result.username, "user");
     }
 
-    #[sqlx::test(fixtures("../../fixtures/users.sql"))]
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_login_error(pool: SqlitePool) {
         let app = create_app(pool);
 
@@ -200,7 +201,7 @@ mod tests {
         assert_eq!(response.status(), 401);
     }
 
-    #[sqlx::test(fixtures("../../fixtures/users.sql"))]
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_logout(pool: SqlitePool) {
         let app = create_app(pool);
 

--- a/backend/src/authentication/password.rs
+++ b/backend/src/authentication/password.rs
@@ -34,6 +34,7 @@ pub(super) fn verify_password(password: &str, password_hash: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_hash_password_and_verify() {

--- a/backend/src/authentication/session.rs
+++ b/backend/src/authentication/session.rs
@@ -148,10 +148,11 @@ impl FromRef<AppState> for Sessions {
 mod test {
     use sqlx::SqlitePool;
     use std::time::Duration;
+    use test_log::test;
 
     use crate::authentication::session::Sessions;
 
-    #[sqlx::test(fixtures("../../fixtures/users.sql"))]
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_create_and_get_session(pool: SqlitePool) {
         let sessions = Sessions::new(pool);
 
@@ -166,7 +167,7 @@ mod test {
         assert_eq!(session, session_from_db);
     }
 
-    #[sqlx::test(fixtures("../../fixtures/users.sql"))]
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_delete_session(pool: SqlitePool) {
         let sessions = Sessions::new(pool);
         let session = sessions.create(1, Duration::from_secs(60)).await.unwrap();
@@ -181,7 +182,7 @@ mod test {
         assert_eq!(None, session_from_db);
     }
 
-    #[sqlx::test(fixtures("../../fixtures/users.sql"))]
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_delete_old_sessions(pool: SqlitePool) {
         let sessions = Sessions::new(pool);
 

--- a/backend/src/authentication/user.rs
+++ b/backend/src/authentication/user.rs
@@ -185,12 +185,13 @@ impl FromRef<AppState> for Users {
 mod tests {
     use sqlx::SqlitePool;
     use std::time::Duration;
+    use test_log::test;
 
     use crate::authentication::{
         error::AuthenticationError, session::Sessions, user::Users, util::get_current_time,
     };
 
-    #[sqlx::test]
+    #[test(sqlx::test)]
     async fn test_create_user(pool: SqlitePool) {
         let users = Users::new(pool.clone());
 
@@ -208,7 +209,7 @@ mod tests {
         assert_eq!(user, fetched_user);
     }
 
-    #[sqlx::test]
+    #[test(sqlx::test)]
     async fn test_authenticate_user(pool: SqlitePool) {
         let users = Users::new(pool.clone());
 
@@ -239,7 +240,7 @@ mod tests {
         ));
     }
 
-    #[sqlx::test]
+    #[test(sqlx::test)]
     async fn test_from_session_key(pool: SqlitePool) {
         let users = Users::new(pool.clone());
         let sessions = Sessions::new(pool.clone());

--- a/backend/src/authentication/util.rs
+++ b/backend/src/authentication/util.rs
@@ -35,6 +35,7 @@ pub(super) fn get_expires_at(duration: Duration) -> Result<u64, AuthenticationEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_create_new_session_key() {

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -3,15 +3,14 @@ use axum::serve::ListenerExt;
 use backend::fixtures;
 use backend::router;
 use clap::Parser;
-use sqlx::sqlite::SqliteConnectOptions;
-use sqlx::SqlitePool;
-use std::error::Error;
-use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
-use tokio::net::TcpListener;
-use tokio::signal;
-use tracing::level_filters::LevelFilter;
-use tracing::{info, trace};
+use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
+use std::{
+    error::Error,
+    net::{Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
+use tokio::{net::TcpListener, signal};
+use tracing::{info, level_filters::LevelFilter, trace};
 use tracing_subscriber::EnvFilter;
 
 /// Abacus API and asset server

--- a/backend/src/bin/gen-openapi.rs
+++ b/backend/src/bin/gen-openapi.rs
@@ -19,6 +19,7 @@ fn get_openapi_json() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn generated_openapi_json_is_up_to_date() {

--- a/backend/src/data_entry/mod.rs
+++ b/backend/src/data_entry/mod.rs
@@ -1,20 +1,22 @@
-use crate::data_entry::repository::PollingStationDataEntries;
-use crate::election::repository::Elections;
-use crate::error::{APIError, ErrorReference, ErrorResponse};
-use crate::polling_station::repository::PollingStations;
-use crate::polling_station::structs::PollingStation;
-use axum::extract::{FromRequest, Path, State};
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
+use crate::{
+    data_entry::repository::PollingStationDataEntries,
+    election::repository::Elections,
+    error::{APIError, ErrorReference, ErrorResponse},
+    polling_station::{repository::PollingStations, structs::PollingStation},
+};
+use axum::{
+    extract::{FromRequest, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use chrono::{DateTime, Utc};
 use entry_number::EntryNumber;
 use serde::{Deserialize, Serialize};
 use status::{ClientState, DataEntryStatus, DataEntryStatusName};
 use utoipa::ToSchema;
 
-pub use self::structs::*;
-pub use self::validation::*;
+pub use self::{structs::*, validation::*};
 
 pub mod entry_number;
 pub mod repository;
@@ -301,6 +303,7 @@ pub async fn election_status(
 pub mod tests {
     use axum::http::StatusCode;
     use sqlx::{query, SqlitePool};
+    use test_log::test;
 
     use super::*;
 
@@ -393,7 +396,7 @@ pub mod tests {
         .into_response()
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_create_data_entry(pool: SqlitePool) {
         let mut request_body = example_data_entry();
         request_body.data.voters_counts.poll_card_count = 100; // incorrect value
@@ -409,7 +412,7 @@ pub mod tests {
         assert_eq!(row_count.count, 1);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_cannot_finalise_with_errors(pool: SqlitePool) {
         let mut request_body = example_data_entry();
         request_body.data.voters_counts.poll_card_count = 100; // incorrect value
@@ -421,7 +424,7 @@ pub mod tests {
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_update_data_entry(pool: SqlitePool) {
         let request_body = example_data_entry();
         let response = save(pool.clone(), request_body.clone(), EntryNumber::FirstEntry).await;
@@ -449,7 +452,7 @@ pub mod tests {
         );
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_finalise_data_entry(pool: SqlitePool) {
         let request_body = example_data_entry();
 
@@ -459,7 +462,7 @@ pub mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_save_second_data_entry(pool: SqlitePool) {
         let request_body = example_data_entry();
 
@@ -489,7 +492,7 @@ pub mod tests {
         assert_eq!(row_count.count, 0);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_finalise_second_data_entry(pool: SqlitePool) {
         let request_body = example_data_entry();
 
@@ -524,7 +527,7 @@ pub mod tests {
     }
 
     // test creating first and different second data entry
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_first_second_data_entry_different(pool: SqlitePool) {
         // Save and finalise the first data entry
         let request_body = example_data_entry();
@@ -558,7 +561,7 @@ pub mod tests {
         assert_eq!(row_count.count, 0);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_polling_station_data_entry_delete(pool: SqlitePool) {
         // create data entry
         let request_body = example_data_entry();
@@ -573,7 +576,7 @@ pub mod tests {
         assert_eq!(status, DataEntryStatus::FirstEntryNotStarted);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_polling_station_data_entry_delete_nonexistent(pool: SqlitePool) {
         // check that deleting a non-existing data entry returns 404
         let response = polling_station_data_entry_delete(
@@ -586,7 +589,7 @@ pub mod tests {
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_data_entry_delete_finalised_not_possible(pool: SqlitePool) {
         for entry_number in 1..=2 {
             let entry_number = EntryNumber::try_from(entry_number).unwrap();

--- a/backend/src/data_entry/repository.rs
+++ b/backend/src/data_entry/repository.rs
@@ -1,11 +1,14 @@
 use axum::extract::FromRef;
 use sqlx::{query, query_as, types::Json, SqlitePool};
 
-use super::status::DataEntryStatus;
-use super::{PollingStation, PollingStationDataEntry, PollingStationResults};
-use crate::data_entry::{ElectionStatusResponseEntry, PollingStationResultsEntry};
-use crate::polling_station::repository::PollingStations;
-use crate::AppState;
+use super::{
+    status::DataEntryStatus, PollingStation, PollingStationDataEntry, PollingStationResults,
+};
+use crate::{
+    data_entry::{ElectionStatusResponseEntry, PollingStationResultsEntry},
+    polling_station::repository::PollingStations,
+    AppState,
+};
 
 pub struct PollingStationDataEntries(SqlitePool);
 

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -505,6 +505,7 @@ mod tests {
     use crate::data_entry::{CandidateVotes, PoliticalGroupVotes, VotersCounts, VotesCounts};
     use crate::election::{Candidate, Election, ElectionCategory, ElectionStatus, PoliticalGroup};
     use crate::polling_station::{PollingStation, PollingStationType};
+    use test_log::test;
 
     fn polling_station_result() -> PollingStationResults {
         PollingStationResults {

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -502,9 +502,11 @@ impl Default for DataEntryStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data_entry::{CandidateVotes, PoliticalGroupVotes, VotersCounts, VotesCounts};
-    use crate::election::{Candidate, Election, ElectionCategory, ElectionStatus, PoliticalGroup};
-    use crate::polling_station::{PollingStation, PollingStationType};
+    use crate::{
+        data_entry::{CandidateVotes, PoliticalGroupVotes, VotersCounts, VotesCounts},
+        election::{Candidate, Election, ElectionCategory, ElectionStatus, PoliticalGroup},
+        polling_station::{PollingStation, PollingStationType},
+    };
     use test_log::test;
 
     fn polling_station_result() -> PollingStationResults {

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -1,10 +1,7 @@
-use crate::data_entry::status::DataEntryStatus;
-use crate::error::ErrorReference;
-use crate::APIError;
+use crate::{data_entry::status::DataEntryStatus, error::ErrorReference, APIError};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::types::Json;
-use sqlx::FromRow;
+use sqlx::{types::Json, FromRow};
 use std::ops::AddAssign;
 use utoipa::ToSchema;
 

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -235,6 +235,7 @@ pub struct CandidateVotes {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_votes_addition() {

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -1,9 +1,11 @@
-use crate::data_entry::{
-    CandidateVotes, Count, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
-    VotersCounts, VotesCounts,
+use crate::{
+    data_entry::{
+        CandidateVotes, Count, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
+        VotersCounts, VotesCounts,
+    },
+    election::Election,
+    polling_station::PollingStation,
 };
-use crate::election::Election;
-use crate::polling_station::PollingStation;
 
 use std::fmt;
 
@@ -887,8 +889,9 @@ impl Validate for CandidateVotes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::election::tests::election_fixture;
-    use crate::polling_station::structs::tests::polling_station_fixture;
+    use crate::{
+        election::tests::election_fixture, polling_station::structs::tests::polling_station_fixture,
+    };
     use test_log::test;
 
     #[test]

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -889,6 +889,7 @@ mod tests {
     use super::*;
     use crate::election::tests::election_fixture;
     use crate::polling_station::structs::tests::polling_station_fixture;
+    use test_log::test;
 
     #[test]
     fn test_validation_result_append() {

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -1,26 +1,28 @@
-use axum::extract::{Path, State};
 #[cfg(feature = "dev-database")]
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Response},
+    Json,
+};
 use axum_extra::response::Attachment;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use zip::result::ZipError;
-use zip::write::SimpleFileOptions;
+use zip::{result::ZipError, write::SimpleFileOptions};
 
 use self::repository::Elections;
 pub use self::structs::*;
-use crate::data_entry::repository::PollingStationResultsEntries;
-use crate::data_entry::PollingStationResults;
-use crate::eml::axum::Eml;
-use crate::eml::{eml_document_hash, EMLDocument, EML510};
-use crate::pdf_gen::generate_pdf;
-use crate::pdf_gen::models::{ModelNa31_2Input, PdfModel};
-use crate::polling_station::repository::PollingStations;
-use crate::polling_station::structs::PollingStation;
-use crate::summary::ElectionSummary;
-use crate::{APIError, ErrorResponse};
+use crate::{
+    data_entry::{repository::PollingStationResultsEntries, PollingStationResults},
+    eml::{axum::Eml, eml_document_hash, EMLDocument, EML510},
+    pdf_gen::{
+        generate_pdf,
+        models::{ModelNa31_2Input, PdfModel},
+    },
+    polling_station::{repository::PollingStations, structs::PollingStation},
+    summary::ElectionSummary,
+    APIError, ErrorResponse,
+};
 
 pub(crate) mod repository;
 pub mod structs;

--- a/backend/src/election/structs.rs
+++ b/backend/src/election/structs.rs
@@ -102,8 +102,7 @@ pub enum CandidateGender {
 pub(crate) mod tests {
     use chrono::NaiveDate;
 
-    use crate::election::CandidateGender::X;
-    use crate::election::{Candidate, ElectionCategory, PoliticalGroup};
+    use crate::election::{Candidate, CandidateGender::X, ElectionCategory, PoliticalGroup};
 
     use super::*;
 

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -104,6 +104,7 @@ pub fn eml_document_hash(input: &str, chunked: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[derive(Debug, Serialize, Deserialize)]
     struct EmptyDoc {

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -603,6 +603,7 @@ impl CandidateIdentifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_eml510() {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,12 +1,15 @@
 use std::error::Error;
 
-use crate::authentication::AuthenticationError;
-use crate::data_entry::status::DataEntryTransitionError;
-use crate::data_entry::DataError;
-use axum::extract::rejection::JsonRejection;
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
+use crate::{
+    authentication::AuthenticationError,
+    data_entry::{status::DataEntryTransitionError, DataError},
+};
+use axum::{
+    extract::rejection::JsonRejection,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use hyper::header::InvalidHeaderValue;
 use quick_xml::SeError;
 use serde::{Deserialize, Serialize};

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,8 @@
-use axum::extract::FromRef;
-use axum::routing::{get, post};
-use axum::Router;
+use axum::{
+    extract::FromRef,
+    routing::{get, post},
+    Router,
+};
 #[cfg(feature = "memory-serve")]
 use memory_serve::MemoryServe;
 use sqlx::SqlitePool;

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -58,9 +58,8 @@ pub(crate) mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::election::ElectionStatus;
     use crate::{
-        election::{tests::election_fixture, Election, ElectionCategory},
+        election::{tests::election_fixture, Election, ElectionCategory, ElectionStatus},
         polling_station::{PollingStation, PollingStationType},
         summary::ElectionSummary,
     };

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -55,6 +55,7 @@ pub fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
 pub(crate) mod tests {
     use chrono::Utc;
     use models::ModelNa31_2Input;
+    use test_log::test;
 
     use super::*;
     use crate::election::ElectionStatus;

--- a/backend/src/pdf_gen/models/model_na_31_2.rs
+++ b/backend/src/pdf_gen/models/model_na_31_2.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::election::Election;
-use crate::polling_station::structs::PollingStation;
-use crate::summary::ElectionSummary;
+use crate::{
+    election::Election, polling_station::structs::PollingStation, summary::ElectionSummary,
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct ModelNa31_2Input {

--- a/backend/src/pdf_gen/world.rs
+++ b/backend/src/pdf_gen/world.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
 use super::models::PdfModel;
-use typst::utils::LazyHash;
 use typst::{
     diag::{FileError, FileResult},
     foundations::{Bytes, Datetime},
     syntax::{FileId, Source, VirtualPath},
     text::{Font, FontBook},
+    utils::LazyHash,
     Library, World,
 };
 

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -1,14 +1,15 @@
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use self::repository::PollingStations;
 pub use self::structs::*;
-use crate::election::repository::Elections;
-use crate::{APIError, ErrorResponse};
+use crate::{election::repository::Elections, APIError, ErrorResponse};
 
 pub mod repository;
 pub mod structs;
@@ -171,8 +172,9 @@ pub async fn polling_station_delete(
 #[cfg(test)]
 mod tests {
     use sqlx::{query, SqlitePool};
+    use test_log::test;
 
-    #[sqlx::test(fixtures(path = "../../fixtures", scripts("election_2", "election_3")))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2", "election_3"))))]
     async fn test_polling_station_number_unique_per_election(pool: SqlitePool) {
         query!("DELETE FROM polling_stations")
             .execute(&pool)

--- a/backend/src/polling_station/repository.rs
+++ b/backend/src/polling_station/repository.rs
@@ -1,8 +1,10 @@
 use axum::extract::FromRef;
 use sqlx::{query, query_as, SqlitePool};
 
-use crate::polling_station::structs::{PollingStation, PollingStationRequest};
-use crate::AppState;
+use crate::{
+    polling_station::structs::{PollingStation, PollingStationRequest},
+    AppState,
+};
 
 pub struct PollingStations(SqlitePool);
 

--- a/backend/src/summary/mod.rs
+++ b/backend/src/summary/mod.rs
@@ -228,6 +228,7 @@ mod tests {
     use super::*;
     use crate::election::tests::election_fixture;
     use crate::pdf_gen::tests::polling_stations_fixture;
+    use test_log::test;
 
     fn polling_station_results_fixture_a() -> PollingStationResults {
         PollingStationResults {

--- a/backend/src/summary/mod.rs
+++ b/backend/src/summary/mod.rs
@@ -226,8 +226,7 @@ impl SumCount {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::election::tests::election_fixture;
-    use crate::pdf_gen::tests::polling_stations_fixture;
+    use crate::{election::tests::election_fixture, pdf_gen::tests::polling_stations_fixture};
     use test_log::test;
 
     fn polling_station_results_fixture_a() -> PollingStationResults {

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -1,28 +1,29 @@
 #![cfg(test)]
 
-use backend::data_entry::status::DataEntryStatusName::*;
-use backend::data_entry::{
-    ElectionStatusResponse, ElectionStatusResponseEntry, GetDataEntryResponse,
-    SaveDataEntryResponse, ValidationResultCode,
+use backend::{
+    data_entry::{
+        status::DataEntryStatusName::*, ElectionStatusResponse, ElectionStatusResponseEntry,
+        GetDataEntryResponse, SaveDataEntryResponse, ValidationResultCode,
+    },
+    ErrorResponse,
 };
-use backend::ErrorResponse;
 use reqwest::{Response, StatusCode};
 use serde_json::json;
 use sqlx::SqlitePool;
-use std::collections::BTreeMap;
-use std::net::SocketAddr;
+use std::{collections::BTreeMap, net::SocketAddr};
+use test_log::test;
 use utils::serve_api;
 
 pub mod shared;
 pub mod utils;
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_data_entry_valid(pool: SqlitePool) {
     let addr = serve_api(pool.clone()).await;
     shared::create_and_finalise_data_entry(&addr, 1, 1).await;
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_data_entry_validation(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -136,7 +137,7 @@ async fn test_polling_station_data_entry_validation(pool: SqlitePool) {
     );
 }
 
-#[sqlx::test]
+#[test(sqlx::test)]
 async fn test_polling_station_data_entry_invalid(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -161,7 +162,7 @@ async fn test_polling_station_data_entry_invalid(pool: SqlitePool) {
     );
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_data_entry_only_for_existing(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -189,7 +190,7 @@ async fn test_polling_station_data_entry_only_for_existing(pool: SqlitePool) {
 }
 
 /// test that we can get a data entry after saving it
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_data_entry_get(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -223,17 +224,8 @@ async fn test_polling_station_data_entry_get(pool: SqlitePool) {
     );
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_data_entry_get_finalised(pool: SqlitePool) {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
-                .from_env()
-                .unwrap(),
-        )
-        .init();
-
     let addr = serve_api(pool.clone()).await;
     shared::create_and_finalise_data_entry(&addr, 1, 1).await;
 
@@ -243,7 +235,7 @@ async fn test_polling_station_data_entry_get_finalised(pool: SqlitePool) {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_data_entry_deletion(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -287,7 +279,7 @@ async fn get_statuses(addr: &SocketAddr) -> BTreeMap<u32, ElectionStatusResponse
         })
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_election_details_status(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -339,7 +331,7 @@ async fn test_election_details_status(pool: SqlitePool) {
     assert_eq!(statuses[&2].second_data_entry_progress, None);
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "election_3")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "election_3"))))]
 async fn test_election_details_status_no_other_election_statuses(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -1,17 +1,17 @@
 #![cfg(test)]
 
-use crate::shared::create_result;
-use crate::utils::serve_api;
+use crate::{shared::create_result, utils::serve_api};
 #[cfg(feature = "dev-database")]
 use backend::election::Election;
 use backend::election::{ElectionDetailsResponse, ElectionListResponse};
 use hyper::StatusCode;
 use sqlx::SqlitePool;
+use test_log::test;
 
 pub mod shared;
 pub mod utils;
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "election_3")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "election_3"))))]
 async fn test_election_list_works(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -26,7 +26,7 @@ async fn test_election_list_works(pool: SqlitePool) {
     assert_eq!(body.elections.len(), 2);
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_election_details_works(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -46,7 +46,7 @@ async fn test_election_details_works(pool: SqlitePool) {
         .any(|ps| ps.name == "Op Rolletjes"));
 }
 
-#[sqlx::test]
+#[test(sqlx::test)]
 #[cfg(feature = "dev-database")]
 async fn test_election_create_works(pool: SqlitePool) {
     let addr = serve_api(pool).await;
@@ -99,7 +99,7 @@ async fn test_election_create_works(pool: SqlitePool) {
     assert_eq!(body.name, "Test Election");
 }
 
-#[sqlx::test]
+#[test(sqlx::test)]
 async fn test_election_details_not_found(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -111,7 +111,7 @@ async fn test_election_details_not_found(pool: SqlitePool) {
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_election_pdf_download(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -136,7 +136,7 @@ async fn test_election_pdf_download(pool: SqlitePool) {
     assert!(content_disposition_string.contains(".pdf"));
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_election_xml_download(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -157,7 +157,7 @@ async fn test_election_xml_download(pool: SqlitePool) {
     assert!(body.contains("<ValidVotes>204</ValidVotes>"));
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_election_zip_download(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -2,18 +2,23 @@
 
 use reqwest::StatusCode;
 use sqlx::SqlitePool;
+use test_log::test;
 
-use crate::shared::{create_and_save_data_entry, create_result};
-use crate::utils::serve_api;
-use backend::polling_station::{
-    PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
+use crate::{
+    shared::{create_and_save_data_entry, create_result},
+    utils::serve_api,
 };
-use backend::ErrorResponse;
+use backend::{
+    polling_station::{
+        PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
+    },
+    ErrorResponse,
+};
 
 pub mod shared;
 pub mod utils;
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_listing(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -32,7 +37,7 @@ async fn test_polling_station_listing(pool: SqlitePool) {
         .any(|ps| ps.name == "Op Rolletjes"))
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_creation(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let election_id = 2;
@@ -67,7 +72,7 @@ async fn test_polling_station_creation(pool: SqlitePool) {
     );
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_get(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let election_id = 2;
@@ -86,7 +91,7 @@ async fn test_polling_station_get(pool: SqlitePool) {
     assert_eq!(body.polling_station_type, Some(PollingStationType::Special));
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_update_ok(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/elections/2/polling_stations/2");
@@ -122,7 +127,7 @@ async fn test_polling_station_update_ok(pool: SqlitePool) {
     assert_eq!(updated_body.address, "Teststraat 2a");
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_update_empty_type_ok(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/elections/2/polling_stations/2");
@@ -158,7 +163,7 @@ async fn test_polling_station_update_empty_type_ok(pool: SqlitePool) {
     assert_eq!(updated_body.polling_station_type, None);
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_update_not_found(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/elections/2/polling_stations/40404");
@@ -182,7 +187,7 @@ async fn test_polling_station_update_not_found(pool: SqlitePool) {
     assert_eq!(status, StatusCode::NOT_FOUND, "Unexpected response status");
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_delete_ok(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/elections/2/polling_stations/2");
@@ -201,7 +206,7 @@ async fn test_polling_station_delete_ok(pool: SqlitePool) {
     );
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_delete_with_data_entry_fails(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -220,7 +225,7 @@ async fn test_polling_station_delete_with_data_entry_fails(pool: SqlitePool) {
     assert_eq!(body.error, "Invalid data");
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_delete_with_results_fails(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -239,7 +244,7 @@ async fn test_polling_station_delete_with_results_fails(pool: SqlitePool) {
     assert_eq!(body.error, "Invalid data");
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_delete_not_found(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/elections/2/polling_stations/40404");
@@ -250,7 +255,7 @@ async fn test_polling_station_delete_not_found(pool: SqlitePool) {
     assert_eq!(status, StatusCode::NOT_FOUND, "Unexpected response status");
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_non_unique(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let election_id = 2;
@@ -275,7 +280,7 @@ async fn test_polling_station_non_unique(pool: SqlitePool) {
     assert_eq!(status, StatusCode::CONFLICT, "Unexpected response status");
 }
 
-#[sqlx::test(fixtures(path = "../fixtures", scripts("election_2")))]
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2"))))]
 async fn test_polling_station_list_invalid_election(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/elections/1234/polling_stations");

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -2,10 +2,10 @@
 
 use std::net::SocketAddr;
 
-use backend::data_entry::status::DataEntryStatusName;
 use backend::data_entry::{
-    status::ClientState, CandidateVotes, DataEntry, DifferencesCounts, ElectionStatusResponse,
-    PoliticalGroupVotes, PollingStationResults, SaveDataEntryResponse, VotersCounts, VotesCounts,
+    status::{ClientState, DataEntryStatusName},
+    CandidateVotes, DataEntry, DifferencesCounts, ElectionStatusResponse, PoliticalGroupVotes,
+    PollingStationResults, SaveDataEntryResponse, VotersCounts, VotesCounts,
 };
 use hyper::StatusCode;
 


### PR DESCRIPTION
Added the https://crates.io/crates/test-log crate to show tracing log messages while running tests.

Note that you should pass `--nocapture` or similar flag to show data written to stdout.

Test this by running: 

```sh
cd backend
cargo test -- --nocapture
```

And look for log messages (starting with INFO or ERROR).

