### PR TITLE
Use `election_1.sql` fixture in builds

### DIFF
--- a/backend/src/fixtures.rs
+++ b/backend/src/fixtures.rs
@@ -23,7 +23,7 @@ macro_rules! load_fixtures {
 ///
 /// This list should be updated manually when a new fixture is added that
 /// needs to be loaded when seeding fixtures.
-const FIXTURES: &[Fixture] = load_fixtures!(["reset", "election_3", "users"]);
+const FIXTURES: &[Fixture] = load_fixtures!(["reset", "election_1", "users"]);
 
 /// The data contained in a fixture file
 struct Fixture {


### PR DESCRIPTION
This was accidentally changed to `election_3.sql` in ff7f6c60208ceb624922070c3a86a0587f75c279.