### PR TITLE
shorten 'Over de Kiesraad' in our README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,9 @@ Alle meldingen over onze software zijn welkom. Voor meldingen kun je het team di
 
 ## Over de Kiesraad
 
-In Nederland mogen we al meer dan honderd jaar via verkiezingen bepalen wie onze volksvertegenwoordigers zijn. Voor onze democratie is het van groot belang om een betrouwbaar, transparant en controleerbaar verkiezingsproces in te richten en in stand te houden. Dat doen we met wetten en regels, maar vooral met mensen, die er samen voor zorgen dat verkiezingen eerlijk verlopen en dat iedere stem meetelt.
-
 De Kiesraad is de onafhankelijke autoriteit in Nederland op het gebied van verkiezingen. De missie van de Kiesraad is dat iedereen de uitslag van de verkiezingen kan vertrouwen.
 
-De Kiesraad adviseert de regering en het parlement over verkiezingen en het kiesrecht. Dit doen we gevraagd en ongevraagd. We evalueren iedere verkiezing en adviseren de minister over mogelijke verbeteringen.
-
-In het verkiezingsproces wordt digitalisering ingezet als hulpmiddel. De Kiesraad is verantwoordelijk voor de ontwikkeling en het beheer van de ondersteunende software die gebruikt wordt bij de kandidaatstelling en de vaststelling van de uitslagen van verkiezingen.
-
-Als informatie- en expertisecentrum over verkiezingen beheert de Kiesraad een verkiezingsdatabank die de uitslagen van meer dan 700 verkiezingen omvat, teruggaand tot 1848. De Kiesraad is benaderbaar voor iedereen die uitleg wil over het verkiezingsproces.
-
-Meer informatie over de verkiezingen en de Kiesraad is te vinden op [www.kiesraad.nl](https://www.kiesraad.nl)
+Meer informatie over de Kiesraad en de verkiezingen is te vinden op onze [GitHub organisatie-pagina](https://github.com/kiesraad) en op [www.kiesraad.nl](https://www.kiesraad.nl)
 
 ## Auteursrecht en licenties
 


### PR DESCRIPTION
closes #677

### Scope
As we now have a README on [our GitHub org profile](https://github.com/kiesraad), we can shorten that section in our Abacus README and link to our org profile.