### PR TITLE
Use `OpenApiRouter` from `utoipa-axum`

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "typst",
  "typst-pdf",
  "utoipa",
+ "utoipa-axum",
  "utoipa-swagger-ui",
  "zip",
 ]
@@ -4116,6 +4117,19 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,6 +27,7 @@ hyper = { version = "1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 memory-serve = { version = "1.0.1", features = ["force-embed"], optional = true }
 utoipa = { version = "5.3.1", features = ["axum_extras"] }
+utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -12,9 +12,6 @@
   "paths": {
     "/api/elections": {
       "get": {
-        "tags": [
-          "election"
-        ],
         "summary": "Get a list of all elections, without their candidate lists",
         "operationId": "election_list",
         "responses": {
@@ -51,9 +48,6 @@
         }
       },
       "post": {
-        "tags": [
-          "election"
-        ],
         "summary": "Create an election. For test usage only!",
         "operationId": "election_create",
         "requestBody": {
@@ -112,9 +106,6 @@
     },
     "/api/elections/{election_id}": {
       "get": {
-        "tags": [
-          "election"
-        ],
         "summary": "Get election details including the election's candidate list (political groups) and its polling stations",
         "operationId": "election_details",
         "parameters": [
@@ -176,9 +167,6 @@
     },
     "/api/elections/{election_id}/apportionment": {
       "post": {
-        "tags": [
-          "apportionment"
-        ],
         "summary": "Get the apportionment for an election",
         "operationId": "election_apportionment",
         "parameters": [
@@ -250,9 +238,6 @@
     },
     "/api/elections/{election_id}/download_pdf_results": {
       "get": {
-        "tags": [
-          "report"
-        ],
         "summary": "Download a generated PDF with election results",
         "operationId": "election_download_pdf_results",
         "parameters": [
@@ -318,9 +303,6 @@
     },
     "/api/elections/{election_id}/download_xml_results": {
       "get": {
-        "tags": [
-          "report"
-        ],
         "summary": "Download a generated EML_NL 510 XML file with election results",
         "operationId": "election_download_xml_results",
         "parameters": [
@@ -378,9 +360,6 @@
     },
     "/api/elections/{election_id}/download_zip_results": {
       "get": {
-        "tags": [
-          "report"
-        ],
         "summary": "Download a zip containing a PDF for the PV and the EML with election results",
         "operationId": "election_download_zip_results",
         "parameters": [
@@ -446,9 +425,6 @@
     },
     "/api/elections/{election_id}/polling_stations": {
       "get": {
-        "tags": [
-          "polling_station"
-        ],
         "summary": "Get a list of all [PollingStation]s for an election",
         "operationId": "polling_station_list",
         "parameters": [
@@ -508,9 +484,6 @@
         }
       },
       "post": {
-        "tags": [
-          "polling_station"
-        ],
         "summary": "Create a new [PollingStation]",
         "operationId": "polling_station_create",
         "parameters": [
@@ -592,9 +565,6 @@
     },
     "/api/elections/{election_id}/polling_stations/{polling_station_id}": {
       "get": {
-        "tags": [
-          "polling_station"
-        ],
         "summary": "Get a [PollingStation]",
         "operationId": "polling_station_get",
         "parameters": [
@@ -665,9 +635,6 @@
         }
       },
       "put": {
-        "tags": [
-          "polling_station"
-        ],
         "summary": "Update a [PollingStation]",
         "operationId": "polling_station_update",
         "parameters": [
@@ -741,9 +708,6 @@
         }
       },
       "delete": {
-        "tags": [
-          "polling_station"
-        ],
         "summary": "Delete a [PollingStation]",
         "operationId": "polling_station_delete",
         "parameters": [
@@ -809,9 +773,6 @@
     },
     "/api/elections/{election_id}/status": {
       "get": {
-        "tags": [
-          "data_entry"
-        ],
         "summary": "Get election polling stations data entry statuses",
         "operationId": "election_status",
         "parameters": [
@@ -873,9 +834,6 @@
     },
     "/api/log": {
       "get": {
-        "tags": [
-          "audit_log"
-        ],
         "summary": "Lists all users",
         "operationId": "audit_log_list",
         "responses": {
@@ -914,9 +872,6 @@
     },
     "/api/polling_stations/{polling_station_id}/data_entries/{entry_number}": {
       "post": {
-        "tags": [
-          "data_entry"
-        ],
         "summary": "Save a data entry for a polling station",
         "operationId": "polling_station_data_entry_save",
         "parameters": [
@@ -1017,9 +972,6 @@
         }
       },
       "delete": {
-        "tags": [
-          "data_entry"
-        ],
         "summary": "Delete an in-progress (not finalised) data entry for a polling station",
         "operationId": "polling_station_data_entry_delete",
         "parameters": [
@@ -1095,9 +1047,6 @@
     },
     "/api/polling_stations/{polling_station_id}/data_entries/{entry_number}/claim": {
       "post": {
-        "tags": [
-          "data_entry"
-        ],
         "summary": "Claim a data entry for a polling station, returning any existing progress",
         "operationId": "polling_station_data_entry_claim",
         "parameters": [
@@ -1170,9 +1119,6 @@
     },
     "/api/polling_stations/{polling_station_id}/data_entries/{entry_number}/finalise": {
       "post": {
-        "tags": [
-          "data_entry"
-        ],
         "summary": "Finalise the data entry for a polling station",
         "operationId": "polling_station_data_entry_finalise",
         "parameters": [
@@ -1258,9 +1204,6 @@
     },
     "/api/user": {
       "get": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Lists all users",
         "operationId": "user_list",
         "responses": {
@@ -1297,9 +1240,6 @@
         }
       },
       "post": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Create a new user",
         "operationId": "user_create",
         "requestBody": {
@@ -1358,9 +1298,6 @@
     },
     "/api/user/account": {
       "put": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Update the user's account with a new password and optionally new fullname",
         "operationId": "account_update",
         "requestBody": {
@@ -1399,9 +1336,6 @@
     },
     "/api/user/login": {
       "post": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Login endpoint, authenticates a user and creates a new session + session cookie",
         "operationId": "login",
         "requestBody": {
@@ -1450,9 +1384,6 @@
     },
     "/api/user/logout": {
       "post": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Logout endpoint, deletes the session cookie",
         "operationId": "logout",
         "responses": {
@@ -1474,9 +1405,6 @@
     },
     "/api/user/whoami": {
       "get": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Get current logged-in user endpoint",
         "operationId": "whoami",
         "responses": {
@@ -1515,9 +1443,6 @@
     },
     "/api/user/{user_id}": {
       "get": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Get a user",
         "operationId": "user_get",
         "parameters": [
@@ -1577,9 +1502,6 @@
         }
       },
       "put": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Update a user",
         "operationId": "user_update",
         "parameters": [
@@ -1648,9 +1570,6 @@
         }
       },
       "delete": {
-        "tags": [
-          "authentication"
-        ],
         "summary": "Delete a user",
         "operationId": "user_delete",
         "parameters": [
@@ -2020,42 +1939,6 @@
           "Female",
           "X"
         ]
-      },
-      "CandidateNominationResult": {
-        "type": "object",
-        "description": "The result of the candidate nomination procedure.\nThis contains the preference threshold and percentage that was used.\nIt contains a list of all chosen candidates in alphabetical order.\nIt also contains the preferential nomination of candidates, the remaining\nnomination of candidates and the final ranking of candidates for each political group.",
-        "required": [
-          "preference_threshold_percentage",
-          "preference_threshold",
-          "chosen_candidates",
-          "political_group_candidate_nomination"
-        ],
-        "properties": {
-          "chosen_candidates": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Candidate"
-            },
-            "description": "List of chosen candidates in alphabetical order"
-          },
-          "political_group_candidate_nomination": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PoliticalGroupCandidateNomination"
-            },
-            "description": "List of chosen candidates and candidate list ranking per political group"
-          },
-          "preference_threshold": {
-            "$ref": "#/components/schemas/Fraction",
-            "description": "Preference threshold number of votes"
-          },
-          "preference_threshold_percentage": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Preference threshold percentage",
-            "minimum": 0
-          }
-        }
       },
       "CandidateVotes": {
         "type": "object",
@@ -2695,21 +2578,6 @@
           }
         }
       },
-      "Pagination": {
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          "perPage": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          }
-        }
-      },
       "PoliticalGroup": {
         "type": "object",
         "description": "Political group with its candidates",
@@ -2732,57 +2600,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          }
-        }
-      },
-      "PoliticalGroupCandidateNomination": {
-        "type": "object",
-        "description": "Contains information about the chosen candidates and the candidate list ranking\nfor a specific political group.",
-        "required": [
-          "pg_number",
-          "pg_name",
-          "pg_seats",
-          "preferential_candidate_nomination",
-          "other_candidate_nomination",
-          "updated_candidate_ranking"
-        ],
-        "properties": {
-          "other_candidate_nomination": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CandidateVotes"
-            },
-            "description": "The list of other chosen candidates, can be empty"
-          },
-          "pg_name": {
-            "type": "string",
-            "description": "Political group name for which this nomination applies"
-          },
-          "pg_number": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Political group number for which this nomination applies",
-            "minimum": 0
-          },
-          "pg_seats": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The number of seats assigned to this group",
-            "minimum": 0
-          },
-          "preferential_candidate_nomination": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CandidateVotes"
-            },
-            "description": "The list of chosen candidates via preferential votes, can be empty"
-          },
-          "updated_candidate_ranking": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Candidate"
-            },
-            "description": "The updated ranking of the whole candidate list, can be empty"
           }
         }
       },
@@ -3441,23 +3258,5 @@
         }
       }
     }
-  },
-  "tags": [
-    {
-      "name": "apportionment",
-      "description": "Election apportionment API"
-    },
-    {
-      "name": "authentication",
-      "description": "Authentication and user API"
-    },
-    {
-      "name": "election",
-      "description": "Election API"
-    },
-    {
-      "name": "polling_station",
-      "description": "Polling station API"
-    }
-  ]
+  }
 }

--- a/backend/src/apportionment/api.rs
+++ b/backend/src/apportionment/api.rs
@@ -44,7 +44,7 @@ pub struct ElectionApportionmentResponse {
         ("election_id" = u32, description = "Election database id"),
   ),
 )]
-pub async fn election_apportionment(
+async fn election_apportionment(
     _user: Coordinator,
     State(elections_repo): State<Elections>,
     State(data_entry_repo): State<PollingStationDataEntries>,

--- a/backend/src/apportionment/api.rs
+++ b/backend/src/apportionment/api.rs
@@ -1,12 +1,5 @@
-use axum::{
-    Json,
-    extract::{Path, State},
-};
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
-
 use crate::{
-    APIError, ErrorResponse,
+    APIError, AppState, ErrorResponse,
     apportionment::{ApportionmentError, SeatAssignmentResult, seat_assignment},
     authentication::Coordinator,
     data_entry::{
@@ -17,6 +10,17 @@ use crate::{
     polling_station::repository::PollingStations,
     summary::ElectionSummary,
 };
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default().routes(routes!(election_apportionment))
+}
 
 /// Election apportionment response, including the seat assignment, candidate nomination and election summary
 #[derive(Serialize, Deserialize, ToSchema, Debug)]

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -1,13 +1,17 @@
+use crate::{APIError, AppState, ErrorResponse, authentication::AdminOrCoordinator};
 use axum::{
     Json,
     extract::{Query, State},
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-
-use crate::{APIError, ErrorResponse, authentication::AdminOrCoordinator};
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use super::{AuditLog, AuditLogEvent};
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default().routes(routes!(audit_log_list))
+}
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -51,7 +51,7 @@ pub struct Pagination {
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn audit_log_list(
+async fn audit_log_list(
     _user: AdminOrCoordinator,
     pagination: Query<Pagination>,
     State(audit_log): State<AuditLog>,
@@ -94,7 +94,7 @@ mod tests {
         AppState,
         audit_log::{
             AuditEvent, AuditLog, AuditLogListResponse, AuditService, UserLoggedInDetails,
-            audit_log_list,
+            api::audit_log_list,
         },
         authentication::{Sessions, Users},
     };

--- a/backend/src/authentication/api.rs
+++ b/backend/src/authentication/api.rs
@@ -5,6 +5,10 @@ use super::{
     session::Sessions,
     user::{User, Users},
 };
+use crate::{
+    APIError, AppState, ErrorResponse,
+    audit_log::{AuditEvent, AuditService, UserLoggedInDetails, UserLoggedOutDetails},
+};
 use axum::{
     extract::{Path, Request, State},
     http::HeaderValue,
@@ -18,11 +22,21 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Error, SqlitePool};
 use tracing::{debug, info};
 use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
-use crate::{
-    APIError, ErrorResponse,
-    audit_log::{AuditEvent, AuditService, UserLoggedInDetails, UserLoggedOutDetails},
-};
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default()
+        .routes(routes!(login))
+        .routes(routes!(whoami))
+        .routes(routes!(account_update))
+        .routes(routes!(logout))
+        .routes(routes!(user_list))
+        .routes(routes!(user_create))
+        .routes(routes!(user_get))
+        .routes(routes!(user_update))
+        .routes(routes!(user_delete))
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct Credentials {
     pub username: String,

--- a/backend/src/authentication/api.rs
+++ b/backend/src/authentication/api.rs
@@ -85,7 +85,7 @@ pub(super) fn set_default_cookie_properties(cookie: &mut Cookie) {
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn login(
+async fn login(
     user_agent: Option<TypedHeader<UserAgent>>,
     State(users): State<Users>,
     State(sessions): State<Sessions>,
@@ -151,7 +151,7 @@ pub struct AccountUpdateRequest {
       (status = 500, description = "Internal server error", body = ErrorResponse),
   ),
 )]
-pub async fn whoami(user: Option<User>) -> Result<impl IntoResponse, APIError> {
+async fn whoami(user: Option<User>) -> Result<impl IntoResponse, APIError> {
     let user = user.ok_or(AuthenticationError::UserNotFound)?;
 
     Ok(Json(LoginResponse::from(&user)))
@@ -167,7 +167,7 @@ pub async fn whoami(user: Option<User>) -> Result<impl IntoResponse, APIError> {
       (status = 500, description = "Internal server error", body = ErrorResponse),
   ),
 )]
-pub async fn account_update(
+async fn account_update(
     user: User,
     State(users): State<Users>,
     Json(account): Json<AccountUpdateRequest>,
@@ -202,7 +202,7 @@ pub async fn account_update(
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn logout(
+async fn logout(
     State(sessions): State<Sessions>,
     State(users): State<Users>,
     audit_service: AuditService,
@@ -294,7 +294,7 @@ pub struct UserListResponse {
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn user_list(
+async fn user_list(
     _user: Admin,
     State(users_repo): State<Users>,
 ) -> Result<Json<UserListResponse>, APIError> {
@@ -336,7 +336,7 @@ pub struct UpdateUserRequest {
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn user_create(
+async fn user_create(
     _user: Admin,
     State(users_repo): State<Users>,
     Json(create_user_req): Json<CreateUserRequest>,
@@ -366,7 +366,7 @@ pub async fn user_create(
         ("user_id" = u32, description = "User id"),
     ),
 )]
-pub async fn user_get(
+async fn user_get(
     _user: Admin,
     State(users_repo): State<Users>,
     Path(user_id): Path<u32>,
@@ -387,7 +387,7 @@ pub async fn user_get(
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn user_update(
+async fn user_update(
     _user: Admin,
     State(users_repo): State<Users>,
     State(session_repo): State<Sessions>,
@@ -421,7 +421,7 @@ pub async fn user_update(
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn user_delete(
+async fn user_delete(
     _user: Admin,
     State(users_repo): State<Users>,
     Path(user_id): Path<u32>,

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -60,7 +60,6 @@ mod tests {
         body::Body,
         http::{HeaderValue, Request, StatusCode},
         middleware,
-        routing::{get, post, put},
     };
     use http_body_util::BodyExt;
     use hyper::{Method, header::CONTENT_TYPE};
@@ -75,17 +74,9 @@ mod tests {
 
     fn create_app(pool: SqlitePool) -> Router {
         let state = AppState { pool: pool.clone() };
-
-        let router = Router::new()
-            .route("/api/user", get(api::user_list).post(api::user_create))
-            .route("/api/user/{user_id}", put(api::user_update))
-            .route("/api/user/login", post(api::login))
-            .route("/api/user/logout", post(api::logout))
-            .route("/api/user/whoami", get(api::whoami))
-            .route("/api/user/account", put(api::account_update))
-            .layer(middleware::from_fn_with_state(pool, extend_session));
-
-        router.with_state(state)
+        Router::from(api::router())
+            .layer(middleware::from_fn_with_state(pool, extend_session))
+            .with_state(state)
     }
 
     async fn login(app: Router) -> HeaderValue {

--- a/backend/src/bin/gen-openapi.rs
+++ b/backend/src/bin/gen-openapi.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use abacus::create_openapi;
+use abacus::openapi_router;
 
 /// Write OpenAPI JSON documentation to `openapi.json`.
 fn main() {
@@ -10,8 +10,8 @@ fn main() {
 }
 
 fn get_openapi_json() -> String {
-    let openapi = create_openapi();
-    openapi
+    openapi_router()
+        .into_openapi()
         .to_pretty_json()
         .expect("Could not generate OpenAPI JSON")
 }

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -56,7 +56,7 @@ pub fn router() -> OpenApiRouter<AppState> {
         ("entry_number" = u8, description = "Data entry number (first or second data entry)"),
     ),
 )]
-pub async fn polling_station_data_entry_claim(
+async fn polling_station_data_entry_claim(
     user: Typist,
     State(polling_station_data_entries): State<PollingStationDataEntries>,
     State(polling_stations): State<PollingStations>,
@@ -153,7 +153,7 @@ impl IntoResponse for SaveDataEntryResponse {
         ("entry_number" = u8, description = "Data entry number (first or second data entry)"),
     ),
 )]
-pub async fn polling_station_data_entry_save(
+async fn polling_station_data_entry_save(
     user: Typist,
     Path((id, entry_number)): Path<(u32, EntryNumber)>,
     State(polling_station_data_entries): State<PollingStationDataEntries>,
@@ -209,7 +209,7 @@ pub async fn polling_station_data_entry_save(
         ("entry_number" = u8, description = "Data entry number (first or second data entry)"),
     ),
 )]
-pub async fn polling_station_data_entry_delete(
+async fn polling_station_data_entry_delete(
     user: Typist,
     State(polling_station_data_entries): State<PollingStationDataEntries>,
     Path((id, entry_number)): Path<(u32, EntryNumber)>,
@@ -242,7 +242,7 @@ pub async fn polling_station_data_entry_delete(
         ("entry_number" = u8, description = "Data entry number (first or second data entry)"),
     ),
 )]
-pub async fn polling_station_data_entry_finalise(
+async fn polling_station_data_entry_finalise(
     user: Typist,
     State(polling_station_data_entries): State<PollingStationDataEntries>,
     State(elections_repo): State<Elections>,
@@ -333,7 +333,7 @@ pub struct ElectionStatusResponseEntry {
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn election_status(
+async fn election_status(
     _user: User,
     State(data_entry_repo): State<PollingStationDataEntries>,
     Path(id): Path<u32>,

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -1,5 +1,5 @@
 use crate::{
-    APIError,
+    APIError, AppState,
     authentication::{Typist, User},
     data_entry::{
         PollingStationResults, ValidationResults,
@@ -21,6 +21,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 /// Response structure for getting data entry of polling station results
 #[derive(Serialize, Deserialize, ToSchema, Debug)]
@@ -29,6 +30,15 @@ pub struct ClaimDataEntryResponse {
     #[schema(value_type = Object)]
     pub client_state: Option<serde_json::Value>,
     pub validation_results: ValidationResults,
+}
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default()
+        .routes(routes!(polling_station_data_entry_claim))
+        .routes(routes!(polling_station_data_entry_save))
+        .routes(routes!(polling_station_data_entry_delete))
+        .routes(routes!(polling_station_data_entry_finalise))
+        .routes(routes!(election_status))
 }
 
 /// Claim a data entry for a polling station, returning any existing progress

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -65,7 +65,7 @@ impl IntoResponse for Election {
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
 )]
-pub async fn election_list(
+async fn election_list(
     _user: User,
     State(elections_repo): State<Elections>,
 ) -> Result<Json<ElectionListResponse>, APIError> {
@@ -87,7 +87,7 @@ pub async fn election_list(
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn election_details(
+async fn election_details(
     _user: User,
     State(elections_repo): State<Elections>,
     State(polling_stations): State<PollingStations>,
@@ -114,7 +114,7 @@ pub async fn election_details(
     ),
 )]
 #[cfg(feature = "dev-database")]
-pub async fn election_create(
+async fn election_create(
     _user: Admin,
     State(elections_repo): State<Elections>,
     Json(new_election): Json<ElectionRequest>,

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -9,19 +9,30 @@ use utoipa::ToSchema;
 use self::repository::Elections;
 pub use self::structs::*;
 use crate::{
-    APIError, ErrorResponse,
+    APIError, AppState, ErrorResponse,
     authentication::User,
     polling_station::{repository::PollingStations, structs::PollingStation},
 };
 
 #[cfg(feature = "dev-database")]
-use axum::http::StatusCode;
-
-#[cfg(feature = "dev-database")]
 use crate::authentication::Admin;
+#[cfg(feature = "dev-database")]
+use axum::http::StatusCode;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 pub(crate) mod repository;
 pub mod structs;
+
+pub fn router() -> OpenApiRouter<AppState> {
+    let router = OpenApiRouter::default()
+        .routes(routes!(election_list))
+        .routes(routes!(election_details));
+
+    #[cfg(feature = "dev-database")]
+    let router = router.routes(routes!(election_create));
+
+    router
+}
 
 /// Election list response
 ///

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,12 +1,6 @@
 #[cfg(feature = "memory-serve")]
 use axum::http::StatusCode;
-use axum::{
-    Router,
-    extract::FromRef,
-    middleware,
-    routing::{get, post, put},
-    serve::ListenerExt,
-};
+use axum::{Router, extract::FromRef, middleware, serve::ListenerExt};
 #[cfg(feature = "memory-serve")]
 use memory_serve::MemoryServe;
 use sqlx::SqlitePool;
@@ -14,6 +8,8 @@ use std::{error::Error, net::SocketAddr};
 use tokio::{net::TcpListener, signal};
 use tower_http::trace::TraceLayer;
 use tracing::{info, trace};
+use utoipa::OpenApi;
+use utoipa_axum::router::OpenApiRouter;
 #[cfg(feature = "openapi")]
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -38,219 +34,56 @@ pub struct AppState {
     pool: SqlitePool,
 }
 
+pub fn openapi_router() -> OpenApiRouter<AppState> {
+    #[derive(utoipa::OpenApi)]
+    struct ApiDoc;
+
+    OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .merge(apportionment::router())
+        .merge(audit_log::router())
+        .merge(authentication::router())
+        .merge(data_entry::router())
+        .merge(election::router())
+        .merge(polling_station::router())
+        .merge(report::router())
+}
+
 /// Axum router for the application
 pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
-    let data_entry_routes = Router::new()
-        .route(
-            "/{entry_number}",
-            post(data_entry::polling_station_data_entry_save)
-                .delete(data_entry::polling_station_data_entry_delete),
-        )
-        .route(
-            "/{entry_number}/claim",
-            post(data_entry::polling_station_data_entry_claim),
-        )
-        .route(
-            "/{entry_number}/finalise",
-            post(data_entry::polling_station_data_entry_finalise),
-        );
+    // Serve the OpenAPI documentation at /api-docs (if the openapi feature is enabled)
+    #[cfg(feature = "openapi")]
+    let router = {
+        let (router, openapi) = openapi_router().split_for_parts();
+        router.merge(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", openapi))
+    };
 
-    let polling_station_routes = Router::new()
-        .route(
-            "/",
-            get(polling_station::polling_station_list)
-                .post(polling_station::polling_station_create),
-        )
-        .route(
-            "/{polling_station_id}",
-            get(polling_station::polling_station_get)
-                .put(polling_station::polling_station_update)
-                .delete(polling_station::polling_station_delete),
-        );
+    // Discard the OpenAPI documentation if the openapi feature is disabled
+    #[cfg(not(feature = "openapi"))]
+    let router = Router::from(openapi_router());
 
-    let election_routes = Router::new()
-        .route("/", get(election::election_list))
-        .route("/{election_id}", get(election::election_details))
-        .route(
-            "/{election_id}/apportionment",
-            post(apportionment::election_apportionment),
-        )
-        .route(
-            "/{election_id}/download_zip_results",
-            get(report::election_download_zip_results),
-        )
-        .route(
-            "/{election_id}/download_pdf_results",
-            get(report::election_download_pdf_results),
-        )
-        .route(
-            "/{election_id}/download_xml_results",
-            get(report::election_download_xml_results),
-        )
-        .route("/{election_id}/status", get(data_entry::election_status));
-
-    #[cfg(feature = "dev-database")]
-    let election_routes = election_routes.route("/", post(election::election_create));
-
-    let user_routes = Router::new()
-        .route(
-            "/",
-            get(authentication::user_list).post(authentication::user_create),
-        )
-        .route(
-            "/{user_id}",
-            get(authentication::user_get)
-                .put(authentication::user_update)
-                .delete(authentication::user_delete),
-        )
-        .route("/login", post(authentication::login))
-        .route("/logout", post(authentication::logout))
-        .route("/whoami", get(authentication::whoami))
-        .route("/account", put(authentication::account_update));
-
-    let audit_log_routes = Router::new().route("/", get(audit_log::audit_log_list));
-
-    let app = Router::new()
-        .nest("/api/user", user_routes)
-        .nest("/api/log", audit_log_routes)
-        .nest("/api/elections", election_routes)
-        .nest(
-            "/api/elections/{election_id}/polling_stations",
-            polling_station_routes,
-        )
-        .nest(
-            "/api/polling_stations/{polling_station_id}/data_entries",
-            data_entry_routes,
-        );
-
-    let app = app
+    // Add middleware to trace all HTTP requests and extend the user's session lifetime if needed
+    let router = router
         .layer(TraceLayer::new_for_http())
         .layer(middleware::from_fn_with_state(
             pool.clone(),
             authentication::extend_session,
         ));
 
+    // Add the memory-serve router to serve the frontend (if the memory-serve feature is enabled)
     #[cfg(feature = "memory-serve")]
-    let app = {
-        app.merge(
-            MemoryServe::from_env()
-                .index_file(Some("/index.html"))
-                .fallback(Some("/index.html"))
-                .fallback_status(StatusCode::OK)
-                .into_router(),
-        )
-    };
+    let router = router.merge(
+        MemoryServe::from_env()
+            .index_file(Some("/index.html"))
+            .fallback(Some("/index.html"))
+            .fallback_status(StatusCode::OK)
+            .into_router(),
+    );
 
     // Add the state to the app
     let state = AppState { pool };
-    let app = app.with_state(state);
+    let router = router.with_state(state);
 
-    // Only include the OpenAPI spec if the feature is enabled
-    #[cfg(feature = "openapi")]
-    let app = {
-        let openapi = create_openapi();
-        app.merge(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", openapi.clone()))
-    };
-
-    Ok(app)
-}
-
-#[cfg(feature = "openapi")]
-pub fn create_openapi() -> utoipa::openapi::OpenApi {
-    use error::ErrorResponse;
-    use utoipa::OpenApi;
-
-    #[derive(OpenApi)]
-    #[openapi(
-        paths(
-            apportionment::election_apportionment,
-            audit_log::audit_log_list,
-            authentication::login,
-            authentication::logout,
-            authentication::whoami,
-            authentication::account_update,
-            authentication::user_list,
-            authentication::user_create,
-            authentication::user_get,
-            authentication::user_update,
-            authentication::user_delete,
-            election::election_list,
-            election::election_create,
-            election::election_details,
-            report::election_download_zip_results,
-            report::election_download_pdf_results,
-            report::election_download_xml_results,
-            data_entry::polling_station_data_entry_save,
-            data_entry::polling_station_data_entry_claim,
-            data_entry::polling_station_data_entry_delete,
-            data_entry::polling_station_data_entry_finalise,
-            data_entry::election_status,
-            polling_station::polling_station_list,
-            polling_station::polling_station_create,
-            polling_station::polling_station_get,
-            polling_station::polling_station_update,
-            polling_station::polling_station_delete,
-        ),
-        components(
-            schemas(
-                ErrorResponse,
-                apportionment::AssignedSeat,
-                apportionment::CandidateNominationResult,
-                apportionment::DisplayFraction,
-                apportionment::LargestAverageAssignedSeat,
-                apportionment::LargestRemainderAssignedSeat,
-                apportionment::PoliticalGroupCandidateNomination,
-                apportionment::PoliticalGroupStanding,
-                apportionment::SeatAssignmentResult,
-                apportionment::SeatAssignmentStep,
-                audit_log::AuditLogListResponse,
-                audit_log::Pagination,
-                authentication::Credentials,
-                authentication::LoginResponse,
-                authentication::AccountUpdateRequest,
-                authentication::UserListResponse,
-                authentication::UpdateUserRequest,
-                authentication::CreateUserRequest,
-                data_entry::CandidateVotes,
-                data_entry::DataEntry,
-                data_entry::SaveDataEntryResponse,
-                data_entry::ClaimDataEntryResponse,
-                data_entry::DifferencesCounts,
-                data_entry::PoliticalGroupVotes,
-                data_entry::status::DataEntryStatusName,
-                data_entry::PollingStationResults,
-                data_entry::VotersCounts,
-                data_entry::VotesCounts,
-                data_entry::ElectionStatusResponse,
-                data_entry::ElectionStatusResponseEntry,
-                data_entry::ValidationResult,
-                data_entry::ValidationResultCode,
-                data_entry::ValidationResults,
-                election::Election,
-                election::ElectionCategory,
-                election::PoliticalGroup,
-                election::Candidate,
-                election::CandidateGender,
-                election::ElectionListResponse,
-                election::ElectionDetailsResponse,
-                election::ElectionRequest,
-                polling_station::PollingStation,
-                polling_station::PollingStationListResponse,
-                polling_station::PollingStationType,
-                polling_station::PollingStationRequest,
-                summary::ElectionSummary,
-                summary::SummaryDifferencesCounts,
-            ),
-        ),
-        tags(
-            (name = "apportionment", description = "Election apportionment API"),
-            (name = "authentication", description = "Authentication and user API"),
-            (name = "election", description = "Election API"),
-            (name = "polling_station", description = "Polling station API"),
-        )
-    )]
-    struct ApiDoc;
-    ApiDoc::openapi()
+    Ok(router)
 }
 
 /// Start the API server on the given port, using the given database pool.

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -1,3 +1,10 @@
+use self::repository::PollingStations;
+pub use self::structs::*;
+use crate::{
+    APIError, AppState, ErrorResponse,
+    authentication::{AdminOrCoordinator, User},
+    election::repository::Elections,
+};
 use axum::{
     Json,
     extract::{Path, State},
@@ -6,17 +13,19 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-
-use self::repository::PollingStations;
-pub use self::structs::*;
-use crate::{
-    APIError, ErrorResponse,
-    authentication::{AdminOrCoordinator, User},
-    election::repository::Elections,
-};
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 pub mod repository;
 pub mod structs;
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default()
+        .routes(routes!(polling_station_list))
+        .routes(routes!(polling_station_create))
+        .routes(routes!(polling_station_get))
+        .routes(routes!(polling_station_update))
+        .routes(routes!(polling_station_delete))
+}
 
 /// Polling station list response
 #[derive(Serialize, Deserialize, ToSchema, Debug)]

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -53,7 +53,7 @@ impl IntoResponse for PollingStationListResponse {
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn polling_station_list(
+async fn polling_station_list(
     _user: User,
     State(polling_stations): State<PollingStations>,
     State(elections): State<Elections>,
@@ -83,7 +83,7 @@ pub async fn polling_station_list(
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn polling_station_create(
+async fn polling_station_create(
     _user: AdminOrCoordinator,
     State(polling_stations): State<PollingStations>,
     State(elections): State<Elections>,
@@ -116,7 +116,7 @@ pub async fn polling_station_create(
         ("polling_station_id" = u32, description = "Polling station database id"),
     ),
 )]
-pub async fn polling_station_get(
+async fn polling_station_get(
     _user: User,
     State(polling_stations): State<PollingStations>,
     Path((election_id, polling_station_id)): Path<(u32, u32)>,
@@ -145,7 +145,7 @@ pub async fn polling_station_get(
         ("polling_station_id" = u32, description = "Polling station database id"),
     ),
 )]
-pub async fn polling_station_update(
+async fn polling_station_update(
     _user: AdminOrCoordinator,
     State(polling_stations): State<PollingStations>,
     Path((election_id, polling_station_id)): Path<(u32, u32)>,
@@ -176,7 +176,7 @@ pub async fn polling_station_update(
         ("polling_station_id" = u32, description = "Polling station database id"),
     ),
 )]
-pub async fn polling_station_delete(
+async fn polling_station_delete(
     _user: AdminOrCoordinator,
     State(polling_stations): State<PollingStations>,
     Path((election_id, polling_station_id)): Path<(u32, u32)>,

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -13,8 +13,7 @@ use crate::{
 };
 use axum::extract::{Path, State};
 use axum_extra::response::Attachment;
-use utoipa_axum::router::OpenApiRouter;
-use utoipa_axum::routes;
+use utoipa_axum::{router::OpenApiRouter, routes};
 use zip::{result::ZipError, write::SimpleFileOptions};
 
 pub fn router() -> OpenApiRouter<AppState> {

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -1,5 +1,5 @@
 use crate::{
-    APIError, ErrorResponse,
+    APIError, AppState, ErrorResponse,
     authentication::Coordinator,
     data_entry::{PollingStationResults, repository::PollingStationResultsEntries},
     election::{Election, repository::Elections},
@@ -13,7 +13,16 @@ use crate::{
 };
 use axum::extract::{Path, State};
 use axum_extra::response::Attachment;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 use zip::{result::ZipError, write::SimpleFileOptions};
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default()
+        .routes(routes!(election_download_zip_results))
+        .routes(routes!(election_download_pdf_results))
+        .routes(routes!(election_download_xml_results))
+}
 
 struct ResultsInput {
     election: Election,

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -125,7 +125,7 @@ impl ResultsInput {
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn election_download_zip_results(
+async fn election_download_zip_results(
     _user: Coordinator,
     State(elections_repo): State<Elections>,
     State(polling_stations_repo): State<PollingStations>,
@@ -194,7 +194,7 @@ pub async fn election_download_zip_results(
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn election_download_pdf_results(
+async fn election_download_pdf_results(
     _user: Coordinator,
     State(elections_repo): State<Elections>,
     State(polling_stations_repo): State<PollingStations>,
@@ -237,7 +237,7 @@ pub async fn election_download_pdf_results(
         ("election_id" = u32, description = "Election database id"),
     ),
 )]
-pub async fn election_download_xml_results(
+async fn election_download_xml_results(
     _user: Coordinator,
     State(elections_repo): State<Elections>,
     State(polling_stations_repo): State<PollingStations>,

--- a/backend/tests/authorization_test.rs
+++ b/backend/tests/authorization_test.rs
@@ -19,7 +19,7 @@ fn expected_response_code(path: &str) -> StatusCode {
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "users"))))]
 async fn test_route_authorization(pool: SqlitePool) {
-    let openapi = abacus::create_openapi();
+    let openapi = abacus::openapi_router().into_openapi();
     let addr = serve_api(pool).await;
 
     // loop through all the paths in the openapi spec

--- a/frontend/lib/api/gen/openapi.ts
+++ b/frontend/lib/api/gen/openapi.ts
@@ -221,24 +221,6 @@ export interface Candidate {
  */
 export type CandidateGender = "Male" | "Female" | "X";
 
-/**
- * The result of the candidate nomination procedure.
- * This contains the preference threshold and percentage that was used.
- * It contains a list of all chosen candidates in alphabetical order.
- * It also contains the preferential nomination of candidates, the remaining
- * nomination of candidates and the final ranking of candidates for each political group.
- */
-export interface CandidateNominationResult {
-  /** List of chosen candidates in alphabetical order */
-  chosen_candidates: Candidate[];
-  /** List of chosen candidates and candidate list ranking per political group */
-  political_group_candidate_nomination: PoliticalGroupCandidateNomination[];
-  /** Preference threshold number of votes */
-  preference_threshold: Fraction;
-  /** Preference threshold percentage */
-  preference_threshold_percentage: number;
-}
-
 export interface CandidateVotes {
   number: number;
   votes: number;
@@ -502,11 +484,6 @@ export interface LoginResponse {
   username: string;
 }
 
-export interface Pagination {
-  page?: number;
-  perPage?: number;
-}
-
 /**
  * Political group with its candidates
  */
@@ -514,25 +491,6 @@ export interface PoliticalGroup {
   candidates: Candidate[];
   name: string;
   number: number;
-}
-
-/**
- * Contains information about the chosen candidates and the candidate list ranking
- * for a specific political group.
- */
-export interface PoliticalGroupCandidateNomination {
-  /** The list of other chosen candidates, can be empty */
-  other_candidate_nomination: CandidateVotes[];
-  /** Political group name for which this nomination applies */
-  pg_name: string;
-  /** Political group number for which this nomination applies */
-  pg_number: number;
-  /** The number of seats assigned to this group */
-  pg_seats: number;
-  /** The list of chosen candidates via preferential votes, can be empty */
-  preferential_candidate_nomination: CandidateVotes[];
-  /** The updated ranking of the whole candidate list, can be empty */
-  updated_candidate_ranking: Candidate[];
 }
 
 /**


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->

Use `OpenApiRouter` from `utoipa-axum` to reduce duplication between Axum and Utopia definitions.

Grouping (using tags) in the OpenAPI JSON is removed, if we think this is useful we can add it back by explicitly adding a tag to each route. Unfortunately, `utoipa-axum` doesn't automatically group by module.