### PR TITLE
Wait for data-storyloaded in Ladle e2e tests

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -58,5 +58,12 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off",
       },
     },
+    {
+      files: ["lib/ui/**/*.e2e.ts"],
+      rules: {
+        // Needed for Ladle, page.waitForSelector("[data-storyloaded]")
+        "playwright/no-wait-for-selector": "off",
+      },
+    },
   ],
 };

--- a/frontend/lib/ui/Badge/Badge.e2e.ts
+++ b/frontend/lib/ui/Badge/Badge.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("badges are visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=badge--all-badges");
+  await page.goto("/?story=badge--all-badges");
   await page.waitForSelector("[data-storyloaded]");
 
   const notStartedBadge = page.getByTestId("first_entry_not_started");

--- a/frontend/lib/ui/Badge/Badge.e2e.ts
+++ b/frontend/lib/ui/Badge/Badge.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("badges are visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=badge--all-badges");
+  await page.waitForSelector("[data-storyloaded]");
 
   const notStartedBadge = page.getByTestId("first_entry_not_started");
   await expect(notStartedBadge).toBeVisible();

--- a/frontend/lib/ui/BottomBar/BottomBar.e2e.ts
+++ b/frontend/lib/ui/BottomBar/BottomBar.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("bottom bar with button and button hint is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=bottom-bar--bottom-bar-form");
+  await page.goto("/?story=bottom-bar--bottom-bar-form");
   await page.waitForSelector("[data-storyloaded]");
 
   const buttonElement = page.getByRole("button", { name: "Click me" });

--- a/frontend/lib/ui/BottomBar/BottomBar.e2e.ts
+++ b/frontend/lib/ui/BottomBar/BottomBar.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("bottom bar with button and button hint is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=bottom-bar--bottom-bar-form");
+  await page.waitForSelector("[data-storyloaded]");
 
   const buttonElement = page.getByRole("button", { name: "Click me" });
   const shiftElement = page.getByText("Shift");

--- a/frontend/lib/ui/Button/Button.e2e.ts
+++ b/frontend/lib/ui/Button/Button.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("buttons are visible and enabled", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=button--buttons");
+  await page.goto("/?story=button--buttons");
   await page.waitForSelector("[data-storyloaded]");
 
   const buttons = await page
@@ -19,7 +19,7 @@ test("buttons are visible and enabled", async ({ page }) => {
 });
 
 test("click disabled button does nothing", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=button--buttons&arg-disabled=true");
+  await page.goto("/?story=button--buttons&arg-disabled=true");
   await page.waitForSelector("[data-storyloaded]");
 
   const buttons = await page

--- a/frontend/lib/ui/Button/Button.e2e.ts
+++ b/frontend/lib/ui/Button/Button.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("buttons are visible and enabled", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=button--buttons");
+  await page.waitForSelector("[data-storyloaded]");
 
   const buttons = await page
     .getByRole("button", {
@@ -19,6 +20,7 @@ test("buttons are visible and enabled", async ({ page }) => {
 
 test("click disabled button does nothing", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=button--buttons&arg-disabled=true");
+  await page.waitForSelector("[data-storyloaded]");
 
   const buttons = await page
     .getByRole("button", {

--- a/frontend/lib/ui/InputField/InputField.e2e.ts
+++ b/frontend/lib/ui/InputField/InputField.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("default small wide input field is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=input-field--wide-input-field");
+  await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Default Small Wide" });
 
@@ -12,6 +13,7 @@ test("default small wide input field is visible", async ({ page }) => {
 
 test("error large wide input field is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=input-field--wide-input-field");
+  await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Error Large Wide" });
 
@@ -23,6 +25,7 @@ test("error large wide input field is visible", async ({ page }) => {
 
 test("default medium narrow input field is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=input-field--narrow-input-field");
+  await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Default Medium Narrow" });
 
@@ -33,6 +36,7 @@ test("default medium narrow input field is visible", async ({ page }) => {
 
 test("error large narrow input field is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=input-field--narrow-input-field");
+  await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Error Large Narrow" });
 
@@ -44,6 +48,7 @@ test("error large narrow input field is visible", async ({ page }) => {
 
 test("default text area input field is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=input-field--text-area-input-field");
+  await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Default Text Area" });
 
@@ -54,6 +59,7 @@ test("default text area input field is visible", async ({ page }) => {
 
 test("error text area input field is visible", async ({ page }) => {
   await page.goto("http://localhost:61000/?story=input-field--text-area-input-field");
+  await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Error Text Area" });
 

--- a/frontend/lib/ui/InputField/InputField.e2e.ts
+++ b/frontend/lib/ui/InputField/InputField.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("default small wide input field is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=input-field--wide-input-field");
+  await page.goto("/?story=input-field--wide-input-field");
   await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Default Small Wide" });
@@ -12,7 +12,7 @@ test("default small wide input field is visible", async ({ page }) => {
 });
 
 test("error large wide input field is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=input-field--wide-input-field");
+  await page.goto("/?story=input-field--wide-input-field");
   await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Error Large Wide" });
@@ -24,7 +24,7 @@ test("error large wide input field is visible", async ({ page }) => {
 });
 
 test("default medium narrow input field is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=input-field--narrow-input-field");
+  await page.goto("/?story=input-field--narrow-input-field");
   await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Default Medium Narrow" });
@@ -35,7 +35,7 @@ test("default medium narrow input field is visible", async ({ page }) => {
 });
 
 test("error large narrow input field is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=input-field--narrow-input-field");
+  await page.goto("/?story=input-field--narrow-input-field");
   await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Error Large Narrow" });
@@ -47,7 +47,7 @@ test("error large narrow input field is visible", async ({ page }) => {
 });
 
 test("default text area input field is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=input-field--text-area-input-field");
+  await page.goto("/?story=input-field--text-area-input-field");
   await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Default Text Area" });
@@ -58,7 +58,7 @@ test("default text area input field is visible", async ({ page }) => {
 });
 
 test("error text area input field is visible", async ({ page }) => {
-  await page.goto("http://localhost:61000/?story=input-field--text-area-input-field");
+  await page.goto("/?story=input-field--text-area-input-field");
   await page.waitForSelector("[data-storyloaded]");
 
   const input = page.getByRole("textbox", { name: "Error Text Area" });

--- a/frontend/lib/ui/InputGrid/InputGrid.e2e.ts
+++ b/frontend/lib/ui/InputGrid/InputGrid.e2e.ts
@@ -3,6 +3,8 @@ import { test as base, expect, Locator } from "@playwright/test";
 const test = base.extend<{ gridPage: Locator }>({
   gridPage: async ({ page }, use) => {
     await page.goto("http://localhost:61000/?story=input-grid--default-grid");
+    await page.waitForSelector("[data-storyloaded]");
+
     const main = page.locator("main.ladle-main");
     const grid = main.locator("table");
     await grid.waitFor();

--- a/frontend/lib/ui/InputGrid/InputGrid.e2e.ts
+++ b/frontend/lib/ui/InputGrid/InputGrid.e2e.ts
@@ -2,7 +2,7 @@ import { test as base, expect, Locator } from "@playwright/test";
 
 const test = base.extend<{ gridPage: Locator }>({
   gridPage: async ({ page }, use) => {
-    await page.goto("http://localhost:61000/?story=input-grid--default-grid");
+    await page.goto("/?story=input-grid--default-grid");
     await page.waitForSelector("[data-storyloaded]");
 
     const main = page.locator("main.ladle-main");

--- a/frontend/playwright.ladle.config.ts
+++ b/frontend/playwright.ladle.config.ts
@@ -11,12 +11,12 @@ const config: PlaywrightTestConfig = defineConfig({
   testMatch: /\.e2e\.ts/,
   use: {
     ...commonConfig.use,
-    baseURL: "http://localhost:61000",
+    baseURL: "http://localhost:61000/ladle/",
   },
   webServer: [
     {
       command: "npm run ladle",
-      port: 61000,
+      url: "http://localhost:61000/ladle/",
     },
   ],
 });


### PR DESCRIPTION
Fixes #1070

Fix flaky Ladle e2e tests by waiting for the `data-storyloaded` attribute, as suggested in https://ladle.dev/docs/meta/#testing