### PR TITLE
Return ref from useFormKeyboardNavigation

### DIFF
--- a/frontend/src/components/ui/Form/Form.stories.tsx
+++ b/frontend/src/components/ui/Form/Form.stories.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useRef, useState } from "react";
+import { FormEvent, useState } from "react";
 
 import type { Story } from "@ladle/react";
 
@@ -33,8 +33,7 @@ export const DefaultForm: Story = () => {
 };
 
 export const UseFormKeyboardNavigation: Story = () => {
-  const ref = useRef(null);
-  useFormKeyboardNavigation(ref);
+  const ref = useFormKeyboardNavigation();
 
   const [keyboardFormSubmitted, setKeyboardFormSubmitted] = useState(false);
 

--- a/frontend/src/components/ui/Form/useFormKeyboardNavigation.test.tsx
+++ b/frontend/src/components/ui/Form/useFormKeyboardNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, FormEventHandler, ReactNode, useRef } from "react";
+import { FormEvent, FormEventHandler, ReactNode } from "react";
 
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
@@ -9,8 +9,7 @@ import { useFormKeyboardNavigation } from "@kiesraad/ui";
 import { Form } from "./Form";
 
 export const FormWithNavigation = ({ onSubmit, children }: { onSubmit: FormEventHandler; children: ReactNode }) => {
-  const ref = useRef(null);
-  useFormKeyboardNavigation(ref);
+  const ref = useFormKeyboardNavigation();
 
   return (
     <Form onSubmit={onSubmit} id="test-form" ref={ref}>

--- a/frontend/src/components/ui/Form/useFormKeyboardNavigation.ts
+++ b/frontend/src/components/ui/Form/useFormKeyboardNavigation.ts
@@ -1,9 +1,11 @@
-import * as React from "react";
+import { RefObject, useCallback, useEffect, useRef } from "react";
 
 type Dir = "up" | "down" | "first" | "last";
 
-export function useFormKeyboardNavigation(innerRef: React.MutableRefObject<HTMLFormElement | null>) {
-  const moveFocus = React.useCallback(
+export function useFormKeyboardNavigation(): RefObject<HTMLFormElement> {
+  const innerRef = useRef<HTMLFormElement>(null);
+
+  const moveFocus = useCallback(
     (dir: Dir) => {
       if (!innerRef.current) {
         return;
@@ -54,7 +56,7 @@ export function useFormKeyboardNavigation(innerRef: React.MutableRefObject<HTMLF
     [innerRef],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       switch (event.key) {
         case "ArrowUp":
@@ -97,4 +99,6 @@ export function useFormKeyboardNavigation(innerRef: React.MutableRefObject<HTMLF
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [innerRef, moveFocus]);
+
+  return innerRef;
 }

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -21,8 +21,7 @@ import { DataEntryFormSectionStatus, getDataEntrySummary } from "../../utils/dat
 import { getUrlForFormSectionID } from "../../utils/utils";
 
 export function CheckAndSaveForm() {
-  const formRef = React.useRef<HTMLFormElement>(null);
-  useFormKeyboardNavigation(formRef);
+  const formRef = useFormKeyboardNavigation();
 
   const navigate = useNavigate();
   const { election } = useElection();

--- a/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
+++ b/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
@@ -51,8 +51,7 @@ export function useDataEntryFormSection<FORM_VALUES>({
   };
 
   // form keyboard navigation
-  const formRef = React.useRef<HTMLFormElement>(null);
-  useFormKeyboardNavigation(formRef);
+  const formRef = useFormKeyboardNavigation();
 
   // submit and save to form contents
   const onSubmit = async (


### PR DESCRIPTION
The `useFormKeyboardNavigation` hook always acts upon a `RefObject<HTMLFormElement>`. It makes sense to move the `useRef` to this hook: `useFormKeyboardNavigation` returns a reference that enables navigation on the form it is bound to.