### PR TITLE
Explicitly exit with statuscode, use fetch

### DIFF
--- a/frontend/scripts/check_server.js
+++ b/frontend/scripts/check_server.js
@@ -1,19 +1,11 @@
-const http = require("http");
-
 const PORT = 8080;
 
-const options = {
-  host: "localhost",
-  port: PORT,
-  timeout: 2000,
-};
-
-const req = http.request(options, (res) => {
-  console.log(`✅ Backend is running on port ${PORT}`);
-});
-
-req.on("error", () => {
-  console.log(`❌ Backend is NOT running on port ${PORT}`);
-});
-
-req.end();
+fetch(`http://localhost:${PORT}`, { signal: AbortSignal.timeout(2000) })
+  .then(() => {
+    console.log(`✅ Backend is running on port ${PORT}`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.log(`❌ Backend is NOT running on port ${PORT} (${err.message})`);
+    process.exit(1);
+  });


### PR DESCRIPTION
- Fix incidental hanging of script by using `exit()`
- Use statuscode to stop the npm run script if the backend is not running
- Use fetch instead of http module