### PR TITLE
Use relative paths for static assets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Abacus</title>
-    <link rel="icon" href="/static/favicon.svg" />
+    <link rel="icon" href="./static/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>

--- a/frontend/lib/ui/style/variables.css
+++ b/frontend/lib/ui/style/variables.css
@@ -1,22 +1,22 @@
 @font-face {
   font-family: "SpaceGrotesk";
-  src: url("/static/font/Space_Grotesk/SpaceGrotesk-VariableFont_wght.ttf") format("TrueType");
+  src: url("../../../static/font/Space_Grotesk/SpaceGrotesk-VariableFont_wght.ttf") format("TrueType");
 }
 
 @font-face {
   font-family: "DMSans";
-  src: url("/static/font/DM_Sans/DMSans-VariableFont_opsz,wght.ttf") format("TrueType");
+  src: url("../../../static/font/DM_Sans/DMSans-VariableFont_opsz,wght.ttf") format("TrueType");
   font-weight: 1 1000;
 }
 
 @font-face {
   font-family: "DMSansItalic";
-  src: url("/static/font/DM_Sans/DMSans-Italic-VariableFont_opsz,wght.ttf") format("TrueType");
+  src: url("../../../static/font/DM_Sans/DMSans-Italic-VariableFont_opsz,wght.ttf") format("TrueType");
 }
 
 @font-face {
   font-family: "GeistMono";
-  src: url("/static/font/Geist_Mono/GeistMono-Regular.otf") format("opentype");
+  src: url("../../../static/font/Geist_Mono/GeistMono-Regular.otf") format("opentype");
   font-feature-settings: "ss09" on;
 }
 

--- a/frontend/static/icon/hex.svg
+++ b/frontend/static/icon/hex.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
-  <polygon points="50,10 90,40 90,70 50,100 10,70 10,40" />
-</svg>


### PR DESCRIPTION
This fixes static assets in Ladle and also works in the regular build. It also removes the unused asset `hex.svg`.

To test: the Ladle build should have the correct fonts rendered (e.g. http://localhost:61000/ladle/?story=badge--all-badges, http://ladle-static-assets.kiesraad-abacus.pages.dev/ladle/?story=badge--all-badges) and the regular build should not show any changes.

Resolves #837