### PR TITLE
Move breadcrumbs/links logic into `NavBar`

### DIFF
--- a/frontend/app/component/navbar/NavBar.module.css
+++ b/frontend/app/component/navbar/NavBar.module.css
@@ -35,8 +35,7 @@
       gap: 0.25rem;
     }
 
-    > a:first-of-type:not(:global(.active)),
-    > span:first-of-type:not(:global(.active)) {
+    :first-child:not(:global(.active)) {
       padding-left: 0;
     }
 

--- a/frontend/app/component/navbar/NavBar.module.css
+++ b/frontend/app/component/navbar/NavBar.module.css
@@ -39,7 +39,7 @@
       padding-left: 0;
     }
 
-    > span:global(.active) {
+    > :global(.active) {
       border-bottom: 4px solid var(--accent-orange);
       padding-bottom: calc(0.5rem - 4px);
       font-weight: bold;

--- a/frontend/app/component/navbar/NavBar.stories.tsx
+++ b/frontend/app/component/navbar/NavBar.stories.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import { Story } from "@ladle/react";
+import { electionDetailsMockResponse } from "lib/api-mocks/ElectionMockData";
+import { ElectionProviderContext } from "lib/api/election/ElectionProviderContext";
+
+import { Election } from "@kiesraad/api";
+
+import { NavBar } from "./NavBar";
+
+export default {
+  title: "App / Navigation bar",
+};
+
+const locations = [
+  { pathname: "/account/login", hash: "" },
+  { pathname: "/account/setup", hash: "" },
+  { pathname: "/elections", hash: "" },
+  { pathname: "/elections/1", hash: "" },
+  { pathname: "/elections/1/data-entry", hash: "" },
+  { pathname: "/elections/1/data-entry/1/1", hash: "" },
+  { pathname: "/elections/1/data-entry/1/1/recounted", hash: "" },
+  { pathname: "/elections/1/data-entry/1/1/voters-and-votes", hash: "" },
+  { pathname: "/elections/1/data-entry/1/1/list/1", hash: "" },
+  { pathname: "/elections/1/data-entry/1/1/save", hash: "" },
+  { pathname: "/dev", hash: "" },
+  { pathname: "/elections", hash: "#administratorcoordinator" },
+  { pathname: "/users", hash: "#administratorcoordinator" },
+  { pathname: "/workstations", hash: "#administrator" },
+  { pathname: "/logs", hash: "#administratorcoordinator" },
+  { pathname: "/elections/1", hash: "#administratorcoordinator" },
+  { pathname: "/elections/1/report", hash: "#administratorcoordinator" },
+  { pathname: "/elections/1/status", hash: "#administratorcoordinator" },
+  { pathname: "/elections/1/polling-stations", hash: "#administratorcoordinator" },
+  { pathname: "/elections/1/polling-stations/create", hash: "#administratorcoordinator" },
+  { pathname: "/elections/1/polling-stations/1/update", hash: "#administratorcoordinator" },
+];
+
+export const AllRoutes: Story = () => (
+  <ElectionProviderContext.Provider
+    value={{
+      election: electionDetailsMockResponse.election as Required<Election>,
+      pollingStations: electionDetailsMockResponse.polling_stations,
+    }}
+  >
+    {locations.map((location) => (
+      <React.Fragment key={location.pathname + location.hash}>
+        <code>
+          {location.pathname}
+          {location.hash}
+        </code>
+        <NavBar location={location} />
+        <br />
+      </React.Fragment>
+    ))}
+  </ElectionProviderContext.Provider>
+);

--- a/frontend/app/component/navbar/NavBar.test.tsx
+++ b/frontend/app/component/navbar/NavBar.test.tsx
@@ -69,44 +69,18 @@ describe("NavBar", () => {
     expect(screen.queryByText("Gemeenteraadsverkiezingen 2026")).toBeVisible();
   });
 
-  test("top level management links for '/elections'", async () => {
+  test.each([
+    { pathname: "/elections", hash: "#administratorcoordinator" },
+    { pathname: "/users", hash: "#administratorcoordinator" },
+    { pathname: "/workstations", hash: "#administratorcoordinator" },
+    { pathname: "/logs", hash: "#administratorcoordinator" },
+  ])("top level management links for $pathname", async () => {
     await renderNavBar({ pathname: "/elections", hash: "#administratorcoordinator" });
 
-    expect(screen.queryByRole("link", { name: "Verkiezingen" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Verkiezingen")).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Gebruikers" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Werkplekken" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
-  });
-
-  test("top level management links for '/users'", async () => {
-    await renderNavBar({ pathname: "/users", hash: "#administratorcoordinator" });
-
-    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Gebruikers" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Gebruikers")).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Werkplekken" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
-  });
-
-  test("top level management links for '/workstations'", async () => {
-    await renderNavBar({ pathname: "/workstations", hash: "#administrator" });
-
-    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Gebruikers" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Werkplekken" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Werkplekken")).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
-  });
-
-  test("top level management links for '/logs'", async () => {
-    await renderNavBar({ pathname: "/logs", hash: "#administratorcoordinator" });
-
     expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
     expect(screen.queryByRole("link", { name: "Gebruikers" })).toBeVisible();
     expect(screen.queryByRole("link", { name: "Werkplekken" })).toBeVisible();
-    expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Logs")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
   });
 
   test.each([

--- a/frontend/app/component/navbar/NavBar.test.tsx
+++ b/frontend/app/component/navbar/NavBar.test.tsx
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { ElectionProvider } from "@kiesraad/api";
+import { ElectionRequestHandler } from "@kiesraad/api-mocks";
+import { render, screen, server } from "@kiesraad/test";
+
+import { NavBar } from "./NavBar";
+
+async function renderNavBar(location: { pathname: string; hash: string }) {
+  render(
+    <ElectionProvider electionId={1}>
+      <NavBar location={location} />
+    </ElectionProvider>,
+  );
+
+  // wait for the NavBar to be rendered
+  expect(await screen.findByLabelText("primary-navigation")).toBeInTheDocument();
+}
+
+describe("NavBar", () => {
+  beforeEach(() => {
+    server.use(ElectionRequestHandler);
+  });
+
+  test.each([
+    { pathname: "/account/login", hash: "" },
+    { pathname: "/account/setup", hash: "" },
+    { pathname: "/elections", hash: "" },
+    { pathname: "/invalid-notfound", hash: "" },
+  ])("no links for $pathname", async (location) => {
+    await renderNavBar(location);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  test("elections link and current election name for '/elections/1/data-entry'", async () => {
+    await renderNavBar({ pathname: "/elections/1/data-entry", hash: "" });
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
+    expect(
+      screen.queryByRole("link", { name: "Heemdamseburg — Gemeenteraadsverkiezingen 2026" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText("Heemdamseburg")).toBeVisible();
+    expect(screen.queryByText("Gemeenteraadsverkiezingen 2026")).toBeVisible();
+  });
+
+  test.each([
+    { pathname: "/elections/1/data-entry/1/1", hash: "" },
+    { pathname: "/elections/1/data-entry/1/1/recounted", hash: "" },
+    { pathname: "/elections/1/data-entry/1/1/voters-and-votes", hash: "" },
+    { pathname: "/elections/1/data-entry/1/1/list/1", hash: "" },
+    { pathname: "/elections/1/data-entry/1/1/save", hash: "" },
+  ])("elections link and current election link for $pathname", async (location) => {
+    await renderNavBar(location);
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Heemdamseburg — Gemeenteraadsverkiezingen 2026" })).toBeVisible();
+  });
+
+  test("current election name for '/elections/1'", async () => {
+    await renderNavBar({ pathname: "/elections/1", hash: "" });
+
+    expect(
+      screen.queryByRole("link", { name: "Heemdamseburg — Gemeenteraadsverkiezingen 2026" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText("Heemdamseburg")).toBeVisible();
+    expect(screen.queryByText("Gemeenteraadsverkiezingen 2026")).toBeVisible();
+  });
+
+  test("top level management links for '/elections'", async () => {
+    await renderNavBar({ pathname: "/elections", hash: "#administratorcoordinator" });
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Verkiezingen")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Gebruikers" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Werkplekken" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
+  });
+
+  test("top level management links for '/users'", async () => {
+    await renderNavBar({ pathname: "/users", hash: "#administratorcoordinator" });
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Gebruikers" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Gebruikers")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Werkplekken" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
+  });
+
+  test("top level management links for '/workstations'", async () => {
+    await renderNavBar({ pathname: "/workstations", hash: "#administrator" });
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Gebruikers" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Werkplekken" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Werkplekken")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Logs" })).toBeVisible();
+  });
+
+  test("top level management links for '/logs'", async () => {
+    await renderNavBar({ pathname: "/logs", hash: "#administratorcoordinator" });
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Gebruikers" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Werkplekken" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Logs")).toBeVisible();
+  });
+
+  test.each([
+    { pathname: "/elections/1/report", hash: "#administratorcoordinator" },
+    { pathname: "/elections/1/status", hash: "#administratorcoordinator" },
+    { pathname: "/elections/1/polling-stations", hash: "#administratorcoordinator" },
+  ])("election management links for $pathname", async (location) => {
+    await renderNavBar(location);
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Heemdamseburg — Gemeenteraadsverkiezingen 2026" })).toBeVisible();
+  });
+
+  test.each([
+    { pathname: "/elections/1/polling-stations/create", hash: "#administratorcoordinator" },
+    { pathname: "/elections/1/polling-stations/1/update", hash: "#administratorcoordinator" },
+  ])("polling station management links for $pathname", async (location) => {
+    await renderNavBar(location);
+
+    expect(screen.queryByRole("link", { name: "Verkiezingen" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Heemdamseburg — Gemeenteraadsverkiezingen 2026" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Stembureaus" })).toBeVisible();
+  });
+});

--- a/frontend/app/component/navbar/NavBar.tsx
+++ b/frontend/app/component/navbar/NavBar.tsx
@@ -4,9 +4,9 @@ import { IconUser } from "@kiesraad/icon";
 import styles from "./NavBar.module.css";
 import { NavBarLinks } from "./NavBarLinks";
 
-type NavBarProps = { location?: { pathname: string; hash: string } };
+type NavBarProps = { location: { pathname: string; hash: string } };
 
-export function NavBar({ location = window.location }: NavBarProps) {
+export function NavBar({ location }: NavBarProps) {
   const isAdministrator = location.hash.includes("administrator");
   const isCoordinator = location.hash.includes("coordinator");
 

--- a/frontend/app/component/navbar/NavBar.tsx
+++ b/frontend/app/component/navbar/NavBar.tsx
@@ -4,7 +4,9 @@ import { IconUser } from "@kiesraad/icon";
 import styles from "./NavBar.module.css";
 import { NavBarLinks } from "./NavBarLinks";
 
-export function NavBar({ showLinks = true }) {
+type NavBarProps = { location?: { pathname: string; hash: string } };
+
+export function NavBar({ location = window.location }: NavBarProps) {
   const isAdministrator = location.hash.includes("administrator");
   const isCoordinator = location.hash.includes("coordinator");
 
@@ -22,7 +24,9 @@ export function NavBar({ showLinks = true }) {
 
   return (
     <nav aria-label="primary-navigation" className={styles.navBar}>
-      <div className={styles.links}>{showLinks && <NavBarLinks />}</div>
+      <div className={styles.links}>
+        <NavBarLinks location={location} />
+      </div>
       <div className={styles.userInfo}>
         <IconUser />
         <span>{role.join("/")}</span>

--- a/frontend/app/component/navbar/NavBar.tsx
+++ b/frontend/app/component/navbar/NavBar.tsx
@@ -1,16 +1,14 @@
-import * as React from "react";
-
 import { t } from "@kiesraad/i18n";
 import { IconUser } from "@kiesraad/icon";
 
 import styles from "./NavBar.module.css";
+import { NavBarLinks } from "./NavBarLinks";
 
-export function NavBar({ children }: { children?: React.ReactNode }) {
+export function NavBar({ showLinks = true }) {
   const isAdministrator = location.hash.includes("administrator");
   const isCoordinator = location.hash.includes("coordinator");
 
   const role = [];
-
   if (isAdministrator || isCoordinator) {
     if (isAdministrator) {
       role.push(t("administrator"));
@@ -24,7 +22,7 @@ export function NavBar({ children }: { children?: React.ReactNode }) {
 
   return (
     <nav aria-label="primary-navigation" className={styles.navBar}>
-      <div className={styles.links}>{children}</div>
+      <div className={styles.links}>{showLinks && <NavBarLinks />}</div>
       <div className={styles.userInfo}>
         <IconUser />
         <span>{role.join("/")}</span>

--- a/frontend/app/component/navbar/NavBarLinks.tsx
+++ b/frontend/app/component/navbar/NavBarLinks.tsx
@@ -1,0 +1,149 @@
+import { Link, useLocation } from "react-router";
+
+import { Election, useElection } from "@kiesraad/api";
+import { t } from "@kiesraad/i18n";
+import { IconChevronRight } from "@kiesraad/icon";
+
+function ElectionBreadcrumb({ election }: { election: Election }) {
+  return (
+    <>
+      <span className="bold">{election.location}</span>
+      <span>&mdash;</span>
+      <span>{election.name}</span>
+    </>
+  );
+}
+
+function DataEntryLinks() {
+  const location = useLocation();
+  const { election } = useElection();
+
+  return (
+    <>
+      <Link to={"/elections"}>{t("election.title.plural")}</Link>
+      <IconChevronRight />
+      {location.pathname.includes("/data-entry/") ? (
+        // Within the data entry, link back to the polling station choice page
+        <Link to={`/elections/${election.id}/data-entry`}>
+          <ElectionBreadcrumb election={election} />
+        </Link>
+      ) : (
+        // On the polling station choice page, display the election breadcrumb without linking
+        <span>
+          <ElectionBreadcrumb election={election} />
+        </span>
+      )}
+    </>
+  );
+}
+
+function ElectionManagementLinks() {
+  const location = useLocation();
+  const { election } = useElection();
+
+  // TODO: Add left side menu, #920
+
+  if (location.pathname.match(/^\/elections\/\d+\/?$/)) {
+    return (
+      <span>
+        <ElectionBreadcrumb election={election} />
+      </span>
+    );
+  } else {
+    return (
+      <>
+        <Link to={`/elections/${election.id}#administratorcoordinator`}>
+          <ElectionBreadcrumb election={election} />
+        </Link>
+        {location.pathname.match(/^\/elections\/\d+\/polling-stations\/\d+\//) && (
+          <>
+            <IconChevronRight />
+            <Link to={`/elections/${election.id}/polling-stations`}>{t("polling_stations")}</Link>
+          </>
+        )}
+      </>
+    );
+  }
+}
+
+function TopLevelManagementLinks() {
+  const location = useLocation();
+
+  const links = [];
+  if (location.pathname.startsWith("/elections")) {
+    links.push(
+      <span key="elections" className="active">
+        {t("election.title.plural")}
+      </span>,
+    );
+  } else {
+    links.push(
+      <Link key="elections-link" to={`/elections#administratorcoordinator`}>
+        {t("election.title.plural")}
+      </Link>,
+    );
+  }
+  if (location.pathname.startsWith("/users")) {
+    links.push(
+      <span key="users" className="active">
+        {t("users")}
+      </span>,
+    );
+  } else {
+    links.push(
+      <Link key="users-link" to={`/users#administratorcoordinator`}>
+        {t("users")}
+      </Link>,
+    );
+  }
+  if (location.pathname.startsWith("/workstations")) {
+    links.push(
+      <span key="workstations" className="active">
+        {t("workstations.workstations")}
+      </span>,
+    );
+  } else {
+    links.push(
+      <Link key="workstations-link" to={`/workstations#administrator`}>
+        {t("workstations.workstations")}
+      </Link>,
+    );
+  }
+  if (location.pathname.startsWith("/logs")) {
+    links.push(
+      <span key="logs" className="active">
+        {t("logs")}
+      </span>,
+    );
+  } else {
+    links.push(
+      <Link key="logs-link" to={`/logs#administratorcoordinator`}>
+        {t("logs")}
+      </Link>,
+    );
+  }
+
+  return <>{links}</>;
+}
+
+export function NavBarLinks() {
+  const location = useLocation();
+
+  const isAdministrator = location.hash.includes("administrator");
+  const isCoordinator = location.hash.includes("coordinator");
+
+  if (location.pathname.match(/^\/elections\/\d+\/data-entry/)) {
+    return <DataEntryLinks />;
+  } else if (location.pathname.match(/^\/elections\/\d+/)) {
+    return <ElectionManagementLinks />;
+  } else if (
+    (location.pathname === "/elections" && (isAdministrator || isCoordinator)) ||
+    location.pathname === "/users" ||
+    location.pathname === "/workstations" ||
+    location.pathname === "/logs"
+  ) {
+    return <TopLevelManagementLinks />;
+  } else {
+    return <></>;
+  }
+}

--- a/frontend/app/component/navbar/NavBarLinks.tsx
+++ b/frontend/app/component/navbar/NavBarLinks.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link, NavLink } from "react-router";
 
 import { Election, useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -66,62 +66,15 @@ function ElectionManagementLinks({ location }: NavBarLinksProps) {
   }
 }
 
-function TopLevelManagementLinks({ location }: NavBarLinksProps) {
-  const links = [];
-  if (location.pathname.startsWith("/elections")) {
-    links.push(
-      <span key="elections" className="active">
-        {t("election.title.plural")}
-      </span>,
-    );
-  } else {
-    links.push(
-      <Link key="elections-link" to={`/elections#administratorcoordinator`}>
-        {t("election.title.plural")}
-      </Link>,
-    );
-  }
-  if (location.pathname.startsWith("/users")) {
-    links.push(
-      <span key="users" className="active">
-        {t("users")}
-      </span>,
-    );
-  } else {
-    links.push(
-      <Link key="users-link" to={`/users#administratorcoordinator`}>
-        {t("users")}
-      </Link>,
-    );
-  }
-  if (location.pathname.startsWith("/workstations")) {
-    links.push(
-      <span key="workstations" className="active">
-        {t("workstations.workstations")}
-      </span>,
-    );
-  } else {
-    links.push(
-      <Link key="workstations-link" to={`/workstations#administrator`}>
-        {t("workstations.workstations")}
-      </Link>,
-    );
-  }
-  if (location.pathname.startsWith("/logs")) {
-    links.push(
-      <span key="logs" className="active">
-        {t("logs")}
-      </span>,
-    );
-  } else {
-    links.push(
-      <Link key="logs-link" to={`/logs#administratorcoordinator`}>
-        {t("logs")}
-      </Link>,
-    );
-  }
-
-  return <>{links}</>;
+function TopLevelManagementLinks() {
+  return (
+    <>
+      <NavLink to={"/elections"}>{t("election.title.plural")}</NavLink>
+      <NavLink to={"/users"}>{t("users")}</NavLink>
+      <NavLink to={"/workstations"}>{t("workstations.workstations")}</NavLink>
+      <NavLink to={"/logs"}>{t("logs")}</NavLink>
+    </>
+  );
 }
 
 export function NavBarLinks({ location }: NavBarLinksProps) {
@@ -138,7 +91,7 @@ export function NavBarLinks({ location }: NavBarLinksProps) {
     location.pathname === "/workstations" ||
     location.pathname === "/logs"
   ) {
-    return <TopLevelManagementLinks location={location} />;
+    return <TopLevelManagementLinks />;
   } else {
     return <></>;
   }

--- a/frontend/app/component/navbar/NavBarLinks.tsx
+++ b/frontend/app/component/navbar/NavBarLinks.tsx
@@ -69,10 +69,10 @@ function ElectionManagementLinks({ location }: NavBarLinksProps) {
 function TopLevelManagementLinks() {
   return (
     <>
-      <NavLink to={"/elections"}>{t("election.title.plural")}</NavLink>
-      <NavLink to={"/users"}>{t("users")}</NavLink>
-      <NavLink to={"/workstations"}>{t("workstations.workstations")}</NavLink>
-      <NavLink to={"/logs"}>{t("logs")}</NavLink>
+      <NavLink to={"/elections#administrator"}>{t("election.title.plural")}</NavLink>
+      <NavLink to={"/users#administratorcoordinator"}>{t("users")}</NavLink>
+      <NavLink to={"/workstations#administrator"}>{t("workstations.workstations")}</NavLink>
+      <NavLink to={"/logs#administratorcoordinator"}>{t("logs")}</NavLink>
     </>
   );
 }

--- a/frontend/app/component/navbar/NavBarLinks.tsx
+++ b/frontend/app/component/navbar/NavBarLinks.tsx
@@ -1,8 +1,10 @@
-import { Link, useLocation } from "react-router";
+import { Link } from "react-router";
 
 import { Election, useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { IconChevronRight } from "@kiesraad/icon";
+
+type NavBarLinksProps = { location: { pathname: string; hash: string } };
 
 function ElectionBreadcrumb({ election }: { election: Election }) {
   return (
@@ -14,8 +16,7 @@ function ElectionBreadcrumb({ election }: { election: Election }) {
   );
 }
 
-function DataEntryLinks() {
-  const location = useLocation();
+function DataEntryLinks({ location }: NavBarLinksProps) {
   const { election } = useElection();
 
   return (
@@ -37,8 +38,7 @@ function DataEntryLinks() {
   );
 }
 
-function ElectionManagementLinks() {
-  const location = useLocation();
+function ElectionManagementLinks({ location }: NavBarLinksProps) {
   const { election } = useElection();
 
   // TODO: Add left side menu, #920
@@ -55,7 +55,7 @@ function ElectionManagementLinks() {
         <Link to={`/elections/${election.id}#administratorcoordinator`}>
           <ElectionBreadcrumb election={election} />
         </Link>
-        {location.pathname.match(/^\/elections\/\d+\/polling-stations\/\d+\//) && (
+        {location.pathname.match(/^\/elections\/\d+\/polling-stations\/(create|\d+\/update)$/) && (
           <>
             <IconChevronRight />
             <Link to={`/elections/${election.id}/polling-stations`}>{t("polling_stations")}</Link>
@@ -66,9 +66,7 @@ function ElectionManagementLinks() {
   }
 }
 
-function TopLevelManagementLinks() {
-  const location = useLocation();
-
+function TopLevelManagementLinks({ location }: NavBarLinksProps) {
   const links = [];
   if (location.pathname.startsWith("/elections")) {
     links.push(
@@ -126,23 +124,21 @@ function TopLevelManagementLinks() {
   return <>{links}</>;
 }
 
-export function NavBarLinks() {
-  const location = useLocation();
-
+export function NavBarLinks({ location }: NavBarLinksProps) {
   const isAdministrator = location.hash.includes("administrator");
   const isCoordinator = location.hash.includes("coordinator");
 
   if (location.pathname.match(/^\/elections\/\d+\/data-entry/)) {
-    return <DataEntryLinks />;
+    return <DataEntryLinks location={location} />;
   } else if (location.pathname.match(/^\/elections\/\d+/)) {
-    return <ElectionManagementLinks />;
+    return <ElectionManagementLinks location={location} />;
   } else if (
     (location.pathname === "/elections" && (isAdministrator || isCoordinator)) ||
     location.pathname === "/users" ||
     location.pathname === "/workstations" ||
     location.pathname === "/logs"
   ) {
-    return <TopLevelManagementLinks />;
+    return <TopLevelManagementLinks location={location} />;
   } else {
     return <></>;
   }

--- a/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
+++ b/frontend/app/component/pollingstation/PollingStationFormNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render as rtlRender, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
 import { defaultFormState, emptyDataEntryRequest } from "app/component/form/testHelperFunctions";
@@ -51,7 +51,7 @@ describe("PollingStationFormNavigation", () => {
       location: { pathname: "/elections/1/data-entry/1/1" },
     });
 
-    render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
+    rtlRender(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
 
     const shouldBlock = mocks.useBlocker.mock.lastCall;
     if (Array.isArray(shouldBlock)) {
@@ -105,7 +105,7 @@ describe("PollingStationFormNavigation", () => {
       location: { pathname: "/elections/1/data-entry/1/1" },
     });
 
-    render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
+    rtlRender(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
 
     const shouldBlock = mocks.useBlocker.mock.lastCall;
     if (Array.isArray(shouldBlock)) {
@@ -154,7 +154,7 @@ describe("PollingStationFormNavigation", () => {
 
     mocks.useBlocker.mockReturnValue({ state: "unblocked" });
 
-    render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
+    rtlRender(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
 
     const feedbackServerError = await screen.findByTestId("error-modal");
     expect(feedbackServerError).toHaveTextContent("De JSON is niet geldig");
@@ -181,7 +181,7 @@ describe("PollingStationFormNavigation", () => {
 
     mocks.useBlocker.mockReturnValue({ state: "unblocked" });
 
-    render(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
+    rtlRender(<PollingStationFormNavigation pollingStationId={1} election={electionMockData} />);
 
     const feedbackServerError = await screen.findByTestId("error-modal");
 

--- a/frontend/app/module/AdministratorLayout.tsx
+++ b/frontend/app/module/AdministratorLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 
 import { Footer } from "app/component/footer/Footer";
 
@@ -7,9 +7,10 @@ import { AppLayout } from "@kiesraad/ui";
 import { NavBar } from "../component/navbar/NavBar";
 
 export function AdministratorLayout() {
+  const location = useLocation();
   return (
     <AppLayout>
-      <NavBar />
+      <NavBar location={location} />
       <Outlet />
       <Footer />
     </AppLayout>

--- a/frontend/app/module/AdministratorLayout.tsx
+++ b/frontend/app/module/AdministratorLayout.tsx
@@ -4,9 +4,12 @@ import { Footer } from "app/component/footer/Footer";
 
 import { AppLayout } from "@kiesraad/ui";
 
+import { NavBar } from "../component/navbar/NavBar";
+
 export function AdministratorLayout() {
   return (
     <AppLayout>
+      <NavBar />
       <Outlet />
       <Footer />
     </AppLayout>

--- a/frontend/app/module/DevHomePage.tsx
+++ b/frontend/app/module/DevHomePage.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router";
 
 import { MockTest } from "app/component/MockTest";
-import { NavBar } from "app/component/navbar/NavBar";
 
 import { ElectionListProvider, useElectionList } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -84,7 +83,6 @@ export function DevHomePage() {
   return (
     <AppLayout>
       <PageTitle title="Dev Homepage - Abacus" />
-      <NavBar />
       <header>
         <section>
           <h1>Abacus 🧮</h1>

--- a/frontend/app/module/FatalErrorPage.tsx
+++ b/frontend/app/module/FatalErrorPage.tsx
@@ -17,7 +17,8 @@ interface FatalErrorPageProps {
 export function FatalErrorPage({ message, code, reference, error }: FatalErrorPageProps) {
   return (
     <AppLayout>
-      <NavBar />
+      {/* Do not show NavBar links to avoid call to useElection outside ElectionProvider */}
+      <NavBar showLinks={false} />
       <Error title={t("error.title")} error={error}>
         {(code || reference) && (
           <p>

--- a/frontend/app/module/FatalErrorPage.tsx
+++ b/frontend/app/module/FatalErrorPage.tsx
@@ -17,8 +17,8 @@ interface FatalErrorPageProps {
 export function FatalErrorPage({ message, code, reference, error }: FatalErrorPageProps) {
   return (
     <AppLayout>
-      {/* Do not show NavBar links to avoid call to useElection outside ElectionProvider */}
-      <NavBar showLinks={false} />
+      {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
+      <NavBar location={{ pathname: "/", hash: "" }} />
       <Error title={t("error.title")} error={error}>
         {(code || reference) && (
           <p>

--- a/frontend/app/module/NotAvailableInMock.tsx
+++ b/frontend/app/module/NotAvailableInMock.tsx
@@ -1,8 +1,4 @@
-import { Link } from "react-router";
-
-import { NavBar } from "app/component/navbar/NavBar";
-
-import { t, tx } from "@kiesraad/i18n";
+import { tx } from "@kiesraad/i18n";
 import { PageTitle } from "@kiesraad/ui";
 
 interface NotAvailableInMockProps {
@@ -13,9 +9,6 @@ export function NotAvailableInMock({ title }: NotAvailableInMockProps) {
   return (
     <>
       {title && <PageTitle title={title} />}
-      <NavBar>
-        <Link to={"/overview"}>{t("overview")}</Link>
-      </NavBar>
       <main>
         <article>
           {tx("messages.not_available_in_mock", {

--- a/frontend/app/module/NotFoundPage.tsx
+++ b/frontend/app/module/NotFoundPage.tsx
@@ -13,8 +13,8 @@ export interface NotFoundPageProps {
 export function NotFoundPage({ message, path }: NotFoundPageProps) {
   return (
     <AppLayout>
-      {/* Do not show NavBar links to avoid call to useElection outside ElectionProvider */}
-      <NavBar showLinks={false} />
+      {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
+      <NavBar location={{ pathname: "/", hash: "" }} />
       <Error title={t(message)}>
         {path && <p>{tx("error.page_not_found", undefined, { path })}</p>}
         <p>{t("error.not_found_feedback")}</p>

--- a/frontend/app/module/NotFoundPage.tsx
+++ b/frontend/app/module/NotFoundPage.tsx
@@ -13,7 +13,8 @@ export interface NotFoundPageProps {
 export function NotFoundPage({ message, path }: NotFoundPageProps) {
   return (
     <AppLayout>
-      <NavBar />
+      {/* Do not show NavBar links to avoid call to useElection outside ElectionProvider */}
+      <NavBar showLinks={false} />
       <Error title={t(message)}>
         {path && <p>{tx("error.page_not_found", undefined, { path })}</p>}
         <p>{t("error.not_found_feedback")}</p>

--- a/frontend/app/module/account/LoginLayout.tsx
+++ b/frontend/app/module/account/LoginLayout.tsx
@@ -1,13 +1,15 @@
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 
 import { NavBar } from "app/component/navbar/NavBar";
 
 import { AppLayout } from "@kiesraad/ui";
 
 export function LoginLayout() {
+  const location = useLocation();
+
   return (
     <AppLayout>
-      <NavBar />
+      <NavBar location={location} />
       <Outlet />
     </AppLayout>
   );

--- a/frontend/app/module/data_entry/page/DataEntryHomePage.test.tsx
+++ b/frontend/app/module/data_entry/page/DataEntryHomePage.test.tsx
@@ -40,10 +40,6 @@ describe("DataEntryHomePage", () => {
         name: electionDetailsMockResponse.election.name,
       }),
     );
-
-    // Check if the navigation bar displays the correct information
-    const nav = await screen.findByRole("navigation", { name: /primary-navigation/i });
-    expect(within(nav).getByRole("link", { name: "Overzicht" })).toHaveAttribute("href", "/elections");
   });
 
   test("Alert not visible when not finished", async () => {

--- a/frontend/app/module/data_entry/page/DataEntryHomePage.tsx
+++ b/frontend/app/module/data_entry/page/DataEntryHomePage.tsx
@@ -1,10 +1,9 @@
 import { useEffect } from "react";
-import { Link, useLocation, useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { ElectionProgress } from "app/component/election/ElectionProgress";
 import { Footer } from "app/component/footer/Footer";
 import { PollingStationChoiceForm } from "app/component/form/data_entry/polling_station_choice/PollingStationChoiceForm";
-import { NavBar } from "app/component/navbar/NavBar";
 
 import { DEFAULT_CANCEL_REASON, useElection, useElectionStatus } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -38,9 +37,6 @@ export function DataEntryHomePage() {
   return (
     <>
       <PageTitle title={`${t("data_entry.pick_polling_station")} - Abacus`} />
-      <NavBar>
-        <Link to={"/elections"}>{t("overview")}</Link>
-      </NavBar>
       <header>
         <section>
           <h1>{election.name}</h1>

--- a/frontend/app/module/data_entry/polling_station/PollingStationLayout.test.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStationLayout.test.tsx
@@ -12,7 +12,7 @@ import {
   PollingStationDataEntrySaveHandler,
   pollingStationMockData,
 } from "@kiesraad/api-mocks";
-import { render, screen, server, within } from "@kiesraad/test";
+import { render, screen, server } from "@kiesraad/test";
 
 import { PollingStationFormController } from "../../../component/form/data_entry/PollingStationFormController";
 
@@ -51,13 +51,5 @@ describe("PollingStationLayout", () => {
     const pollingStation = pollingStationMockData[0]!;
     expect(await screen.findByRole("heading", { level: 1, name: pollingStation.name }));
     expect(await screen.findByText(pollingStation.number));
-
-    // Check if the navigation bar displays the correct information
-    const nav = await screen.findByRole("navigation", { name: /primary-navigation/i });
-    expect(within(nav).getByRole("link", { name: "Overzicht" })).toHaveAttribute("href", "/elections");
-    expect(within(nav).getByRole("link", { name: new RegExp(election.name) })).toHaveAttribute(
-      "href",
-      `/elections/${election.id}/data-entry`,
-    );
   });
 });

--- a/frontend/app/module/data_entry/polling_station/PollingStationLayout.tsx
+++ b/frontend/app/module/data_entry/polling_station/PollingStationLayout.tsx
@@ -1,13 +1,11 @@
-import { Link, Outlet } from "react-router";
+import { Outlet } from "react-router";
 
-import { NavBar } from "app/component/navbar/NavBar";
 import { PollingStationFormNavigation } from "app/component/pollingstation/PollingStationFormNavigation";
 import { PollingStationProgress } from "app/component/pollingstation/PollingStationProgress";
 import { AbortDataEntryControl } from "app/module/data_entry";
 
 import { NotFoundError, useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
-import { IconChevronRight } from "@kiesraad/icon";
 import { Badge, PageTitle, PollingStationNumber, StickyNav, WorkStationNumber } from "@kiesraad/ui";
 import { useNumericParam, usePollingStationStatus } from "@kiesraad/util";
 
@@ -30,15 +28,6 @@ export function PollingStationLayout() {
   return (
     <PollingStationFormController election={election} pollingStationId={pollingStation.id} entryNumber={entryNumber}>
       <PageTitle title={`${t("data_entry.title")} ${pollingStation.number} ${pollingStation.name} - Abacus`} />
-      <NavBar>
-        <Link to={"/elections"}>{t("overview")}</Link>
-        <IconChevronRight />
-        <Link to={`/elections/${election.id}/data-entry`}>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </Link>
-      </NavBar>
       <header>
         <section className="smaller-gap">
           <PollingStationNumber>{pollingStation.number}</PollingStationNumber>

--- a/frontend/app/module/election/ElectionLayout.tsx
+++ b/frontend/app/module/election/ElectionLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 
 import { ElectionProvider, ElectionStatusProvider } from "@kiesraad/api";
 import { useNumericParam } from "@kiesraad/util";
@@ -7,11 +7,12 @@ import { NavBar } from "../../component/navbar/NavBar";
 
 export function ElectionLayout() {
   const electionId = useNumericParam("electionId");
+  const location = useLocation();
 
   return (
     <ElectionProvider electionId={electionId}>
       <ElectionStatusProvider electionId={electionId}>
-        <NavBar />
+        <NavBar location={location} />
         <Outlet />
       </ElectionStatusProvider>
     </ElectionProvider>

--- a/frontend/app/module/election/ElectionLayout.tsx
+++ b/frontend/app/module/election/ElectionLayout.tsx
@@ -3,12 +3,15 @@ import { Outlet } from "react-router";
 import { ElectionProvider, ElectionStatusProvider } from "@kiesraad/api";
 import { useNumericParam } from "@kiesraad/util";
 
+import { NavBar } from "../../component/navbar/NavBar";
+
 export function ElectionLayout() {
   const electionId = useNumericParam("electionId");
 
   return (
     <ElectionProvider electionId={electionId}>
       <ElectionStatusProvider electionId={electionId}>
+        <NavBar />
         <Outlet />
       </ElectionStatusProvider>
     </ElectionProvider>

--- a/frontend/app/module/election/ElectionLayout.tsx
+++ b/frontend/app/module/election/ElectionLayout.tsx
@@ -1,9 +1,9 @@
 import { Outlet, useLocation } from "react-router";
 
+import { NavBar } from "app/component/navbar/NavBar";
+
 import { ElectionProvider, ElectionStatusProvider } from "@kiesraad/api";
 import { useNumericParam } from "@kiesraad/util";
-
-import { NavBar } from "../../component/navbar/NavBar";
 
 export function ElectionLayout() {
   const electionId = useNumericParam("electionId");

--- a/frontend/app/module/election/page/ElectionHomePage.tsx
+++ b/frontend/app/module/election/page/ElectionHomePage.tsx
@@ -1,8 +1,6 @@
 import { Link } from "react-router";
 
 import { Footer } from "app/component/footer/Footer";
-import { MockTest } from "app/component/MockTest";
-import { NavBar } from "app/component/navbar/NavBar";
 
 import { useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -14,13 +12,6 @@ export function ElectionHomePage() {
   return (
     <>
       <PageTitle title={`${t("election.title.details")} - Abacus`} />
-      <NavBar>
-        <span>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </span>
-      </NavBar>
       <header>
         <section>
           <h1>{election.name}</h1>
@@ -49,7 +40,6 @@ export function ElectionHomePage() {
               </ul>
             </li>
           </ul>
-          {__API_MSW__ && <MockTest />}
         </article>
       </main>
       <Footer />

--- a/frontend/app/module/election/page/ElectionReportPage.tsx
+++ b/frontend/app/module/election/page/ElectionReportPage.tsx
@@ -1,7 +1,3 @@
-import { Link } from "react-router";
-
-import { NavBar } from "app/component/navbar/NavBar";
-
 import { useElection, useElectionStatus } from "@kiesraad/api";
 import { t, tx } from "@kiesraad/i18n";
 import { Button, FormLayout, PageTitle } from "@kiesraad/ui";
@@ -65,13 +61,6 @@ export function ElectionReportPage() {
   return (
     <>
       <PageTitle title={`${t("election.title.finish_data_entry")} - Abacus`} />
-      <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("election_status.finish_data_entry_first_session")}</h1>

--- a/frontend/app/module/election/page/ElectionStatusPage.tsx
+++ b/frontend/app/module/election/page/ElectionStatusPage.tsx
@@ -1,9 +1,8 @@
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
 import { HeaderElectionStatusWithIcon } from "app/component/election/ElectionStatusWithIcon";
 import { ElectionStatus } from "app/component/election/status/ElectionStatus";
 import { Footer } from "app/component/footer/Footer";
-import { NavBar } from "app/component/navbar/NavBar";
 
 import { useElection, useElectionStatus } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -21,13 +20,6 @@ export function ElectionStatusPage() {
   return (
     <>
       <PageTitle title={`${t("election_status.title")} - Abacus`} />
-      <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("election_status.first_session")}</h1>

--- a/frontend/app/module/election/page/OverviewPage.tsx
+++ b/frontend/app/module/election/page/OverviewPage.tsx
@@ -2,12 +2,11 @@ import { To, useLocation, useNavigate } from "react-router";
 
 import { ElectionStatusWithIcon } from "app/component/election/ElectionStatusWithIcon";
 import { Footer } from "app/component/footer/Footer";
+import { NavBar } from "app/component/navbar/NavBar";
 
 import { Election, useElectionList } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { Alert, PageTitle, Table, WorkStationNumber } from "@kiesraad/ui";
-
-import { NavBar } from "../../../component/navbar/NavBar";
 
 export function OverviewPage() {
   const navigate = useNavigate();

--- a/frontend/app/module/election/page/OverviewPage.tsx
+++ b/frontend/app/module/election/page/OverviewPage.tsx
@@ -1,12 +1,13 @@
-import { Link, To, useLocation, useNavigate } from "react-router";
+import { To, useLocation, useNavigate } from "react-router";
 
 import { ElectionStatusWithIcon } from "app/component/election/ElectionStatusWithIcon";
 import { Footer } from "app/component/footer/Footer";
-import { NavBar } from "app/component/navbar/NavBar";
 
 import { Election, useElectionList } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { Alert, PageTitle, Table, WorkStationNumber } from "@kiesraad/ui";
+
+import { NavBar } from "../../../component/navbar/NavBar";
 
 export function OverviewPage() {
   const navigate = useNavigate();
@@ -14,11 +15,11 @@ export function OverviewPage() {
   const { electionList } = useElectionList();
 
   const isNewAccount = location.hash === "#new-account";
-  const isAdministrator = location.hash.includes("administrator");
+  const isAdminOrCoordinator = location.hash.includes("administrator") || location.hash.includes("coordinator");
 
   function electionLink(election: Election): To {
-    if (isAdministrator) {
-      return `/elections/${election.id}#coordinator`;
+    if (isAdminOrCoordinator) {
+      return `/elections/${election.id}#administratorcoordinator`;
     } else {
       return `/elections/${election.id}/data-entry`;
     }
@@ -31,23 +32,12 @@ export function OverviewPage() {
   return (
     <>
       <PageTitle title={`${t("election.title.overview")} - Abacus`} />
-      <NavBar>
-        <span className={isAdministrator ? "active" : ""}>
-          {isAdministrator ? t("election.title.plural") : t("overview")}
-        </span>
-        {isAdministrator && (
-          <>
-            <Link to={"/users#administratorcoordinator"}>{t("users")}</Link>
-            <Link to={"/workstations#administrator"}>{t("workstations.workstations")}</Link>
-            <Link to={"/logs#administratorcoordinator"}>{t("logs")}</Link>
-          </>
-        )}
-      </NavBar>
+      <NavBar />
       <header>
         <section>
-          <h1>{isAdministrator ? t("election.manage") : t("election.title.plural")}</h1>
+          <h1>{isAdminOrCoordinator ? t("election.manage") : t("election.title.plural")}</h1>
         </section>
-        {!isAdministrator && (
+        {!isAdminOrCoordinator && (
           <section>
             <WorkStationNumber>16</WorkStationNumber>
           </section>
@@ -65,7 +55,7 @@ export function OverviewPage() {
             <Table.Header>
               <Table.Column>{t("election.title.singular")}</Table.Column>
               <Table.Column>
-                {!isAdministrator ? t("election.location") : t("election.level_polling_station")}
+                {!isAdminOrCoordinator ? t("election.location") : t("election.level_polling_station")}
               </Table.Column>
               <Table.Column>{t("election_status.label")}</Table.Column>
             </Table.Header>
@@ -73,11 +63,11 @@ export function OverviewPage() {
               {electionList.map((election) => (
                 <Table.LinkRow key={election.id} to={electionLink(election)}>
                   <Table.Cell className="fs-body">{election.name}</Table.Cell>
-                  <Table.Cell>{!isAdministrator ? election.location : ""}</Table.Cell>
+                  <Table.Cell>{!isAdminOrCoordinator ? election.location : ""}</Table.Cell>
                   <Table.Cell>
                     <ElectionStatusWithIcon
                       status={election.status}
-                      userRole={isAdministrator ? "coordinator" : "typist"}
+                      userRole={isAdminOrCoordinator ? "coordinator" : "typist"}
                     />
                   </Table.Cell>
                 </Table.LinkRow>

--- a/frontend/app/module/election/page/OverviewPage.tsx
+++ b/frontend/app/module/election/page/OverviewPage.tsx
@@ -32,7 +32,7 @@ export function OverviewPage() {
   return (
     <>
       <PageTitle title={`${t("election.title.overview")} - Abacus`} />
-      <NavBar />
+      <NavBar location={location} />
       <header>
         <section>
           <h1>{isAdminOrCoordinator ? t("election.manage") : t("election.title.plural")}</h1>

--- a/frontend/app/module/logs/LogsHomePage.tsx
+++ b/frontend/app/module/logs/LogsHomePage.tsx
@@ -1,7 +1,3 @@
-import { Link } from "react-router";
-
-import { NavBar } from "app/component/navbar/NavBar";
-
 import { t } from "@kiesraad/i18n";
 import { PageTitle } from "@kiesraad/ui";
 
@@ -9,12 +5,6 @@ export function LogsHomePage() {
   return (
     <>
       <PageTitle title={`${t("activity_log")} - Abacus`} />
-      <NavBar>
-        <Link to={"/elections#administrator"}>{t("election.title.plural")}</Link>
-        <Link to={"/users#administratorcoordinator"}>{t("users")}</Link>
-        <Link to={"/workstations#administrator"}>{t("workstations.workstations")}</Link>
-        <span className="active">{t("logs")}</span>
-      </NavBar>
       <header>
         <section>
           <h1>{t("activity_log")}</h1>

--- a/frontend/app/module/polling_stations/page/PollingStationCreatePage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationCreatePage.tsx
@@ -1,11 +1,9 @@
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
 import { PollingStationForm } from "app/component/form/polling_station/PollingStationForm";
-import { NavBar } from "app/component/navbar/NavBar";
 
 import { PollingStation, useElection } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
-import { IconChevronRight } from "@kiesraad/icon";
 import { PageTitle } from "@kiesraad/ui";
 
 export function PollingStationCreatePage() {
@@ -21,17 +19,6 @@ export function PollingStationCreatePage() {
   return (
     <>
       <PageTitle title={`${t("polling_stations")} - Abacus`} />
-      <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </Link>
-        <IconChevronRight />
-        <Link to={`..`}>
-          <span>{t("polling_stations")}</span>
-        </Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("polling_station.create")}</h1>

--- a/frontend/app/module/polling_stations/page/PollingStationListPage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationListPage.tsx
@@ -1,6 +1,4 @@
-import { Link, useSearchParams } from "react-router";
-
-import { NavBar } from "app/component/navbar/NavBar";
+import { useSearchParams } from "react-router";
 
 import { useElection, usePollingStationListRequest } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -44,13 +42,6 @@ export function PollingStationListPage() {
   return (
     <>
       <PageTitle title={`${t("polling_stations")} - Abacus`} />
-      <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("polling_station.title.plural")}</h1>

--- a/frontend/app/module/polling_stations/page/PollingStationUpdatePage.tsx
+++ b/frontend/app/module/polling_stations/page/PollingStationUpdatePage.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
 import { PollingStationForm } from "app/component/form/polling_station/PollingStationForm";
-import { NavBar } from "app/component/navbar/NavBar";
 import { PollingStationDeleteModal } from "app/module/polling_stations/page/PollingStationDeleteModal";
 
 import { useElection, usePollingStationGet } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
-import { IconChevronRight, IconTrash } from "@kiesraad/icon";
+import { IconTrash } from "@kiesraad/icon";
 import { Alert, Button, Loader, PageTitle } from "@kiesraad/ui";
 import { useNumericParam } from "@kiesraad/util";
 
@@ -59,17 +58,6 @@ export function PollingStationUpdatePage() {
   return (
     <>
       <PageTitle title={`${t("polling_stations")} - Abacus`} />
-      <NavBar>
-        <Link to={`/elections/${election.id}#coordinator`}>
-          <span className="bold">{election.location}</span>
-          <span>&mdash;</span>
-          <span>{election.name}</span>
-        </Link>
-        <IconChevronRight />
-        <Link to={`..`}>
-          <span>{t("polling_stations")}</span>
-        </Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("polling_station.update")}</h1>

--- a/frontend/app/module/users/UsersHomePage.tsx
+++ b/frontend/app/module/users/UsersHomePage.tsx
@@ -1,7 +1,3 @@
-import { Link } from "react-router";
-
-import { NavBar } from "app/component/navbar/NavBar";
-
 import { t } from "@kiesraad/i18n";
 import { PageTitle } from "@kiesraad/ui";
 
@@ -9,12 +5,6 @@ export function UsersHomePage() {
   return (
     <>
       <PageTitle title={`${t("user.management")} - Abacus`} />
-      <NavBar>
-        <Link to={"/elections#administrator"}>{t("election.title.plural")}</Link>
-        <span className="active">{t("users")}</span>
-        <Link to={"/workstations#administrator"}>{t("workstations.workstations")}</Link>
-        <Link to={"/logs#administratorcoordinator"}>{t("logs")}</Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("user.manage")}</h1>

--- a/frontend/app/module/workstations/WorkstationsHomePage.tsx
+++ b/frontend/app/module/workstations/WorkstationsHomePage.tsx
@@ -1,7 +1,3 @@
-import { Link } from "react-router";
-
-import { NavBar } from "app/component/navbar/NavBar";
-
 import { t } from "@kiesraad/i18n";
 import { PageTitle } from "@kiesraad/ui";
 
@@ -9,12 +5,6 @@ export function WorkstationsHomePage() {
   return (
     <>
       <PageTitle title={`${t("workstations.entry_stations")} - Abacus`} />
-      <NavBar>
-        <Link to={"/elections#administrator"}>{t("election.title.plural")}</Link>
-        <Link to={"/users#administratorcoordinator"}>{t("users")}</Link>
-        <span className="active">{t("workstations.workstations")}</span>
-        <Link to={"/logs#administratorcoordinator"}>{t("logs")}</Link>
-      </NavBar>
       <header>
         <section>
           <h1>{t("workstations.manage")}</h1>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -19,6 +19,8 @@ export default defineConfig((configEnv) =>
             "*.config.mjs",
             "mockServiceWorker.js",
             "e2e-tests/**",
+            "**/*.stories.tsx",
+            "**/*.e2e.ts",
             ...coverageConfigDefaults.exclude,
           ],
         },


### PR DESCRIPTION
Resolves #724

- Clarify that `PollingStationFormNavigation.test.tsx` is using the vanilla React Testing Library (RTL) render function and not our custom one.
- Move logic to render navigation links into NavBar, and move the NavBar rendering up to a parent component where possible. The navigation links are rendered in a new `NavBarLinks` component with several subcomponents for readability.
- Add location as an optional parameter to NavBar.
- Add test and Ladle stories for NavBar.