### PR TITLE
Upgrade to React Router 7.2.0

### DIFF
--- a/frontend/app/module/data_entry/page/DataEntryHomePage.test.tsx
+++ b/frontend/app/module/data_entry/page/DataEntryHomePage.test.tsx
@@ -5,14 +5,14 @@ import { beforeEach, describe, expect, test } from "vitest";
 
 import { routes } from "app/routes";
 
-import { ElectionProvider, ElectionStatusProvider, ElectionStatusResponse } from "@kiesraad/api";
+import { ElectionProvider, ElectionStatusProvider } from "@kiesraad/api";
 import {
   electionDetailsMockResponse,
   ElectionListRequestHandler,
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
 } from "@kiesraad/api-mocks";
-import { overrideOnce, Providers, render, screen, server, setupTestRouter, waitFor, within } from "@kiesraad/test";
+import { overrideOnce, Providers, render, screen, server, setupTestRouter, within } from "@kiesraad/test";
 
 import { DataEntryHomePage } from "./DataEntryHomePage";
 
@@ -95,52 +95,6 @@ describe("DataEntryHomePage", () => {
     // Ensure the page is rendered before testing
     await screen.findByText("Gemeenteraadsverkiezingen 2026");
     expect(screen.queryByRole("alert")).toBeNull();
-  });
-
-  test("Rerender re-fetches election status", async () => {
-    overrideOnce("get", "/api/elections/1/status", 200, {
-      statuses: [
-        { polling_station_id: 1, status: "first_entry_not_started" },
-        { polling_station_id: 2, status: "first_entry_not_started" },
-      ],
-    } satisfies ElectionStatusResponse);
-
-    // render and expect the initial status to be fetched
-    const { rerender } = renderDataEntryHomePage();
-    await waitFor(() => {
-      expect(screen.queryByText("Welk stembureau ga je invoeren?")).not.toBeInTheDocument();
-    });
-    expect(screen.queryByText("Alle stembureaus zijn ingevoerd")).not.toBeInTheDocument();
-
-    // unmount DataEntryHomePage, but keep the providers as-is
-    rerender(
-      <ElectionProvider electionId={1}>
-        <ElectionStatusProvider electionId={1}>
-          <></>
-        </ElectionStatusProvider>
-      </ElectionProvider>,
-    );
-    await waitFor(() => {
-      expect(screen.queryByText("Welk stembureau ga je invoeren?")).not.toBeInTheDocument();
-    });
-
-    // new status is that all polling stations are definitive, so the alert should be visible
-    overrideOnce("get", "/api/elections/1/status", 200, {
-      statuses: [
-        { polling_station_id: 1, status: "definitive" },
-        { polling_station_id: 2, status: "definitive" },
-      ],
-    } satisfies ElectionStatusResponse);
-
-    // rerender DataEntryHomePage and expect the new status to be fetched
-    rerender(
-      <ElectionProvider electionId={1}>
-        <ElectionStatusProvider electionId={1}>
-          <DataEntryHomePage />
-        </ElectionStatusProvider>
-      </ElectionProvider>,
-    );
-    expect(screen.queryByText("Alle stembureaus zijn ingevoerd")).not.toBeInTheDocument();
   });
 
   test("Data entry saved alert works", async () => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "postcss-nesting": "^13.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router": "^7.1.3",
+        "react-router": "^7.2.0",
         "vite": "^6.2.0"
       },
       "devDependencies": {
@@ -10219,9 +10219,10 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
-      "integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.2.0.tgz",
+      "integrity": "sha512-fXyqzPgCPZbqhrk7k3hPcCpYIlQ2ugIXDboHUzhJISFVy2DEPsmHgN588MyGmkIOv3jDgNfUE3kJi83L28s/LQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
         "cookie": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "postcss-nesting": "^13.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.1.3",
+    "react-router": "^7.2.0",
     "vite": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Remove "Rerender re-fetches election status" test
  This test was not asserting the correct behaviour (since at least [this commit](https://github.com/kiesraad/abacus/commit/f8c92a8802dcdc70a2a678f551be5b9a74321a82#diff-1e12088a84e737db07a6e3f0c0cbd0cfd4c946287aa524d0dc30751168ec0acb)) and now also conflicts with React Router behaviour.
- Upgrade to React Router 7.2.0

Resolves #953