### PR TITLE
DifferencesTable and ResolveDifferencesTables components

### DIFF
--- a/frontend/src/components/ui/Table/Table.tsx
+++ b/frontend/src/components/ui/Table/Table.tsx
@@ -7,15 +7,11 @@ import { cn } from "@kiesraad/util";
 import { getFractionInteger, getFractionWithoutInteger } from "../util";
 import cls from "./Table.module.css";
 
-export interface TableProps {
-  id?: string;
-  children?: React.ReactNode;
-  className?: string;
-}
+export type TableProps = React.TableHTMLAttributes<HTMLTableElement>;
 
-export function Table({ id, children, className }: TableProps) {
+export function Table({ children, className, ...props }: TableProps) {
   return (
-    <table id={id} className={cn(cls.table, className)}>
+    <table className={cn(cls.table, className)} {...props}>
       {children}
     </table>
   );

--- a/frontend/src/components/ui/style/util.css
+++ b/frontend/src/components/ui/style/util.css
@@ -27,6 +27,10 @@
   margin-bottom: var(--space-lg);
 }
 
+.mb-xl {
+  margin-bottom: var(--space-xl);
+}
+
 /* Color */
 .bg-gray {
   background-color: var(--bg-gray);
@@ -41,6 +45,14 @@
 }
 
 /* Width */
+.w-6 {
+  width: 6rem;
+}
+
+.w-13 {
+  width: 13rem;
+}
+
 .w-14 {
   width: 14rem;
 }

--- a/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import { render, screen } from "@/testing";
+
+import { DifferencesRow, DifferencesTable } from "./DifferencesTable";
+
+const tableHeaders = ["Code", "First", "Second", "Description"];
+
+function renderTable(rows: DifferencesRow[]) {
+  render(<DifferencesTable title={"Differences"} headers={tableHeaders} rows={rows} />);
+}
+
+describe("DifferencesTable", () => {
+  test("Render nothing when there are no differences", () => {
+    renderTable([
+      { first: 10, second: 10 },
+      { first: 20, second: 20 },
+    ]);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  test("Render rows that have differences", async () => {
+    renderTable([
+      { code: "A", first: 10, second: 20, description: "Some value" },
+      { code: "B", first: 30, second: 30, description: "Another value" },
+    ]);
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveTableContent([tableHeaders, ["A", "10", "20", "Some value"]]);
+  });
+
+  test("Falsy values are considered equal", async () => {
+    renderTable([
+      { code: "A", first: "A", second: undefined, description: "Truthy string" },
+      { code: "B", first: 1, second: undefined, description: "Truthy number" },
+      { code: "A.1", first: "", second: undefined, description: "Falsy string" },
+      { code: "B.1", first: 0, second: undefined, description: "Falsy number" },
+      { code: "C", first: "", second: 0, description: "Falsy string and number" },
+      { code: "D", first: undefined, second: undefined, description: "Undefined" },
+    ]);
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveTableContent([
+      tableHeaders,
+      ["A", "A", "\u2014", "Truthy string"],
+      ["B", "1", "\u2014", "Truthy number"],
+    ]);
+  });
+
+  test("Render an mdash as the zero value", async () => {
+    renderTable([{ code: "A", first: 10, second: 0, description: "Some value" }]);
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveTableContent([tableHeaders, ["A", "10", "\u2014", "Some value"]]);
+  });
+
+  test("Render gap rows between rows with differences", async () => {
+    renderTable([
+      { code: "A", first: 10, second: 10, description: "Same" },
+      { code: "B", first: 20, second: 20, description: "Same" },
+      { code: "C", first: 30, second: 33, description: "But different" },
+      { code: "D", first: 40, second: 40, description: "Same" },
+      { code: "E", first: 50, second: 55, description: "Other" },
+      { code: "F", first: 60, second: 60, description: "Same" },
+      { code: "G", first: 70, second: 70, description: "Same" },
+      { code: "H", first: 80, second: 88, description: "Skip two" },
+      { code: "I", first: 90, second: 90, description: "Same" },
+    ]);
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveTableContent([
+      tableHeaders,
+      ["C", "30", "33", "But different"],
+      [""],
+      ["E", "50", "55", "Other"],
+      [""],
+      ["H", "80", "88", "Skip two"],
+    ]);
+  });
+});

--- a/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
@@ -1,0 +1,79 @@
+import { Fragment, useId } from "react";
+
+import cls from "@/features/resolve_differences/components/ResolveDifferences.module.css";
+
+import { Table } from "@kiesraad/ui";
+
+interface DifferencesTableProps {
+  title: string;
+  headers: string[];
+  rows: DifferencesRow[];
+}
+
+const zeroDash = <span className={cls.zeroDash}>&mdash;</span>;
+
+export interface DifferencesRow {
+  code?: number | string;
+  first?: number | string;
+  second?: number | string;
+  description?: string;
+}
+
+export function DifferencesTable({ title, headers, rows }: DifferencesTableProps) {
+  const id = useId();
+  // An array of indices for rows that are different, also used to detect row gaps.
+  // Two falsy values are considered equal (e.g. 0 and undefined)
+  const differences = rows.reduce<number[]>(
+    (show, row, index) => (row.first === row.second || (!row.first && !row.second) ? show : [...show, index]),
+    [],
+  );
+
+  if (differences.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-lg mb-xl">
+      <h2 id={id}>{title}</h2>
+      <div>
+        <Table className={cls.differencesTable} aria-labelledby={id}>
+          <Table.Header>
+            <Table.HeaderCell className="w-6 text-align-r">{headers[0]}</Table.HeaderCell>
+            <Table.HeaderCell className="w-13 text-align-r">{headers[1]}</Table.HeaderCell>
+            <Table.HeaderCell className="w-13 text-align-r">{headers[2]}</Table.HeaderCell>
+            <Table.HeaderCell>{headers[3]}</Table.HeaderCell>
+          </Table.Header>
+          <Table.Body>
+            {differences.map((rowIndex, differenceIndex) => {
+              // There is a gap if the previous row is not index - 1
+              const gapRow = differenceIndex > 0 && differences[differenceIndex - 1] !== rowIndex - 1;
+
+              return (
+                <Fragment key={differenceIndex}>
+                  {gapRow && (
+                    <Table.Row>
+                      <Table.Cell className={cls.gapRow} colSpan={4}></Table.Cell>
+                    </Table.Row>
+                  )}
+
+                  <Table.Row>
+                    <Table.HeaderCell scope="row" className="text-align-r normal">
+                      {rows[rowIndex]?.code}
+                    </Table.HeaderCell>
+                    <Table.Cell className="text-align-r font-number bold">
+                      {rows[rowIndex]?.first || zeroDash}
+                    </Table.Cell>
+                    <Table.Cell className="text-align-r font-number bold">
+                      {rows[rowIndex]?.second || zeroDash}
+                    </Table.Cell>
+                    <Table.Cell>{rows[rowIndex]?.description}</Table.Cell>
+                  </Table.Row>
+                </Fragment>
+              );
+            })}
+          </Table.Body>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -1,0 +1,18 @@
+.differences-table {
+  td {
+    height: 4.5rem;
+  }
+
+  td.gap-row {
+    height: 2rem;
+  }
+
+  td:not(.gap-row) {
+    border-left: 1px solid var(--bg-gray-darkest);
+  }
+}
+
+.zero-dash {
+  font-family: var(--font-text);
+  color: var(--gray-300);
+}

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.stories.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.stories.tsx
@@ -1,0 +1,19 @@
+import { Story } from "@ladle/react";
+
+import { pollingStationResultsMockData } from "@/features/resolve_differences/testing/polling-station-results";
+import { politicalGroupsMockData } from "@/testing/api-mocks";
+
+import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
+
+export default {
+  title: "App / Resolve Differences",
+};
+
+export const DefaultResolveDifferencesTables: Story = () => (
+  <ResolveDifferencesTables
+    first={pollingStationResultsMockData(true)}
+    second={pollingStationResultsMockData(false)}
+    politicalGroups={politicalGroupsMockData}
+  />
+);
+DefaultResolveDifferencesTables.storyName = "ResolveDifferencesTables";

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+
+import { render, screen } from "@/testing";
+import { politicalGroupsMockData } from "@/testing/api-mocks";
+
+import { pollingStationResultsMockData } from "../testing/polling-station-results";
+import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
+
+describe("ResolveDifferencesTables", () => {
+  test("renders the resolve differences tables", async () => {
+    render(
+      <ResolveDifferencesTables
+        first={pollingStationResultsMockData(true)}
+        second={pollingStationResultsMockData(false)}
+        politicalGroups={politicalGroupsMockData}
+      />,
+    );
+
+    const recountedTable = await screen.findByRole("table", {
+      name: "Is het selectievakje op de eerste pagina aangevinkt?",
+    });
+    expect(recountedTable).toBeVisible();
+    expect(recountedTable).toHaveTableContent([
+      ["Veld", "Eerste invoer", "Tweede invoer", "Omschrijving"],
+      ["", "Ja", "Nee", "Is er herteld?"],
+    ]);
+
+    const votersVotesCountsTable = await screen.findByRole("table", {
+      name: "Toegelaten kiezers en uitgebrachte stemmen",
+    });
+    expect(votersVotesCountsTable).toBeVisible();
+    expect(votersVotesCountsTable).toHaveTableContent([
+      ["Veld", "Eerste invoer", "Tweede invoer", "Omschrijving"],
+      ["E", "42", "44", "Stemmen op kandidaten"],
+      [""],
+      ["H", "42", "44", "Totaal uitgebrachte stemmen"],
+      ["A.2", "43", "—", "Stempassen"],
+      ["B.2", "1", "—", "Volmachtbewijzen"],
+      [""],
+      ["D.2", "44", "—", "Totaal toegelaten kiezers"],
+    ]);
+
+    const differencesCountsTable = screen.queryByRole("table", {
+      name: "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen",
+    });
+    expect(differencesCountsTable).not.toBeInTheDocument();
+
+    const fieryWingsPartyTable = await screen.findByRole("table", {
+      name: "Lijst 1 – Vurige Vleugels Partij",
+    });
+    expect(fieryWingsPartyTable).toBeVisible();
+    expect(fieryWingsPartyTable).toHaveTableContent([
+      ["Nummer", "Eerste invoer", "Tweede invoer", "Kandidaat"],
+      ["3", "65", "63", "Fluisterwind, S. (Seraphina)"],
+      ["4", "26", "28", "Nachtschaduw, V. (Vesper)"],
+      [""],
+      ["12", "4", "—", "Groenhart, T. (Timo)"],
+      ["13", "2", "4", "Veldbloem, N. (Naima)"],
+      ["14", "—", "2", "IJzeren, V. (Vincent)"],
+    ]);
+
+    const wiseOfWaterAndWindTable = screen.queryByRole("table", {
+      name: "Lijst 2 – Wijzen van Water en Wind",
+    });
+    expect(wiseOfWaterAndWindTable).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
@@ -1,0 +1,97 @@
+import { PoliticalGroup, PoliticalGroupVotes, PollingStationResults } from "@/api";
+import { t } from "@/lib/i18n";
+import { getCandidateFullName } from "@/lib/util";
+
+import { DataEntrySection, getFromResults, sections } from "../utils/dataEntry";
+import { DifferencesTable } from "./DifferencesTable";
+
+export interface ResolveDifferencesTablesProps {
+  first: PollingStationResults;
+  second: PollingStationResults;
+  politicalGroups: PoliticalGroup[];
+}
+
+export function ResolveDifferencesTables({ first, second, politicalGroups }: ResolveDifferencesTablesProps) {
+  return (
+    <>
+      {sections.map((section) => (
+        <SectionTable key={section.id} section={section} first={first} second={second} />
+      ))}
+
+      {politicalGroups.map((politicalGroup, i) => (
+        <CandidatesTable
+          key={politicalGroup.number}
+          politicalGroup={politicalGroup}
+          first={first.political_group_votes[i]}
+          second={second.political_group_votes[i]}
+        />
+      ))}
+    </>
+  );
+}
+
+interface SectionTableProps {
+  section: DataEntrySection;
+  first: PollingStationResults;
+  second: PollingStationResults;
+}
+
+function SectionTable({ section, first, second }: SectionTableProps) {
+  const title = t(`resolve_differences.section.${section.id}`);
+
+  const headers = [
+    t("resolve_differences.headers.field"),
+    t("resolve_differences.headers.first_entry"),
+    t("resolve_differences.headers.second_entry"),
+    t("resolve_differences.headers.description"),
+  ];
+
+  const rows = section.fields.map((field) => ({
+    code: field.code,
+    first: yesno(getFromResults(first, field.path)),
+    second: yesno(getFromResults(second, field.path)),
+    description: t(`polling_station_results.field.${field.path}`),
+  }));
+
+  return <DifferencesTable title={title} headers={headers} rows={rows} />;
+}
+
+function yesno<T>(value: T) {
+  if (value === true) {
+    return t("resolve_differences.yes");
+  } else if (value === false) {
+    return t("resolve_differences.no");
+  } else {
+    return value as Exclude<T, boolean>;
+  }
+}
+
+interface CandidatesTableProps {
+  politicalGroup: PoliticalGroup;
+  first?: PoliticalGroupVotes;
+  second?: PoliticalGroupVotes;
+}
+
+function CandidatesTable({ politicalGroup, first, second }: CandidatesTableProps) {
+  if (!first || !second) {
+    return null;
+  }
+
+  const title = `${t("list")} ${politicalGroup.number} – ${politicalGroup.name}`;
+
+  const headers = [
+    t("resolve_differences.headers.number"),
+    t("resolve_differences.headers.first_entry"),
+    t("resolve_differences.headers.second_entry"),
+    t("resolve_differences.headers.candidate"),
+  ];
+
+  const rows = politicalGroup.candidates.map((candidate, i) => ({
+    code: candidate.number,
+    first: first.candidate_votes[i]?.votes,
+    second: second.candidate_votes[i]?.votes,
+    description: getCandidateFullName(candidate),
+  }));
+
+  return <DifferencesTable title={title} headers={headers} rows={rows} />;
+}

--- a/frontend/src/features/resolve_differences/testing/polling-station-results.ts
+++ b/frontend/src/features/resolve_differences/testing/polling-station-results.ts
@@ -1,0 +1,70 @@
+import { PollingStationResults } from "@/api";
+
+/**
+ * Return PollingStationResults data for testing the resolve differences feature.
+ * @param first true for the first entry, false for the second entry
+ */
+export function pollingStationResultsMockData(first: boolean): PollingStationResults {
+  return {
+    recounted: first,
+    voters_counts: {
+      poll_card_count: 42,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 42,
+    },
+    votes_counts: {
+      votes_candidates_count: first ? 42 : 44,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: first ? 42 : 44,
+    },
+    voters_recounts: first
+      ? {
+          poll_card_count: 43,
+          proxy_certificate_count: 1,
+          voter_card_count: 0,
+          total_admitted_voters_count: 44,
+        }
+      : undefined,
+    differences_counts: {
+      more_ballots_count: 0,
+      fewer_ballots_count: 0,
+      unreturned_ballots_count: 0,
+      too_few_ballots_handed_out_count: 0,
+      too_many_ballots_handed_out_count: 0,
+      other_explanation_count: 0,
+      no_explanation_count: 0,
+    },
+    political_group_votes: [
+      {
+        number: 1,
+        total: first ? 512 : 481,
+        candidate_votes: [
+          { number: 1, votes: 256 },
+          { number: 2, votes: 128 },
+          { number: 3, votes: first ? 65 : 63 },
+          { number: 4, votes: first ? 26 : 28 },
+          { number: 3, votes: 10 },
+          { number: 4, votes: 8 },
+          { number: 5, votes: 4 },
+          { number: 6, votes: 4 },
+          { number: 7, votes: 3 },
+          { number: 8, votes: 2 },
+          { number: 9, votes: 0 },
+          { number: 10, votes: first ? 4 : 0 },
+          { number: 11, votes: first ? 2 : 4 },
+          { number: 12, votes: first ? 0 : 2 },
+        ],
+      },
+      {
+        number: 2,
+        total: 2,
+        candidate_votes: [
+          { number: 1, votes: 2 },
+          { number: 2, votes: 0 },
+        ],
+      },
+    ],
+  };
+}

--- a/frontend/src/features/resolve_differences/utils/dataEntry.ts
+++ b/frontend/src/features/resolve_differences/utils/dataEntry.ts
@@ -1,0 +1,67 @@
+import { PollingStationResults } from "@/api";
+import { FormSectionId } from "@/components/form/data_entry/state/types";
+
+type ObjectPath<T> = {
+  // For each entry, if it is an object (including optional)
+  [K in keyof T]: NonNullable<T[K]> extends object
+    ? T[K] extends unknown[]
+      ? never // Skip arrays, which are also objects
+      : `${K & string}.${Extract<keyof NonNullable<T[K]>, string>}` // "parent.child" template literal for string keys
+    : K & string; // else, the key itself when it is a string
+}[keyof T]; // Get all values together
+
+type SectionId = Extract<FormSectionId, "recounted" | "voters_votes_counts" | "differences_counts">;
+
+export type PollingStationResultsPath = NonNullable<ObjectPath<PollingStationResults>>;
+
+export interface DataEntrySection {
+  id: SectionId;
+  fields: { code?: string; path: PollingStationResultsPath }[];
+}
+
+export const sections: DataEntrySection[] = [
+  {
+    id: "recounted",
+    fields: [{ path: "recounted" }],
+  },
+  {
+    id: "voters_votes_counts",
+    fields: [
+      { code: "A", path: "voters_counts.poll_card_count" },
+      { code: "B", path: "voters_counts.proxy_certificate_count" },
+      { code: "C", path: "voters_counts.voter_card_count" },
+      { code: "D", path: "voters_counts.total_admitted_voters_count" },
+      { code: "E", path: "votes_counts.votes_candidates_count" },
+      { code: "F", path: "votes_counts.blank_votes_count" },
+      { code: "G", path: "votes_counts.invalid_votes_count" },
+      { code: "H", path: "votes_counts.total_votes_cast_count" },
+      { code: "A.2", path: "voters_recounts.poll_card_count" },
+      { code: "B.2", path: "voters_recounts.proxy_certificate_count" },
+      { code: "C.2", path: "voters_recounts.voter_card_count" },
+      { code: "D.2", path: "voters_recounts.total_admitted_voters_count" },
+    ],
+  },
+  {
+    id: "differences_counts",
+    fields: [
+      { code: "I", path: "differences_counts.more_ballots_count" },
+      { code: "J", path: "differences_counts.fewer_ballots_count" },
+      { code: "K", path: "differences_counts.unreturned_ballots_count" },
+      { code: "L", path: "differences_counts.too_few_ballots_handed_out_count" },
+      { code: "M", path: "differences_counts.too_many_ballots_handed_out_count" },
+      { code: "N", path: "differences_counts.other_explanation_count" },
+      { code: "O", path: "differences_counts.no_explanation_count" },
+    ],
+  },
+];
+
+export function getFromResults(results: PollingStationResults, path: PollingStationResultsPath) {
+  const segments = path.split(".");
+  return segments.reduce((o: unknown, k: string) => {
+    if (o && typeof o === "object" && k in o) {
+      return o[k as keyof typeof o] as string | number | boolean | undefined;
+    } else {
+      return undefined;
+    }
+  }, results) as string | number | boolean | undefined;
+}

--- a/frontend/src/lib/i18n/locales/nl/nl.ts
+++ b/frontend/src/lib/i18n/locales/nl/nl.ts
@@ -16,7 +16,9 @@ import log from "./log.json";
 import messages from "./messages.json";
 import polling_station from "./polling_station.json";
 import polling_station_choice from "./polling_station_choice.json";
+import polling_station_results from "./polling_station_results.json";
 import recounted from "./recounted.json";
+import resolve_differences from "./resolve_differences.json";
 import status from "./status.json";
 import users from "./users.json";
 import voters_and_votes from "./voters_and_votes.json";
@@ -41,7 +43,9 @@ const nl = {
   messages,
   polling_station,
   polling_station_choice,
+  polling_station_results,
   recounted,
+  resolve_differences,
   status,
   users,
   voters_and_votes,

--- a/frontend/src/lib/i18n/locales/nl/polling_station_results.json
+++ b/frontend/src/lib/i18n/locales/nl/polling_station_results.json
@@ -1,0 +1,32 @@
+{
+  "field": {
+    "recounted": "Is er herteld?",
+    "voters_counts": {
+      "poll_card_count": "Stempassen",
+      "proxy_certificate_count": "Volmachtbewijzen",
+      "total_admitted_voters_count": "Totaal toegelaten kiezers",
+      "voter_card_count": "Kiezerspassen"
+    },
+    "votes_counts": {
+      "blank_votes_count": "Blanco stemmen",
+      "invalid_votes_count": "Ongeldige stemmen",
+      "total_votes_cast_count": "Totaal uitgebrachte stemmen",
+      "votes_candidates_count": "Stemmen op kandidaten"
+    },
+    "voters_recounts": {
+      "poll_card_count": "Stempassen",
+      "proxy_certificate_count": "Volmachtbewijzen",
+      "total_admitted_voters_count": "Totaal toegelaten kiezers",
+      "voter_card_count": "Kiezerspassen"
+    },
+    "differences_counts": {
+      "fewer_ballots_count": "Stembiljetten minder geteld",
+      "more_ballots_count": "Stembiljetten méér geteld",
+      "no_explanation_count": "Geen verklaring voor het verschil",
+      "other_explanation_count": "Andere verklaring voor het verschil",
+      "too_few_ballots_handed_out_count": "Te weinig uitgereikte stembiljetten",
+      "too_many_ballots_handed_out_count": "Te veel uitgereikte stembiljetten",
+      "unreturned_ballots_count": "Niet ingeleverde stembiljetten"
+    }
+  }
+}

--- a/frontend/src/lib/i18n/locales/nl/resolve_differences.json
+++ b/frontend/src/lib/i18n/locales/nl/resolve_differences.json
@@ -1,0 +1,17 @@
+{
+  "headers": {
+    "candidate": "Kandidaat",
+    "description": "Omschrijving",
+    "field": "Veld",
+    "first_entry": "Eerste invoer",
+    "number": "Nummer",
+    "second_entry": "Tweede invoer"
+  },
+  "no": "Nee",
+  "section": {
+    "differences_counts": "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen",
+    "recounted": "Is het selectievakje op de eerste pagina aangevinkt?",
+    "voters_votes_counts": "Toegelaten kiezers en uitgebrachte stemmen"
+  },
+  "yes": "Ja"
+}

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -1,4 +1,9 @@
-import type { ClaimDataEntryResponse, SaveDataEntryResponse, ValidationResults } from "@kiesraad/api";
+import type {
+  ClaimDataEntryResponse,
+  PollingStationResults,
+  SaveDataEntryResponse,
+  ValidationResults,
+} from "@kiesraad/api";
 
 import { electionMockData } from "./ElectionMockData";
 
@@ -7,7 +12,7 @@ export const emptyValidationResults: ValidationResults = {
   warnings: [],
 };
 
-export const emptyData = {
+export const emptyData: PollingStationResults = {
   voters_counts: {
     poll_card_count: 0,
     proxy_certificate_count: 0,

--- a/frontend/src/testing/api-mocks/ElectionMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionMockData.ts
@@ -212,7 +212,7 @@ export const politicalGroupMockData: PoliticalGroup = {
   ],
 };
 
-const politicalGroupsMockData: PoliticalGroup[] = [
+export const politicalGroupsMockData: PoliticalGroup[] = [
   politicalGroupMockData,
   {
     number: 2,


### PR DESCRIPTION
Implements https://github.com/kiesraad/abacus/issues/1246

Not implemented yet : styling to indicate keeping first or second data entry, this will be done in https://github.com/kiesraad/abacus/issues/1247

---

New component `DifferencesTable`:
- Labelled by heading
- Styling for the data entry differences page
- Show only rows with differences between first and second
- Show "gap row" for one or more hidden rows in between rows that do have differences
- Renders nothing if there are no differences at all

New component `ResolveDifferencesTables`:
- Show `DifferencesTable` for all sections
- Show `DifferencesTable` for all political groups
- [Ladle story](https://dcf21c28.kiesraad-abacus.pages.dev/ladle/?story=app--resolve-differences--resolve-differences-tables)

Translation between `PollingStationResults` structure and data entry sections and fields, to be able to iterate over section and fields in `ResolveDifferencesTables`.
- Object to "configure" data entry fields with code and corresponding paths within `PollingStationResults` 
- Function to get the field value according to its path
- Translations corresponding to paths in `PollingStationResults`