### PR TITLE
Add ESLint rules to restrict cross-feature imports

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,3 +1,14 @@
+const restrictFeatureImports = require("fs")
+  .readdirSync("./src/features", { withFileTypes: true })
+  .filter((file) => file.isDirectory())
+  .map((dir) => dir.name)
+  .map((feature) => ({
+    target: `./src/features/${feature}`,
+    from: "./src/features",
+    except: [feature],
+    message: "Cross-feature imports are not allowed.",
+  }));
+
 module.exports = {
   root: true,
   env: { browser: true, es2020: true },
@@ -34,17 +45,23 @@ module.exports = {
       "error",
       {
         zones: [
+          // disables cross-feature imports:
+          // eg. src/features/abc should not import from src/features/xyz, etc.
+          ...restrictFeatureImports,
+
           // enforce unidirectional codebase:
           // e.g. src/app can import from src/features but not the other way around
           {
             target: "./src/features",
             from: "./src/app",
+            message: "Imports from app are not allowed in features.",
           },
 
           // e.g src/features and src/app can import from these shared modules but not the other way around
           {
             target: ["./src/components", "./src/hooks", "./src/lib", "./src/types", "./src/utils"],
             from: ["./src/features", "./src/app"],
+            message: "Imports from shared folders are not allowed in features and app.",
           },
         ],
       },


### PR DESCRIPTION
Add ESLint rules to restrict cross-feature imports and add message to the other rules.

Relates to #1281, #1284
