### PR TITLE
Remove database reset endpoint

### DIFF
--- a/backend/fixtures/reset.sql
+++ b/backend/fixtures/reset.sql
@@ -1,7 +1,0 @@
--- Delete all data from the database in the correct order to avoid violating foreign key constraints
-DELETE FROM polling_station_results;
-DELETE FROM polling_station_data_entries;
-DELETE FROM polling_stations;
-DELETE FROM elections;
-DELETE FROM users;
-DELETE FROM sessions;

--- a/backend/src/fixtures.rs
+++ b/backend/src/fixtures.rs
@@ -1,5 +1,3 @@
-use crate::APIError;
-use axum::extract::State;
 use sqlx::SqlitePool;
 use tracing::info;
 
@@ -23,7 +21,7 @@ macro_rules! load_fixtures {
 ///
 /// This list should be updated manually when a new fixture is added that
 /// needs to be loaded when seeding fixtures.
-const FIXTURES: &[Fixture] = load_fixtures!(["reset", "election_1", "users"]);
+const FIXTURES: &[Fixture] = load_fixtures!(["election_1", "users"]);
 
 /// The data contained in a fixture file
 struct Fixture {
@@ -37,11 +35,5 @@ pub async fn seed_fixture_data(pool: &SqlitePool) -> Result<(), Box<dyn std::err
         sqlx::raw_sql(fixture.data).execute(pool).await?;
     }
     info!("loaded fixtures");
-    Ok(())
-}
-
-/// API endpoint to reset the database and seed it with fixture data
-pub async fn reset_database(State(pool): State<SqlitePool>) -> Result<(), APIError> {
-    seed_fixture_data(&pool).await?;
     Ok(())
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -123,10 +123,6 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
         )
     };
 
-    // Add a route to reset the database if the dev-database feature is enabled
-    #[cfg(feature = "dev-database")]
-    let app = app.route("/reset", post(fixtures::reset_database));
-
     // Add the state to the app
     let state = AppState { pool };
     let app = app.with_state(state);


### PR DESCRIPTION
No longer needed now that we use Playwright fixtures to create new elections.