### PR TITLE
adds check that polling station number is larger than 0

### DIFF
--- a/frontend/app/component/form/polling_station/PollingStationForm.test.tsx
+++ b/frontend/app/component/form/polling_station/PollingStationForm.test.tsx
@@ -94,26 +94,28 @@ describe("PollingStationForm", () => {
       expect(onSaved).not.toHaveBeenCalled();
     });
 
-    test("Validation client errors", async () => {
-      const onSaved = vi.fn();
-      render(<PollingStationForm electionId={1} onSaved={onSaved} />);
+    test.each([["asd"], ["0"]])(
+      "Validation client error - invalid polling station number: %s",
+      async (pollingStationNumber) => {
+        const onSaved = vi.fn();
+        render(<PollingStationForm electionId={1} onSaved={onSaved} />);
 
-      const user = userEvent.setup();
+        const user = userEvent.setup();
 
-      const inputs = getInputs();
+        const inputs = getInputs();
 
-      await user.type(inputs.number, "abc");
-      await user.click(inputs.typeOptionFixedLocation);
+        await user.type(inputs.number, pollingStationNumber);
 
-      await user.click(screen.getByRole("button", { name: "Opslaan en toevoegen" }));
+        await user.click(screen.getByRole("button", { name: "Opslaan en toevoegen" }));
 
-      await waitFor(() => {
-        expect(inputs.number).toBeInvalid();
-        expect(inputs.number).toHaveAccessibleErrorMessage("Dit is geen getal. Voer een getal in");
-      });
+        await waitFor(() => {
+          expect(inputs.number).toBeInvalid();
+          expect(inputs.number).toHaveAccessibleErrorMessage("Dit is geen getal. Voer een getal in");
+        });
 
-      expect(onSaved).not.toHaveBeenCalled();
-    });
+        expect(onSaved).not.toHaveBeenCalled();
+      },
+    );
 
     test("Validation backend errors", async () => {
       const onSaved = vi.fn();

--- a/frontend/app/component/form/polling_station/PollingStationForm.tsx
+++ b/frontend/app/component/form/polling_station/PollingStationForm.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { isSuccess, PollingStation, PollingStationRequest, useCrud } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { Alert, Button, ChoiceList, Form, FormLayout, InputField } from "@kiesraad/ui";
-import { FormFields, useForm } from "@kiesraad/util";
+import { FormFields, useForm, ValidationError } from "@kiesraad/util";
 
 export interface PollingStationFormProps {
   electionId: number;
@@ -69,11 +69,11 @@ export function PollingStationForm({ electionId, pollingStation, onSaved, onCanc
 
   let numberFieldError;
   if (validationResult.number) {
-    validationResult.number =
+    const errorTextKey: ValidationError =
       validationResult.number === "FORM_VALIDATION_RESULT_MIN"
         ? "FORM_VALIDATION_RESULT_INVALID_NUMBER"
         : validationResult.number;
-    numberFieldError = t(`form_errors.${validationResult.number}`);
+    numberFieldError = t(`form_errors.${errorTextKey}`);
   } else if (isValid && requestState.status === "api-error" && requestState.error.reference === "EntryNotUnique") {
     numberFieldError = t("polling_station.form.not_unique.error");
   }

--- a/frontend/app/component/form/polling_station/PollingStationForm.tsx
+++ b/frontend/app/component/form/polling_station/PollingStationForm.tsx
@@ -21,7 +21,7 @@ interface Form extends HTMLFormElement {
 }
 
 const formFields: FormFields<PollingStationRequest> = {
-  number: { required: true, type: "number" },
+  number: { required: true, type: "number", min: 1 },
   name: { required: true, type: "string" },
   polling_station_type: { type: "string", mapUndefined: true },
   number_of_voters: { type: "number", isFormatted: true },
@@ -69,6 +69,10 @@ export function PollingStationForm({ electionId, pollingStation, onSaved, onCanc
 
   let numberFieldError;
   if (validationResult.number) {
+    validationResult.number =
+      validationResult.number === "FORM_VALIDATION_RESULT_MIN"
+        ? "FORM_VALIDATION_RESULT_INVALID_NUMBER"
+        : validationResult.number;
     numberFieldError = t(`form_errors.${validationResult.number}`);
   } else if (isValid && requestState.status === "api-error" && requestState.error.reference === "EntryNotUnique") {
     numberFieldError = t("polling_station.form.not_unique.error");


### PR DESCRIPTION
It was possible to create polling stations with a "nummer" that was `0` or negative. This PR adds validation to the front-end to stop that from happening:
![image](https://github.com/user-attachments/assets/cd88c957-99e4-428a-ad9a-c91515a1c9ce)

Note that I did have to override the `validationResult.number` from `form.ts` in `PollingStationForm.tsx`. Otherwise the error message would be "Waarde is te laag" instead of "Dit is geen getal. Voer een getal in".

closes #883 