### PR TITLE
Data entry reducer cleanup

### DIFF
--- a/frontend/src/components/form/data_entry/state/dataEntryUtils.ts
+++ b/frontend/src/components/form/data_entry/state/dataEntryUtils.ts
@@ -114,46 +114,6 @@ function sortFormSections(a: FormSection, b: FormSection): number {
   return 0;
 }
 
-export function getInitialValues(
-  election: Required<Election>,
-  defaultValues?: Partial<PollingStationResults>,
-): PollingStationResults {
-  return {
-    recounted: undefined,
-    voters_counts: {
-      poll_card_count: 0,
-      proxy_certificate_count: 0,
-      voter_card_count: 0,
-      total_admitted_voters_count: 0,
-    },
-    votes_counts: {
-      votes_candidates_count: 0,
-      blank_votes_count: 0,
-      invalid_votes_count: 0,
-      total_votes_cast_count: 0,
-    },
-    voters_recounts: undefined,
-    differences_counts: {
-      more_ballots_count: 0,
-      fewer_ballots_count: 0,
-      unreturned_ballots_count: 0,
-      too_few_ballots_handed_out_count: 0,
-      too_many_ballots_handed_out_count: 0,
-      other_explanation_count: 0,
-      no_explanation_count: 0,
-    },
-    political_group_votes: election.political_groups.map((pg) => ({
-      number: pg.number,
-      total: 0,
-      candidate_votes: pg.candidates.map((c) => ({
-        number: c.number,
-        votes: 0,
-      })),
-    })),
-    ...defaultValues,
-  };
-}
-
 export function getInitialFormState(election: Required<Election>): FormState {
   const result: FormState = {
     current: INITIAL_FORM_SECTION_ID,

--- a/frontend/src/components/form/data_entry/state/reducer.test.ts
+++ b/frontend/src/components/form/data_entry/state/reducer.test.ts
@@ -2,14 +2,53 @@ import { expect, test } from "vitest";
 
 import { mockElection } from "@/components/election/status/mockData";
 
-import { ApiResponseStatus } from "@kiesraad/api";
+import { ApiResponseStatus, Election, PollingStationResults } from "@kiesraad/api";
 
-import { getInitialValues as _getInitialValues } from "./dataEntryUtils";
 import dataEntryReducer, { getInitialState as _getInitialState } from "./reducer";
 import { DataEntryAction, DataEntryState } from "./types";
 
 function getInitialState(): DataEntryState {
   return _getInitialState(mockElection, 1, 1);
+}
+
+export function _getInitialValues(
+  election: Required<Election>,
+  defaultValues?: Partial<PollingStationResults>,
+): PollingStationResults {
+  return {
+    recounted: undefined,
+    voters_counts: {
+      poll_card_count: 0,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 0,
+    },
+    votes_counts: {
+      votes_candidates_count: 0,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 0,
+    },
+    voters_recounts: undefined,
+    differences_counts: {
+      more_ballots_count: 0,
+      fewer_ballots_count: 0,
+      unreturned_ballots_count: 0,
+      too_few_ballots_handed_out_count: 0,
+      too_many_ballots_handed_out_count: 0,
+      other_explanation_count: 0,
+      no_explanation_count: 0,
+    },
+    political_group_votes: election.political_groups.map((pg) => ({
+      number: pg.number,
+      total: 0,
+      candidate_votes: pg.candidates.map((c) => ({
+        number: c.number,
+        votes: 0,
+      })),
+    })),
+    ...defaultValues,
+  };
 }
 
 function getInitialValues() {
@@ -33,16 +72,6 @@ test("should handle DATA_ENTRY_LOADED with client_state", () => {
   expect(state.targetFormSectionId).toBeDefined();
   expect(state.pollingStationResults).toEqual(action.dataEntry.data);
   expect(state.error).toBeNull();
-});
-
-test("should handle DATA_ENTRY_NOT_FOUND", () => {
-  const action: DataEntryAction = {
-    type: "DATA_ENTRY_NOT_FOUND",
-  };
-
-  const state = dataEntryReducer(getInitialState(), action);
-  expect(state.error).toBeNull();
-  expect(state.pollingStationResults).toStrictEqual(getInitialValues());
 });
 
 test("should handle DATA_ENTRY_LOAD_FAILED", () => {

--- a/frontend/src/components/form/data_entry/state/reducer.test.ts
+++ b/frontend/src/components/form/data_entry/state/reducer.test.ts
@@ -55,9 +55,9 @@ function getInitialValues() {
   return _getInitialValues(mockElection);
 }
 
-test("should handle DATA_ENTRY_LOADED with client_state", () => {
+test("should handle DATA_ENTRY_CLAIMED with client_state", () => {
   const action: DataEntryAction = {
-    type: "DATA_ENTRY_LOADED",
+    type: "DATA_ENTRY_CLAIMED",
     dataEntry: {
       client_state: null,
       data: getInitialValues(),
@@ -74,9 +74,9 @@ test("should handle DATA_ENTRY_LOADED with client_state", () => {
   expect(state.error).toBeNull();
 });
 
-test("should handle DATA_ENTRY_LOAD_FAILED", () => {
+test("should handle DATA_ENTRY_CLAIM_FAILED", () => {
   const action: DataEntryAction = {
-    type: "DATA_ENTRY_LOAD_FAILED",
+    type: "DATA_ENTRY_CLAIM_FAILED",
     error: {
       message: "error",
       code: 1,

--- a/frontend/src/components/form/data_entry/state/reducer.ts
+++ b/frontend/src/components/form/data_entry/state/reducer.ts
@@ -1,12 +1,6 @@
 import { Election } from "@kiesraad/api";
 
-import {
-  buildFormState,
-  getInitialFormState,
-  getInitialValues,
-  getNextSectionID,
-  updateFormStateAfterSubmit,
-} from "./dataEntryUtils";
+import { buildFormState, getInitialFormState, getNextSectionID, updateFormStateAfterSubmit } from "./dataEntryUtils";
 import { ClientState, DataEntryAction, DataEntryState, FormSectionId, FormSectionReference } from "./types";
 
 export const INITIAL_FORM_SECTION_ID: FormSectionId = "recounted";
@@ -61,13 +55,6 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         targetFormSectionId: INITIAL_FORM_SECTION_ID,
         pollingStationResults: action.dataEntry.data,
         error: null,
-      };
-    case "DATA_ENTRY_NOT_FOUND":
-      return {
-        ...state,
-        pollingStationResults: getInitialValues(state.election),
-        formState: getInitialFormState(state.election),
-        targetFormSectionId: INITIAL_FORM_SECTION_ID,
       };
     case "DATA_ENTRY_LOAD_FAILED":
       return {

--- a/frontend/src/components/form/data_entry/state/reducer.ts
+++ b/frontend/src/components/form/data_entry/state/reducer.ts
@@ -33,7 +33,7 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
   // console.log("ACTION", action);
 
   switch (action.type) {
-    case "DATA_ENTRY_LOADED":
+    case "DATA_ENTRY_CLAIMED":
       if (action.dataEntry.client_state) {
         const { formState, targetFormSectionId } = buildFormState(
           action.dataEntry.client_state as ClientState,
@@ -56,7 +56,7 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         pollingStationResults: action.dataEntry.data,
         error: null,
       };
-    case "DATA_ENTRY_LOAD_FAILED":
+    case "DATA_ENTRY_CLAIM_FAILED":
       return {
         ...state,
         error: action.error,

--- a/frontend/src/components/form/data_entry/state/types.ts
+++ b/frontend/src/components/form/data_entry/state/types.ts
@@ -42,11 +42,11 @@ export type DataEntryDispatch = Dispatch<DataEntryAction>;
 
 export type DataEntryAction =
   | {
-      type: "DATA_ENTRY_LOADED";
+      type: "DATA_ENTRY_CLAIMED";
       dataEntry: ClaimDataEntryResponse;
     }
   | {
-      type: "DATA_ENTRY_LOAD_FAILED";
+      type: "DATA_ENTRY_CLAIM_FAILED";
       error: AnyApiError;
     }
   | {

--- a/frontend/src/components/form/data_entry/state/types.ts
+++ b/frontend/src/components/form/data_entry/state/types.ts
@@ -54,9 +54,6 @@ export type DataEntryAction =
       error: AnyApiError;
     }
   | {
-      type: "DATA_ENTRY_NOT_FOUND";
-    }
-  | {
       type: "FORM_SAVE_FAILED";
       error: AnyApiError;
     }

--- a/frontend/src/components/form/data_entry/state/useInitialDataEntryState.ts
+++ b/frontend/src/components/form/data_entry/state/useInitialDataEntryState.ts
@@ -21,12 +21,12 @@ export function useInitialDataEntryState(
         const dataEntry = result.data;
 
         dispatch({
-          type: "DATA_ENTRY_LOADED",
+          type: "DATA_ENTRY_CLAIMED",
           dataEntry,
         });
       } else {
         dispatch({
-          type: "DATA_ENTRY_LOAD_FAILED",
+          type: "DATA_ENTRY_CLAIM_FAILED",
           error: result,
         });
       }


### PR DESCRIPTION
- Remove the `DATA_ENTRY_NOT_FOUND` state from the data entry reducer, which was unused after the backend claim endpoint was changed to always return an initial state.
- Rename data entry reducer states to match usage of the claim endpoint:
  `DATA_ENTRY_LOADED` -> `DATA_ENTRY_CLAIMED`
  `DATA_ENTRY_LOAD_FAILED` -> `DATA_ENTRY_CLAIM_FAILED`