### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/frontend/e2e-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/data-entry.e2e.ts
@@ -117,7 +117,7 @@ test.describe("full data entry flow", () => {
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
 
     const recountedPage = new RecountedPage(page);
     await expect(recountedPage.fieldset).toBeVisible();
@@ -174,7 +174,7 @@ test.describe("full data entry flow", () => {
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
 
     const recountedPage = new RecountedPage(page);
     await expect(recountedPage.fieldset).toBeVisible();
@@ -239,7 +239,7 @@ test.describe("full data entry flow", () => {
 
     const pollingStationChoicePage = new PollingStationChoicePage(page);
     await expect(pollingStationChoicePage.fieldset).toBeVisible();
-    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+    await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
 
     const recountedPage = new RecountedPage(page);
     await expect(recountedPage.fieldset).toBeVisible();

--- a/frontend/e2e-tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/data-entry.e2e.ts
@@ -791,6 +791,7 @@ test.describe("navigation", () => {
 
       await candidatesListPage_1.fillCandidatesAndTotal([1, 1], 100);
       await candidatesListPage_1.next.click();
+      await expect(candidatesListPage_1.error).toBeVisible();
       await candidatesListPage_1.navPanel.differences.click();
 
       await expect(differencesPage.fieldset).toBeVisible();

--- a/frontend/e2e-tests/data-entry.error.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.error.model.e2e.ts
@@ -423,7 +423,7 @@ test.describe("Data entry model test - errors", () => {
         expect(new Set(events)).toEqual(new Set(machineEvents));
 
         await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
         await recountedPage.checkNoAndClickNext();
 
         type MachineStates = typeof dataEntryMachineDefinition.states;

--- a/frontend/e2e-tests/data-entry.valid.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.valid.model.e2e.ts
@@ -369,7 +369,7 @@ test.describe("Data entry model test - valid data", () => {
         expect(new Set(events)).toEqual(new Set(machineEvents));
 
         await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
         await recountedPage.checkNoAndClickNext();
 
         type MachineStates = typeof dataEntryMachineDefinition.states;

--- a/frontend/e2e-tests/data-entry.warning.model.e2e.ts
+++ b/frontend/e2e-tests/data-entry.warning.model.e2e.ts
@@ -460,7 +460,7 @@ test.describe("Data entry model test - warnings", () => {
         expect(new Set(events)).toEqual(new Set(machineEvents));
 
         await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation.number);
+        await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
         await recountedPage.checkNoAndClickNext();
 
         type MachineStates = typeof dataEntryMachineDefinition.states;

--- a/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
@@ -6,12 +6,12 @@ export class PollingStationChoicePage {
   readonly pollingStationNumber: Locator;
   readonly pollingStationFeedback: Locator;
   readonly pollingStationSubmitFeedback: Locator;
-  protected readonly start: Locator; // use clickStart() instead
   readonly alertInputSaved: Locator;
   readonly dataEntrySuccess: Locator;
   readonly resumeDataEntry: Locator;
   readonly alertDataEntryInProgress: Locator;
   readonly allDataEntriesInProgress: Locator;
+  protected readonly start: Locator; // use clickStart() instead
 
   constructor(protected readonly page: Page) {
     this.fieldset = page.getByRole("group", {
@@ -48,7 +48,7 @@ export class PollingStationChoicePage {
   }
 
   async selectPollingStationAndClickStart(pollingStationNumber: number) {
-    await this.pollingStationNumber.fill(pollingStationNumber.toString());
+    await this.pollingStationNumber.pressSequentially(pollingStationNumber.toString(), { delay: 50 });
     await this.clickStart();
   }
 

--- a/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/PollingStationChoicePgObj.ts
@@ -1,4 +1,6 @@
-import { type Locator, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
+
+import { PollingStation } from "@/api";
 
 export class PollingStationChoicePage {
   readonly fieldset: Locator;
@@ -47,8 +49,9 @@ export class PollingStationChoicePage {
     await button.click({ timeout: 2000 });
   }
 
-  async selectPollingStationAndClickStart(pollingStationNumber: number) {
-    await this.pollingStationNumber.pressSequentially(pollingStationNumber.toString(), { delay: 50 });
+  async selectPollingStationAndClickStart(pollingStation: PollingStation) {
+    await this.pollingStationNumber.pressSequentially(pollingStation.number.toString(), { delay: 50 });
+    await expect(this.pollingStationFeedback).toContainText(pollingStation.name);
     await this.clickStart();
   }
 

--- a/frontend/e2e-tests/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/resume-data-entry.e2e.ts
@@ -190,7 +190,7 @@ test.describe("resume data entry flow", () => {
         },
       });
 
-      await pollingStationChoicePage.selectPollingStationAndClickStart(33);
+      await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
       await expect(votersAndVotesPage.fieldset).toBeVisible();
     });
 
@@ -265,7 +265,7 @@ test.describe("resume data entry flow", () => {
         },
       });
 
-      await pollingStationChoicePage.selectPollingStationAndClickStart(33);
+      await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
       await expect(votersAndVotesPage.fieldset).toBeVisible();
     });
 
@@ -293,7 +293,7 @@ test.describe("resume data entry flow", () => {
       await abortInputModal.saveInput.click();
 
       const pollingStationChoicePage = new PollingStationChoicePage(page);
-      await pollingStationChoicePage.selectPollingStationAndClickStart(33);
+      await pollingStationChoicePage.selectPollingStationAndClickStart(pollingStation);
 
       await expect(recountedPage.fieldset).toBeVisible();
       await recountedPage.navPanel.votersAndVotes.click();

--- a/frontend/playwright.common.config.ts
+++ b/frontend/playwright.common.config.ts
@@ -10,8 +10,6 @@ const commonConfig: PlaywrightTestConfig = defineConfig({
   retries: process.env.CI ? 2 : 0,
   // Use all available cores on GitHub Actions. Default is 50%, use that locally.
   workers: process.env.CI ? "100%" : undefined,
-  // Increase the test timeout on CI, which is usually slower
-  timeout: process.env.CI ? 30_000 : 10_000,
   fullyParallel: true,
   globalSetup: "./e2e-tests/setup.ts",
   use: {

--- a/frontend/playwright.e2e.config.ts
+++ b/frontend/playwright.e2e.config.ts
@@ -20,6 +20,8 @@ function returnWebserverCommand(): string {
 
 const config: PlaywrightTestConfig = defineConfig({
   ...commonConfig,
+  // Increase the test timeout on CI, which is usually slower
+  timeout: process.env.CI ? 30_000 : 20_000,
   reporter: process.env.CI
     ? [["list"], ["github"], ["junit", { outputFile: "playwright.ladle.junit.xml" }], ["html", { open: "never" }]]
     : "list",

--- a/frontend/playwright.ladle.config.ts
+++ b/frontend/playwright.ladle.config.ts
@@ -4,6 +4,8 @@ import commonConfig from "./playwright.common.config";
 
 const config: PlaywrightTestConfig = defineConfig({
   ...commonConfig,
+  // Increase the test timeout on CI, which is usually slower
+  timeout: process.env.CI ? 30_000 : 10_000,
   // Use the list reporter even on CI, to get immediate feedback
   reporter: process.env.CI ? [["list"], ["github"], ["junit", { outputFile: "playwright.ladle.junit.xml" }]] : "list",
   testDir: "./src/components/ui",


### PR DESCRIPTION
In recent PR's I see a lot of flaky tests for the model based tests on MacOS. It seems that filling in a polling station number is not working and the test cannot continue to data entry. This potential fix uses `pressSequentially` to enter the polling station number.

<img width="1745" alt="image" src="https://github.com/user-attachments/assets/1931ae8b-2829-476c-b291-d78a6ec81abe" />

Additional changes:
- add an `expect()` after the `pressSequentially` for the name of the polling station being shown
- increase local e2e test timeout to 20 seconds, so you can run them all for a single browser engine
- add an `expect()` to the left-nav-panel icon test (test was flaky at that point when running locally)
