### PR TITLE
Add typist name to election status page

### DIFF
--- a/frontend/src/components/election/status/ElectionStatus.stories.tsx
+++ b/frontend/src/components/election/status/ElectionStatus.stories.tsx
@@ -1,5 +1,7 @@
 import type { Story } from "@ladle/react";
 
+import { userMockData } from "@/testing/api-mocks";
+
 import { ElectionStatus } from "./ElectionStatus";
 import { mockElection, mockPollingStations } from "./mockData";
 
@@ -21,6 +23,7 @@ export const PollingStationStatus: Story<StoryProps> = ({ navigate }) => {
         {
           polling_station_id: 2,
           status: "second_entry_not_started",
+          first_entry_user_id: 1,
           finished_at: today.toISOString(),
         },
         {
@@ -40,13 +43,14 @@ export const PollingStationStatus: Story<StoryProps> = ({ navigate }) => {
       ]}
       election={mockElection}
       pollingStations={mockPollingStations}
+      users={userMockData}
       navigate={navigate}
     />
   );
 };
 
 export const Empty: Story<StoryProps> = ({ navigate }) => (
-  <ElectionStatus statuses={[]} election={mockElection} pollingStations={[]} navigate={navigate} />
+  <ElectionStatus statuses={[]} election={mockElection} pollingStations={[]} users={userMockData} navigate={navigate} />
 );
 
 export default {

--- a/frontend/src/components/election/status/ElectionStatus.test.tsx
+++ b/frontend/src/components/election/status/ElectionStatus.test.tsx
@@ -47,9 +47,9 @@ describe("ElectionStatus", () => {
 
     expect(headings[0]).toHaveTextContent("Invoer bezig (2)");
     expect(tables[0]).toHaveTableContent([
-      ["Nummer", "Stembureau", "Voortgang"],
-      ["35", "Testschool 1e invoer", "60%"],
-      ["36", "Testbuurthuis 2e invoer", "20%"],
+      ["Nummer", "Stembureau", "Invoerder", "Voortgang"],
+      ["35", "Testschool 1e invoer", "Sanne Molenaar", "60%"],
+      ["36", "Testbuurthuis 2e invoer", "Jayden Ahmen", "20%"],
     ]);
 
     const inProgressRows = within(tables[0]!).getAllByRole("row");
@@ -58,8 +58,8 @@ describe("ElectionStatus", () => {
 
     expect(headings[1]).toHaveTextContent("Eerste invoer klaar (1)");
     expect(tables[1]).toHaveTableContent([
-      ["Nummer", "Stembureau", "Afgerond op"],
-      ["34", "Testplek", "vandaag 10:20"],
+      ["Nummer", "Stembureau", "Invoerder", "Afgerond op"],
+      ["34", "Testplek", "Sanne Molenaar", "vandaag 10:20"],
     ]);
 
     expect(headings[2]).toHaveTextContent("Werkvoorraad (1)");

--- a/frontend/src/components/election/status/ElectionStatus.tsx
+++ b/frontend/src/components/election/status/ElectionStatus.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { DataEntryStatusName, Election, ElectionStatusResponseEntry, PollingStation } from "@kiesraad/api";
+import { DataEntryStatusName, Election, ElectionStatusResponseEntry, PollingStation, User } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { IconPlus } from "@kiesraad/icon";
 import {
@@ -31,9 +31,14 @@ export interface ElectionStatusProps {
   election: Required<Election>;
   pollingStations: PollingStation[];
   navigate: (path: string) => void;
+  users: User[];
 }
 
-export function ElectionStatus({ statuses, election, pollingStations, navigate }: ElectionStatusProps) {
+interface PollingStationWithStatusAndTypist extends PollingStation, Partial<ElectionStatusResponseEntry> {
+  typist?: string;
+}
+
+export function ElectionStatus({ statuses, election, pollingStations, navigate, users }: ElectionStatusProps) {
   const categoryCounts: Record<StatusCategory, number> = React.useMemo(
     () =>
       Object.fromEntries(statusCategories.map((cat) => [cat, statusCount(statuses, cat)])) as Record<
@@ -58,9 +63,40 @@ export function ElectionStatus({ statuses, election, pollingStations, navigate }
     return data;
   }, [statuses, categoryCounts]);
 
-  const pollingStationsWithStatuses = pollingStations.map((ps) => {
+  function getTypistName(status: ElectionStatusResponseEntry | undefined) {
+    if (status === undefined || users.length === 0) {
+      return "";
+    }
+
+    let typistId: number | undefined;
+    switch (status.status) {
+      case "first_entry_in_progress":
+        typistId = status.first_entry_user_id;
+        break;
+      case "second_entry_in_progress":
+        typistId = status.second_entry_user_id;
+        break;
+      case "second_entry_not_started":
+        typistId = status.first_entry_user_id;
+        break;
+      default:
+        break;
+    }
+    if (typistId === undefined) {
+      return "";
+    }
+
+    const user = users.find((user) => user.id === typistId);
+    return user?.fullname ?? user?.username ?? "";
+  }
+
+  const pollingStationWithStatusAndTypist = pollingStations.map((ps) => {
     const status = statuses.find((element) => element.polling_station_id === ps.id);
-    return { ...ps, ...status } as PollingStationWithStatus;
+    return {
+      ...ps,
+      ...status,
+      typist: getTypistName(status),
+    } satisfies PollingStationWithStatusAndTypist;
   });
 
   const tableCategories = statusCategories.filter((cat) => categoryCounts[cat] !== 0);
@@ -121,8 +157,8 @@ export function ElectionStatus({ statuses, election, pollingStations, navigate }
                     <Table id={cat} key={cat}>
                       {getTableHeaderForCategory(cat)}
                       <Table.Body key={cat} className="fs-sm">
-                        {pollingStationsWithStatuses
-                          .filter((ps) => statusesForCategory[cat].includes(ps.status))
+                        {pollingStationWithStatusAndTypist
+                          .filter((ps) => ps.status !== undefined && statusesForCategory[cat].includes(ps.status))
                           .map((ps) => getTableRowForCategory(cat, ps))}
                       </Table.Body>
                     </Table>
@@ -136,8 +172,6 @@ export function ElectionStatus({ statuses, election, pollingStations, navigate }
     </>
   );
 }
-
-interface PollingStationWithStatus extends PollingStation, ElectionStatusResponseEntry {}
 
 const categoryColorClass: Record<StatusCategory, ProgressBarColorClass> = {
   errors_and_warnings: "errors-and-warnings",
@@ -168,17 +202,29 @@ function getTableHeaderForCategory(category: StatusCategory): React.ReactNode {
     );
   }
 
-  const finishedAtColumn = <Table.HeaderCell key={`${category}-time`}>{t("finished_at")}</Table.HeaderCell>;
+  const finishedAtColumn = (
+    <Table.HeaderCell key={`${category}-time`} className="w-14">
+      {t("finished_at")}
+    </Table.HeaderCell>
+  );
+
   const progressColumn = (
-    <Table.HeaderCell key={`${category}-progress`} className="w-13">
+    <Table.HeaderCell key={`${category}-progress`} className="w-14">
       {t("progress")}
+    </Table.HeaderCell>
+  );
+
+  const typistColumn = (
+    <Table.HeaderCell key={`${category}-typist`} className="w-14">
+      {t("typist")}
     </Table.HeaderCell>
   );
 
   switch (category) {
     case "in_progress":
-      return <CategoryHeader>{[progressColumn]}</CategoryHeader>;
+      return <CategoryHeader>{[typistColumn, progressColumn]}</CategoryHeader>;
     case "first_entry_finished":
+      return <CategoryHeader>{[typistColumn, finishedAtColumn]}</CategoryHeader>;
     case "definitive":
       return <CategoryHeader>{[finishedAtColumn]}</CategoryHeader>;
     default:
@@ -186,7 +232,10 @@ function getTableHeaderForCategory(category: StatusCategory): React.ReactNode {
   }
 }
 
-function getTableRowForCategory(category: StatusCategory, polling_station: PollingStationWithStatus): React.ReactNode {
+function getTableRowForCategory(
+  category: StatusCategory,
+  polling_station: PollingStationWithStatusAndTypist,
+): React.ReactNode {
   const showBadge: DataEntryStatusName[] = ["first_entry_in_progress", "second_entry_in_progress", "entries_different"];
 
   function CategoryPollingStationRow({ children }: { children?: React.ReactNode[] }) {
@@ -195,13 +244,16 @@ function getTableRowForCategory(category: StatusCategory, polling_station: Polli
         <Table.NumberCell key={`${polling_station.id}-number`}>{polling_station.number}</Table.NumberCell>
         <Table.Cell key={`${polling_station.id}-name`}>
           <span>{polling_station.name}</span>
-          {showBadge.includes(polling_station.status) && <Badge type={polling_station.status} />}
+          {polling_station.status && showBadge.includes(polling_station.status) && (
+            <Badge type={polling_station.status} />
+          )}
         </Table.Cell>
         {children}
       </Table.Row>
     );
   }
 
+  const typistCell = <Table.Cell key={`${polling_station.id}-typist`}>{polling_station.typist}</Table.Cell>;
   const finishedAtCell = (
     <Table.Cell key={`${polling_station.id}-time`}>
       {polling_station.finished_at ? formatDateTime(new Date(polling_station.finished_at)) : ""}
@@ -219,11 +271,15 @@ function getTableRowForCategory(category: StatusCategory, polling_station: Polli
       />
     </Table.Cell>
   );
-  // TODO: #1131 add user names
   switch (category) {
     case "in_progress":
-      return <CategoryPollingStationRow key={polling_station.id}>{[progressCell]}</CategoryPollingStationRow>;
+      return (
+        <CategoryPollingStationRow key={polling_station.id}>{[typistCell, progressCell]}</CategoryPollingStationRow>
+      );
     case "first_entry_finished":
+      return (
+        <CategoryPollingStationRow key={polling_station.id}>{[typistCell, finishedAtCell]}</CategoryPollingStationRow>
+      );
     case "definitive":
       return <CategoryPollingStationRow key={polling_station.id}>{[finishedAtCell]}</CategoryPollingStationRow>;
     default:

--- a/frontend/src/components/ui/Table/Table.module.css
+++ b/frontend/src/components/ui/Table/Table.module.css
@@ -21,7 +21,8 @@
   th[scope="col"] {
     height: 2.75rem;
     line-height: 1.125rem;
-    padding: 0.75rem 1.5rem;
+    padding: 0 1.5rem;
+
     &:global(.link-cell-padding) {
       padding-right: 4.5rem;
     }
@@ -31,7 +32,8 @@
   td {
     height: 3.5rem;
     line-height: 1.25rem;
-    padding: 1rem 1.5rem;
+    padding: 0 1.5rem;
+
     &:global(.link-cell-padding) {
       padding-right: 4.5rem;
     }

--- a/frontend/src/components/ui/Table/Table.stories.tsx
+++ b/frontend/src/components/ui/Table/Table.stories.tsx
@@ -16,7 +16,7 @@ export const BasicTable: Story = () => (
   <Table id="basic_table">
     <Table.Header>
       <Table.HeaderCell>Number</Table.HeaderCell>
-      <Table.HeaderCell className="w-13">Fixed width</Table.HeaderCell>
+      <Table.HeaderCell className="w-14">Fixed width</Table.HeaderCell>
       <Table.HeaderCell>Some value</Table.HeaderCell>
     </Table.Header>
     <Table.Body>

--- a/frontend/src/components/ui/style/util.css
+++ b/frontend/src/components/ui/style/util.css
@@ -41,8 +41,8 @@
 }
 
 /* Width */
-.w-13 {
-  width: 13rem;
+.w-14 {
+  width: 14rem;
 }
 
 .w-full {

--- a/frontend/src/features/apportionment/components/Apportionment.module.css
+++ b/frontend/src/features/apportionment/components/Apportionment.module.css
@@ -26,7 +26,6 @@
   color: var(--gray-900);
   td {
     line-height: 1.5rem;
-    padding: 0 1.5rem;
     font-size: var(--font-size-md);
   }
   th {

--- a/frontend/src/features/election/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election/components/ElectionStatusPage.test.tsx
@@ -1,8 +1,8 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import { ElectionProvider, ElectionStatusProvider, ElectionStatusResponse } from "@kiesraad/api";
-import { getElectionMockData } from "@kiesraad/api-mocks";
-import { overrideOnce, render, screen } from "@kiesraad/test";
+import { getElectionMockData, UserListRequestHandler } from "@kiesraad/api-mocks";
+import { overrideOnce, render, screen, server } from "@kiesraad/test";
 
 import { ElectionStatusPage } from "./ElectionStatusPage";
 
@@ -16,6 +16,10 @@ const renderElectionStatusPage = () =>
   );
 
 describe("ElectionStatusPage", () => {
+  beforeEach(() => {
+    server.use(UserListRequestHandler);
+  });
+
   test("Finish input not visible when data entry is in progress", () => {
     overrideOnce("get", "/api/elections/1", 200, getElectionMockData());
 

--- a/frontend/src/features/election/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election/components/ElectionStatusPage.tsx
@@ -4,7 +4,13 @@ import { HeaderElectionStatusWithIcon } from "@/components/election/ElectionStat
 import { ElectionStatus } from "@/components/election/status/ElectionStatus";
 import { Footer } from "@/components/footer/Footer";
 
-import { useElection, useElectionStatus } from "@kiesraad/api";
+import {
+  useElection,
+  useElectionStatus,
+  useInitialApiGet,
+  USER_LIST_REQUEST_PATH,
+  UserListResponse,
+} from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 import { Alert, Button, PageTitle } from "@kiesraad/ui";
 
@@ -12,6 +18,9 @@ export function ElectionStatusPage() {
   const navigate = useNavigate();
   const { election, pollingStations } = useElection();
   const { statuses } = useElectionStatus();
+  const { requestState } = useInitialApiGet<UserListResponse>("/api/user" satisfies USER_LIST_REQUEST_PATH);
+
+  const users = requestState.status === "success" ? requestState.data.users : [];
 
   function finishInput() {
     void navigate("../report");
@@ -46,6 +55,7 @@ export function ElectionStatusPage() {
           election={election}
           pollingStations={pollingStations}
           statuses={statuses}
+          users={users}
           navigate={(path) => void navigate(path)}
         />
       </main>

--- a/frontend/src/testing/api-mocks/ElectionMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionMockData.ts
@@ -273,6 +273,9 @@ export const getElectionMockData = (election: Partial<Election> = {}): Required<
 export const electionDetailsMockResponse: Required<ElectionDetailsResponse> = getElectionMockData();
 export const electionMockData = electionDetailsMockResponse.election as Required<Election>;
 
+const today = new Date();
+today.setHours(10, 20);
+
 export const electionStatusMockResponse: ElectionStatusResponse = {
   statuses: [
     {
@@ -282,10 +285,21 @@ export const electionStatusMockResponse: ElectionStatusResponse = {
     {
       polling_station_id: 2,
       status: "definitive",
+      first_entry_user_id: 2,
+      second_entry_user_id: 1,
+      finished_at: today.toISOString(),
     },
     {
       polling_station_id: 3,
       status: "entries_different",
+    },
+    {
+      polling_station_id: 4,
+      status: "second_entry_in_progress",
+      first_entry_user_id: 1,
+      second_entry_user_id: 2,
+      first_entry_progress: 100,
+      second_entry_progress: 20,
     },
   ],
 };


### PR DESCRIPTION
- Determine which typist to show in the election status page for "in_progress" and "first_entry_finished"
- Retrieve users and show these extra columns with proper widths
- Remove vertical padding from table cells to avoid rows becoming too high when text wrap is needed
- Add data to status mocks