### PR TITLE
Only fetch a user once per request

### DIFF
--- a/backend/.sqlx/query-1019d87a89eb4087ab3d931e41d633572bde7edacf9f5fa19c064f92d723d801.json
+++ b/backend/.sqlx/query-1019d87a89eb4087ab3d931e41d633572bde7edacf9f5fa19c064f92d723d801.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n            SELECT\n                session_key,\n                user_id as \"user_id: u32\",\n                expires_at as \"expires_at: _\",\n                created_at as \"created_at: _\"\n            FROM sessions WHERE session_key = ?\n            ",
+  "query": "\n            SELECT\n                session_key,\n                user_id as \"user_id: u32\",\n                expires_at as \"expires_at: _\",\n                created_at as \"created_at: _\"\n            FROM sessions\n            WHERE session_key = ?\n            AND expires_at > ?\n            ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       }
     ],
     "parameters": {
-      "Right": 1
+      "Right": 2
     },
     "nullable": [
       false,
@@ -34,5 +34,5 @@
       false
     ]
   },
-  "hash": "a1e7b011b8103b39059df43cdfa7970b18d97dedf6bb24debc0bb3a1a532d30a"
+  "hash": "1019d87a89eb4087ab3d931e41d633572bde7edacf9f5fa19c064f92d723d801"
 }

--- a/backend/.sqlx/query-efba7caf7f767b2c41e36a423588c11766dbda1e332c040c775a162d9db78944.json
+++ b/backend/.sqlx/query-efba7caf7f767b2c41e36a423588c11766dbda1e332c040c775a162d9db78944.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n          UPDATE sessions\n          SET expires_at = ?\n          WHERE expires_at < ?\n          AND session_key = ?\n          AND expires_at > ?\n          RETURNING\n              session_key,\n              user_id as \"user_id: u32\",\n              expires_at as \"expires_at: _\",\n              created_at as \"created_at: _\"\n          ",
+  "query": "\n          UPDATE sessions\n          SET expires_at = ?\n          WHERE session_key = ?\n          RETURNING\n              session_key,\n              user_id as \"user_id: u32\",\n              expires_at as \"expires_at: _\",\n              created_at as \"created_at: _\"\n          ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       }
     ],
     "parameters": {
-      "Right": 4
+      "Right": 2
     },
     "nullable": [
       false,
@@ -34,5 +34,5 @@
       false
     ]
   },
-  "hash": "6f03a8784315d018fef230a45d89886a4b7f4412f1172339aec8cacb3611a52b"
+  "hash": "efba7caf7f767b2c41e36a423588c11766dbda1e332c040c775a162d9db78944"
 }

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -136,7 +136,7 @@ mod tests {
             UserLoggedInDetails,
             api::{audit_log_list, audit_log_list_users},
         },
-        authentication::{Sessions, Users, inject_user},
+        authentication::{Sessions, User, Users, inject_user},
     };
 
     fn new_test_audit_service(pool: SqlitePool, user: User) -> AuditService {

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -119,6 +119,7 @@ mod tests {
         Router,
         body::Body,
         http::{Method, Request},
+        middleware,
         routing::get,
     };
     use chrono::TimeDelta;
@@ -135,7 +136,7 @@ mod tests {
             UserLoggedInDetails,
             api::{audit_log_list, audit_log_list_users},
         },
-        authentication::{Sessions, User, Users},
+        authentication::{Sessions, Users, inject_user},
     };
 
     fn new_test_audit_service(pool: SqlitePool, user: User) -> AuditService {
@@ -173,6 +174,10 @@ mod tests {
 
         let app = Router::new()
             .route("/api/log", get(audit_log_list))
+            .layer(middleware::map_request_with_state(
+                state.clone(),
+                inject_user,
+            ))
             .with_state(state);
 
         create_log_entries(pool).await;
@@ -228,6 +233,10 @@ mod tests {
 
         let app = Router::new()
             .route("/api/log-users", get(audit_log_list_users))
+            .layer(middleware::map_request_with_state(
+                state.clone(),
+                inject_user,
+            ))
             .with_state(state);
 
         create_log_entries(pool).await;

--- a/backend/src/audit_log/service.rs
+++ b/backend/src/audit_log/service.rs
@@ -11,6 +11,7 @@ use crate::{
 
 use super::{AuditEvent, AuditLog, AuditLogEvent};
 
+#[derive(Clone)]
 pub struct AuditService {
     log: AuditLog,
     user: Option<User>,

--- a/backend/src/audit_log/service.rs
+++ b/backend/src/audit_log/service.rs
@@ -27,6 +27,7 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, APIError> {
         let log = AuditLog::from_ref(state);
+
         let user: Option<User> = User::from_request_parts(parts, state).await.ok();
         let ip = ConnectInfo::<SocketAddr>::from_request_parts(parts, state)
             .await

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -11,6 +11,7 @@ pub enum AuthenticationError {
     HashPassword(password_hash::Error),
     BackwardTimeTravel,
     Unauthorized,
+    Unauthenticated,
     PasswordRejection,
 }
 

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -9,7 +9,6 @@ pub enum AuthenticationError {
     NoSessionCookie,
     Database(sqlx::Error),
     HashPassword(password_hash::Error),
-    BackwardTimeTravel,
     Unauthorized,
     Unauthenticated,
     PasswordRejection,

--- a/backend/src/authentication/middleware.rs
+++ b/backend/src/authentication/middleware.rs
@@ -1,0 +1,58 @@
+use crate::{
+    audit_log::{AuditEvent, AuditService},
+    authentication::{SESSION_COOKIE_NAME, set_default_cookie_properties},
+};
+use axum::{extract::State, http::HeaderValue, response::Response};
+use axum_extra::extract::CookieJar;
+use hyper::header::SET_COOKIE;
+use tracing::{debug, info};
+
+use super::{Users, session::Sessions};
+
+/// Middleware to extend the session lifetime
+pub async fn extend_session(
+    State(users): State<Users>,
+    State(sessions): State<Sessions>,
+    jar: CookieJar,
+    audit_service: AuditService,
+    mut response: Response,
+) -> Response {
+    let Some(session_cookie) = jar.get(SESSION_COOKIE_NAME) else {
+        return response;
+    };
+
+    let mut expires = None;
+
+    // extend lifetime of session and set new cookie if the session is still valid and will soon be expired
+    if let Ok(Some(session)) = sessions.extend_session(session_cookie.value()).await {
+        info!("Session extended for user {}", session.user_id());
+
+        if let Some(user) = users.get_by_id(session.user_id()).await.ok().flatten() {
+            let _ = audit_service
+                .with_user(user)
+                .log_success(&AuditEvent::UserSessionExtended, None)
+                .await;
+
+            let mut cookie = session.get_cookie();
+            set_default_cookie_properties(&mut cookie);
+
+            debug!("Setting cookie: {:?}", cookie);
+
+            if let Ok(header_value) = cookie.encoded().to_string().parse() {
+                response.headers_mut().append(SET_COOKIE, header_value);
+            }
+        }
+
+        expires = Some(session.expires_at());
+    } else if let Ok(Some(session)) = sessions.get_by_key(session_cookie.value()).await {
+        expires = Some(session.expires_at());
+    }
+
+    if let Some(expires) = expires.and_then(|e| HeaderValue::from_str(&e.to_rfc3339()).ok()) {
+        response
+            .headers_mut()
+            .append("X-Session-Expires-At", expires);
+    }
+
+    response
+}

--- a/backend/src/authentication/middleware.rs
+++ b/backend/src/authentication/middleware.rs
@@ -79,7 +79,7 @@ pub async fn extend_session(
             if let Some(user) = user {
                 let _ = audit_service
                     .with_user(user.clone())
-                    .log_success(&AuditEvent::UserSessionExtended, None)
+                    .log(&AuditEvent::UserSessionExtended, None)
                     .await;
 
                 let mut cookie = session.get_cookie();

--- a/backend/src/authentication/middleware.rs
+++ b/backend/src/authentication/middleware.rs
@@ -142,7 +142,7 @@ mod test {
             "inject_user should not inject a user if there is no session cookie"
         );
 
-        let user = User::test_user(Role::Administrator);
+        let user = User::test_user(Role::Administrator, 1);
         let session = sessions.create(user.id(), SESSION_LIFE_TIME).await.unwrap();
 
         let mut jar = CookieJar::new();
@@ -181,7 +181,7 @@ mod test {
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_extend_session(pool: SqlitePool) {
         let sessions = Sessions::new(pool.clone());
-        let user = User::test_user(Role::Administrator);
+        let user = User::test_user(Role::Administrator, 1);
 
         let audit_service = AuditService::new(
             AuditLog::new(pool.clone()),

--- a/backend/src/authentication/middleware.rs
+++ b/backend/src/authentication/middleware.rs
@@ -1,54 +1,104 @@
 use crate::{
     audit_log::{AuditEvent, AuditService},
-    authentication::{SESSION_COOKIE_NAME, set_default_cookie_properties},
+    authentication::{SESSION_COOKIE_NAME, User, set_default_cookie_properties},
 };
-use axum::{extract::State, http::HeaderValue, response::Response};
+use axum::{
+    extract::{Request, State},
+    http::HeaderValue,
+    response::Response,
+};
 use axum_extra::extract::CookieJar;
+use chrono::Utc;
 use hyper::header::SET_COOKIE;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
-use super::{Users, session::Sessions};
+use super::{
+    SESSION_MIN_LIFE_TIME, Users,
+    session::{Session, Sessions},
+    util::get_expires_at,
+};
 
-/// Middleware to extend the session lifetime
-pub async fn extend_session(
+/// Inject user and session
+pub async fn inject_user<B>(
     State(users): State<Users>,
     State(sessions): State<Sessions>,
     jar: CookieJar,
+    mut request: Request<B>,
+) -> Request<B> {
+    let Some(session_cookie) = jar.get(SESSION_COOKIE_NAME) else {
+        return request;
+    };
+
+    // fetch the session from the database
+    let Ok(Some(session)) = sessions.get_by_key(session_cookie.value()).await else {
+        return request;
+    };
+
+    let session_id = session.user_id();
+
+    let extensions = request.extensions_mut();
+
+    extensions.insert(session);
+
+    // fetch the user from the database
+    let Ok(Some(user)) = users.get_by_id(session_id).await else {
+        return request;
+    };
+
+    if let Err(e) = user.update_last_activity_at(&users).await {
+        error!("Error updating last activity at: {e:?}")
+    }
+
+    extensions.insert(user);
+
+    request
+}
+
+/// Middleware to extend the session lifetime
+pub async fn extend_session(
+    State(sessions): State<Sessions>,
     audit_service: AuditService,
+    session: Option<Session>,
+    user: Option<User>,
     mut response: Response,
 ) -> Response {
-    let Some(session_cookie) = jar.get(SESSION_COOKIE_NAME) else {
+    let Some(session) = session else {
         return response;
     };
 
-    let mut expires = None;
+    let mut expires = session.expires_at();
+
+    let Ok(min_life_time) = get_expires_at(SESSION_MIN_LIFE_TIME) else {
+        return response;
+    };
+    let now = Utc::now();
 
     // extend lifetime of session and set new cookie if the session is still valid and will soon be expired
-    if let Ok(Some(session)) = sessions.extend_session(session_cookie.value()).await {
-        info!("Session extended for user {}", session.user_id());
+    if expires < min_life_time && expires > now {
+        if let Ok(session) = sessions.extend_session(&session).await {
+            if let Some(user) = user {
+                let _ = audit_service
+                    .with_user(user.clone())
+                    .log_success(&AuditEvent::UserSessionExtended, None)
+                    .await;
 
-        if let Some(user) = users.get_by_id(session.user_id()).await.ok().flatten() {
-            let _ = audit_service
-                .with_user(user)
-                .log_success(&AuditEvent::UserSessionExtended, None)
-                .await;
+                let mut cookie = session.get_cookie();
+                set_default_cookie_properties(&mut cookie);
 
-            let mut cookie = session.get_cookie();
-            set_default_cookie_properties(&mut cookie);
+                debug!("Setting cookie: {:?}", cookie);
 
-            debug!("Setting cookie: {:?}", cookie);
-
-            if let Ok(header_value) = cookie.encoded().to_string().parse() {
-                response.headers_mut().append(SET_COOKIE, header_value);
+                if let Ok(header_value) = cookie.encoded().to_string().parse() {
+                    response.headers_mut().append(SET_COOKIE, header_value);
+                }
             }
-        }
 
-        expires = Some(session.expires_at());
-    } else if let Ok(Some(session)) = sessions.get_by_key(session_cookie.value()).await {
-        expires = Some(session.expires_at());
+            info!("Session extended for user {}", session.user_id());
+            expires = session.expires_at();
+        }
     }
 
-    if let Some(expires) = expires.and_then(|e| HeaderValue::from_str(&e.to_rfc3339()).ok()) {
+    // always return a header with the current expiration time for authenticated requests
+    if let Ok(expires) = HeaderValue::from_str(&expires.to_rfc3339()) {
         response
             .headers_mut()
             .append("X-Session-Expires-At", expires);

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -1,13 +1,15 @@
-pub use self::api::*;
 use chrono::TimeDelta;
-pub use user::{User, Users};
 
-pub use self::role::{Admin, AdminOrCoordinator, Coordinator, Role, Typist};
+pub use self::api::*;
 #[cfg(test)]
 pub use self::session::Sessions;
+pub use middleware::*;
+pub use role::{Admin, AdminOrCoordinator, Coordinator, Role, Typist};
+pub use user::{User, Users};
 
 pub mod api;
 pub mod error;
+mod middleware;
 mod password;
 mod role;
 mod session;
@@ -45,7 +47,7 @@ mod tests {
 
     use crate::{
         AppState,
-        authentication::{session::Sessions, *},
+        authentication::{middleware::extend_session, session::Sessions, *},
     };
 
     fn create_app(pool: SqlitePool) -> Router {

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -58,6 +58,10 @@ mod tests {
                 state.clone(),
                 extend_session,
             ))
+            .layer(middleware::map_request_with_state(
+                state.clone(),
+                inject_user,
+            ))
             .with_state(state)
     }
 

--- a/backend/src/authentication/session.rs
+++ b/backend/src/authentication/session.rs
@@ -45,7 +45,7 @@ impl Session {
     // Create a new session for a specific user
     pub(super) fn new(user_id: u32, life_time: TimeDelta) -> Result<Self, AuthenticationError> {
         let session_key = create_new_session_key();
-        let expires_at = get_expires_at(life_time)?;
+        let expires_at = get_expires_at(life_time);
         let created_at = Utc::now();
 
         Ok(Self {
@@ -194,7 +194,7 @@ impl Sessions {
         &self,
         session: &Session,
     ) -> Result<Session, AuthenticationError> {
-        let new_expires_at = get_expires_at(SESSION_LIFE_TIME)?;
+        let new_expires_at = get_expires_at(SESSION_LIFE_TIME);
         let session_key = session.session_key();
 
         let session = sqlx::query_as!(

--- a/backend/src/authentication/session.rs
+++ b/backend/src/authentication/session.rs
@@ -132,6 +132,7 @@ impl Sessions {
         &self,
         session_key: &str,
     ) -> Result<Option<Session>, AuthenticationError> {
+        let now = Utc::now();
         let session: Option<Session> = sqlx::query_as!(
             Session,
             r#"
@@ -140,9 +141,12 @@ impl Sessions {
                 user_id as "user_id: u32",
                 expires_at as "expires_at: _",
                 created_at as "created_at: _"
-            FROM sessions WHERE session_key = ?
+            FROM sessions
+            WHERE session_key = ?
+            AND expires_at > ?
             "#,
-            session_key
+            session_key,
+            now
         )
         .fetch_optional(&self.0)
         .await?;

--- a/backend/src/authentication/session.rs
+++ b/backend/src/authentication/session.rs
@@ -90,6 +90,7 @@ impl Session {
 }
 
 /// Sessions repository
+#[derive(Clone)]
 pub struct Sessions(SqlitePool);
 
 impl Sessions {

--- a/backend/src/authentication/user.rs
+++ b/backend/src/authentication/user.rs
@@ -148,6 +148,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct Users(SqlitePool);
 
 impl Users {

--- a/backend/src/authentication/util.rs
+++ b/backend/src/authentication/util.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, TimeDelta, Utc};
 use rand::{Rng, distr::Alphanumeric};
 
-use super::error::AuthenticationError;
-
 /// Create a new session key, a secure random alphanumeric string of 24 characters
 /// Which corresponds to ~142 bits of entropy
 pub(super) fn create_new_session_key() -> String {
@@ -13,11 +11,13 @@ pub(super) fn create_new_session_key() -> String {
         .collect()
 }
 
-/// Get the time when the session expires as a unix timestamp in seconds
-pub(super) fn get_expires_at(duration: TimeDelta) -> Result<DateTime<Utc>, AuthenticationError> {
+/// Get the time when the session expires
+/// Note this will return the current time if adding the duration would be out of range,
+/// which will happen in the next 260117 years, since the duration is only set using constants in out codebase
+pub(super) fn get_expires_at(duration: TimeDelta) -> DateTime<Utc> {
     Utc::now()
         .checked_add_signed(duration)
-        .ok_or(AuthenticationError::BackwardTimeTravel)
+        .unwrap_or(Utc::now())
 }
 
 #[cfg(test)]
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn test_get_expires_at() {
         let current_time = Utc::now();
-        let expires_at = get_expires_at(TimeDelta::seconds(60)).unwrap();
+        let expires_at = get_expires_at(TimeDelta::seconds(60));
 
         assert!(expires_at > current_time);
         assert_eq!((expires_at - current_time).num_seconds(), 60);

--- a/backend/src/authentication/util.rs
+++ b/backend/src/authentication/util.rs
@@ -13,7 +13,7 @@ pub(super) fn create_new_session_key() -> String {
 
 /// Get the time when the session expires
 /// Note this will return the current time if adding the duration would be out of range,
-/// which will happen in the next 260117 years, since the duration is only set using constants in out codebase
+/// which will not happen in the next 260117 years, since the duration is only set using constants in out codebase
 pub(super) fn get_expires_at(duration: TimeDelta) -> DateTime<Utc> {
     Utc::now()
         .checked_add_signed(duration)

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -229,7 +229,7 @@ impl IntoResponse for APIError {
                         StatusCode::UNAUTHORIZED,
                         to_error("Invalid session", ErrorReference::InvalidSession, false),
                     ),
-                    AuthenticationError::Unauthorized => (
+                    AuthenticationError::Unauthorized | AuthenticationError::Unauthenticated => (
                         StatusCode::UNAUTHORIZED,
                         to_error("Unauthorized", ErrorReference::Unauthorized, false),
                     ),

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -240,7 +240,6 @@ impl IntoResponse for APIError {
                     // server errors
                     AuthenticationError::Database(_)
                     | AuthenticationError::HashPassword(_)
-                    | AuthenticationError::BackwardTimeTravel
                     | AuthenticationError::InvalidSessionDuration => (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         to_error(

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -62,6 +62,7 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
     let router = Router::from(openapi_router());
 
     // Add middleware to trace all HTTP requests and extend the user's session lifetime if needed
+    // Caution: make sure "inject_user" is added after "extend_session"
     let router = router
         .layer(
             TraceLayer::new_for_http()
@@ -75,6 +76,10 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
         .layer(middleware::map_response_with_state(
             state.clone(),
             authentication::extend_session,
+        ))
+        .layer(middleware::map_request_with_state(
+            state.clone(),
+            authentication::inject_user,
         ));
 
     // Add the memory-serve router to serve the frontend (if the memory-serve feature is enabled)


### PR DESCRIPTION
We inject the authenticated user using the `FromRequestParts` trait on User. Since there are now multiple middlewares and extractors the trait implementation will be called multiple times, resulting in the same code / queries being executed multiple times for a single request. In some cases the session and user are queried 3 times for a single request.

This PR adds an `inject_user` middleware that adds the session and user as an extension to the request. The `FromRequestParts` and `OptionalFromRequestParts` implementations use this injected user directly and do not have to execute database queries every time.