### PR TITLE
Call memory-serve from build.rs, remove `ASSET_DIR` environm,ent variable

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -33,7 +33,6 @@ jobs:
         working-directory: ./backend
     env:
       CARGO_TERM_COLOR: always
-      ASSET_DIR: ${{ github.workspace }}/frontend/dist
       SQLX_OFFLINE: "true"
       NODE_ENV: production
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
         working-directory: ./backend
     env:
       CARGO_TERM_COLOR: always
-      ASSET_DIR: ${{ github.workspace }}/frontend/dist
       SQLX_OFFLINE: "true"
       NODE_ENV: production
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /build
 COPY ./backend ./backend
 COPY --from=frontend-builder /build/frontend/dist ./frontend/dist
 WORKDIR /build/backend
-ENV ASSET_DIR=/build/frontend/dist
 RUN cargo build --release --features memory-serve
 
 FROM debian:bookworm-slim

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "memory-serve"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfc92aa7fd45743d406a4e8ab0ecc3262d35851525c85903ca296db0cf10f3c"
+checksum = "e3cc9a6d8b135c31154a1f3b14f902a77cd9172871dedc7df503e7b05c433182"
 dependencies = [
  "axum",
  "brotli",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "memory-serve-core"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08a56e08967b27df85eed2b90d3fbe92300481188d8f2f6bb377f09c8e35d03"
+checksum = "520282572b66169a1362b4e843bcccea5fb59dc92f8617a08a9c0c25e89ab47f"
 dependencies = [
  "brotli",
  "mime_guess",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "memory-serve-macros"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1d3e59fb7742ad32e357cf504fd0fe36c9f35aa5b2797321eb13cf52603af"
+checksum = "dc76af6993714bb4f3ef5192c3d78cccf1c4df5f9c75a6bfbc25fa5b84208a88"
 dependencies = [
  "memory-serve-core",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4", features = ["alloc", "std", "serde"] }
 clap = { version = "4.5", default-features = false, features = ["derive", "std", "help"] }
 hyper = { version = "1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
-memory-serve = { version = "1.1.0", features = ["force-embed"], optional = true }
+memory-serve = { version = "1.2.1", features = ["force-embed"], optional = true }
 utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"], optional = true }
@@ -51,6 +51,9 @@ zip = { version = "2.3.0", default-features = false, features = ["deflate", "chr
 test-log = "0.2.17"
 http-body-util = "0.1.3"
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
+
+[build-dependencies]
+memory-serve = { version = "1.2.1", optional = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,17 +21,14 @@ Use `cargo run` to run the API on port 8080 (http://localhost:8080).
 
 To let the API server serve the frontend, first compile the frontend using
 `npm run build` in the `frontend` directory. Then run the API server with the
-`memory-serve` feature enabled. Also make sure to point the `ASSET_DIR` environment
-variable to the directory where `vite` outputs the assets, e.g. `frontend/dist`.
-In this version of `memory-serve`, the path must be absolute, since `build.rs`
-has no knowledge of the project it is currently built in. Example:
+`memory-serve` feature enabled:
 
 ```shell
 cd frontend
 npm run build
 cd ../backend
 sqlx database setup
-ASSET_DIR=$PWD/../frontend/dist cargo run --features memory-serve
+cargo run --features memory-serve
 ```
 
 By default Abacus will use an external typst binary which should be available on
@@ -42,7 +39,7 @@ can simply enable the `embed-typst` feature. This can be combined with the
 memory-serve feature as well, e.g.:
 
 ```shell
-ASSET_DIR=$PWD/../frontend/dist cargo build --features memory-serve,embed-typst
+cargo build --features memory-serve,embed-typst
 ```
 
 [typst releases page]: https://github.com/typst/typst/releases

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(feature = "memory-serve")]
+    memory_serve::load_directory_with_embed("../frontend/dist", true);
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "memory-serve")]
 use axum::http::StatusCode;
 use axum::{Router, extract::FromRef, middleware, serve::ListenerExt};
-#[cfg(feature = "memory-serve")]
-use memory_serve::MemoryServe;
 use sqlx::SqlitePool;
 use std::{error::Error, net::SocketAddr};
 use tokio::{net::TcpListener, signal};
@@ -75,7 +73,7 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
     // Add the memory-serve router to serve the frontend (if the memory-serve feature is enabled)
     #[cfg(feature = "memory-serve")]
     let router = router.merge(
-        MemoryServe::from_env()
+        memory_serve::from_local_build!()
             .index_file(Some("/index.html"))
             .fallback(Some("/index.html"))
             .fallback_status(StatusCode::OK)

--- a/frontend/playwright.e2e.config.ts
+++ b/frontend/playwright.e2e.config.ts
@@ -11,10 +11,10 @@ function returnWebserverCommand(): string {
     // LOCAL CI: build frontend, then build and run backend with database reset and seed playwright-specific database
     return `npm run build &&
       cd ../backend &&
-      npx cross-env ASSET_DIR=$PWD/../frontend/dist cargo run --features memory-serve -- --database target/debug/playwright.sqlite --reset-database --seed-data --port 8081`;
+      cargo run --features memory-serve -- --database target/debug/playwright.sqlite --reset-database --seed-data --port 8081`;
   } else {
     // DEV: expects frontend build and playwright-specific database setup/seeding to have been done
-    return `cd ../backend && npx cross-env ASSET_DIR=$PWD/../frontend/dist cargo run --features memory-serve -- --database ../backend/target/debug/playwright.sqlite --port 8081`;
+    return `cd ../backend && cargo run --features memory-serve -- --database ../backend/target/debug/playwright.sqlite --port 8081`;
   }
 }
 

--- a/pull-and-run
+++ b/pull-and-run
@@ -24,5 +24,5 @@ echo "Building and running backend..."
 
 pushd "backend" > /dev/null 2>&1
 cargo sqlx database reset -y
-ASSET_DIR="$PWD/../frontend/dist" cargo run --features memory-serve -- -s
+cargo run --features memory-serve -- -s
 popd > /dev/null 2>&1


### PR DESCRIPTION
Updates memory serve to v1.2.1

Added a `build.rs` that calls into memory-serve.

Updated documentation related to memory serve.

To test: run the application.