### PR TITLE
Remove flaky assert on user create time (Rust)

### DIFF
--- a/backend/.sqlx/query-9074758cd2f5fafb51332f94f082deb10b072e1667ec177de5611059b59588af.json
+++ b/backend/.sqlx/query-9074758cd2f5fafb51332f94f082deb10b072e1667ec177de5611059b59588af.json
@@ -16,12 +16,12 @@
       {
         "name": "updated_at: _",
         "ordinal": 2,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       },
       {
         "name": "created_at: _",
         "ordinal": 3,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       }
     ],
     "parameters": {

--- a/backend/.sqlx/query-a05098423f372acd52a02a0fa20afe5f16a93769bf29cf91220b28448ae26fb5.json
+++ b/backend/.sqlx/query-a05098423f372acd52a02a0fa20afe5f16a93769bf29cf91220b28448ae26fb5.json
@@ -21,12 +21,12 @@
       {
         "name": "updated_at: _",
         "ordinal": 3,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       },
       {
         "name": "created_at: _",
         "ordinal": 4,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       }
     ],
     "parameters": {

--- a/backend/.sqlx/query-a973de604e0606e4025d2dfa191f7a7888e3e2c421e417f3d1908a32f25a350d.json
+++ b/backend/.sqlx/query-a973de604e0606e4025d2dfa191f7a7888e3e2c421e417f3d1908a32f25a350d.json
@@ -21,12 +21,12 @@
       {
         "name": "updated_at: _",
         "ordinal": 3,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       },
       {
         "name": "created_at: _",
         "ordinal": 4,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       }
     ],
     "parameters": {

--- a/backend/.sqlx/query-b9eacf02a1333eb1cb3dcb1afa6a7549d0b80a624d5cd770778e01c03f30b945.json
+++ b/backend/.sqlx/query-b9eacf02a1333eb1cb3dcb1afa6a7549d0b80a624d5cd770778e01c03f30b945.json
@@ -21,12 +21,12 @@
       {
         "name": "updated_at: _",
         "ordinal": 3,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       },
       {
         "name": "created_at: _",
         "ordinal": 4,
-        "type_info": "Integer"
+        "type_info": "Datetime"
       }
     ],
     "parameters": {

--- a/backend/src/authentication/user.rs
+++ b/backend/src/authentication/user.rs
@@ -259,7 +259,7 @@ impl FromRef<AppState> for Users {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeDelta, Utc};
+    use chrono::TimeDelta;
     use sqlx::SqlitePool;
     use test_log::test;
 
@@ -271,7 +271,6 @@ mod tests {
 
         let user = users.create("test_user", "password").await.unwrap();
 
-        assert!(Utc::now().timestamp() - user.created_at.timestamp() <= 1);
         assert_eq!(user.username, "test_user");
 
         let fetched_user = users.get_by_id(user.id).await.unwrap().unwrap();


### PR DESCRIPTION
Test: 

```sh
cd backend
cargo test
```

Repeat 100 times, and witness no flaky tests.

Fixes #948

Note that lefthook also fixed some inconsistencies in de sqlx offline query check.