### PR TITLE
Return 409 Conflict for duplicate username

### DIFF
--- a/backend/migrations/5_users.sql
+++ b/backend/migrations/5_users.sql
@@ -9,5 +9,5 @@ CREATE TABLE users
     last_activity_at       DATETIME        ,
     updated_at             DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at             DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(username)
+    UNIQUE(username COLLATE NOCASE)
 );

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1290,6 +1290,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict (username already exists)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2298,6 +2298,7 @@
           "PollingStationSecondEntryAlreadyFinalised",
           "PollingStationValidationErrors",
           "UserNotFound",
+          "UsernameNotUnique",
           "Unauthorized",
           "PasswordRejection"
         ]

--- a/backend/src/authentication/api.rs
+++ b/backend/src/authentication/api.rs
@@ -297,6 +297,7 @@ pub struct UpdateUserRequest {
     responses(
         (status = 201, description = "User created", body = User),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 409, description = "Conflict (username already exists)", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -4,6 +4,7 @@ pub enum AuthenticationError {
     InvalidUsernameOrPassword,
     InvalidPassword,
     InvalidSessionDuration,
+    UsernameAlreadyExists,
     SessionKeyNotFound,
     NoSessionCookie,
     Database(sqlx::Error),

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -49,6 +49,7 @@ pub enum ErrorReference {
     PollingStationSecondEntryAlreadyFinalised,
     PollingStationValidationErrors,
     UserNotFound,
+    UsernameNotUnique,
     Unauthorized,
     PasswordRejection,
 }
@@ -195,6 +196,14 @@ impl IntoResponse for APIError {
                         to_error(
                             "Invalid username and/or password",
                             ErrorReference::InvalidUsernameOrPassword,
+                            false,
+                        ),
+                    ),
+                    AuthenticationError::UsernameAlreadyExists => (
+                        StatusCode::CONFLICT,
+                        to_error(
+                            "Username already exists",
+                            ErrorReference::UsernameNotUnique,
                             false,
                         ),
                     ),

--- a/backend/tests/user_integration_test.rs
+++ b/backend/tests/user_integration_test.rs
@@ -114,6 +114,51 @@ async fn test_user_creation(pool: SqlitePool) {
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_user_creation_duplicate_username(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let url = format!("http://{addr}/api/user");
+    let admin_cookie = shared::admin_login(&addr).await;
+
+    let response = reqwest::Client::new()
+        .post(&url)
+        .json(&json!({
+            "role": "administrator",
+            "username": "username",
+            "fullname": "fullname",
+            "temp_password": "MyLongPassword13"
+        }))
+        .header("cookie", admin_cookie.clone())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "Unexpected response status"
+    );
+
+    let response = reqwest::Client::new()
+        .post(&url)
+        .json(&json!({
+            "role": "administrator",
+            "username": "Username",
+            "fullname": "fullname",
+            "temp_password": "MyLongPassword13"
+        }))
+        .header("cookie", admin_cookie)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::CONFLICT,
+        "Unexpected response status"
+    );
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
 async fn test_user_creation_anonymous(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/user");

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -380,6 +380,7 @@ export type ErrorReference =
   | "PollingStationSecondEntryAlreadyFinalised"
   | "PollingStationValidationErrors"
   | "UserNotFound"
+  | "UsernameNotUnique"
   | "Unauthorized"
   | "PasswordRejection";
 

--- a/frontend/lib/i18n/locales/nl/error.json
+++ b/frontend/lib/i18n/locales/nl/error.json
@@ -40,6 +40,7 @@
     "PollingStationValidationErrors": "Er zijn fouten opgetreden bij het valideren van het stembureau",
     "Unauthorized": "Je hebt geen toestemming om deze actie uit te voeren",
     "UserNotFound": "De gebruiker is niet gevonden",
+    "UsernameNotUnique": "De gebruikersnaam is al in gebruik",
     "PasswordRejection": "Het opgegeven wachtwoord voldoet niet aan de eisen"
   }
 }


### PR DESCRIPTION
Fixes #1022

This makes sure there are no duplicate usernames (case-insensitive) and that trying to create a user with a duplicate username results in a 409 server response.

Test by create two users with the same username.