### PR TITLE
Remove `FormSectionReference` from data entry

### DIFF
--- a/frontend/src/components/form/data_entry/candidates_votes/useCandidateVotes.ts
+++ b/frontend/src/components/form/data_entry/candidates_votes/useCandidateVotes.ts
@@ -11,11 +11,7 @@ import {
 
 export function useCandidateVotes(political_group_number: number) {
   const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<CandidateVotesFormValues>({
-    section: {
-      id: `political_group_votes_${political_group_number}`,
-      type: "political_group_votes",
-      number: political_group_number,
-    },
+    section: `political_group_votes_${political_group_number}`,
     getDefaultFormValues: (results, cache) =>
       cache?.key === `political_group_votes_${political_group_number}`
         ? valuesToFormValues(cache.data as CandidateVotesValues)

--- a/frontend/src/components/form/data_entry/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/components/form/data_entry/check_and_save/CheckAndSaveForm.tsx
@@ -28,10 +28,7 @@ export function CheckAndSaveForm() {
 
   const navigate = useNavigate();
   const { election } = useElection();
-  const { error, formState, status, onFinaliseDataEntry, pollingStationId, entryNumber } = useDataEntryContext({
-    id: "save",
-    type: "save",
-  });
+  const { error, formState, status, onFinaliseDataEntry, pollingStationId, entryNumber } = useDataEntryContext("save");
 
   const getUrlForFormSection = React.useCallback(
     (id: FormSectionId) => {

--- a/frontend/src/components/form/data_entry/differences/useDifferences.ts
+++ b/frontend/src/components/form/data_entry/differences/useDifferences.ts
@@ -4,10 +4,7 @@ import { DifferencesFormValues, DifferencesValues, formValuesToValues, valuesToF
 
 export function useDifferences() {
   const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<DifferencesFormValues>({
-    section: {
-      id: "differences_counts",
-      type: "differences",
-    },
+    section: "differences_counts",
     getDefaultFormValues: (results, cache) =>
       cache?.key === "differences_counts"
         ? valuesToFormValues(cache.data as DifferencesValues)

--- a/frontend/src/components/form/data_entry/recounted/useRecounted.ts
+++ b/frontend/src/components/form/data_entry/recounted/useRecounted.ts
@@ -7,10 +7,7 @@ export type RecountedValue = Pick<PollingStationResults, "recounted">;
 
 export function useRecounted() {
   const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<boolean | undefined>({
-    section: {
-      id: "recounted",
-      type: "recounted",
-    },
+    section: "recounted",
     getDefaultFormValues: (results) => results.recounted,
   });
 

--- a/frontend/src/components/form/data_entry/state/actions.ts
+++ b/frontend/src/components/form/data_entry/state/actions.ts
@@ -12,14 +12,14 @@ import {
   DataEntryDispatch,
   DataEntryState,
   FormSection,
-  FormSectionReference,
+  FormSectionId,
   SubmitCurrentFormOptions,
   TemporaryCache,
 } from "./types";
 
 export function registerForm(dispatch: DataEntryDispatch) {
-  return (form: FormSectionReference) => {
-    dispatch({ type: "REGISTER_CURRENT_FORM", form });
+  return (formSectionId: FormSectionId) => {
+    dispatch({ type: "REGISTER_CURRENT_FORM", formSectionId });
   };
 }
 

--- a/frontend/src/components/form/data_entry/state/reducer.test.ts
+++ b/frontend/src/components/form/data_entry/state/reducer.test.ts
@@ -185,15 +185,12 @@ test("should handle RESET_TARGET_FORM_SECTION", () => {
 test("should handle REGISTER_CURRENT_FORM", () => {
   const action: DataEntryAction = {
     type: "REGISTER_CURRENT_FORM",
-    form: {
-      id: "voters_votes_counts",
-      type: "voters_and_votes",
-    },
+    formSectionId: "voters_votes_counts",
   };
 
   const state = dataEntryReducer(getInitialState(), action);
   expect(state.formState.current).toBeDefined();
-  expect(state.formState.current).toEqual(action.form.id);
+  expect(state.formState.current).toEqual(action.formSectionId);
   expect(state.formState.sections.recounted.isSubmitted).toBeDefined();
   expect(state.formState.sections.recounted.isSubmitted).toEqual(false);
 });

--- a/frontend/src/components/form/data_entry/state/reducer.ts
+++ b/frontend/src/components/form/data_entry/state/reducer.ts
@@ -1,13 +1,9 @@
 import { Election } from "@kiesraad/api";
 
 import { buildFormState, getInitialFormState, getNextSectionID, updateFormStateAfterSubmit } from "./dataEntryUtils";
-import { ClientState, DataEntryAction, DataEntryState, FormSectionId, FormSectionReference } from "./types";
+import { ClientState, DataEntryAction, DataEntryState, FormSectionId } from "./types";
 
 export const INITIAL_FORM_SECTION_ID: FormSectionId = "recounted";
-export const INITIAL_FORM_SECTION_REFERENCE: FormSectionReference = {
-  id: "recounted",
-  type: "recounted",
-};
 
 export function getInitialState(
   election: Required<Election>,
@@ -117,7 +113,7 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         ...state,
         formState: {
           ...state.formState,
-          current: action.form.id,
+          current: action.formSectionId,
           sections: {
             ...state.formState.sections,
             ...(state.formState.sections[state.formState.current]

--- a/frontend/src/components/form/data_entry/state/types.ts
+++ b/frontend/src/components/form/data_entry/state/types.ts
@@ -29,7 +29,7 @@ export interface DataEntryStateAndActions extends DataEntryState {
   onSubmitForm: (data: Partial<PollingStationResults>, options?: SubmitCurrentFormOptions) => Promise<boolean>;
   onDeleteDataEntry: () => Promise<boolean>;
   onFinaliseDataEntry: () => Promise<boolean>;
-  register: (form: FormSectionReference) => void;
+  register: (formSectionId: FormSectionId) => void;
   setCache: (cache: TemporaryCache) => void;
   updateFormSection: (partialFormSection: Partial<FormSection>) => void;
 }
@@ -81,7 +81,7 @@ export type DataEntryAction =
     }
   | {
       type: "REGISTER_CURRENT_FORM";
-      form: FormSectionReference;
+      formSectionId: FormSectionId;
     };
 
 export type FormSectionData =
@@ -104,29 +104,6 @@ export type FormSectionId =
   | "differences_counts"
   | `political_group_votes_${number}`
   | "save";
-
-export type FormSectionReference =
-  | {
-      id: "recounted";
-      type: "recounted";
-    }
-  | {
-      id: "voters_votes_counts";
-      type: "voters_and_votes";
-    }
-  | {
-      id: "differences_counts";
-      type: "differences";
-    }
-  | {
-      id: `political_group_votes_${number}`;
-      type: "political_group_votes";
-      number: number;
-    }
-  | {
-      id: "save";
-      type: "save";
-    };
 
 //store unvalidated data
 export type TemporaryCache = {

--- a/frontend/src/components/form/data_entry/state/useDataEntryContext.ts
+++ b/frontend/src/components/form/data_entry/state/useDataEntryContext.ts
@@ -1,9 +1,9 @@
 import { useContext, useEffect } from "react";
 
 import { DataEntryContext } from "./DataEntryContext";
-import { DataEntryStateAndActionsLoaded, FormSectionReference } from "./types";
+import { DataEntryStateAndActionsLoaded, FormSectionId } from "./types";
 
-export function useDataEntryContext(form?: FormSectionReference): DataEntryStateAndActionsLoaded {
+export function useDataEntryContext(formSectionId?: FormSectionId): DataEntryStateAndActionsLoaded {
   const context = useContext(DataEntryContext);
 
   if (!context) {
@@ -13,10 +13,10 @@ export function useDataEntryContext(form?: FormSectionReference): DataEntryState
   // register the current form
   const register = context.register;
   useEffect(() => {
-    if (form && context.formState.current !== form.id) {
-      register(form);
+    if (formSectionId && context.formState.current !== formSectionId) {
+      register(formSectionId);
     }
-  }, [form, context.formState, register]);
+  }, [formSectionId, context.formState, register]);
 
   return context;
 }

--- a/frontend/src/components/form/data_entry/state/useDataEntryFormSection.ts
+++ b/frontend/src/components/form/data_entry/state/useDataEntryFormSection.ts
@@ -3,13 +3,13 @@ import * as React from "react";
 import { PollingStationResults } from "@kiesraad/api";
 import { useFormKeyboardNavigation } from "@kiesraad/ui";
 
-import { FormSectionReference, SubmitCurrentFormOptions, TemporaryCache } from "./types";
+import { FormSectionId, SubmitCurrentFormOptions, TemporaryCache } from "./types";
 import { useDataEntryContext } from "./useDataEntryContext";
 import { mapValidationResultsToFields } from "./ValidationResults";
 
 export interface UseDataEntryFormSectionParams<FORM_VALUES> {
   getDefaultFormValues: (results: PollingStationResults, cache?: TemporaryCache | null) => FORM_VALUES;
-  section: FormSectionReference;
+  section: FormSectionId;
 }
 
 export function useDataEntryFormSection<FORM_VALUES>({
@@ -25,9 +25,9 @@ export function useDataEntryFormSection<FORM_VALUES>({
   );
 
   // derived state
-  const formSection = formState.sections[section.id];
+  const formSection = formState.sections[section];
   if (!formSection) {
-    throw new Error(`Form section ${section.id} not found in form state`);
+    throw new Error(`Form section ${section} not found in form state`);
   }
   const { errors, warnings, isSaved, acceptWarnings, hasChanges } = formSection;
   const defaultProps = {

--- a/frontend/src/components/form/data_entry/voters_and_votes/useVotersAndVotes.ts
+++ b/frontend/src/components/form/data_entry/voters_and_votes/useVotersAndVotes.ts
@@ -9,10 +9,7 @@ import {
 
 export function useVotersAndVotes() {
   const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<VotersAndVotesFormValues>({
-    section: {
-      id: "voters_votes_counts",
-      type: "voters_and_votes",
-    },
+    section: "voters_votes_counts",
     getDefaultFormValues: (results, cache) =>
       cache?.key === "voters_votes_counts"
         ? valuesToFormValues(cache.data as VotersAndVotesValues)


### PR DESCRIPTION
The `type` in `FormSectionReference` was not used so all usages could be replaced with `FormSectionId`.