### PR TITLE
add model-based test for data entry

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -36,7 +36,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["*.e2e.ts", "*PgObj.ts", "e2e-tests/**/fixtures.ts"],
+      files: ["*.e2e.ts", "e2e-tests/**/*"],
       extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended-type-checked",
@@ -49,6 +49,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-floating-promises": "error",
         "react-hooks/rules-of-hooks": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
       },
     },
     {

--- a/frontend/e2e-tests/data-entry.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.model.e2e.ts
@@ -182,15 +182,8 @@ test.describe("Data entry", () => {
         const abortModal = new AbortInputModal(page);
 
         await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-
-        await expect(pollingStationChoicePage.fieldset).toBeVisible();
-        await pollingStationChoicePage.pollingStationNumber.fill(pollingStation.number.toString());
-        await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(pollingStation.name);
-        await pollingStationChoicePage.clickStart();
-
-        await expect(recountedPage.fieldset).toBeVisible();
-        await recountedPage.no.check();
-        await recountedPage.next.click();
+        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+        await recountedPage.checkNoAndClickNext();
 
         await path.test({
           states: {

--- a/frontend/e2e-tests/data-entry.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.model.e2e.ts
@@ -234,66 +234,48 @@ test.describe("Data entry", () => {
             },
             voterVotesPageCached: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(voters);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters, votes });
             },
             voterVotesPageEmpty: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(votersEmpty);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votesEmpty);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters: votersEmpty, votes: votesEmpty });
             },
             votersVotesPageFilled: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(voters);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters, votes });
             },
             votersVotesPageSubmitted: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(voters);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters, votes });
             },
             votersVotesPageChangedSubmitted: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(votersChanged);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters: votersChanged, votes });
             },
             votersVotesPageChangedFilled: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(votersChanged);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters: votersChanged, votes });
             },
             votersVotesPageAfterResumeSaved: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(voters);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters, votes });
             },
             votersVotesPageAfterResumeChanged: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(votersChanged);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votes);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters: votersChanged, votes });
             },
             votersVotesPageAfterResumeEmpty: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const votersFields = await votersAndVotesPage.getVotersCounts();
-              expect(votersFields).toStrictEqual(votersEmpty);
-              const votesFields = await votersAndVotesPage.getVotesCounts();
-              expect(votesFields).toStrictEqual(votesEmpty);
+              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(fields).toStrictEqual({ voters: votersEmpty, votes: votesEmpty });
             },
             differencesPage: async () => {
               await expect(differencesPage.fieldset).toBeVisible();

--- a/frontend/e2e-tests/data-entry.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.model.e2e.ts
@@ -174,7 +174,7 @@ test.describe("Data entry", () => {
     .getSimplePaths()
     .forEach((path) => {
       // eslint-disable-next-line playwright/valid-title
-      test(path.description, async ({ page, pollingStation }) => {
+      test(path.description, async ({ page, pollingStation, election }) => {
         const pollingStationChoicePage = new PollingStationChoicePage(page);
         const recountedPage = new RecountedPage(page);
         const votersAndVotesPage = new VotersAndVotesPage(page);
@@ -200,9 +200,9 @@ test.describe("Data entry", () => {
             },
             pollingStationsPageEmptySaved: async () => {
               await expect(pollingStationChoicePage.fieldset).toBeVisible();
-              await expect(pollingStationChoicePage.alertDataEntryInProgress).toContainText(
+              await expect(pollingStationChoicePage.allDataEntriesInProgress).toHaveText([
                 `${pollingStation.number} - ${pollingStation.name}`,
-              );
+              ]);
             },
             pollingStationsPageFilledSaved: async () => {
               await expect(pollingStationChoicePage.fieldset).toBeVisible();
@@ -234,48 +234,48 @@ test.describe("Data entry", () => {
             },
             voterVotesPageCached: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters, votes });
             },
             voterVotesPageEmpty: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters: votersEmpty, votes: votesEmpty });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters: votersEmpty, votes: votesEmpty });
             },
             votersVotesPageFilled: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters, votes });
             },
             votersVotesPageSubmitted: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters, votes });
             },
             votersVotesPageChangedSubmitted: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters: votersChanged, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters: votersChanged, votes });
             },
             votersVotesPageChangedFilled: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters: votersChanged, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters: votersChanged, votes });
             },
             votersVotesPageAfterResumeSaved: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters, votes });
             },
             votersVotesPageAfterResumeChanged: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters: votersChanged, votes });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters: votersChanged, votes });
             },
             votersVotesPageAfterResumeEmpty: async () => {
               await expect(votersAndVotesPage.fieldset).toBeVisible();
-              const fields = await votersAndVotesPage.getVotersAndVotesCounts();
-              expect(fields).toStrictEqual({ voters: votersEmpty, votes: votesEmpty });
+              const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
+              expect(votersVotesFields).toStrictEqual({ voters: votersEmpty, votes: votesEmpty });
             },
             differencesPage: async () => {
               await expect(differencesPage.fieldset).toBeVisible();
@@ -305,8 +305,7 @@ test.describe("Data entry", () => {
               await votersAndVotesPage.abortInput.click();
             },
             NAV_TO_POLLING_STATION_PAGE: async () => {
-              // TODO: add to page object
-              await page.getByRole("link", { name: "Test Location" }).click();
+              await votersAndVotesPage.clickElectionInNavBar(election.election.location, election.election.name);
             },
             GO_TO_RECOUNTED_PAGE: async () => {
               await votersAndVotesPage.navPanel.recounted.click();
@@ -330,10 +329,7 @@ test.describe("Data entry", () => {
               await recountedPage.unsavedChangesModal.discardInput.click();
             },
             RESUME_DATA_ENTRY: async () => {
-              // TODO: add to page object
-              await pollingStationChoicePage.alertDataEntryInProgress
-                .getByRole("link", { name: `${pollingStation.number} - ${pollingStation.name}` })
-                .click();
+              await pollingStationChoicePage.clickDataEntryInProgress(pollingStation.number, pollingStation.name);
             },
           },
         });

--- a/frontend/e2e-tests/data-entry.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.model.e2e.ts
@@ -199,15 +199,15 @@ test.describe("Data entry", () => {
             },
             pollingStationsPageFilledSaved: async () => {
               await expect(pollingStationChoicePage.fieldset).toBeVisible();
-              await expect(pollingStationChoicePage.alertDataEntryInProgress).toContainText(
+              await expect(pollingStationChoicePage.allDataEntriesInProgress).toHaveText([
                 `${pollingStation.number} - ${pollingStation.name}`,
-              );
+              ]);
             },
             pollingStationsPageChangedSaved: async () => {
               await expect(pollingStationChoicePage.fieldset).toBeVisible();
-              await expect(pollingStationChoicePage.alertDataEntryInProgress).toContainText(
+              await expect(pollingStationChoicePage.allDataEntriesInProgress).toHaveText([
                 `${pollingStation.number} - ${pollingStation.name}`,
-              );
+              ]);
             },
             recountedPageEmpty: async () => {
               await expect(recountedPage.fieldset).toBeVisible();

--- a/frontend/e2e-tests/data-entry.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.model.e2e.ts
@@ -1,0 +1,360 @@
+import { expect } from "@playwright/test";
+import { createTestModel } from "@xstate/graph";
+import {
+  AbortInputModal,
+  DifferencesPage,
+  PollingStationChoicePage,
+  RecountedPage,
+  VotersAndVotesPage,
+} from "e2e-tests/page-objects/data_entry";
+import { createMachine } from "xstate";
+
+import { VotersCounts, VotesCounts } from "@kiesraad/api";
+
+import { test } from "./fixtures";
+
+/*
+Not covered in the model:
+- fill in page with error data, then fix, nav, abort
+- fill in page with warning data, then fix, accept, nav abort
+*/
+
+/*
+The names of the states in the machine keep track of two states:
+1. the current page
+2. the state of the data on the voters and votes page
+
+So the state pollingStationsPageChangedSaved means that we're on the polling stations page, we have
+changed the initial input on the voters and votes page, and we have saved it as part of navigating
+to the polling stations page.
+*/
+
+const machine = createMachine({
+  initial: "voterVotesPageEmpty",
+  states: {
+    pollingStationsPageDiscarded: {},
+    pollingStationsPageEmptySaved: {
+      on: {
+        RESUME_DATA_ENTRY: "votersVotesPageAfterResumeEmpty",
+      },
+    },
+    pollingStationsPageFilledSaved: {
+      on: {
+        RESUME_DATA_ENTRY: "votersVotesPageAfterResumeSaved",
+      },
+    },
+    pollingStationsPageChangedSaved: {
+      on: {
+        RESUME_DATA_ENTRY: "votersVotesPageAfterResumeChanged",
+      },
+    },
+    recountedPageEmpty: {},
+    recountedPageSaved: {
+      on: {
+        GO_TO_VOTERS_VOTES_PAGE: "votersVotesPageChangedSubmitted",
+      },
+    },
+    recountedPageDiscarded: {
+      on: {
+        GO_TO_VOTERS_VOTES_PAGE: "votersVotesPageSubmitted",
+      },
+    },
+    recountedPageCached: {
+      on: {
+        GO_TO_VOTERS_VOTES_PAGE: "voterVotesPageCached",
+      },
+    },
+    voterVotesPageCached: {
+      on: {
+        SUBMIT: "differencesPage",
+      },
+    },
+    voterVotesPageEmpty: {
+      on: {
+        FILL_WITH_VALID_DATA: "votersVotesPageFilled",
+        CLICK_ABORT: "abortInputModalEmpty",
+        NAV_TO_POLLING_STATION_PAGE: "abortInputModalEmpty",
+        GO_TO_RECOUNTED_PAGE: "recountedPageEmpty",
+      },
+    },
+    votersVotesPageFilled: {
+      on: {
+        SUBMIT: "differencesPage",
+        CLICK_ABORT: "abortInputModalFilled",
+        NAV_TO_POLLING_STATION_PAGE: "abortInputModalFilled",
+        GO_TO_RECOUNTED_PAGE: "recountedPageCached",
+      },
+    },
+    votersVotesPageSubmitted: {
+      on: {
+        CHANGE_VALID_DATA: "votersVotesPageChangedFilled",
+      },
+    },
+    votersVotesPageChangedSubmitted: {},
+    votersVotesPageChangedFilled: {
+      on: {
+        SUBMIT: "differencesPage",
+        CLICK_ABORT: "abortInputModalChanged",
+        NAV_TO_POLLING_STATION_PAGE: "abortInputModalChanged",
+        GO_TO_RECOUNTED_PAGE: "unsavedChangesModalChanged",
+      },
+    },
+    votersVotesPageAfterResumeSaved: {},
+    votersVotesPageAfterResumeChanged: {},
+    votersVotesPageAfterResumeEmpty: {},
+    differencesPage: {
+      on: {
+        GO_TO_VOTERS_VOTES_PAGE: "votersVotesPageSubmitted",
+      },
+    },
+    abortInputModalFilled: {
+      on: {
+        SAVE_INPUT: "pollingStationsPageFilledSaved",
+        DISCARD_INPUT: "pollingStationsPageDiscarded",
+      },
+    },
+    abortInputModalEmpty: {
+      on: {
+        SAVE_INPUT: "pollingStationsPageEmptySaved",
+        DISCARD_INPUT: "pollingStationsPageDiscarded",
+      },
+    },
+    abortInputModalChanged: {
+      on: {
+        SAVE_INPUT: "pollingStationsPageChangedSaved",
+        DISCARD_INPUT: "pollingStationsPageDiscarded",
+      },
+    },
+    unsavedChangesModalChanged: {
+      on: {
+        SAVE_UNSUBMITTED_CHANGES: "recountedPageSaved",
+        DISCARD_UNSUBMITTED_CHANGES: "recountedPageDiscarded",
+      },
+    },
+  },
+});
+
+const voters: VotersCounts = {
+  poll_card_count: 90,
+  proxy_certificate_count: 10,
+  voter_card_count: 0,
+  total_admitted_voters_count: 100,
+};
+
+const votersChanged: VotersCounts = {
+  poll_card_count: 80,
+  proxy_certificate_count: 20,
+  voter_card_count: 0,
+  total_admitted_voters_count: 100,
+};
+
+const votersEmpty: VotersCounts = {
+  poll_card_count: 0,
+  proxy_certificate_count: 0,
+  voter_card_count: 0,
+  total_admitted_voters_count: 0,
+};
+
+const votes: VotesCounts = {
+  votes_candidates_count: 100,
+  blank_votes_count: 0,
+  invalid_votes_count: 0,
+  total_votes_cast_count: 100,
+};
+
+const votesEmpty: VotesCounts = {
+  votes_candidates_count: 0,
+  blank_votes_count: 0,
+  invalid_votes_count: 0,
+  total_votes_cast_count: 0,
+};
+
+test.describe("Data entry", () => {
+  createTestModel(machine)
+    .getSimplePaths()
+    .forEach((path) => {
+      // eslint-disable-next-line playwright/valid-title
+      test(path.description, async ({ page, pollingStation }) => {
+        const pollingStationChoicePage = new PollingStationChoicePage(page);
+        const recountedPage = new RecountedPage(page);
+        const votersAndVotesPage = new VotersAndVotesPage(page);
+        const differencesPage = new DifferencesPage(page);
+        const abortModal = new AbortInputModal(page);
+
+        await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+
+        await expect(pollingStationChoicePage.fieldset).toBeVisible();
+        await pollingStationChoicePage.pollingStationNumber.fill(pollingStation.number.toString());
+        await expect(pollingStationChoicePage.pollingStationFeedback).toContainText(pollingStation.name);
+        await pollingStationChoicePage.clickStart();
+
+        await expect(recountedPage.fieldset).toBeVisible();
+        await recountedPage.no.check();
+        await recountedPage.next.click();
+
+        await path.test({
+          states: {
+            pollingStationsPageDiscarded: async () => {
+              await expect(pollingStationChoicePage.fieldset).toBeVisible();
+              await expect(pollingStationChoicePage.alertDataEntryInProgress).toBeHidden();
+            },
+            pollingStationsPageEmptySaved: async () => {
+              await expect(pollingStationChoicePage.fieldset).toBeVisible();
+              await expect(pollingStationChoicePage.alertDataEntryInProgress).toContainText(
+                `${pollingStation.number} - ${pollingStation.name}`,
+              );
+            },
+            pollingStationsPageFilledSaved: async () => {
+              await expect(pollingStationChoicePage.fieldset).toBeVisible();
+              await expect(pollingStationChoicePage.alertDataEntryInProgress).toContainText(
+                `${pollingStation.number} - ${pollingStation.name}`,
+              );
+            },
+            pollingStationsPageChangedSaved: async () => {
+              await expect(pollingStationChoicePage.fieldset).toBeVisible();
+              await expect(pollingStationChoicePage.alertDataEntryInProgress).toContainText(
+                `${pollingStation.number} - ${pollingStation.name}`,
+              );
+            },
+            recountedPageEmpty: async () => {
+              await expect(recountedPage.fieldset).toBeVisible();
+              await expect(recountedPage.no).toBeChecked();
+            },
+            recountedPageSaved: async () => {
+              await expect(recountedPage.fieldset).toBeVisible();
+              await expect(recountedPage.no).toBeChecked();
+            },
+            recountedPageDiscarded: async () => {
+              await expect(recountedPage.fieldset).toBeVisible();
+              await expect(recountedPage.no).toBeChecked();
+            },
+            recountedPageCached: async () => {
+              await expect(recountedPage.fieldset).toBeVisible();
+              await expect(recountedPage.no).toBeChecked();
+            },
+            voterVotesPageCached: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(voters);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            voterVotesPageEmpty: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(votersEmpty);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votesEmpty);
+            },
+            votersVotesPageFilled: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(voters);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            votersVotesPageSubmitted: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(voters);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            votersVotesPageChangedSubmitted: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(votersChanged);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            votersVotesPageChangedFilled: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(votersChanged);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            votersVotesPageAfterResumeSaved: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(voters);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            votersVotesPageAfterResumeChanged: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(votersChanged);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votes);
+            },
+            votersVotesPageAfterResumeEmpty: async () => {
+              await expect(votersAndVotesPage.fieldset).toBeVisible();
+              const votersFields = await votersAndVotesPage.getVotersCounts();
+              expect(votersFields).toStrictEqual(votersEmpty);
+              const votesFields = await votersAndVotesPage.getVotesCounts();
+              expect(votesFields).toStrictEqual(votesEmpty);
+            },
+            differencesPage: async () => {
+              await expect(differencesPage.fieldset).toBeVisible();
+            },
+            abortInputModalFilled: async () => {
+              await expect(abortModal.heading).toBeVisible();
+            },
+            abortInputModalEmpty: async () => {
+              await expect(abortModal.heading).toBeVisible();
+            },
+            abortInputModalChanged: async () => {
+              await expect(abortModal.heading).toBeVisible();
+            },
+            unsavedChangesModalChanged: async () => {
+              await expect(recountedPage.unsavedChangesModal.heading).toBeVisible();
+            },
+          },
+          events: {
+            FILL_WITH_VALID_DATA: async () => {
+              await votersAndVotesPage.inputVotersCounts(voters);
+              await votersAndVotesPage.inputVotesCounts(votes);
+            },
+            CHANGE_VALID_DATA: async () => {
+              await votersAndVotesPage.inputVotersCounts(votersChanged);
+            },
+            CLICK_ABORT: async () => {
+              await votersAndVotesPage.abortInput.click();
+            },
+            NAV_TO_POLLING_STATION_PAGE: async () => {
+              // TODO: add to page object
+              await page.getByRole("link", { name: "Test Location" }).click();
+            },
+            GO_TO_RECOUNTED_PAGE: async () => {
+              await votersAndVotesPage.navPanel.recounted.click();
+            },
+            GO_TO_VOTERS_VOTES_PAGE: async () => {
+              await differencesPage.navPanel.votersAndVotes.click();
+            },
+            SUBMIT: async () => {
+              await votersAndVotesPage.next.click();
+            },
+            SAVE_INPUT: async () => {
+              await abortModal.saveInput.click();
+            },
+            DISCARD_INPUT: async () => {
+              await abortModal.discardInput.click();
+            },
+            SAVE_UNSUBMITTED_CHANGES: async () => {
+              await recountedPage.unsavedChangesModal.saveInput.click();
+            },
+            DISCARD_UNSUBMITTED_CHANGES: async () => {
+              await recountedPage.unsavedChangesModal.discardInput.click();
+            },
+            RESUME_DATA_ENTRY: async () => {
+              // TODO: add to page object
+              await pollingStationChoicePage.alertDataEntryInProgress
+                .getByRole("link", { name: `${pollingStation.number} - ${pollingStation.name}` })
+                .click();
+            },
+          },
+        });
+      });
+    });
+});

--- a/frontend/e2e-tests/page-objects/data_entry/DataEntryBasePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/DataEntryBasePgObj.ts
@@ -23,4 +23,9 @@ export class DataEntryBasePage {
     this.warning = page.getByTestId("feedback-warning");
     this.feedbackHeader = page.getByRole("heading", { level: 3 });
   }
+
+  async clickElectionInNavBar(electionLocation: string, electionName: string) {
+    const linkText = `${electionLocation} — ${electionName}`;
+    await this.page.getByRole("navigation").getByRole("link", { name: linkText }).click();
+  }
 }

--- a/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
@@ -11,6 +11,7 @@ export class PollingStationChoicePage {
   readonly dataEntrySuccess: Locator;
   readonly resumeDataEntry: Locator;
   readonly alertDataEntryInProgress: Locator;
+  readonly allDataEntriesInProgress: Locator;
 
   constructor(protected readonly page: Page) {
     this.fieldset = page.getByRole("group", {
@@ -35,6 +36,8 @@ export class PollingStationChoicePage {
     this.alertInputSaved = page.getByRole("alert").filter({ has: this.dataEntrySuccess });
 
     this.alertDataEntryInProgress = page.getByRole("alert").filter({ has: this.resumeDataEntry });
+
+    this.allDataEntriesInProgress = this.alertDataEntryInProgress.getByRole("link");
   }
 
   async clickStart() {
@@ -47,5 +50,12 @@ export class PollingStationChoicePage {
   async selectPollingStationAndClickStart(pollingStationNumber: number) {
     await this.pollingStationNumber.fill(pollingStationNumber.toString());
     await this.clickStart();
+  }
+
+  async clickDataEntryInProgress(pollingStationNumber: number, pollingStationName: string) {
+    const dataEntryLink = this.alertDataEntryInProgress.getByRole("link", {
+      name: `${pollingStationNumber} - ${pollingStationName}`,
+    });
+    await dataEntryLink.click();
   }
 }

--- a/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
@@ -10,6 +10,7 @@ export class PollingStationChoicePage {
   readonly alertInputSaved: Locator;
   readonly dataEntrySuccess: Locator;
   readonly resumeDataEntry: Locator;
+  readonly alertDataEntryInProgress: Locator;
 
   constructor(protected readonly page: Page) {
     this.fieldset = page.getByRole("group", {
@@ -32,6 +33,8 @@ export class PollingStationChoicePage {
     this.resumeDataEntry = page.getByRole("heading", { level: 2, name: "Je hebt nog een openstaande invoer" });
 
     this.alertInputSaved = page.getByRole("alert").filter({ has: this.dataEntrySuccess });
+
+    this.alertDataEntryInProgress = page.getByRole("alert").filter({ has: this.resumeDataEntry });
   }
 
   async clickStart() {

--- a/frontend/e2e-tests/page-objects/data_entry/VotersAndVotesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/VotersAndVotesPgObj.ts
@@ -91,6 +91,13 @@ export class VotersAndVotesPage extends DataEntryBasePage {
     };
   }
 
+  async getVotersAndVotesCounts(): Promise<{ voters: VotersCounts; votes: VotesCounts }> {
+    return {
+      voters: await this.getVotersCounts(),
+      votes: await this.getVotesCounts(),
+    };
+  }
+
   async inputVotersRecounts(votersRecounts: VotersCounts) {
     await this.pollCardRecount.fill(votersRecounts.poll_card_count.toString());
     await this.proxyCertificateRecount.fill(votersRecounts.proxy_certificate_count.toString());

--- a/frontend/e2e-tests/page-objects/data_entry/VotersAndVotesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/VotersAndVotesPgObj.ts
@@ -64,11 +64,31 @@ export class VotersAndVotesPage extends DataEntryBasePage {
     await this.totalAdmittedVotersCount.fill(votersCounts.total_admitted_voters_count.toString());
   }
 
+  async getVotersCounts(): Promise<VotersCounts> {
+    return {
+      // using Number() so that "" is parsed to 0
+      poll_card_count: Number(await this.pollCardCount.inputValue()),
+      proxy_certificate_count: Number(await this.proxyCertificateCount.inputValue()),
+      voter_card_count: Number(await this.voterCardCount.inputValue()),
+      total_admitted_voters_count: Number(await this.totalAdmittedVotersCount.inputValue()),
+    };
+  }
+
   async inputVotesCounts(votesCounts: VotesCounts) {
     await this.votesCandidatesCount.fill(votesCounts.votes_candidates_count.toString());
     await this.blankVotesCount.fill(votesCounts.blank_votes_count.toString());
     await this.invalidVotesCount.fill(votesCounts.invalid_votes_count.toString());
     await this.totalVotesCastCount.fill(votesCounts.total_votes_cast_count.toString());
+  }
+
+  async getVotesCounts(): Promise<VotesCounts> {
+    return {
+      // using Number() so that "" is parsed to 0
+      votes_candidates_count: Number(await this.votesCandidatesCount.inputValue()),
+      blank_votes_count: Number(await this.blankVotesCount.inputValue()),
+      invalid_votes_count: Number(await this.invalidVotesCount.inputValue()),
+      total_votes_cast_count: Number(await this.totalVotesCastCount.inputValue()),
+    };
   }
 
   async inputVotersRecounts(votersRecounts: VotersCounts) {

--- a/frontend/e2e-tests/xstate-helpers.ts
+++ b/frontend/e2e-tests/xstate-helpers.ts
@@ -1,0 +1,35 @@
+export type TestStates = Record<string, () => Promise<void>>;
+export type TestEvents = Record<string, () => Promise<void>>;
+
+interface MyMachineConfig {
+  initial: string;
+  states: {
+    [key: string]: { on?: Record<string, string> };
+  };
+}
+
+export function getStatesAndEventsFromMachineDefinition(machineDef: MyMachineConfig) {
+  const machineStates: string[] = Object.keys(machineDef.states);
+
+  let machineEvents: string[] = [];
+  Object.values(machineDef.states).forEach((value) => {
+    if ("on" in value) {
+      machineEvents = [...machineEvents, ...Object.keys(value.on!)];
+    }
+  });
+
+  return { machineStates, machineEvents };
+}
+
+export function getStatesAndEventsFromTest(testStates: TestStates[], testEvents: TestEvents[]) {
+  let states: string[] = [];
+  testStates.forEach((element) => {
+    states = [...states, ...Object.keys(element)];
+  });
+  let events: string[] = [];
+  testEvents.forEach((element) => {
+    events = [...events, ...Object.keys(element)];
+  });
+
+  return { states, events };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "@typescript-eslint/parser": "^8.21.0",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "@vitest/coverage-v8": "^3.0.4",
+        "@xstate/graph": "^3.0.2",
         "cross-env": "^7.0.3",
         "eslint": "^9.19.0",
         "eslint-config-prettier": "^10.0.1",
@@ -51,7 +52,8 @@
         "typescript": "^5.7.3",
         "vite-node": "^3.0.4",
         "vitest": "^3.0.4",
-        "vitest-fail-on-console": "^0.7.1"
+        "vitest-fail-on-console": "^0.7.1",
+        "xstate": "^5.19.2"
       },
       "engines": {
         "node": ">=22"
@@ -3336,6 +3338,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xstate/graph": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@xstate/graph/-/graph-3.0.2.tgz",
+      "integrity": "sha512-UvexSqy8V3LgUa5amm9r/MzQtI/+wHrXAbOBtXKmhdLfMqyfs0N6SlM6R9u6T9AhsYA1U3W1OYARhgUPfXFn4A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "xstate": "^5.19.2"
       }
     },
     "node_modules/accepts": {
@@ -12567,6 +12579,17 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xstate": {
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.2.tgz",
+      "integrity": "sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "^8.21.0",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "@vitest/coverage-v8": "^3.0.4",
+    "@xstate/graph": "^3.0.2",
     "cross-env": "^7.0.3",
     "eslint": "^9.19.0",
     "eslint-config-prettier": "^10.0.1",
@@ -71,7 +72,8 @@
     "typescript": "^5.7.3",
     "vite-node": "^3.0.4",
     "vitest": "^3.0.4",
-    "vitest-fail-on-console": "^0.7.1"
+    "vitest-fail-on-console": "^0.7.1",
+    "xstate": "^5.19.2"
   },
   "msw": {
     "workerDirectory": [


### PR DESCRIPTION
### Scope
- add model-based test for data entry
- make the test check that the events and states in the machine match the events and states in the test

### Questions
It would be nice to only check once that the events and states in the machine match the events and states in the test. However, the events and states in the test require the Playwright fixtures `page`, `pollingStation`, `election`. So I don't think there's a way to do this. If you know of a solution, please share!

I made the model-based tests part of the e2e tests. So this PR adds 3 x 23 tests to the e2e tests. Part of issue #898 Change PollingStation.test.tsx to Playwright tests is to check the coverage of the e2e tests, because I think there currently is some overlap between the existing e2e tests, the model-based tests in this PR, and the tests in PollingStation.test.tsx.
