### PR TITLE
Candidate fullname util and model changes

### DIFF
--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -303,7 +303,21 @@ de telling is onjuist.
       let election_candidate = election_pg.candidates.find(c => c.number == candidate.number)
       (
         align(right)[#candidate.number],
-        [#election_candidate.initials #election_candidate.last_name (#election_candidate.first_name)],
+        [
+          #if "last_name_prefix" in election_candidate [ #election_candidate.last_name_prefix ]
+          #election_candidate.last_name,
+          #election_candidate.initials
+          #if "first_name" in election_candidate [ (#election_candidate.first_name) ]
+          #if "gender" in election_candidate [
+            #if election_candidate.gender == "Male" [
+              (m)
+            ] else if election_candidate.gender == "Female" [
+              (v)
+            ] else if election_candidate.gender == "X" [
+              (x)
+            ]
+          ]
+        ],
         align(right, mono[#candidate.votes]),
       )
     },

--- a/frontend/src/components/form/data_entry/candidates_votes/CandidatesVotesForm.tsx
+++ b/frontend/src/components/form/data_entry/candidates_votes/CandidatesVotesForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { ErrorModal } from "@/components/error";
+import { getCandidateFullName } from "@/lib/util/candidate";
 
 import { ApiError, PoliticalGroup } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
@@ -80,15 +81,13 @@ export function CandidatesVotesForm({ group }: CandidatesVotesFormProps) {
         <InputGrid.Header>
           <th>{t("number")}</th>
           <th>{t("vote_count")}</th>
-          <th>{t("candidate")}</th>
+          <th>{t("candidate.title")}</th>
         </InputGrid.Header>
         <InputGrid.Body>
           {group.candidates.map((candidate, index) => {
             const addSeparator = (index + 1) % 25 === 0 && index + 1 !== group.candidates.length;
             const defaultValue = currentValues.candidate_votes[index] || "";
-            const candidateFullName = candidate.first_name
-              ? `${candidate.last_name}, ${candidate.initials} (${candidate.first_name})`
-              : `${candidate.last_name}, ${candidate.initials}`;
+            const candidateFullName = getCandidateFullName(candidate);
 
             return (
               <InputGridRow

--- a/frontend/src/components/form/data_entry/test-data/test.utils.ts
+++ b/frontend/src/components/form/data_entry/test-data/test.utils.ts
@@ -1,5 +1,7 @@
 import { expect } from "vitest";
 
+import { getCandidateFullName } from "@/lib/util";
+
 import {
   ClaimDataEntryResponse,
   PoliticalGroup,
@@ -74,10 +76,5 @@ export function expectFieldsToNotHaveIcon(fields: Array<string>) {
 }
 
 export function getCandidateFullNamesFromMockData(politicalGroupMockData: PoliticalGroup): string[] {
-  const candidateNames = politicalGroupMockData.candidates.map((candidate) => {
-    return candidate.first_name
-      ? `${candidate.last_name}, ${candidate.initials} (${candidate.first_name})`
-      : `${candidate.last_name}, ${candidate.initials}`;
-  });
-  return candidateNames;
+  return politicalGroupMockData.candidates.map(getCandidateFullName);
 }

--- a/frontend/src/lib/i18n/locales/nl/candidate.json
+++ b/frontend/src/lib/i18n/locales/nl/candidate.json
@@ -1,0 +1,7 @@
+{
+  "title": "Kandidaat",
+  "Female": "v",
+  "locality": "Woonplaats",
+  "Male": "m",
+  "X": "x"
+}

--- a/frontend/src/lib/i18n/locales/nl/generic.json
+++ b/frontend/src/lib/i18n/locales/nl/generic.json
@@ -5,7 +5,6 @@
   "activity_log": "Activiteitenlog",
   "administrator": "Beheerder",
   "cancel": "Annuleren",
-  "candidate": "Kandidaat",
   "close_message": "Melding sluiten",
   "close": "Sluiten",
   "contains_error": "bevat een fout",

--- a/frontend/src/lib/i18n/locales/nl/nl.ts
+++ b/frontend/src/lib/i18n/locales/nl/nl.ts
@@ -1,5 +1,6 @@
 import account from "./account.json";
 import apportionment from "./apportionment.json";
+import candidate from "./candidate.json";
 import candidates_votes from "./candidates_votes.json";
 import check_and_save from "./check_and_save.json";
 import data_entry from "./data_entry.json";
@@ -25,6 +26,7 @@ const nl = {
   ...generic,
   account,
   apportionment,
+  candidate,
   candidates_votes,
   check_and_save,
   data_entry,

--- a/frontend/src/lib/util/candidate.test.ts
+++ b/frontend/src/lib/util/candidate.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { Candidate } from "@/api";
+
+import { getCandidateFullName, getCandidateFullNameWithGender } from "./candidate";
+
+const last_name_prefix = "de";
+const last_name = "Boer";
+const initials = "A.B.";
+const first_name = "Anne";
+const gender = "Female";
+
+describe("getCandidateFullName util", () => {
+  test("without first name", () => {
+    const candidate = { last_name, initials } as Candidate;
+    expect(getCandidateFullName(candidate)).toBe("Boer, A.B.");
+  });
+
+  test("with first name", () => {
+    const candidate = { last_name, initials, first_name } as Candidate;
+    expect(getCandidateFullName(candidate)).toBe("Boer, A.B. (Anne)");
+  });
+
+  test("with firstname and lastname prefix", () => {
+    const candidate = { last_name_prefix, last_name, initials, first_name } as Candidate;
+    expect(getCandidateFullName(candidate)).toBe("de Boer, A.B. (Anne)");
+  });
+});
+
+describe("getCandidateFullNameWithGender util", () => {
+  test("with gender", () => {
+    const candidate = { last_name, initials, first_name, gender } as Candidate;
+    expect(getCandidateFullNameWithGender(candidate)).toBe("Boer, A.B. (Anne) (v)");
+  });
+
+  test("without gender", () => {
+    const candidate = { last_name, initials, first_name } as Candidate;
+    expect(getCandidateFullNameWithGender(candidate)).toBe("Boer, A.B. (Anne)");
+  });
+});

--- a/frontend/src/lib/util/candidate.ts
+++ b/frontend/src/lib/util/candidate.ts
@@ -1,0 +1,19 @@
+import { Candidate } from "@/api";
+
+import { t } from "@kiesraad/i18n";
+
+export function getCandidateFullName(candidate: Candidate): string {
+  const lastName = candidate.last_name_prefix
+    ? `${candidate.last_name_prefix} ${candidate.last_name}`
+    : candidate.last_name;
+
+  return candidate.first_name
+    ? `${lastName}, ${candidate.initials} (${candidate.first_name})`
+    : `${lastName}, ${candidate.initials}`;
+}
+
+export function getCandidateFullNameWithGender(candidate: Candidate): string {
+  const fullName = getCandidateFullName(candidate);
+  const gender = candidate.gender ? t(`candidate.${candidate.gender}`) : undefined;
+  return gender ? fullName + ` (${gender})` : fullName;
+}

--- a/frontend/src/lib/util/index.ts
+++ b/frontend/src/lib/util/index.ts
@@ -1,4 +1,5 @@
 export * from "./hook";
+export * from "./candidate";
 export * from "./classnames";
 export * from "./compare";
 export * from "./data-entry";


### PR DESCRIPTION
Originally implemented in PR https://github.com/kiesraad/abacus/pull/1268 now extracted as a separate PR.
- `getCandidateFullName` changed from one function to two
- `model-na-31-2.typ` update to show correct candidate name with gender