### PR TITLE
limit download of artifacts to builds in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Download abacus
         uses: actions/download-artifact@v4
         with:
+          pattern: abacus-*
           path: release/
       - name: Rename binary
         run: |


### PR DESCRIPTION
closes #1038 

See linked issue for analysis and test of fix on fork.