### PR TITLE
Fix for docker-compose frontend command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,4 @@ services:
       TZ: "Europe/Amsterdam"
       API_HOST: http://backend:8080
       VITE_HOST: "0.0.0.0"
-    command: ["npm", "run", "dev:server", "--", "--host"]
+    command: ["npx", "vite", "--host"]


### PR DESCRIPTION
The check-server script broke starting via docker compose. This PR updates the obsolete `command` for the frontend service in `docker-compose.yml` and bypasses the check-server script. The dependency on `backend` already makes sure the backend will be run.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->