### PR TITLE
Update testen-en-kwaliteit.md

### DIFF
--- a/documentatie/ontwikkelproces/testen-en-kwaliteit.md
+++ b/documentatie/ontwikkelproces/testen-en-kwaliteit.md
@@ -76,7 +76,7 @@ We gebruiken deze kwaliteitscriteria om ons werk te toetsen. Ze sluiten aan op d
 - één ticket/taak mag in meerdere PR's gebouwd worden.
 - Pair/ensemble programming telt als review.
 - Vraag vroeg om feedback: [editing over proof-reading](https://buttondown.email/hillelwayne/archive/code-review-vs-code-proofreading/) (Hillel Wayne)
-- Zoveel mogelijk afvangen d.m.v. linting, static code analysis, code kwaliteit en testcoverage zodat menselijke code review kan focussen op architectuur e.d.
+- Zoveel mogelijk afvangen d.m.v. linting, static code analysis, codekwaliteit en testcoverage zodat menselijke code review kan focussen op architectuur e.d.
 
 #### Handmatige tests en automatische tests
 
@@ -96,7 +96,7 @@ We gebruiken deze kwaliteitscriteria om ons werk te toetsen. Ze sluiten aan op d
   - Integration tests
   - End-to-end tests
   - Security scan
-  - Code kwaliteit
+  - Codekwaliteit
   - Test coverage
   - Performance test
   - Installeerbaarheidstest


### PR DESCRIPTION
Aanvulling NAV sig aanbeveling om sigrid en vergelijkbare tools (bv codecov) in de kwaliteitsaanpak te verankeren. 

Expliciet afgezien van het opnemen van een target ('vier sterren') of een percentage ('95% code coverage') omdat je dan met percentages en dashboards bezig bent en niet met de inhoud.
