### PR TITLE
Run PDF gen using typst binary instead of embedded typst by default

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Check Clippy without default features
         run: cargo --verbose --locked clippy --target=${{ matrix.target.name }} --all-targets --no-default-features -- -D warnings
       - name: Run tests
-        run: cargo --verbose --locked test --target=${{ matrix.target.name }} -- --nocapture
+        run: cargo --verbose --locked test --target=${{ matrix.target.name }} --features embed-typst -- --nocapture
       - name: Build
         run: cargo --verbose --locked build --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Backend (${{ matrix.target.os }})
     strategy:
       matrix:
-        target: 
+        target:
           - os: ubuntu-latest
             name: x86_64-unknown-linux-musl
             binary: backend/target/x86_64-unknown-linux-musl/debug/abacus
@@ -83,12 +83,12 @@ jobs:
       - name: Run tests
         run: cargo --verbose --locked test --target=${{ matrix.target.name }} -- --nocapture
       - name: Build
-        run: cargo --verbose --locked build --features memory-serve --target=${{ matrix.target.name }}
+        run: cargo --verbose --locked build --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4
         with:
           name: abacus-${{ matrix.target.os }}
           path: ${{ matrix.target.binary }}
-  
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
       - name: Run tests with coverage
-        run: cargo llvm-cov --branch nextest --profile ci
+        run: cargo llvm-cov --branch nextest --profile ci --features embed-typst
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        target: 
+        target:
           - os: ubuntu-latest
             name: x86_64-unknown-linux-musl
             binary: backend/target/x86_64-unknown-linux-musl/release/abacus
@@ -53,7 +53,7 @@ jobs:
       - name: Run tests
         run: cargo --locked test --release
       - name: Build
-        run: cargo --locked build --release --features memory-serve --target=${{ matrix.target.name }}
+        run: cargo --locked build --release --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4
         with:
           name: abacus-${{ matrix.target.os }}

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,6 +10,7 @@ default-run = "abacus"
 default = ["openapi", "dev-database"]
 openapi = ["dep:utoipa-swagger-ui"]
 memory-serve = ["dep:memory-serve"]
+embed-typst = ["dep:typst", "dep:typst-pdf"]
 dev-database = []
 
 [[bin]]
@@ -36,8 +37,8 @@ tower = "0.5"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing = "0.1.41"
 tower-http = { version = "0.6.2", features = ["trace"] }
-typst = "0.13.1"
-typst-pdf = "0.13.1"
+typst = { version = "0.13.1", optional = true }
+typst-pdf = { version = "0.13.1", optional = true }
 quick-xml = { version = "0.37.2", features = ["serialize"] }
 sha2 = "0.10.8"
 argon2 = "0.5.3"

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,7 +20,7 @@ The built binary will be located in `target/release/`.
 Use `cargo run` to run the API on port 8080 (http://localhost:8080).
 
 To let the API server serve the frontend, first compile the frontend using
-`npm run build` in the `frontend` directory. The run the API server with the
+`npm run build` in the `frontend` directory. Then run the API server with the
 `memory-serve` feature enabled. Also make sure to point the `ASSET_DIR` environment
 variable to the directory where `vite` outputs the assets, e.g. `frontend/dist`.
 In this version of `memory-serve`, the path must be absolute, since `build.rs`
@@ -33,6 +33,19 @@ cd ../backend
 sqlx database setup
 ASSET_DIR=$PWD/../frontend/dist cargo run --features memory-serve
 ```
+
+By default Abacus will use an external typst binary which should be available on
+your `$PATH` in order to generate PDF output. You can download typst for your
+platform on the [typst releases page] or by running `cargo install typst-cli`.
+You can also build Abacus to include typst in the binary itself. To do this, you
+can simply enable the `embed-typst` feature. This can be combined with the
+memory-serve feature as well, e.g.:
+
+```shell
+ASSET_DIR=$PWD/../frontend/dist cargo build --features memory-serve,embed-typst
+```
+
+[typst releases page]: https://github.com/typst/typst/releases
 
 ### Linting
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -4,6 +4,7 @@ use crate::{
     apportionment::ApportionmentError,
     authentication::error::AuthenticationError,
     data_entry::{DataError, status::DataEntryTransitionError},
+    pdf_gen::PdfGenError,
 };
 use axum::{
     Json,
@@ -16,7 +17,6 @@ use quick_xml::SeError;
 use serde::{Deserialize, Serialize};
 use sqlx::Error::RowNotFound;
 use tracing::error;
-use typst::diag::SourceDiagnostic;
 use utoipa::ToSchema;
 use zip::result::ZipError;
 
@@ -80,7 +80,7 @@ pub enum APIError {
     SerdeJsonError(serde_json::Error),
     SqlxError(sqlx::Error),
     InvalidHeaderValue,
-    PdfGenError(Vec<SourceDiagnostic>),
+    PdfGenError(PdfGenError),
     StdError(Box<dyn Error>),
     AddError(String, ErrorReference),
     XmlError(SeError),

--- a/backend/src/pdf_gen/embedded/mod.rs
+++ b/backend/src/pdf_gen/embedded/mod.rs
@@ -1,0 +1,57 @@
+mod world;
+
+use std::time::Instant;
+
+use super::{PdfGenResult, models::PdfModel};
+use tracing::{debug, info, warn};
+use typst::{diag::SourceDiagnostic, ecow::EcoVec};
+
+use crate::APIError;
+use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
+
+pub fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
+    let start = Instant::now();
+    let mut world = world::PdfWorld::new();
+    world.set_input_model(model);
+
+    let compile_start = Instant::now();
+    let result = typst::compile(&world);
+    let document = result
+        .output
+        .map_err(|err| APIError::PdfGenError(PdfGenError::from_typst(err)))?;
+    info!("Compile took {} ms", compile_start.elapsed().as_millis());
+
+    info!("{} warnings", result.warnings.len());
+    result.warnings.iter().for_each(|warning| {
+        warn!("Warning: {:?}", warning);
+    });
+
+    debug!("Generating PDF...");
+    let pdf_gen_start = Instant::now();
+    let pdf_standards =
+        PdfStandards::new(&[PdfStandard::A_2b]).expect("PDF standards should be valid");
+    let pdf_options = PdfOptions {
+        standards: pdf_standards,
+        ..Default::default()
+    };
+    let buffer = typst_pdf::pdf(&document, &pdf_options)
+        .map_err(|err| APIError::PdfGenError(PdfGenError::from_typst(err)))?;
+    debug!(
+        "PDF generation took {} ms",
+        pdf_gen_start.elapsed().as_millis()
+    );
+
+    info!("Finished in {} ms", start.elapsed().as_millis());
+    Ok(PdfGenResult { buffer })
+}
+
+#[derive(Debug)]
+pub enum PdfGenError {
+    Typst(EcoVec<SourceDiagnostic>),
+}
+
+impl PdfGenError {
+    fn from_typst(typst_errors: EcoVec<SourceDiagnostic>) -> PdfGenError {
+        PdfGenError::Typst(typst_errors)
+    }
+}

--- a/backend/src/pdf_gen/embedded/world.rs
+++ b/backend/src/pdf_gen/embedded/world.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::models::PdfModel;
+use super::super::models::PdfModel;
 use typst::{
     Library, World,
     diag::{FileError, FileResult},
@@ -59,7 +59,8 @@ impl PdfWorld {
             .cloned()
             .expect("could not find input model");
         let input_path = input.as_input_path();
-        let input_data = input.get_input().expect("unable to parse JSON into model");
+        let input_data =
+            Bytes::from_string(input.get_input().expect("unable to parse JSON into model"));
         self.main_source = main_source;
         self.input_data = (FileId::new(None, VirtualPath::new(input_path)), input_data);
     }
@@ -127,21 +128,21 @@ impl World for PdfWorld {
 /// In a debug build, this is done at runtime, for a release build this is
 /// done at compile time.
 macro_rules! include_filedata {
-    ($path:literal) => {{ include_bytes!(concat!("../../templates/", $path)) as &'static [u8] }};
+    ($path:expr) => {{ include_bytes!(concat!("../../../templates/", $path)) as &'static [u8] }};
 }
 
 /// Macro that loads data as a string from a file
 /// In a debug build, this is done at runtime, for a release build this is
 /// done at compile time.
 macro_rules! include_strdata {
-    ($path:literal) => {{ include_str!(concat!("../../templates/", $path)) as &'static str }};
+    ($path:expr) => {{ include_str!(concat!("../../../templates/", $path)) as &'static str }};
 }
 
 /// Load all sources available from the `templates/` directory (i.e. all typst
 /// files).
 fn load_sources() -> Vec<Source> {
     macro_rules! include_source {
-        ($path:literal) => {
+        ($path:expr) => {
             Source::new(
                 FileId::new(None, VirtualPath::new($path)),
                 include_strdata!($path).to_string(),
@@ -167,7 +168,7 @@ fn load_fonts() -> (Vec<Font>, FontBook) {
 
     macro_rules! include_font {
         ($path:literal) => {
-            let fontdata = include_filedata!($path);
+            let fontdata = include_filedata!(concat!("fonts/", $path));
             let font = Font::new(Bytes::new(fontdata), 0).expect("Error reading font file");
             fontbook.push(font.info().clone());
             fonts.push(font);
@@ -178,13 +179,13 @@ fn load_fonts() -> (Vec<Font>, FontBook) {
     // Note that these font files are only read at font index 0 (i.e. font files with multiple
     // fonts are not supported, split them up in separate files instead)
     // Typst also doesn't support variable fonts at this time, so we cannot use those either.
-    include_font!("fonts/DM_Sans/DMSans-Bold.ttf");
-    include_font!("fonts/DM_Sans/DMSans-BoldItalic.ttf");
-    include_font!("fonts/DM_Sans/DMSans-ExtraBold.ttf");
-    include_font!("fonts/DM_Sans/DMSans-ExtraBoldItalic.ttf");
-    include_font!("fonts/DM_Sans/DMSans-Italic.ttf");
-    include_font!("fonts/DM_Sans/DMSans-Regular.ttf");
-    include_font!("fonts/Geist_Mono/GeistMono-Regular.otf");
+    include_font!("DM_Sans/DMSans-Bold.ttf");
+    include_font!("DM_Sans/DMSans-BoldItalic.ttf");
+    include_font!("DM_Sans/DMSans-ExtraBold.ttf");
+    include_font!("DM_Sans/DMSans-ExtraBoldItalic.ttf");
+    include_font!("DM_Sans/DMSans-Italic.ttf");
+    include_font!("DM_Sans/DMSans-Regular.ttf");
+    include_font!("Geist_Mono/GeistMono-Regular.otf");
 
     (fonts, fontbook)
 }

--- a/backend/src/pdf_gen/external.rs
+++ b/backend/src/pdf_gen/external.rs
@@ -1,0 +1,112 @@
+use std::{path::PathBuf, process::Command};
+
+use rand::{Rng, distr::Alphanumeric};
+
+use crate::APIError;
+
+use super::{PdfGenResult, models::PdfModel};
+
+pub fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
+    generate_pdf_internal(model).map_err(APIError::PdfGenError)
+}
+
+/// Uses environment variables `ABACUS_TYPST_BIN` (`typst` by default) and `ABACUS_TEMPLATES_DIR` (`./templates` by
+/// default) to generate a PDF using an external binary of typst.
+fn generate_pdf_internal(model: PdfModel) -> Result<PdfGenResult, PdfGenError> {
+    // create a temporary copy of the template files
+    let tmp_path = prep_tmp_templates_dir()?;
+
+    // write json data to model input file
+    let json_path = {
+        let mut full_path = tmp_path.clone();
+        full_path.push(model.as_input_path());
+        full_path
+    };
+    let json_data = model.get_input()?;
+    std::fs::write(json_path, json_data)?;
+
+    // construct the typst command to run
+    let typst_binary = std::env::var("ABACUS_TYPST_BIN").unwrap_or("typst".into());
+    let mut command = Command::new(typst_binary);
+    command
+        .args([
+            "compile",
+            "--format",
+            "pdf",
+            "--ignore-system-fonts",
+            "--font-path",
+            "fonts/",
+            model
+                .as_template_path()
+                .to_str()
+                .expect("Model template path should always be UTF-8"),
+            "-",
+        ])
+        .current_dir(&tmp_path);
+
+    // get the command output
+    let res = command.output()?;
+
+    // remove the temporary directory
+    std::fs::remove_dir_all(&tmp_path)?;
+
+    // return the result
+    Ok(PdfGenResult { buffer: res.stdout })
+}
+
+/// Creates a temporary copy of the templates directory
+fn prep_tmp_templates_dir() -> Result<PathBuf, std::io::Error> {
+    let from_dir =
+        PathBuf::from(&std::env::var("ABACUS_TEMPLATES_DIR").unwrap_or("./templates".into()));
+    let temp_dir = {
+        let mut temp_dir = std::env::temp_dir();
+        let mut tmp_dir_name = "abacus-".to_string();
+        for c in rand::rng()
+            .sample_iter(Alphanumeric)
+            .take(8)
+            .map(char::from)
+        {
+            tmp_dir_name.push(c);
+        }
+        temp_dir.push(tmp_dir_name);
+        temp_dir
+    };
+    copy_dir(&from_dir, &temp_dir)?;
+
+    Ok(temp_dir)
+}
+
+/// Copy a directory recusively to another location
+fn copy_dir(
+    source: impl AsRef<std::path::Path>,
+    dest: impl AsRef<std::path::Path>,
+) -> Result<(), std::io::Error> {
+    std::fs::create_dir_all(&dest)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            copy_dir(entry.path(), dest.as_ref().join(entry.file_name()))?;
+        } else {
+            std::fs::copy(entry.path(), dest.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum PdfGenError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+}
+
+impl From<std::io::Error> for PdfGenError {
+    fn from(err: std::io::Error) -> Self {
+        PdfGenError::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for PdfGenError {
+    fn from(err: serde_json::Error) -> Self {
+        PdfGenError::Json(err)
+    }
+}

--- a/backend/src/pdf_gen/models/mod.rs
+++ b/backend/src/pdf_gen/models/mod.rs
@@ -3,7 +3,6 @@ mod model_na_31_2;
 use std::{error::Error, path::PathBuf};
 
 pub use model_na_31_2::*;
-use typst::foundations::Bytes;
 
 /// Defines the available models and what their input parameters are.
 pub enum PdfModel {
@@ -35,12 +34,12 @@ impl PdfModel {
     }
 
     /// Get the input, serialized as json
-    pub fn get_input(&self) -> serde_json::Result<Bytes> {
+    pub fn get_input(&self) -> serde_json::Result<String> {
         let data = match self {
             Self::ModelNa31_2(input) => serde_json::to_string(input),
         }?;
 
-        Ok(Bytes::from_string(data))
+        Ok(data)
     }
 
     pub fn from_name_with_input(name: &str, input: &str) -> Result<PdfModel, Box<dyn Error>> {


### PR DESCRIPTION
Typst is an enormous dependency that requires around 200 dependencies and causes my rust-analyzer instance to be killed all the time by the Linux OOM (out of memory) killer. While I would say that this is technically more of a rust-analyzer and rust compiler problem in that it can't handle the size of our project, it is still something I run into on an almost daily basis.

Meanwhile we don't do that much PDF generation during regular development. And if you are actually developing PDFs you don't really need to touch the typst code at all. This made me look at how easy it was to actually split of typst during regular development and just call the typst CLI binary directly. It turns out: not that hard at all, as long as we don't mind the binary invocation to be a little heavy handed: I just copy over the entire templates directory to a temporary location and replace the input with the actual input in that temporary location.

Meanwhile, CI still produces the binaries with typst support build-in, meaning that there should be no changes at all for our release binaries with this. But it would be good to at least test that development still works as expected.