### PR TITLE
Simplify number formatting functions

### DIFF
--- a/frontend/src/lib/util/format.ts
+++ b/frontend/src/lib/util/format.ts
@@ -4,12 +4,8 @@ const numberFormatter = new Intl.NumberFormat("nl-NL", {
   maximumFractionDigits: 0,
 });
 
-export function formatNumber(s: string | number | null | undefined | readonly string[]): string {
-  if (typeof s !== "string" && typeof s !== "number") {
-    return "";
-  }
-
-  if (typeof s === "number" && s === 0) {
+export function formatNumber(s: string | number | null | undefined | readonly string[]) {
+  if ((typeof s !== "string" && typeof s !== "number") || (typeof s === "number" && s === 0)) {
     return "";
   }
 
@@ -21,18 +17,8 @@ export function formatNumber(s: string | number | null | undefined | readonly st
   }
 }
 
-const separator = numberFormatter.format(11111).replace(/\p{Number}/gu, "");
-const escapedSeparator = separator.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-const cleanRegex = new RegExp(escapedSeparator, "g");
-
-export function deformatNumber(s: FormDataEntryValue | string | null): number {
-  if (s === null || typeof s !== "string") {
-    return 0;
-  }
-
-  const cleaned = s.replace(cleanRegex, "");
-
-  // Make sure empty value is converted to 0 instead of null
+export function deformatNumber(s: string) {
+  const cleaned = s.replace(/[.]/g, "");
   if (cleaned == "") {
     // An empty value should be parsed as 0
     return 0;


### PR DESCRIPTION
This restores the cleanup from https://github.com/kiesraad/abacus/commit/e1ee261a59176a9968f3cadd31c84716cd141d09#diff-c1c8e49c9dafc2e5734e0878411108c333421c0f00c8e2d97ada5bc21b272052 which was (accidentally?) reverted in   https://github.com/kiesraad/abacus/commit/56c0b54d0feba145dae437fdbdf106b279fcee50#diff-c1c8e49c9dafc2e5734e0878411108c333421c0f00c8e2d97ada5bc21b272052.