### PR TITLE
Keep React Router version 7.1.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,9 @@ updates:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
       # React Router major upgrades usually have breaking changes
+      # React Router 7.1.4 causes DataEntryHomePage.test.tsx to fail, investigate in issue #953
       - dependency-name: "react-router"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # React major upgrades usually have breaking changes, see #716 for React 19
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->
Update React Router to 7.1.4 or 7.1.5 causes DataEntryHomePage.test.tsx to fail. Issue https://github.com/kiesraad/abacus/issues/953 has been created to fix this.