### PR TITLE
Strip binary before upload and soft fail

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -180,14 +180,18 @@ jobs:
       contents: read
       deployments: write
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Download abacus
         uses: actions/download-artifact@v4
         with:
           name: abacus-ubuntu-latest
+      - name: Strip debug symbols
+        run: strip abacus
       - name: Upload binary to test server
         run: |
           curl -s \
+          --fail \
           -H "Authorization: Bearer ${{ secrets.ABACUS_TEST_API_KEY }}" \
           -T ./abacus \
           https://abacus-test.nl/etes/api/v1/executable/${{ github.event.pull_request.head.sha || github.sha }}/${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Upload binary to test server
         run: |
           curl -s \
+          --fail \
           -H "Authorization: Bearer ${{ secrets.ABACUS_TEST_API_KEY }}" \
           -T ./abacus \
           https://abacus-test.nl/etes/api/v1/executable/${{ github.sha }}/${{ github.sha }}


### PR DESCRIPTION
- Strip debug symbols from binary before upload to abacus-test
- Show error if upload to abacus-test fails, do not let the pipeline fail on error

See https://github.com/kiesraad/abacus/actions/runs/13115508331/job/36589105293
After `strip` the binary size is down from 374M to 79M

Fixes #742