### PR TITLE
Rename backend to abacus

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,40 @@
 version = 3
 
 [[package]]
+name = "abacus"
+version = "0.1.0"
+dependencies = [
+ "argon2",
+ "axum",
+ "axum-extra",
+ "chrono",
+ "clap",
+ "cookie",
+ "http-body-util",
+ "hyper",
+ "memory-serve",
+ "password-hash",
+ "quick-xml 0.37.2",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "test-log",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "typst",
+ "typst-pdf",
+ "utoipa",
+ "utoipa-swagger-ui",
+ "zip",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,40 +326,6 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
-name = "backend"
-version = "0.1.0"
-dependencies = [
- "argon2",
- "axum",
- "axum-extra",
- "chrono",
- "clap",
- "cookie",
- "http-body-util",
- "hyper",
- "memory-serve",
- "password-hash",
- "quick-xml 0.37.2",
- "rand",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "sqlx",
- "test-log",
- "tokio",
- "tower",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "typst",
- "typst-pdf",
- "utoipa",
- "utoipa-swagger-ui",
- "zip",
-]
 
 [[package]]
 name = "backtrace"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "backend"
+name = "abacus"
 version = "0.1.0"
 edition = "2021"
 license = "EUPL-1.2"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "backend",
+    "title": "abacus",
     "description": "",
     "license": {
       "name": "EUPL-1.2",

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -1,7 +1,7 @@
-use axum::serve::ListenerExt;
 #[cfg(feature = "dev-database")]
-use backend::fixtures;
-use backend::router;
+use abacus::fixtures;
+use abacus::router;
+use axum::serve::ListenerExt;
 use clap::Parser;
 use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
 use std::{

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "dev-database")]
-use abacus::fixtures;
-use abacus::router;
+use abacus::{fixtures, router};
 use axum::serve::ListenerExt;
 use clap::Parser;
 use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "dev-database")]
-use abacus::{fixtures, router};
+use abacus::fixtures;
+use abacus::router;
 use axum::serve::ListenerExt;
 use clap::Parser;
 use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};

--- a/backend/src/bin/gen-openapi.rs
+++ b/backend/src/bin/gen-openapi.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use backend::create_openapi;
+use abacus::create_openapi;
 
 /// Write OpenAPI JSON documentation to `openapi.json`.
 fn main() {

--- a/backend/src/eml/util.rs
+++ b/backend/src/eml/util.rs
@@ -15,7 +15,7 @@
 ///
 /// ```
 /// mod example {
-///     # use backend::gen_wrap_list;
+///     # use abacus::gen_wrap_list;
 ///     #[derive(serde::Deserialize, serde::Serialize)]
 ///     pub struct Element {}
 ///

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use backend::{
+use abacus::{
     data_entry::{
         status::DataEntryStatusName::*, ElectionStatusResponse, ElectionStatusResponseEntry,
         GetDataEntryResponse, SaveDataEntryResponse, ValidationResultCode,

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -2,8 +2,8 @@
 
 use crate::{shared::create_result, utils::serve_api};
 #[cfg(feature = "dev-database")]
-use backend::election::Election;
-use backend::election::{ElectionDetailsResponse, ElectionListResponse};
+use abacus::election::Election;
+use abacus::election::{ElectionDetailsResponse, ElectionListResponse};
 use hyper::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -8,7 +8,7 @@ use crate::{
     shared::{create_and_save_data_entry, create_result},
     utils::serve_api,
 };
-use backend::{
+use abacus::{
     polling_station::{
         PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
     },

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddr;
 
-use backend::data_entry::{
+use abacus::data_entry::{
     status::{ClientState, DataEntryStatusName},
     CandidateVotes, DataEntry, DifferencesCounts, ElectionStatusResponse, PoliticalGroupVotes,
     PollingStationResults, SaveDataEntryResponse, VotersCounts, VotesCounts,

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -3,7 +3,7 @@
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 
-use backend::router;
+use abacus::router;
 use sqlx::SqlitePool;
 
 pub async fn serve_api(pool: SqlitePool) -> SocketAddr {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,7 @@ pre-commit:
     backend-openapi:
       root: "backend/"
       glob: "*.rs"
-      run: cargo run --package backend --bin gen-openapi && git add openapi.json
+      run: cargo run --package abacus --bin gen-openapi && git add openapi.json
     frontend-formatter:
       root: "frontend/"
       run: npx prettier --ignore-unknown --write {staged_files}


### PR DESCRIPTION
- This renames the backend crate from `backend` to `abacus`, which is a better name for what our crate actually is.
- This allows filtering log messages on `RUST_LOG=abacus=trace` to only show trace messages for abacus (in contrast to `RUST_LOG=trace` which would show trace level log messages for all crates we rely on as well), instead of having to use the somewhat unintuitive `RUST_LOG=backend=trace`.
- No changes in the frontend should be needed for this change. Almost everything stays the way it was, just some updated imports.