### PR TITLE
Prevent truncation of integers

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -54,6 +54,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json"] }
 unsafe_code = "forbid"
 
 [lints.clippy]
+cast_possible_truncation = "deny"
 unwrap_used = "warn"
 
 [profile.release]

--- a/backend/src/apportionment/mod.rs
+++ b/backend/src/apportionment/mod.rs
@@ -503,7 +503,7 @@ mod tests {
         let mut political_group_votes: Vec<PoliticalGroupVotes> = vec![];
         for (index, votes) in pg_votes.iter().enumerate() {
             political_group_votes.push(PoliticalGroupVotes::from_test_data_auto(
-                (index + 1) as u8,
+                u8::try_from(index + 1).unwrap(),
                 *votes,
                 &[],
             ))

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -216,7 +216,7 @@ impl PoliticalGroupVotes {
             &candidate_votes
                 .iter()
                 .enumerate()
-                .map(|(i, votes)| (i as u8 + 1, *votes))
+                .map(|(i, votes)| (u8::try_from(i).unwrap() + 1, *votes))
                 .collect::<Vec<_>>(),
         )
     }

--- a/backend/src/election/structs.rs
+++ b/backend/src/election/structs.rs
@@ -113,7 +113,7 @@ pub(crate) mod tests {
             .iter()
             .enumerate()
             .map(|(i, &candidates)| PoliticalGroup {
-                number: (i + 1) as u8,
+                number: u8::try_from(i + 1).unwrap(),
                 name: format!("Political group {}", i + 1),
                 candidates: (0..candidates)
                     .map(|j| Candidate {

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -72,7 +72,7 @@ pub(crate) mod tests {
         for (i, voter_count) in polling_station_voter_count.iter().enumerate() {
             let idx = i + 1;
             polling_stations.push(PollingStation {
-                id: idx as u32,
+                id: u32::try_from(idx).unwrap(),
                 election_id: election.id,
                 name: format!("Testplek {idx}"),
                 number: idx as i64 + 30,


### PR DESCRIPTION
I've enabled the clippy lint [`cast_possible_truncation`](https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation) to disallow integer truncation, as this behavior is generally undesirable. If in the future integer truncation happens to be needed somewhere, we can always use `#[allow(..)]` to explicitly allow the truncation.

This PR also fixes the places where integer truncation could occur by using `try_from`, which will panic if a number doesn't fit. Fortunately, the only places in Abacus where truncation currently can happen are in functions that are only used in tests, but this behavior is still undesirable as it can lead to unexpected results.

Here's an example of what could go wrong because of integer truncation:
```rust
#[test]
fn party_number_truncation() {
    let totals = get_election_summary(vec![
        19858427, 0, 50397184, 511, 16777727, 0, 0, 0, 0, 65791, 65787, 0, 0, 0, 65791, 133631,
        17301755, 0, 0, 65791, 65787, 0, 0, 0, 0, 0, 255, 0, 0, 0, 65791, 65787, 0, 133631,
        17301755, 0, 33357824, 0, 0, 0, 16777467, 0, 0, 0, 0, 16777727, 0, 0, 0, 0, 65791, 511,
        0, 0, 0, 0, 0, 65791, 65787, 16777216, 0, 0, 0, 0, 0, 0, 65791, 65787, 0, 0, 511, 0, 0,
        0, 0, 0, 0, 65791, 65787, 0, 0, 0, 65791, 133631, 17301755, 0, 0, 0, 65791, 65787, 0,
        133631, 17301755, 0, 33357824, 0, 0, 0, 16777467, 0, 0, 0, 0, 16777727, 0, 0, 0, 0,
        65791, 511, 0, 0, 0, 0, 255, 0, 0, 16777215, 65791, 65787, 16777216, 0, 0, 0, 0, 0, 0,
        16777467, 0, 0, 0, 0, 16777727, 0, 0, 0, 0, 16843007, 0, 0, 0, 0, 65791, 65787, 0, 0,
        511, 0, 0, 0, 133376, 17301755, 0, 33488896, 0, 0, 0, 16777467, 0, 0, 0, 0, 255, 0, 0,
        0, 65791, 65787, 16777216, 0, 0, 0, 16777467, 0, 0, 0, 0, 16777473, 0, 0, 0, 0, 65791,
        65787, 0, 0, 511, 0, 0, 0, 255, 0, 0, 0, 65791, 65787, 0, 133631, 17301755, 0,
        33357824, 0, 0, 0, 16777467, 0, 0, 0, 0, 16777727, 0, 0, 0, 0, 65791, 511, 0, 0, 0, 0,
        255, 0, 0, 0, 65791, 65787, 16777216, 0, 0, 0, 0, 0, 0, 65791, 65787, 0, 0, 0, 0, 255,
        0, 16777216, 0, 0, 0, 16777467, 0, 0, 0, 0, 16777727, 0, 0, 0, 0, 16843007, 0, 0, 0, 0,
        65791, 65787, 0, 0, 511, 0, 0, 0, 133376, 17301755, 0, 33488896, 0, 0, 0, 16777467, 0,
        0, 0, 0, 255, 0, 0, 0, 65791,
    ]);
    let result = seat_allocation(18, &totals).unwrap();
    let total_seats = result
        .final_standing
        .iter()
        .map(|p| p.total_seats)
        .sum::<u64>();
    assert_eq!(18, total_seats);
}
```
If we add this test to `backend/src/appointment/mod.rs`, you will notice it will fail because Abacus will allocate 24 seats despite there only being 18 seats to be allocated. Because there are more than 255 parties, the parties' `pg_number`s will be [truncated](https://github.com/kiesraad/abacus/blob/bf79c6f429413d852b7cf07617cf2bc00ec3f39f/backend/src/apportionment/mod.rs#L506), causing duplicate rest seats to be added by [this logic](https://github.com/kiesraad/abacus/blob/bf79c6f429413d852b7cf07617cf2bc00ec3f39f/backend/src/apportionment/mod.rs#L296).

Whether the `pg_number`s should be `u8`s  is a separate discussion. I would suggest using `u32` instead of `u8`, and I will create a separate PR for this.

---

We came across this problem while fuzzing the apportionment logic. Our fuzzer also uses the `get_election_summary` function which caused us to notice this issue. In practice, this truncation should not be a problem because SQLx will give an error if a party's `pg_number` doesn't fit into the `u8`:
```
ERROR abacus::error: SQLx error: ColumnDecode { index: "\"political_groups\"", source: Error("invalid value: integer `270`, expected u8", line: 1, column: 14) }
```