### PR TITLE
Show abort dialog on check and save form

### DIFF
--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -30,6 +30,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
 
     if (
       status === "deleted" ||
+      status === "finalising" ||
       status === "finalised" ||
       status === "aborted" ||
       currentLocation.pathname === nextLocation.pathname

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -9,10 +9,10 @@ import { SubmitCurrentFormOptions } from "../types/types";
 
 export interface DataEntryNavigationProps {
   onSubmit: (options?: SubmitCurrentFormOptions) => Promise<boolean>;
-  currentValues: Partial<PollingStationResults>;
+  currentValues?: Partial<PollingStationResults>;
 }
 
-export function DataEntryNavigation({ onSubmit, currentValues }: DataEntryNavigationProps) {
+export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryNavigationProps) {
   const { status, election, pollingStationId, formState, setCache, entryNumber, onDeleteDataEntry, updateFormSection } =
     useDataEntryContext();
   const user = useUser();

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -17,6 +17,7 @@ import { t, tx } from "@/lib/i18n";
 import { FormSectionId } from "@/types/types";
 
 import { useDataEntryContext } from "../../hooks/useDataEntryContext";
+import { SubmitCurrentFormOptions } from "../../types/types";
 import { DataEntryFormSectionStatus, getDataEntrySummary } from "../../utils/dataEntryUtils";
 import { getUrlForFormSectionID } from "../../utils/utils";
 import { DataEntryNavigation } from "../DataEntryNavigation";
@@ -27,7 +28,8 @@ export function CheckAndSaveForm() {
 
   const navigate = useNavigate();
   const { election } = useElection();
-  const { error, formState, status, onFinaliseDataEntry, pollingStationId, entryNumber } = useDataEntryContext("save");
+  const { error, formState, onSubmitForm, status, onFinaliseDataEntry, pollingStationId, entryNumber } =
+    useDataEntryContext("save");
 
   const getUrlForFormSection = React.useCallback(
     (id: FormSectionId) => {
@@ -44,28 +46,36 @@ export function CheckAndSaveForm() {
     (section) => section.errors.isEmpty() && (section.warnings.isEmpty() || section.acceptWarnings),
   );
 
+  // save the current state, without finalising (for the abort dialog)
+  const onSubmit = async (options?: SubmitCurrentFormOptions) => {
+    return await onSubmitForm({}, options);
+  };
+
+  // finalise the data entry and navigate away
   const onFinalise = async () => {
     if (!finalisationAllowed) {
       return false;
     }
 
-    const result = await onFinaliseDataEntry();
-
-    if (result) {
+    if (await onFinaliseDataEntry()) {
       await navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
+      return true;
     }
 
-    return result;
-  };
-
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    void onFinalise();
+    return false;
   };
 
   return (
-    <Form onSubmit={handleSubmit} id="check_save_form" title={t("check_and_save.title")} ref={formRef}>
-      <DataEntryNavigation onSubmit={onFinalise} />
+    <Form
+      onSubmit={(event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        void onFinalise();
+      }}
+      id="check_save_form"
+      title={t("check_and_save.title")}
+      ref={formRef}
+    >
+      <DataEntryNavigation onSubmit={onSubmit} />
       {error instanceof ApiError && <ErrorModal error={error} />}
       <section className="md" id="save-form-summary-text">
         {!summary.hasBlocks && summary.countsAddUp && (

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -49,10 +49,13 @@ export function CheckAndSaveForm() {
       return false;
     }
 
-    await onFinaliseDataEntry();
-    await navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
+    const result = await onFinaliseDataEntry();
 
-    return true;
+    if (result) {
+      await navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
+    }
+
+    return result;
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -19,6 +19,7 @@ import { FormSectionId } from "@/types/types";
 import { useDataEntryContext } from "../../hooks/useDataEntryContext";
 import { DataEntryFormSectionStatus, getDataEntrySummary } from "../../utils/dataEntryUtils";
 import { getUrlForFormSectionID } from "../../utils/utils";
+import { DataEntryNavigation } from "../DataEntryNavigation";
 
 export function CheckAndSaveForm() {
   const formRef = React.useRef<HTMLFormElement>(null);
@@ -43,18 +44,25 @@ export function CheckAndSaveForm() {
     (section) => section.errors.isEmpty() && (section.warnings.isEmpty() || section.acceptWarnings),
   );
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) =>
-    void (async (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
+  const onFinalise = async () => {
+    if (!finalisationAllowed) {
+      return false;
+    }
 
-      if (!finalisationAllowed) return;
+    await onFinaliseDataEntry();
+    await navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
 
-      await onFinaliseDataEntry();
-      await navigate(`/elections/${election.id}/data-entry#data-entry-saved-${entryNumber}`);
-    })(event);
+    return true;
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void onFinalise();
+  };
 
   return (
     <Form onSubmit={handleSubmit} id="check_save_form" title={t("check_and_save.title")} ref={formRef}>
+      <DataEntryNavigation onSubmit={onFinalise} />
       {error instanceof ApiError && <ErrorModal error={error} />}
       <section className="md" id="save-form-summary-text">
         {!summary.hasBlocks && summary.countsAddUp && (


### PR DESCRIPTION
Fixes #1316 

To test: try to abort on the check and save section of the form (Controleren en opslaan). An abort dialog should appear.