### PR TITLE
Make default dev:server -> dev

### DIFF
--- a/documentatie/gebruikersdocumentatie/installeren-en-starten.md
+++ b/documentatie/gebruikersdocumentatie/installeren-en-starten.md
@@ -157,7 +157,7 @@ cargo install sqlx-cli
 
 *Let op: voor deze methode moet je de repository klonen of downloaden.*
 
-In plaats van het script kun je ook handmatig `cargo run` vanuit de backend-map en `npm run dev:server` vanuit de frontend-map in twee verschillende terminals starten. Hiervoor gelden dezelfde vereisten als bij het uitvoeren van het pull-and-run-script. Deze optie is bedoeld voor development.
+In plaats van het script kun je ook handmatig `cargo run` vanuit de backend-map en `npm run dev` vanuit de frontend-map in twee verschillende terminals starten. Hiervoor gelden dezelfde vereisten als bij het uitvoeren van het pull-and-run-script. Deze optie is bedoeld voor development.
 
 ### Methode 5: Docker compose (Linux, macOS, Windows)
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,16 +22,16 @@ npx playwright install --with-deps --no-shell
 
 ### Running
 
-This runs the client with a (client-side) mock API:
+To run with the backend API server, first [start the API server](../backend/README.md#running) and use:
 
 ```sh
 npm run dev
 ```
 
-To run with the backend API server, first [start the API server](../backend/README.md#running) and use:
+This runs the client with a (client-side) mock API:
 
 ```sh
-npm run dev:server
+npm run dev:mock
 ```
 
 ### Linting

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "dev": "cross-env API_MODE=mock vite",
-    "dev:server": "vite",
+    "dev:mock": "cross-env API_MODE=mock vite",
+    "dev": "npm run check-server && vite",
     "build": "vite build --config vite-prod.config.ts",
     "build:msw": "cross-env API_MODE=mock vite build && cp mockServiceWorker.js dist/",
     "lint": "tsc && cross-env ESLINT_ENV=production ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
@@ -26,6 +26,7 @@
     "gen:openapi": "vite-node scripts/gen_openapi.ts",
     "gen:po": "vite-node scripts/gen_po.js",
     "gen:translation-json": "vite-node scripts/gen_translation-json.js",
+    "check-server": "vite-node scripts/check_server.js",
     "serve": "npm run build:msw && npx serve dist"
   },
   "dependencies": {

--- a/frontend/scripts/check_server.js
+++ b/frontend/scripts/check_server.js
@@ -1,0 +1,19 @@
+const http = require("http");
+
+const PORT = 8080;
+
+const options = {
+  host: "localhost",
+  port: PORT,
+  timeout: 2000,
+};
+
+const req = http.request(options, (res) => {
+  console.log(`✅ Backend is running on port ${PORT}`);
+});
+
+req.on("error", () => {
+  console.log(`❌ Backend is NOT running on port ${PORT}`);
+});
+
+req.end();


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->

Since the functionality of the mock service worker is now the bare minimum it's preferable to develop via the backend.
Hence this change to make `npm run dev` default use the backend and introducing `npm run dev:mock` if you want to click through the UI.

This also introduces a small script that checks if the server is running and displays a message.