### PR TITLE
Disable login e2e tests for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,8 @@ jobs:
         if: runner.os != 'Windows'
       - name: Run Playwright e2e tests
         run: npm run test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        env:
+          BACKEND_BUILD: release
 
   release:
     name: Release

--- a/frontend/e2e-tests/authentication.e2e.ts
+++ b/frontend/e2e-tests/authentication.e2e.ts
@@ -2,6 +2,11 @@ import { expect, test } from "@playwright/test";
 import { webcrypto as crypto } from "crypto";
 
 test.describe("authentication", () => {
+  // These tests only run in development mode (non-release backend builds)
+  // TODO: create user with normal production flow when available
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip(process.env.BACKEND_BUILD === "release");
+
   test("login happy path", async ({ page, request }) => {
     const array = new Uint32Array(1);
     crypto.getRandomValues(array);


### PR DESCRIPTION
The create user (development) endpoint should never be available in production and thereby in release builds.
Currently the e2e login tests rely on this endpoint.
This PR skips these tests for release builds. We can enable them again if we have implemented the setup / create user flow (#946).