### PR TITLE
scroll to top if errors

### DIFF
--- a/frontend/app/component/form/data_entry/state/useDataEntryFormSection.ts
+++ b/frontend/app/component/form/data_entry/state/useDataEntryFormSection.ts
@@ -58,7 +58,12 @@ export function useDataEntryFormSection<FORM_VALUES>({
     data: Partial<PollingStationResults>,
     options?: SubmitCurrentFormOptions,
   ): Promise<boolean> => {
-    return await onSubmitForm(data, { ...options, showAcceptWarnings });
+    const result = await onSubmitForm(data, { ...options, showAcceptWarnings });
+    if (formSection.errors.length) {
+      // scroll to top when there are errors, this is mainly necesarry when users click "volgende" a second time without chaning anything
+      window.scrollTo(0, 0);
+    }
+    return result;
   };
 
   // scroll to top when saved


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->

This change scrolls to top when there are errors when you press the "volgende" button a second time without changing something.

It's a minor tweak discovered in the refactoring of data entry.
Note that it should not scroll on warnings due to the "accept warnings" checkbox being at the bottom of the screen.

How to test:
go to voters and votes and add numbers that don't add up, press "volgende", scroll down and press it again.

closes #1113 