### PR TITLE
Finding a user by username is now case insensitive

### DIFF
--- a/backend/.sqlx/query-4a177db4cae120abc9d6218c6b26dbef5b12b6fbe9e7d49d1266b1b4b7eef0ec.json
+++ b/backend/.sqlx/query-4a177db4cae120abc9d6218c6b26dbef5b12b6fbe9e7d49d1266b1b4b7eef0ec.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n            SELECT\n                id as \"id: u32\",\n                username,\n                fullname,\n                role,\n                password_hash,\n                needs_password_change,\n                last_activity_at as \"last_activity_at: _\",\n                updated_at as \"updated_at: _\",\n                created_at as \"created_at: _\"\n            FROM users WHERE username = ?\n            ",
+  "query": "\n            SELECT\n                id as \"id: u32\",\n                username,\n                fullname,\n                role,\n                password_hash,\n                needs_password_change,\n                last_activity_at as \"last_activity_at: _\",\n                updated_at as \"updated_at: _\",\n                created_at as \"created_at: _\"\n            FROM users WHERE username = ? COLLATE NOCASE\n            ",
   "describe": {
     "columns": [
       {
@@ -64,5 +64,5 @@
       false
     ]
   },
-  "hash": "28772ab9ee9a7b53b9c97e0bfc4b20ac1f50f42dca01adc54144cd61e29a7527"
+  "hash": "4a177db4cae120abc9d6218c6b26dbef5b12b6fbe9e7d49d1266b1b4b7eef0ec"
 }

--- a/backend/src/authentication/user.rs
+++ b/backend/src/authentication/user.rs
@@ -390,7 +390,7 @@ impl Users {
                 last_activity_at as "last_activity_at: _",
                 updated_at as "updated_at: _",
                 created_at as "created_at: _"
-            FROM users WHERE username = ?
+            FROM users WHERE username = ? COLLATE NOCASE
             "#,
             username
         )
@@ -543,6 +543,14 @@ mod tests {
 
         let authenticated_user = users
             .authenticate("test_user", "TotallyValidP4ssW0rd")
+            .await
+            .unwrap();
+
+        assert_eq!(user, authenticated_user);
+
+        // Username should be case insensitive
+        let authenticated_user = users
+            .authenticate("Test_User", "TotallyValidP4ssW0rd")
             .await
             .unwrap();
 


### PR DESCRIPTION
Fixes #1091 

#1091 was mostly fixed by #1125. This PR implements user login being case sensitive.
Also adds an assert to the authentication test.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->