### PR TITLE
Fixed code and added tests to prevent missed cargo mutants in fraction and candidate_nomination

### DIFF
--- a/backend/src/apportionment/candidate_nomination.rs
+++ b/backend/src/apportionment/candidate_nomination.rs
@@ -557,6 +557,78 @@ mod tests {
         );
     }
 
+    /// Candidate nomination with no preferential candidate nomination
+    ///
+    /// PG seats: [6, 6, 5, 2, 0]  
+    /// PG 1: Preferential candidate nominations of candidates 1, 2, 3, 4 and 5 and other candidate nominations of candidate 6  
+    /// PG 2: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidates 5 and 6  
+    /// PG 3: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidate 5  
+    /// PG 4: Preferential candidate nominations of candidates 1 and 2 and no other candidate nominations  
+    /// PG 5: No preferential candidate nominations and no other candidate nomination
+    #[test]
+    fn test_with_gte_19_seats_and_candidate_votes_meeting_preference_threshold_but_no_seat() {
+        let election = election_fixture_with_given_number_of_seats(&[6, 6, 6, 5, 5], 19);
+        let quota = Fraction::new(960, 19);
+        let totals = election_summary_fixture_with_given_candidate_votes(vec![
+            vec![80, 70, 60, 50, 40, 0],
+            vec![80, 70, 60, 50, 5, 0],
+            vec![80, 70, 60, 50, 0, 0],
+            vec![80, 40, 0, 0, 0],
+            vec![0, 0, 0, 0, 15],
+        ]);
+        let result = candidate_nomination(&election, quota, &totals, vec![6, 6, 5, 2, 0]).unwrap();
+        assert_eq!(result.preference_threshold.percentage, 25);
+        assert_eq!(
+            result.preference_threshold.number_of_votes,
+            quota * Fraction::new(result.preference_threshold.percentage, 100)
+        );
+        check_political_group_candidate_nomination(
+            &result.political_group_candidate_nomination[0],
+            &[1, 2, 3, 4, 5],
+            &[6],
+            &[],
+        );
+        check_political_group_candidate_nomination(
+            &result.political_group_candidate_nomination[1],
+            &[1, 2, 3, 4],
+            &[5, 6],
+            &[],
+        );
+        check_political_group_candidate_nomination(
+            &result.political_group_candidate_nomination[2],
+            &[1, 2, 3, 4],
+            &[5],
+            &[],
+        );
+        check_political_group_candidate_nomination(
+            &result.political_group_candidate_nomination[3],
+            &[1, 2],
+            &[],
+            &[],
+        );
+        check_political_group_candidate_nomination(
+            &result.political_group_candidate_nomination[4],
+            &[],
+            &[],
+            &[],
+        );
+
+        let pgs = election.political_groups.unwrap_or_default();
+        check_chosen_candidates(&result.chosen_candidates, &pgs[0].candidates, &[]);
+        check_chosen_candidates(&result.chosen_candidates, &pgs[1].candidates, &[]);
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            &pgs[2].candidates[..5],
+            &pgs[2].candidates[5..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            &pgs[3].candidates[..2],
+            &pgs[3].candidates[2..],
+        );
+        check_chosen_candidates(&result.chosen_candidates, &[], &pgs[4].candidates);
+    }
+
     /// Candidate nomination with more candidates eligible for preferential nomination than seats
     ///
     /// PG seats: [6, 5, 4, 2, 2]  

--- a/backend/src/apportionment/fraction.rs
+++ b/backend/src/apportionment/fraction.rs
@@ -163,8 +163,7 @@ impl Debug for Fraction {
 
 impl PartialEq for DisplayFraction {
     fn eq(&self, other: &Self) -> bool {
-        (self.integer == other.integer)
-            && (self.numerator * other.denominator == self.denominator * other.numerator)
+        Fraction::from(*self) == Fraction::from(*other)
     }
 }
 
@@ -315,6 +314,38 @@ mod tests {
                 integer: 0,
                 numerator: 2,
                 denominator: 5
+            }
+        );
+    }
+
+    #[test]
+    fn test_display_fraction_eq() {
+        assert_eq!(
+            DisplayFraction {
+                integer: 1,
+                numerator: 1,
+                denominator: 4
+            },
+            DisplayFraction {
+                integer: 0,
+                numerator: 10,
+                denominator: 8
+            }
+        );
+    }
+
+    #[test]
+    fn test_display_fraction_ne() {
+        assert_ne!(
+            DisplayFraction {
+                integer: 1,
+                numerator: 1,
+                denominator: 4
+            },
+            DisplayFraction {
+                integer: 0,
+                numerator: 9,
+                denominator: 8
             }
         );
     }


### PR DESCRIPTION
Note: The missed mutants in `seat_assignment.rs` will be fixed in another PR.

Result when run by Joep for https://github.com/kiesraad/abacus/issues/1290:
```
~/workspace/tweede-abacus/backend (main %=) $ cargo mutants --in-place -f src/apportionment/**/*.rs -- --features embed-typst
Found 285 mutants to test
ok       Unmutated baseline in 15.7s build + 49.0s test
 INFO Auto-set test timeout to 4m 6s
MISSED   src/apportionment/seat_assignment.rs:841:5: replace political_group_numbers -> Vec<PGNumber> with vec![] in 18.4s build + 48.6s test
MISSED   src/apportionment/seat_assignment.rs:841:5: replace political_group_numbers -> Vec<PGNumber> with vec![Default::default()] in 16.0s build + 48.9s test
MISSED   src/apportionment/fraction.rs:160:9: replace <impl Debug for Fraction>::fmt -> Result with Ok(Default::default()) in 15.7s build + 49.3s test
MISSED   src/apportionment/seat_assignment.rs:497:77: replace > with < in reassign_residual_seats_for_exhausted_lists in 15.7s build + 49.4s test
MISSED   src/apportionment/fraction.rs:167:13: replace && with || in <impl PartialEq for DisplayFraction>::eq in 13.4s build + 49.5s test
MISSED   src/apportionment/seat_assignment.rs:195:9: replace SeatChange::is_changed_by_absolute_majority_reassignment -> bool with true in 13.2s build + 49.2s test
MISSED   src/apportionment/candidate_nomination.rs:173:46: replace >= with < in candidate_nomination_per_political_group in 13.1s build + 49.0s test
MISSED   src/apportionment/fraction.rs:166:9: replace <impl PartialEq for DisplayFraction>::eq -> bool with true in 14.5s build + 49.4s test
MISSED   src/apportionment/candidate_nomination.rs:173:17: replace || with && in candidate_nomination_per_political_group in 13.1s build + 48.6s test
MISSED   src/apportionment/seat_assignment.rs:200:9: replace SeatChange::is_changed_by_list_exhaustion_removal -> bool with true in 12.9s build + 49.0s test
285 mutants tested in 2h 38m 9s: 10 missed, 223 caught, 52 unviable
```

Fixed;
```
MISSED   src/apportionment/fraction.rs:167:13: replace && with || in <impl PartialEq for DisplayFraction>::eq in 13.4s build + 49.5s test
```

Result when run by Ellen on branch of https://github.com/kiesraad/abacus/pull/1291:
```
cargo mutants --in-place -f src/apportionment/**/*.rs -- --features embed-typst
Found 291 mutants to test
ok       Unmutated baseline in 5.1s build + 53.2s test
 INFO Auto-set test timeout to 4m 27s
MISSED   src/apportionment/seat_assignment.rs:911:5: replace political_group_numbers -> Vec<PGNumber> with vec![Default::default()] in 7.9s build + 53.6s test
MISSED   src/apportionment/fraction.rs:166:9: replace <impl PartialEq for DisplayFraction>::eq -> bool with true in 5.6s build + 48.6s test
MISSED   src/apportionment/candidate_nomination.rs:179:46: replace >= with < in candidate_nomination_per_political_group in 13.4s build + 48.4s test
MISSED   src/apportionment/fraction.rs:160:9: replace <impl Debug for Fraction>::fmt -> Result with Ok(Default::default()) in 13.1s build + 53.8s test
MISSED   src/apportionment/seat_assignment.rs:520:77: replace > with < in reassign_residual_seats_for_exhausted_lists in 5.2s build + 53.0s test
MISSED   src/apportionment/candidate_nomination.rs:179:17: replace || with && in candidate_nomination_per_political_group in 5.5s build + 70.2s test
MISSED   src/apportionment/seat_assignment.rs:911:5: replace political_group_numbers -> Vec<PGNumber> with vec![] in 6.3s build + 58.7s test
MISSED   src/apportionment/seat_assignment.rs:222:9: replace SeatChange::is_changed_by_list_exhaustion_removal -> bool with true in 14.1s build + 66.8s test
291 mutants tested in 3h 10m 33s: 8 missed, 231 caught, 52 unviable
```

Fixed;
```
MISSED   src/apportionment/fraction.rs:166:9: replace <impl PartialEq for DisplayFraction>::eq -> bool with true in 5.6s build + 48.6s test
MISSED   src/apportionment/candidate_nomination.rs:179:46: replace >= with < in candidate_nomination_per_political_group in 13.4s build + 48.4s test
MISSED   src/apportionment/candidate_nomination.rs:179:17: replace || with && in candidate_nomination_per_political_group in 5.5s build + 70.2s test
```

Result when run by Ellen on branch of https://github.com/kiesraad/abacus/pull/1291:
```
cargo mutants --in-place -f src/apportionment/**/*.rs -- --features embed-typst
Found 297 mutants to test
ok       Unmutated baseline in 21.1s build + 165.9s test
 INFO Auto-set test timeout to 13m 50s
MISSED   src/apportionment/fraction.rs:160:9: replace <impl Debug for Fraction>::fmt -> Result with Ok(Default::default()) in 7.4s build + 56.3s test
MISSED   src/apportionment/seat_assignment.rs:933:5: replace political_group_numbers -> Vec<PGNumber> with vec![] in 13.3s build + 54.4s test
MISSED   src/apportionment/seat_assignment.rs:808:60: replace == with != in political_group_qualifies_for_extra_seat in 15.4s build + 66.3s test
MISSED   src/apportionment/seat_assignment.rs:933:5: replace political_group_numbers -> Vec<PGNumber> with vec![Default::default()] in 15.4s build + 63.5s test
MISSED   src/apportionment/seat_assignment.rs:222:9: replace SeatChange::is_changed_by_list_exhaustion_removal -> bool with true in 15.9s build + 66.2s test
MISSED   src/apportionment/seat_assignment.rs:520:77: replace > with < in reassign_residual_seats_for_exhausted_lists in 5.8s build + 64.1s test
297 mutants tested in 3h 25m 16s: 6 missed, 239 caught, 52 unviable
```

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->