### PR TITLE
Fix `cargo test` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Run tests
-        run: cargo --locked test --release
+        run: cargo --locked test --release --features embed-typst
       - name: Build
         run: cargo --locked build --release --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Run tests
-        run: cargo --locked test --release --features embed-typst
+        run: cargo --locked test --release --features embed-typst --target=${{ matrix.target.name }}
       - name: Build
         run: cargo --locked build --release --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `cargo test` command in our release workflow did not have the `embed-typst` feature - which caused an error. Also added `--target` to test for the specific architecture.

To test: [run release workflow](https://github.com/kiesraad/abacus/actions/runs/14303859418) (not that the upload will not succeed because of PR permissions)