### PR TITLE
Remove `development_create_user` endpoint

### DIFF
--- a/backend/src/authentication/api.rs
+++ b/backend/src/authentication/api.rs
@@ -255,33 +255,6 @@ pub async fn extend_session(State(pool): State<SqlitePool>, req: Request, next: 
     res
 }
 
-/// Development endpoint: create a new user (unauthenticated)
-#[cfg(debug_assertions)]
-#[utoipa::path(
-  post,
-  path = "/api/user/development/create",
-  request_body = Credentials,
-  responses(
-      (status = 201, description = "User was successfully created"),
-      (status = 500, description = "Internal server error", body = ErrorResponse),
-  ),
-)]
-pub async fn development_create_user(
-    State(users): State<Users>,
-    Json(credentials): Json<Credentials>,
-) -> Result<impl IntoResponse, APIError> {
-    use super::role::Role;
-
-    let Credentials { username, password } = credentials;
-
-    // Create a new user
-    users
-        .create(&username, None, &password, Role::Typist)
-        .await?;
-
-    Ok(StatusCode::CREATED)
-}
-
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct UserListResponse {
     pub users: Vec<User>,

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -84,12 +84,6 @@ mod tests {
             .route("/api/user/account", put(api::account_update))
             .layer(middleware::from_fn_with_state(pool, extend_session));
 
-        #[cfg(debug_assertions)]
-        let router = router.route(
-            "/api/user/development/create",
-            post(api::development_create_user),
-        );
-
         router.with_state(state)
     }
 
@@ -346,55 +340,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[cfg(debug_assertions)]
-    #[test(sqlx::test)]
-    async fn test_development_create_user(pool: SqlitePool) {
-        let app = create_app(pool);
-
-        // create a new user
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/api/user/development/create")
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&Credentials {
-                            username: "user_test".to_string(),
-                            password: "password_test".to_string(),
-                        })
-                        .unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::CREATED);
-
-        // test login
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/api/user/login")
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&Credentials {
-                            username: "user_test".to_string(),
-                            password: "password_test".to_string(),
-                        })
-                        .unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -109,12 +109,6 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
             authentication::extend_session,
         ));
 
-    #[cfg(debug_assertions)]
-    let user_router = user_router.route(
-        "/development/create",
-        post(authentication::development_create_user),
-    );
-
     let app = Router::new()
         .nest("/api/user", user_router)
         .nest("/api/elections", election_routes)


### PR DESCRIPTION
This endpoint was used for testing and development but is no longer needed now that we use user fixtures.