### PR TITLE
Custom matcher toHaveTableContent spaces between elements

### DIFF
--- a/frontend/app/component/election/status/ElectionStatus.test.tsx
+++ b/frontend/app/component/election/status/ElectionStatus.test.tsx
@@ -48,8 +48,8 @@ describe("ElectionStatus", () => {
     expect(headings[0]).toHaveTextContent("Invoer bezig (2)");
     expect(tables[0]).toHaveTableContent([
       ["Nummer", "Stembureau", "Voortgang"],
-      ["35", "Testschool" + "1e invoer", "60%"],
-      ["36", "Testbuurthuis" + "2e invoer", "20%"],
+      ["35", "Testschool 1e invoer", "60%"],
+      ["36", "Testbuurthuis 2e invoer", "20%"],
     ]);
 
     const inProgressRows = within(tables[0]!).getAllByRole("row");

--- a/frontend/lib/test/matchers.test.tsx
+++ b/frontend/lib/test/matchers.test.tsx
@@ -28,6 +28,19 @@ describe("Custom matchers", () => {
               <tr>
                 <td colSpan={2}>Big Cell</td>
               </tr>
+              <tr>
+                <td>
+                  Text<span>badge</span>
+                </td>
+                <td>
+                  <div>
+                    <span>{52}</span>
+                    <span>
+                      {4}/{23}
+                    </span>
+                  </div>
+                </td>
+              </tr>
             </tbody>
           </table>
         </>,
@@ -36,7 +49,12 @@ describe("Custom matchers", () => {
 
     test("Expect to have table content", async () => {
       const table = await screen.findByRole("table");
-      expect(table).toHaveTableContent([["Column One", "Column Two"], ["Cell One", "Cell Two"], ["Big Cell"]]);
+      expect(table).toHaveTableContent([
+        ["Column One", "Column Two"],
+        ["Cell One", "Cell Two"],
+        ["Big Cell"],
+        ["Text badge", "52 4/23"],
+      ]);
     });
 
     test("Expect to have table content to fail", async () => {
@@ -52,7 +70,12 @@ describe("Custom matchers", () => {
     test("Expect not to have table content to fail", async () => {
       const table = await screen.findByRole("table");
       expect(() => {
-        expect(table).not.toHaveTableContent([["Column One", "Column Two"], ["Cell One", "Cell Two"], ["Big Cell"]]);
+        expect(table).not.toHaveTableContent([
+          ["Column One", "Column Two"],
+          ["Cell One", "Cell Two"],
+          ["Big Cell"],
+          ["Text badge", "52 4/23"],
+        ]);
       }).toThrowError(/Expected table not to have content/);
     });
 

--- a/frontend/lib/test/matchers.ts
+++ b/frontend/lib/test/matchers.ts
@@ -1,5 +1,22 @@
 import type { ExpectationResult } from "@vitest/expect";
 
+function isTextNode(node: Node): boolean {
+  return node.nodeType === Node.TEXT_NODE;
+}
+
+/**
+ * Get the text content, adding spaces between different child elements to make sure contents such as
+ * `<span>text</span><Badge />` and `<DisplayFractions />` can be tested in a more readable way.
+ */
+function getTextContent(node: Node): string {
+  const childNodes = Array.from(node.childNodes);
+  if (isTextNode(node) || childNodes.every(isTextNode)) {
+    return node.textContent?.trim() || "";
+  }
+
+  return childNodes.map(getTextContent).filter(Boolean).join(" ").trim();
+}
+
 function toHaveTableContent(htmlElement: unknown, expected: string[][]): ExpectationResult {
   if (!(htmlElement instanceof HTMLTableElement)) {
     return {
@@ -9,7 +26,7 @@ function toHaveTableContent(htmlElement: unknown, expected: string[][]): Expecta
   }
 
   const actual = Array.from(htmlElement.querySelectorAll("tr")).map((row) =>
-    Array.from(row.querySelectorAll("th, td")).map((cell) => cell.textContent?.trim() || ""),
+    Array.from(row.querySelectorAll("th, td")).map(getTextContent),
   );
 
   const pass = JSON.stringify(actual) === JSON.stringify(expected);


### PR DESCRIPTION
The `toHaveTableContent()` used `textContent` to get the text from each cell in the table, which just concatenates texts from all child elements. We would like to add spaces in between these elements, especially for apportionment fractions to properly test the difference between `<span>5</span><span>12/40</span>` and `<span>51</span><span>2/40</span>`.

With this change, the child elements textContents will be joined with a space in between, and the resulting expected cell string will now be `"5 12/40"` instead of `"512/40"`