### PR TITLE
Reduce boilerplate for data entry form sections

### DIFF
--- a/frontend/app/component/form/data_entry/candidates_votes/useCandidateVotes.ts
+++ b/frontend/app/component/form/data_entry/candidates_votes/useCandidateVotes.ts
@@ -16,10 +16,12 @@ export function useCandidateVotes(political_group_number: number) {
       type: "political_group_votes",
       number: political_group_number,
     },
-    getDefaultFormValues: (results) =>
-      valuesToFormValues(
-        results.political_group_votes.find((pg) => pg.number === political_group_number) as CandidateVotesValues,
-      ),
+    getDefaultFormValues: (results, cache) =>
+      cache?.key === `political_group_votes_${political_group_number}`
+        ? valuesToFormValues(cache.data as CandidateVotesValues)
+        : valuesToFormValues(
+            results.political_group_votes.find((pg) => pg.number === political_group_number) as CandidateVotesValues,
+          ),
   });
 
   const [missingTotalError, setMissingTotalError] = React.useState(false);

--- a/frontend/app/component/form/data_entry/differences/useDifferences.ts
+++ b/frontend/app/component/form/data_entry/differences/useDifferences.ts
@@ -1,80 +1,30 @@
-import { useEffect, useRef, useState } from "react";
-
-import { useFormKeyboardNavigation } from "@kiesraad/ui";
-
-import { getErrorsAndWarnings } from "../state/dataEntryUtils";
 import { SubmitCurrentFormOptions } from "../state/types";
-import { useDataEntryContext } from "../state/useDataEntryContext";
+import { useDataEntryFormSection } from "../state/useDataEntryFormSection";
 import { DifferencesFormValues, DifferencesValues, formValuesToValues, valuesToFormValues } from "./differencesValues";
 
 export function useDifferences() {
-  const { error, cache, status, pollingStationResults, formState, onSubmitForm, updateFormSection } =
-    useDataEntryContext({
+  const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<DifferencesFormValues>({
+    section: {
       id: "differences_counts",
       type: "differences",
-    });
-
-  // local form state
-  const defaultValues =
-    cache?.key === "differences_counts" ? (cache.data as DifferencesValues) : pollingStationResults.differences_counts;
-
-  const [currentValues, setCurrentValues] = useState<DifferencesFormValues>(valuesToFormValues(defaultValues));
-
-  // derived state
-  const { errors, warnings, isSaved, acceptWarnings, hasChanges } = formState.sections.differences_counts;
-  const defaultProps = {
-    errorsAndWarnings: isSaved ? getErrorsAndWarnings(errors, warnings) : undefined,
-    warningsAccepted: acceptWarnings,
-  };
-  const formSection = formState.sections.differences_counts;
-  const showAcceptWarnings = formSection.warnings.length > 0 && formSection.errors.length === 0 && !hasChanges;
-
-  // register changes when fields change
-  const setValues = (values: DifferencesFormValues) => {
-    if (!hasChanges) {
-      updateFormSection({ hasChanges: true, acceptWarnings: false, acceptWarningsError: false });
-    }
-    setCurrentValues(values);
-  };
-
-  const setAcceptWarnings = (acceptWarnings: boolean) => {
-    updateFormSection({ acceptWarningsError: false, acceptWarnings });
-  };
-
-  // form keyboard navigation
-  const formRef = useRef<HTMLFormElement>(null);
-  useFormKeyboardNavigation(formRef);
+    },
+    getDefaultFormValues: (results) => valuesToFormValues(results.differences_counts),
+  });
 
   // submit and save to form contents
   const onSubmit = async (options?: SubmitCurrentFormOptions): Promise<boolean> => {
-    const data: DifferencesValues = formValuesToValues(currentValues);
+    const data: DifferencesValues = formValuesToValues(section.currentValues);
 
-    return await onSubmitForm(
+    return await _onSubmit(
       {
         differences_counts: data,
       },
-      { ...options, showAcceptWarnings },
+      { ...options, showAcceptWarnings: section.showAcceptWarnings },
     );
   };
 
-  // scroll to top when saved
-  useEffect(() => {
-    if (isSaved || error) {
-      window.scrollTo(0, 0);
-    }
-  }, [isSaved, error]);
-
   return {
-    error,
-    formRef,
+    ...section,
     onSubmit,
-    pollingStationResults,
-    currentValues,
-    formSection: formState.sections.differences_counts,
-    setValues,
-    status,
-    setAcceptWarnings,
-    defaultProps,
-    showAcceptWarnings,
   };
 }

--- a/frontend/app/component/form/data_entry/differences/useDifferences.ts
+++ b/frontend/app/component/form/data_entry/differences/useDifferences.ts
@@ -8,7 +8,10 @@ export function useDifferences() {
       id: "differences_counts",
       type: "differences",
     },
-    getDefaultFormValues: (results) => valuesToFormValues(results.differences_counts),
+    getDefaultFormValues: (results, cache) =>
+      cache?.key === "differences_counts"
+        ? valuesToFormValues(cache.data as DifferencesValues)
+        : valuesToFormValues(results.differences_counts),
   });
 
   // submit and save to form contents

--- a/frontend/app/component/form/data_entry/recounted/RecountedForm.tsx
+++ b/frontend/app/component/form/data_entry/recounted/RecountedForm.tsx
@@ -8,8 +8,7 @@ import { DataEntryNavigation } from "../DataEntryNavigation";
 import { useRecounted } from "./useRecounted";
 
 export function RecountedForm() {
-  const { error, recounted, formRef, setRecounted, errors, hasValidationError, isSaved, isSaving, onSubmit } =
-    useRecounted();
+  const { error, recounted, formRef, setRecounted, formSection, isSaving, onSubmit } = useRecounted();
 
   return (
     <Form
@@ -23,8 +22,8 @@ export function RecountedForm() {
     >
       <DataEntryNavigation onSubmit={onSubmit} currentValues={{ recounted }} />
       {error instanceof ApiError && <ErrorModal error={error} />}
-      {isSaved && hasValidationError && (
-        <Feedback id="feedback-error" type="error" data={errors.map((error) => error.code)} />
+      {formSection.isSaved && formSection.errors.length > 0 && (
+        <Feedback id="feedback-error" type="error" data={formSection.errors.map((error) => error.code)} />
       )}
       <p className="form-paragraph md">{t("recounted.message")}</p>
       <div className="radio-form">

--- a/frontend/app/component/form/data_entry/state/useDataEntryFormSection.ts
+++ b/frontend/app/component/form/data_entry/state/useDataEntryFormSection.ts
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { PollingStationResults } from "@kiesraad/api";
+import { useFormKeyboardNavigation } from "@kiesraad/ui";
+
+import { getErrorsAndWarnings } from "./dataEntryUtils";
+import { FormSectionReference, SubmitCurrentFormOptions } from "./types";
+import { useDataEntryContext } from "./useDataEntryContext";
+
+export interface UseDataEntryFormSectionParams<FORM_VALUES> {
+  getDefaultFormValues: (results: PollingStationResults) => FORM_VALUES;
+  section: FormSectionReference;
+}
+
+export function useDataEntryFormSection<FORM_VALUES>({
+  getDefaultFormValues,
+  section,
+}: UseDataEntryFormSectionParams<FORM_VALUES>) {
+  const { error, cache, status, pollingStationResults, formState, onSubmitForm, updateFormSection } =
+    useDataEntryContext(section);
+
+  //local form state
+
+  const [currentValues, setCurrentValues] = React.useState<FORM_VALUES>(() =>
+    cache?.key === section.id ? (cache.data as FORM_VALUES) : getDefaultFormValues(pollingStationResults),
+  );
+
+  // derived state
+  const formSection = formState.sections[section.id];
+  if (!formSection) {
+    throw new Error(`Form section ${section.id} not found in form state`);
+  }
+  const { errors, warnings, isSaved, acceptWarnings, hasChanges } = formSection;
+  const defaultProps = {
+    errorsAndWarnings: isSaved ? getErrorsAndWarnings(errors, warnings) : undefined,
+    warningsAccepted: acceptWarnings,
+  };
+
+  const showAcceptWarnings = formSection.warnings.length > 0 && formSection.errors.length === 0 && !hasChanges;
+
+  // register changes when fields change
+  const setValues = (values: FORM_VALUES) => {
+    if (!hasChanges) {
+      updateFormSection({ hasChanges: true, acceptWarnings: false, acceptWarningsError: false });
+    }
+    setCurrentValues(values);
+  };
+
+  const setAcceptWarnings = (acceptWarnings: boolean) => {
+    updateFormSection({ acceptWarningsError: false, acceptWarnings });
+  };
+
+  // form keyboard navigation
+  const formRef = React.useRef<HTMLFormElement>(null);
+  useFormKeyboardNavigation(formRef);
+
+  // submit and save to form contents
+  const onSubmit = async (
+    data: Partial<PollingStationResults>,
+    options?: SubmitCurrentFormOptions,
+  ): Promise<boolean> => {
+    return await onSubmitForm(data, { ...options, showAcceptWarnings });
+  };
+
+  // scroll to top when saved
+  React.useEffect(() => {
+    if (isSaved || error) {
+      window.scrollTo(0, 0);
+    }
+  }, [isSaved, error]);
+
+  return {
+    error,
+    formRef,
+    onSubmit,
+    pollingStationResults,
+    currentValues,
+    formSection,
+    setValues,
+    status,
+    setAcceptWarnings,
+    defaultProps,
+    showAcceptWarnings,
+    isSaving: status === "saving",
+  };
+}

--- a/frontend/app/component/form/data_entry/state/useDataEntryFormSection.ts
+++ b/frontend/app/component/form/data_entry/state/useDataEntryFormSection.ts
@@ -4,11 +4,11 @@ import { PollingStationResults } from "@kiesraad/api";
 import { useFormKeyboardNavigation } from "@kiesraad/ui";
 
 import { getErrorsAndWarnings } from "./dataEntryUtils";
-import { FormSectionReference, SubmitCurrentFormOptions } from "./types";
+import { FormSectionReference, SubmitCurrentFormOptions, TemporaryCache } from "./types";
 import { useDataEntryContext } from "./useDataEntryContext";
 
 export interface UseDataEntryFormSectionParams<FORM_VALUES> {
-  getDefaultFormValues: (results: PollingStationResults) => FORM_VALUES;
+  getDefaultFormValues: (results: PollingStationResults, cache?: TemporaryCache | null) => FORM_VALUES;
   section: FormSectionReference;
 }
 
@@ -20,9 +20,8 @@ export function useDataEntryFormSection<FORM_VALUES>({
     useDataEntryContext(section);
 
   //local form state
-
-  const [currentValues, setCurrentValues] = React.useState<FORM_VALUES>(() =>
-    cache?.key === section.id ? (cache.data as FORM_VALUES) : getDefaultFormValues(pollingStationResults),
+  const [currentValues, setCurrentValues] = React.useState<FORM_VALUES>(
+    getDefaultFormValues(pollingStationResults, cache),
   );
 
   // derived state

--- a/frontend/app/component/form/data_entry/voters_and_votes/useVotersAndVotes.ts
+++ b/frontend/app/component/form/data_entry/voters_and_votes/useVotersAndVotes.ts
@@ -13,12 +13,14 @@ export function useVotersAndVotes() {
       id: "voters_votes_counts",
       type: "voters_and_votes",
     },
-    getDefaultFormValues: (results) =>
-      valuesToFormValues({
-        voters_counts: results.voters_counts,
-        votes_counts: results.votes_counts,
-        voters_recounts: results.voters_recounts || undefined,
-      }),
+    getDefaultFormValues: (results, cache) =>
+      cache?.key === "voters_votes_counts"
+        ? valuesToFormValues(cache.data as VotersAndVotesValues)
+        : valuesToFormValues({
+            voters_counts: results.voters_counts,
+            votes_counts: results.votes_counts,
+            voters_recounts: results.voters_recounts || undefined,
+          }),
   });
 
   // submit and save to form contents

--- a/frontend/app/component/form/data_entry/voters_and_votes/useVotersAndVotes.ts
+++ b/frontend/app/component/form/data_entry/voters_and_votes/useVotersAndVotes.ts
@@ -1,10 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-
-import { useFormKeyboardNavigation } from "@kiesraad/ui";
-
-import { getErrorsAndWarnings } from "../state/dataEntryUtils";
 import { SubmitCurrentFormOptions } from "../state/types";
-import { useDataEntryContext } from "../state/useDataEntryContext";
+import { useDataEntryFormSection } from "../state/useDataEntryFormSection";
 import {
   formValuesToValues,
   valuesToFormValues,
@@ -13,74 +8,31 @@ import {
 } from "./votersAndVotesValues";
 
 export function useVotersAndVotes() {
-  const { error, cache, status, pollingStationResults, formState, onSubmitForm, updateFormSection } =
-    useDataEntryContext({
+  const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<VotersAndVotesFormValues>({
+    section: {
       id: "voters_votes_counts",
       type: "voters_and_votes",
-    });
-
-  // local form state
-  const defaultValues =
-    cache?.key === "voters_votes_counts"
-      ? (cache.data as VotersAndVotesValues)
-      : {
-          voters_counts: pollingStationResults.voters_counts,
-          votes_counts: pollingStationResults.votes_counts,
-          voters_recounts: pollingStationResults.voters_recounts || undefined,
-        };
-
-  const [currentValues, setCurrentValues] = useState<VotersAndVotesFormValues>(valuesToFormValues(defaultValues));
-
-  // derived state
-  const { errors, warnings, isSaved, acceptWarnings, hasChanges } = formState.sections.voters_votes_counts;
-  const defaultProps = {
-    errorsAndWarnings: isSaved ? getErrorsAndWarnings(errors, warnings) : undefined,
-    warningsAccepted: acceptWarnings,
-  };
-  const formSection = formState.sections.voters_votes_counts;
-  const showAcceptWarnings = formSection.warnings.length > 0 && formSection.errors.length === 0 && !hasChanges;
-
-  // register changes when fields change
-  const setValues = (values: VotersAndVotesFormValues) => {
-    if (!hasChanges) {
-      updateFormSection({ hasChanges: true, acceptWarnings: false, acceptWarningsError: false });
-    }
-    setCurrentValues(values);
-  };
-
-  const setAcceptWarnings = (acceptWarnings: boolean) => {
-    updateFormSection({ acceptWarningsError: false, acceptWarnings });
-  };
-
-  // form keyboard navigation
-  const formRef = useRef<HTMLFormElement>(null);
-  useFormKeyboardNavigation(formRef);
+    },
+    getDefaultFormValues: (results) =>
+      valuesToFormValues({
+        voters_counts: results.voters_counts,
+        votes_counts: results.votes_counts,
+        voters_recounts: results.voters_recounts || undefined,
+      }),
+  });
 
   // submit and save to form contents
   const onSubmit = async (options?: SubmitCurrentFormOptions): Promise<boolean> => {
-    const data: VotersAndVotesValues = formValuesToValues(currentValues, pollingStationResults.recounted || false);
+    const data: VotersAndVotesValues = formValuesToValues(
+      section.currentValues,
+      section.pollingStationResults.recounted || false,
+    );
 
-    return await onSubmitForm(data, { ...options, showAcceptWarnings });
+    return await _onSubmit(data, { ...options, showAcceptWarnings: section.showAcceptWarnings });
   };
 
-  // scroll to top when saved
-  useEffect(() => {
-    if (isSaved || error) {
-      window.scrollTo(0, 0);
-    }
-  }, [isSaved, error]);
-
   return {
-    error,
-    formRef,
+    ...section,
     onSubmit,
-    pollingStationResults,
-    currentValues,
-    formSection,
-    setValues,
-    status,
-    setAcceptWarnings,
-    defaultProps,
-    showAcceptWarnings,
   };
 }


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->

These changes add a new hook `useDataEntryFormSection` to handle overlapping functionality between the different form sections in data entry.

onSubmit has been chained due to overlapping functionality introduced in #1113 

This current version maximizes the shared code, we need to decide which boilerplate we want to keep over this generic approach. 

closes #1162 