### PR TITLE
OpenAPI TS generator: no required array means all fields are optional

### DIFF
--- a/frontend/scripts/openapi/generator.ts
+++ b/frontend/scripts/openapi/generator.ts
@@ -165,7 +165,7 @@ function tsType(s: ReferenceObject | SchemaObject | undefined): string {
 
 function isRequired(k: string, req: string[] | undefined): string {
   if (!req) {
-    return "";
+    return "?";
   }
   return req.includes(k) ? "" : "?";
 }


### PR DESCRIPTION
Right now the OpenAPI type generator assumes the absence of a `required` field means all fields are required, but the opposite is true; no `required` field, means all fields are optional.

### To test
1. Run the generator on the `main` branch, should result in no diff
2. Create a Rust struct with optional fields only e.g.:
```rust
struct TestStruct {
    #[serde(skip_serializing_if = "Option::is_none")]
    #[schema(value_type = String, nullable = false)]
    test_field_one: Option<String>,
    #[serde(skip_serializing_if = "Option::is_none")]
    #[schema(value_type = String, nullable = false)]
    test_field_two: Option<String>,
}
```
and see that the generator generates optional TS interfaces

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->