### PR TITLE
Log requests by default

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,8 +4,8 @@ use axum::{Router, extract::FromRef, middleware, serve::ListenerExt};
 use sqlx::SqlitePool;
 use std::{error::Error, net::SocketAddr};
 use tokio::{net::TcpListener, signal};
-use tower_http::trace::TraceLayer;
-use tracing::{info, trace};
+use tower_http::trace::{self, TraceLayer};
+use tracing::{Level, info, trace};
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 #[cfg(feature = "openapi")]
@@ -62,13 +62,16 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
     let router = Router::from(openapi_router());
 
     // Add middleware to trace all HTTP requests and extend the user's session lifetime if needed
-    let router =
-        router
-            .layer(TraceLayer::new_for_http())
-            .layer(middleware::map_response_with_state(
-                state.clone(),
-                authentication::extend_session,
-            ));
+    let router = router
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
+                .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
+        )
+        .layer(middleware::map_response_with_state(
+            state.clone(),
+            authentication::extend_session,
+        ));
 
     // Add the memory-serve router to serve the frontend (if the memory-serve feature is enabled)
     #[cfg(feature = "memory-serve")]


### PR DESCRIPTION
Currently our backend does not log incoming requests by default. This PR sets the log level of incoming requests and their response to INFO, so that these will be logged by default. This helps when debugging and adds context. to other logged messages.