### PR TITLE
Added data entry difference state transitions

### DIFF
--- a/documentatie/flowcharts/data-entry-state.md
+++ b/documentatie/flowcharts/data-entry-state.md
@@ -5,19 +5,22 @@ The transition labels describe the endpoint that is used for performing the tran
 The "save" endpoint, used to for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
 
 ```mermaid
-stateDiagram
-  direction LR
+stateDiagram-v2
+  [*] --> FirstEntryNotStarted
+  FirstEntryNotStarted --> FirstEntryInProgress: claim
+  #FirstEntryInProgress --> FirstEntryInProgress: save
+  FirstEntryInProgress --> SecondEntryNotStarted: finalise
+  FirstEntryInProgress --> FirstEntryNotStarted: delete
+  SecondEntryNotStarted --> SecondEntryInProgress: claim
+  #SecondEntryInProgress --> SecondEntryInProgress: save
   state is_equal <<choice>>
-  FirstEntryNotStarted --> FirstEntryInProgress:claim
-  #FirstEntryInProgress --> FirstEntryInProgress:save
-  FirstEntryInProgress --> SecondEntryNotStarted:finalise
-  FirstEntryInProgress --> FirstEntryNotStarted:delete
-  SecondEntryNotStarted --> SecondEntryInProgress:claim
-  is_equal --> Definitive:equal? yes
-  is_equal --> EntriesDifferent:equal? no
-  #SecondEntryInProgress --> SecondEntryInProgress:save
-  SecondEntryInProgress --> is_equal:finalise
-  SecondEntryInProgress --> SecondEntryNotStarted:delete
-  EntriesDifferent --> FirstEntryInProgress: discard both entries
-  EntriesDifferent --> SecondEntryInProgress:keep one entry
+  SecondEntryInProgress --> is_equal: finalise
+  SecondEntryInProgress --> SecondEntryNotStarted: delete
+  state resolve <<choice>>
+  EntriesDifferent --> resolve: resolve
+  resolve --> SecondEntryNotStarted: keep one entry
+  resolve --> FirstEntryNotStarted: discard both entries
+  is_equal --> Definitive: equal? yes
+  is_equal --> EntriesDifferent: equal? no
+  Definitive --> [*]
 ```

--- a/documentatie/flowcharts/data-entry-state.md
+++ b/documentatie/flowcharts/data-entry-state.md
@@ -24,3 +24,7 @@ stateDiagram-v2
   is_equal --> EntriesDifferent: equal? no
   Definitive --> [*]
 ```
+
+When resolving differences between the first and second entry (`EntriesDifferent` state), the coordinator can choose to
+keep one of the entries or discard both. If one of the entries is kept, the other entry is deleted. The remaining entry
+will from then on be the first entry, and the data entry is open for a new second entry.

--- a/documentatie/flowcharts/data-entry-state.md
+++ b/documentatie/flowcharts/data-entry-state.md
@@ -2,7 +2,7 @@
 
 This document describes the states a data entry can have.
 The transition labels describe the endpoint that is used for performing the transition.
-The "save" endpoint, used to for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
+The "save" endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
 
 ```mermaid
 stateDiagram-v2

--- a/documentatie/flowcharts/data-entry-state.md
+++ b/documentatie/flowcharts/data-entry-state.md
@@ -10,12 +10,12 @@ stateDiagram-v2
   FirstEntryNotStarted --> FirstEntryInProgress: claim
   #FirstEntryInProgress --> FirstEntryInProgress: save
   FirstEntryInProgress --> SecondEntryNotStarted: finalise
-  FirstEntryInProgress --> FirstEntryNotStarted: delete
+  FirstEntryInProgress --> FirstEntryNotStarted: discard
   SecondEntryNotStarted --> SecondEntryInProgress: claim
   #SecondEntryInProgress --> SecondEntryInProgress: save
   state is_equal <<choice>>
   SecondEntryInProgress --> is_equal: finalise
-  SecondEntryInProgress --> SecondEntryNotStarted: delete
+  SecondEntryInProgress --> SecondEntryNotStarted: discard
   state resolve <<choice>>
   EntriesDifferent --> resolve: resolve
   resolve --> SecondEntryNotStarted: keep one entry
@@ -26,5 +26,5 @@ stateDiagram-v2
 ```
 
 When resolving differences between the first and second entry (`EntriesDifferent` state), the coordinator can choose to
-keep one of the entries or discard both. If one of the entries is kept, the other entry is deleted. The remaining entry
+keep one of the entries or discard both. If one of the entries is kept, the other entry is discarded. The remaining entry
 will from then on be the first entry, and the data entry is open for a new second entry.

--- a/documentatie/flowcharts/data-entry-state.md
+++ b/documentatie/flowcharts/data-entry-state.md
@@ -6,20 +6,18 @@ The "save" endpoint, used to for [First/Second]EntryInProgress states is kept ou
 
 ```mermaid
 stateDiagram
-FirstEntryNotStarted --> FirstEntryInProgress: claim
-#FirstEntryInProgress --> FirstEntryInProgress: claim
-#FirstEntryInProgress --> FirstEntryInProgress: save
-FirstEntryInProgress --> SecondEntryNotStarted: finalise
-FirstEntryInProgress --> FirstEntryNotStarted: delete
-SecondEntryNotStarted --> SecondEntryInProgress: claim
-#SecondEntryInProgress --> SecondEntryInProgress: claim
-#SecondEntryInProgress --> SecondEntryInProgress: save
-state is_equal <<choice>>
-is_equal --> Definitive: equal? yes
-is_equal --> EntriesDifferent: equal? no
-SecondEntryInProgress --> is_equal: finalise
-SecondEntryInProgress --> SecondEntryNotStarted: delete
-#EntriesDifferent --> EntriesDifferent: save
-# Will be Implemented in #130: EntriesDifferent --> NotStarted: delete
-EntriesDifferent --> Definitive: resolve
+  direction LR
+  state is_equal <<choice>>
+  FirstEntryNotStarted --> FirstEntryInProgress:claim
+  #FirstEntryInProgress --> FirstEntryInProgress:save
+  FirstEntryInProgress --> SecondEntryNotStarted:finalise
+  FirstEntryInProgress --> FirstEntryNotStarted:delete
+  SecondEntryNotStarted --> SecondEntryInProgress:claim
+  is_equal --> Definitive:equal? yes
+  is_equal --> EntriesDifferent:equal? no
+  #SecondEntryInProgress --> SecondEntryInProgress:save
+  SecondEntryInProgress --> is_equal:finalise
+  SecondEntryInProgress --> SecondEntryNotStarted:delete
+  EntriesDifferent --> FirstEntryInProgress: discard both entries
+  EntriesDifferent --> SecondEntryInProgress:keep one entry
 ```


### PR DESCRIPTION
Fixes #1243  

The diagram looks _much_ better, even with the looping `save` transitions, using:
```
---
config:
  layout: elk
---
```
Unfortunately the `elk` layout is not available on GitHub. If anyone knows how to change the layout algorithm, let me know

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->