### PR TITLE
uploads Playwright html report for e2e Playwright tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -172,7 +172,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: frontend/playwright-report/
           retention-days: 30
 
   deploy:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -171,7 +171,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.os }}
           path: frontend/playwright-report/
           retention-days: 30
 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -166,7 +166,7 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
         if: runner.os != 'Windows'
       - name: Run e2e playwright tests
-        run: npm run test:e2e -- --reporter=html
+        run: npm run test:e2e
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -166,7 +166,14 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
         if: runner.os != 'Windows'
       - name: Run e2e playwright tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --reporter=html
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
 
   deploy:
     name: Deploy to abacus-test.nl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,16 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
         if: runner.os != 'Windows'
       - name: Run Playwright e2e tests
-        run: npm run test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: npm run test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=html
         env:
           BACKEND_BUILD: release
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: playwright-report/
+          path: frontend/playwright-report/
           retention-days: 30
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,12 @@ jobs:
           path: ${{ matrix.target.binary }}
 
   playwright-e2e:
-    name: Playwright e2e tests (${{ matrix.os }}, ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: Playwright e2e tests (${{ matrix.os }}
     needs:
       - build
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -90,14 +88,14 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
         if: runner.os != 'Windows'
       - name: Run Playwright e2e tests
-        run: npm run test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=html
+        run: npm run test:e2e -- --reporter=html
         env:
           BACKEND_BUILD: release
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report-release
+          name: playwright-report-release-${{ matrix.os }}
           path: frontend/playwright-report/
           retention-days: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
         if: runner.os != 'Windows'
       - name: Run Playwright e2e tests
-        run: npm run test:e2e -- --reporter=html
+        run: npm run test:e2e
         env:
           BACKEND_BUILD: release
       - name: Upload Playwright report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
+          name: playwright-report-release
           path: frontend/playwright-report/
           retention-days: 30
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -29,6 +29,7 @@ test-results
 coverage
 mock
 test-report.junit.xml
+playwright-report/
 
 # Automatically created: https://github.com/mswjs/msw/discussions/1015#discussioncomment-1747585
 mockServiceWorker.js

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -60,6 +60,9 @@ npm run test:ladle
 npm run test:e2e
 # run tests, expect builds and database to be available:
 npm run test:e2e-dev
+
+# view reports and traces, e.g. the ones saved by our pipeline:
+npx playwright show-report <path-to-unzipped-report-folder>
 ```
 
 ### UI Component development

--- a/frontend/playwright.common.config.ts
+++ b/frontend/playwright.common.config.ts
@@ -16,7 +16,8 @@ const commonConfig: PlaywrightTestConfig = defineConfig({
   reporter: "list",
   fullyParallel: true,
   use: {
-    trace: "retain-on-failure",
+    // Local runs don't have retries, so we have a trace of each failure. On CI we do have retries, so keeping the trace of the first failure allows us to investigate flaky tests.
+    trace: "retain-on-first-failure",
     testIdAttribute: "id",
   },
   projects: [

--- a/frontend/playwright.common.config.ts
+++ b/frontend/playwright.common.config.ts
@@ -12,8 +12,6 @@ const commonConfig: PlaywrightTestConfig = defineConfig({
   workers: process.env.CI ? "100%" : undefined,
   // Increase the test timeout on CI, which is usually slower
   timeout: process.env.CI ? 30_000 : 10_000,
-  // Use the list reporter even on CI, to get immediate feedback
-  reporter: "list",
   fullyParallel: true,
   use: {
     // Local runs don't have retries, so we have a trace of each failure. On CI we do have retries, so keeping the trace of the first failure allows us to investigate flaky tests.

--- a/frontend/playwright.e2e.config.ts
+++ b/frontend/playwright.e2e.config.ts
@@ -20,6 +20,7 @@ function returnWebserverCommand(): string {
 
 const config: PlaywrightTestConfig = defineConfig({
   ...commonConfig,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   testDir: "./e2e-tests",
   outputDir: "./test-results/e2e-tests",
   testMatch: /\.e2e\.ts/,

--- a/frontend/playwright.ladle.config.ts
+++ b/frontend/playwright.ladle.config.ts
@@ -4,6 +4,8 @@ import commonConfig from "./playwright.common.config";
 
 const config: PlaywrightTestConfig = defineConfig({
   ...commonConfig,
+  // Use the list reporter even on CI, to get immediate feedback
+  reporter: "list",
   testDir: "./lib/ui",
   outputDir: "./test-results/ladle",
   testMatch: /\.e2e\.ts/,


### PR DESCRIPTION
relates to #991

Enable the html report (inc. traces of failed tests) for Playwright tests in the pipeline and upload the report as artifact.

Pipeline runs with this enabled:
- build, lint & test: https://github.com/kiesraad/abacus/actions/runs/13241029768

Release pipeline was also updated, but won't run until after merge and on Sunday.