### PR TITLE
Build frontend and backend in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+backend/target
+frontend/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,25 @@
+FROM node:22 as frontend-builder
+WORKDIR /build
+COPY . .
+WORKDIR /build/frontend
+RUN npm ci --omit=dev
+RUN npm run build
+
+FROM rust:bookworm as backend-builder
+WORKDIR /build
+COPY ./backend ./backend
+COPY --from=frontend-builder /build/frontend/dist ./frontend/dist
+WORKDIR /build/backend
+ENV ASSET_DIR=/build/frontend/dist
+RUN cargo build --release --features memory-serve
+
 FROM debian:bookworm-slim
-
 WORKDIR /abacus
-
-RUN groupadd -r abacus --gid=999 
+RUN groupadd -r abacus --gid=999
 RUN useradd --no-log-init -r -g abacus --uid=999 abacus
-
-# Creates the /abacus folder owned by the abacus user
-RUN install -o abacus -g abacus -d  /abacus
-
-# Copy the binary
-COPY ./backend/target/release/abacus /usr/local/bin/abacus
-
+RUN install -o abacus -g abacus -d /abacus
+COPY --from=backend-builder /build/backend/target/release/abacus /usr/local/bin/abacus
 USER 999
-
-# Run
 ENTRYPOINT ["/usr/local/bin/abacus"]
-
+CMD ["--seed-data"]
 EXPOSE 8080


### PR DESCRIPTION
Change the Dockerfile to build the frontend and backend using two build containers, and put the built binary in a third container.

Relates to https://github.com/kiesraad/abacus/issues/479#issuecomment-2457464173.