### PR TITLE
Use `Swatinem/rust-cache` action for CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -30,36 +30,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Install dependencies
+      - name: Install npm dependencies
         run: npm ci
         working-directory: ./frontend
-      - name: Build
+      - name: Build frontend
         run: npm run build
         working-directory: ./frontend
       # Compile and test backend
+      - name: Install musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Setup Rust
         shell: bash
         run: >
           rustup update stable &&
           rustup default stable &&
-          echo RUST_VERSION=$(rustc --version | cut -d' ' -f2) >> $GITHUB_ENV
+          rustup target add x86_64-unknown-linux-musl
       - name: Cargo cache
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./backend/target/
-          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
-      - name: Install musl
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Install target
-        run: rustup target add x86_64-unknown-linux-musl
+          workspaces: "backend -> target"
       - name: Check rustfmt
         run: cargo --verbose --locked fmt --all -- --check
       - name: Check Clippy with all features

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,28 +30,20 @@ jobs:
         shell: bash
         run: >
           rustup update nightly &&
-          rustup default nightly &&
-          echo RUST_VERSION=$(rustc --version | awk -F '[( ]' '{print $4}') >> $GITHUB_ENV
+          rustup default nightly
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "backend -> target"
+          cache-bin: "false"
       - name: Install Binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-llvm-cov
         run: cargo binstall cargo-llvm-cov
       - name: Install Nextest
         run: cargo binstall cargo-nextest
-      - name: Cargo cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./backend/target/
-          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
       - name: Run tests with coverage
-        run: cargo llvm-cov --branch nextest --profile ci --features embed-typst
+        run: cargo llvm-cov nextest --branch --profile ci --features embed-typst
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1


### PR DESCRIPTION
Use the [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) action in our CI workflows. This action manages the Cargo caches a lot better than our current approach, greatly reducing our cache size which increases performance (downloading and extracting the cache takes time) and avoids caches from being purged (because GitHub limits the total cache size for a repository to 10GB).

In my tests the savings is as follows:
- Build, lint & test: 2.4-4.4GB -> 880MB, 1min10s -> 11s to download
- Codecov: 3GB -> 640MB, 50s -> 8s to download