### PR TITLE
Move to Lightning CSS

### DIFF
--- a/frontend/.ladle/vite.config.ts
+++ b/frontend/.ladle/vite.config.ts
@@ -1,9 +1,11 @@
+import browserslist from "browserslist";
+import { browserslistToTargets } from "lightningcss";
+
 export default {
   css: {
-    modules: {
-      // Only dashes in class names will be converted to camelCase,
-      // the original class name will not to be removed from the locals
-      localsConvention: "dashes",
+    transformer: "lightningcss",
+    lightningcss: {
+      targets: browserslistToTargets(browserslist(">= 0.25% and not dead")),
     },
   },
 };

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -105,7 +105,7 @@ The application uses the following dependencies:
 - `react-dom`: DOM implementation for rendering UI
 - `react-router`: Handling browser routing for React applications
 - `vite`: frontend build tool
-- `postcss` and `autoprefixer`: CSS post processors
+- `lightningcss`: CSS post processor
 
 #### Development dependencies
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,7 @@
       "name": "abacus-frontend",
       "version": "0.0.1",
       "dependencies": {
-        "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.3",
-        "postcss-import": "^16.1.0",
-        "postcss-nesting": "^13.0.1",
+        "lightningcss": "^1.29.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router": "^7.2.0",
@@ -705,48 +702,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/selector-resolve-nested": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-      "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^7.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3984,43 +3939,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4147,6 +4065,7 @@
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4298,6 +4217,7 @@
       "version": "1.0.30001703",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001703.tgz",
       "integrity": "sha512-kRlAGTRWgPsOj7oARC9m1okJEXdL/8fekFVcxA8Hl7GH4r/sN4OJn/i6Flde373T50KS7Y37oFbMwlE8+F42kQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4721,17 +4641,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/cssstyle": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.2.1.tgz",
@@ -5030,6 +4939,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -5097,6 +5015,7 @@
       "version": "1.5.113",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.113.tgz",
       "integrity": "sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5376,6 +5295,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6364,19 +6284,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -6405,6 +6312,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6754,6 +6662,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7345,6 +7254,7 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -8234,6 +8144,234 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.3.tgz",
+      "integrity": "sha512-GlOJwTIP6TMIlrTFsxTerwC0W6OpQpCGuX1ECRLBUVRh6fpJH3xTqjCjRgQHTb4ZXexH9rtHou1Lf03GKzmhhQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.29.3",
+        "lightningcss-darwin-x64": "1.29.3",
+        "lightningcss-freebsd-x64": "1.29.3",
+        "lightningcss-linux-arm-gnueabihf": "1.29.3",
+        "lightningcss-linux-arm64-gnu": "1.29.3",
+        "lightningcss-linux-arm64-musl": "1.29.3",
+        "lightningcss-linux-x64-gnu": "1.29.3",
+        "lightningcss-linux-x64-musl": "1.29.3",
+        "lightningcss-win32-arm64-msvc": "1.29.3",
+        "lightningcss-win32-x64-msvc": "1.29.3"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.3.tgz",
+      "integrity": "sha512-fb7raKO3pXtlNbQbiMeEu8RbBVHnpyqAoxTyTRMEWFQWmscGC2wZxoHzZ+YKAepUuKT9uIW5vL2QbFivTgprZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.3.tgz",
+      "integrity": "sha512-KF2XZ4ZdmDGGtEYmx5wpzn6u8vg7AdBHaEOvDKu8GOs7xDL/vcU2vMKtTeNe1d4dogkDdi3B9zC77jkatWBwEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.3.tgz",
+      "integrity": "sha512-VUWeVf+V1UM54jv9M4wen9vMlIAyT69Krl9XjI8SsRxz4tdNV/7QEPlW6JASev/pYdiynUCW0pwaFquDRYdxMw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.3.tgz",
+      "integrity": "sha512-UhgZ/XVNfXQVEJrMIWeK1Laj8KbhjbIz7F4znUk7G4zeGw7TRoJxhb66uWrEsonn1+O45w//0i0Fu0wIovYdYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.3.tgz",
+      "integrity": "sha512-Pqau7jtgJNmQ/esugfmAT1aCFy/Gxc92FOxI+3n+LbMHBheBnk41xHDhc0HeYlx9G0xP5tK4t0Koy3QGGNqypw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.3.tgz",
+      "integrity": "sha512-dxakOk66pf7KLS7VRYFO7B8WOJLecE5OPL2YOk52eriFd/yeyxt2Km5H0BjLfElokIaR+qWi33gB8MQLrdAY3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.3.tgz",
+      "integrity": "sha512-ySZTNCpbfbK8rqpKJeJR2S0g/8UqqV3QnzcuWvpI60LWxnFN91nxpSSwCbzfOXkzKfar9j5eOuOplf+klKtINg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.3.tgz",
+      "integrity": "sha512-3pVZhIzW09nzi10usAXfIGTTSTYQ141dk88vGFNCgawIzayiIzZQxEcxVtIkdvlEq2YuFsL9Wcj/h61JHHzuFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.3.tgz",
+      "integrity": "sha512-VRnkAvtIkeWuoBJeGOTrZxsNp4HogXtcaaLm8agmbYtLDOhQdpgxW6NjZZjDXbvGF+eOehGulXZ3C1TiwHY4QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.3.tgz",
+      "integrity": "sha512-IszwRPu2cPnDQsZpd7/EAr0x2W7jkaWqQ1SwCVIZ/tSbZVXPLt6k8s6FkcyBjViCzvB5CW0We0QbbP7zp2aBjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -9659,16 +9797,8 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -10021,6 +10151,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -10100,15 +10231,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/playwright": {
@@ -10194,67 +10316,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postcss-import": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
-      "integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-nesting": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-      "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "dependencies": {
-        "@csstools/selector-resolve-nested": "^3.0.0",
-        "@csstools/selector-specificity": "^5.0.0",
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -10522,15 +10583,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
       }
     },
     "node_modules/readdirp": {
@@ -10820,6 +10872,7 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -11620,6 +11673,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12303,6 +12357,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
       "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12349,11 +12404,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "abacus-frontend",
       "version": "0.0.1",
       "dependencies": {
+        "browserslist": "^4.24.4",
         "lightningcss": "^1.29.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4065,7 +4066,6 @@
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4217,7 +4217,6 @@
       "version": "1.0.30001703",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001703.tgz",
       "integrity": "sha512-kRlAGTRWgPsOj7oARC9m1okJEXdL/8fekFVcxA8Hl7GH4r/sN4OJn/i6Flde373T50KS7Y37oFbMwlE8+F42kQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5015,7 +5014,6 @@
       "version": "1.5.113",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.113.tgz",
       "integrity": "sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5295,7 +5293,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9797,7 +9794,6 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nth-check": {
@@ -12357,7 +12353,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
       "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "serve": "npm run build:msw && npx serve dist"
   },
   "dependencies": {
+    "browserslist": "^4.24.4",
     "lightningcss": "^1.29.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,10 +30,7 @@
     "serve": "npm run build:msw && npx serve dist"
   },
   "dependencies": {
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.3",
-    "postcss-import": "^16.1.0",
-    "postcss-nesting": "^13.0.1",
+    "lightningcss": "^1.29.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^7.2.0",

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,7 +1,0 @@
-export default {
-  plugins: {
-    "postcss-import": {},
-    "postcss-nesting": {},
-    autoprefixer: {},
-  },
-};

--- a/frontend/src/components/navbar/NavBar.module.css
+++ b/frontend/src/components/navbar/NavBar.module.css
@@ -1,4 +1,4 @@
-.nav-bar {
+.navBar {
   flex: 0 0 2.75rem;
   padding: 0 5rem;
   background-color: var(--base-brand-blue);
@@ -46,7 +46,7 @@
     }
   }
 
-  .user-info {
+  .userInfo {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -73,7 +73,7 @@
   }
 }
 
-.nav-bar-menu {
+.navBarMenu {
   position: absolute;
   top: 0.75rem;
   left: 0;
@@ -118,7 +118,7 @@
   }
 }
 
-.nav-bar-menu-container {
+.navBarMenuContainer {
   position: relative;
   height: 3rem;
   padding: 0.75rem;

--- a/frontend/src/components/navbar/NavBar.stories.tsx
+++ b/frontend/src/components/navbar/NavBar.stories.tsx
@@ -8,7 +8,7 @@ import { Election, Role, TestUserProvider } from "@kiesraad/api";
 import { electionDetailsMockResponse } from "@kiesraad/api-mocks";
 
 import { NavBar } from "./NavBar";
-import styles from "./NavBar.module.css";
+import cls from "./NavBar.module.css";
 import { NavBarMenu, NavBarMenuButton } from "./NavBarMenu";
 
 export default {
@@ -65,14 +65,14 @@ export const AllRoutes: Story = () => (
 );
 
 export const Menu: Story = () => (
-  <div className={styles.navBarMenuContainer}>
+  <div className={cls.navBarMenuContainer}>
     <NavBarMenu />
   </div>
 );
 
 export const MenuButton: Story = () => (
-  <nav aria-label="primary-navigation" className={styles.navBar}>
-    <div className={styles.links}>
+  <nav aria-label="primary-navigation" className={cls.navBar}>
+    <div className={cls.links}>
       <NavBarMenuButton />
     </div>
   </nav>

--- a/frontend/src/components/navbar/NavBar.tsx
+++ b/frontend/src/components/navbar/NavBar.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import { useApiState } from "@kiesraad/api";
 import { t } from "@kiesraad/i18n";
 
-import styles from "./NavBar.module.css";
+import cls from "./NavBar.module.css";
 import { NavBarLinks } from "./NavBarLinks";
 
 type NavBarProps = { location: { pathname: string } };
@@ -12,15 +12,15 @@ export function NavBar({ location }: NavBarProps) {
   const { user } = useApiState();
 
   return (
-    <nav aria-label="primary-navigation" className={styles.navBar}>
-      <div className={styles.links}>
+    <nav aria-label="primary-navigation" className={cls.navBar}>
+      <div className={cls.links}>
         <NavBarLinks location={location} />
       </div>
-      <div className={styles.userInfo}>
+      <div className={cls.userInfo}>
         {user ? (
           <>
             <strong id="navbar-username">{user.fullname || user.username}</strong>
-            <span className={styles.lower} id="navbar-role">
+            <span className={cls.lower} id="navbar-role">
               ({t(user.role)})
             </span>
             <Link to={`/account/logout`}>{t("account.logout")}</Link>

--- a/frontend/src/components/navbar/NavBarMenu.tsx
+++ b/frontend/src/components/navbar/NavBarMenu.tsx
@@ -4,11 +4,11 @@ import { NavLink } from "react-router";
 import { t } from "@kiesraad/i18n";
 import { IconCompass, IconFile, IconHamburger, IconLaptop, IconUsers } from "@kiesraad/icon";
 
-import styles from "./NavBar.module.css";
+import cls from "./NavBar.module.css";
 
 export function NavBarMenu() {
   return (
-    <div className={styles.navBarMenu}>
+    <div className={cls.navBarMenu}>
       <NavLink to={"/elections"}>
         <IconCompass />
         {t("election.title.plural")}
@@ -35,7 +35,7 @@ export function NavBarMenuButton() {
   React.useEffect(() => {
     if (isMenuVisible) {
       const handleClickOutside = (event: MouseEvent) => {
-        if (!document.querySelector(`.${styles.navBarMenu}`)?.contains(event.target as Node)) {
+        if (!document.querySelector(`.${cls.navBarMenu}`)?.contains(event.target as Node)) {
           setMenuVisible(false);
         }
       };
@@ -52,7 +52,7 @@ export function NavBarMenuButton() {
   };
 
   return (
-    <button className={styles.navBarMenuContainer} onClick={toggleMenu} title={t("menu")}>
+    <button className={cls.navBarMenuContainer} onClick={toggleMenu} title={t("menu")}>
       <IconHamburger />
       {isMenuVisible && <NavBarMenu />}
     </button>

--- a/frontend/src/components/ui/AppFrame/AppFrame.module.css
+++ b/frontend/src/components/ui/AppFrame/AppFrame.module.css
@@ -1,4 +1,4 @@
-.app-frame {
+.appFrame {
   position: absolute;
   left: 0;
   top: 0;

--- a/frontend/src/components/ui/AppFrame/AppFrame.tsx
+++ b/frontend/src/components/ui/AppFrame/AppFrame.tsx
@@ -10,7 +10,7 @@ export interface AppFrameProps {
 
 export function AppFrame({ children }: AppFrameProps) {
   return (
-    <div id="app-frame" className={cls["app-frame"]}>
+    <div id="app-frame" className={cls.appFrame}>
       {children}
     </div>
   );

--- a/frontend/src/components/ui/AppLayout/AppLayout.module.css
+++ b/frontend/src/components/ui/AppLayout/AppLayout.module.css
@@ -1,4 +1,4 @@
-.app-layout {
+.appLayout {
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/ui/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/ui/AppLayout/AppLayout.tsx
@@ -7,5 +7,5 @@ export interface AppLayoutProps {
 }
 
 export function AppLayout({ children }: AppLayoutProps) {
-  return <div className={cls["app-layout"]}>{children}</div>;
+  return <div className={cls.appLayout}>{children}</div>;
 }

--- a/frontend/src/components/ui/AppLayout/StickyNav.module.css
+++ b/frontend/src/components/ui/AppLayout/StickyNav.module.css
@@ -1,4 +1,4 @@
-.sticky-nav {
+.stickyNav {
   position: sticky;
   top: 0;
   max-height: calc(100vh - 7rem - 3rem);

--- a/frontend/src/components/ui/AppLayout/StickyNav.tsx
+++ b/frontend/src/components/ui/AppLayout/StickyNav.tsx
@@ -56,7 +56,7 @@ export function StickyNav({ children }: StickyNavProps) {
   }, []);
 
   return (
-    <nav ref={ref} className={cls["sticky-nav"]}>
+    <nav ref={ref} className={cls.stickyNav}>
       {children}
     </nav>
   );

--- a/frontend/src/components/ui/BottomBar/BottomBar.module.css
+++ b/frontend/src/components/ui/BottomBar/BottomBar.module.css
@@ -1,4 +1,4 @@
-.bottom-bar {
+.bottomBar {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -11,7 +11,7 @@
   &.form {
     margin: 2rem 0;
   }
-  &.input-grid {
+  &.inputGrid {
     background: var(--base-white);
     width: 100%;
     margin: 2.5rem 0;

--- a/frontend/src/components/ui/BottomBar/BottomBar.tsx
+++ b/frontend/src/components/ui/BottomBar/BottomBar.tsx
@@ -10,7 +10,7 @@ export interface BottomBarProps {
 }
 
 export function BottomBar({ type, children }: BottomBarProps) {
-  return <div className={cn(cls["bottom-bar"], cls[type])}>{children}</div>;
+  return <div className={cn(cls.bottomBar, cls[type])}>{children}</div>;
 }
 
 BottomBar.Row = function BottomBarRow({ children, hidden }: { children: React.ReactNode; hidden?: boolean }) {

--- a/frontend/src/components/ui/Button/Button.tsx
+++ b/frontend/src/components/ui/Button/Button.tsx
@@ -28,7 +28,7 @@ export function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`${cls["button"] || ""} ${cls[variant] || ""} ${cls[size] || ""}`}
+      className={`${cls.button || ""} ${cls[variant] || ""} ${cls[size] || ""}`}
       disabled={isDisabled || isLoading}
       {...htmlButtonProps}
     >

--- a/frontend/src/components/ui/CheckboxAndRadio/CheckboxAndRadio.module.css
+++ b/frontend/src/components/ui/CheckboxAndRadio/CheckboxAndRadio.module.css
@@ -1,5 +1,5 @@
 /* Fieldset styling */
-.choice-list {
+.choiceList {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -27,7 +27,7 @@
 }
 
 /* Checkbox and radio input styling */
-.checkbox-and-radio {
+.checkboxAndRadio {
   display: inline-flex;
 
   /* General checkbox and radio styling */

--- a/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.tsx
+++ b/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.tsx
@@ -10,7 +10,7 @@ export interface ChoiceListProps {
 }
 
 export function ChoiceList({ children }: ChoiceListProps) {
-  return <fieldset className={cn(cls["choice-list"])}>{children}</fieldset>;
+  return <fieldset className={cn(cls.choiceList)}>{children}</fieldset>;
 }
 
 interface ChoiceListOptionProps extends CheckboxAndRadioProps {

--- a/frontend/src/components/ui/DisplayFraction/DisplayFraction.module.css
+++ b/frontend/src/components/ui/DisplayFraction/DisplayFraction.module.css
@@ -1,11 +1,11 @@
-.display-fraction {
+.displayFraction {
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 0.5rem;
 
   /* Fraction part */
-  .fraction-part {
+  .fractionPart {
     font-size: var(--font-size-xs);
   }
 }

--- a/frontend/src/components/ui/FileInput/FileInput.module.css
+++ b/frontend/src/components/ui/FileInput/FileInput.module.css
@@ -1,12 +1,12 @@
 /* Hides the browser-rendered input, so we can render our own */
-input.file-input {
+input.fileInput {
   opacity: 0;
   width: 0.1px;
   height: 0.1px;
   position: absolute;
 }
 
-label.selected-file {
+label.selectedFile {
   padding-left: 1rem;
   color: var(--gray-600);
 }

--- a/frontend/src/components/ui/Form/FormLayout.module.css
+++ b/frontend/src/components/ui/Form/FormLayout.module.css
@@ -1,12 +1,12 @@
-.form-layout {
+.formLayout {
   margin-bottom: var(--space-md);
 }
 
-.form-layout.medium-width {
+.formLayout.mediumWidth {
   max-width: 32rem;
 }
 
-.form-section {
+.formSection {
   margin-bottom: var(--space-md);
 
   h2 {
@@ -16,12 +16,12 @@
   }
 }
 
-.form-row {
+.formRow {
   display: flex;
   gap: var(--space-md-lg);
 }
 
-.form-field {
+.formField {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
@@ -29,23 +29,23 @@
   margin-bottom: var(--space-lg);
 }
 
-.form-field > label {
+.formField > label {
   font-weight: bold;
 }
 
-.root-fieldset {
+.rootFieldset {
   border: none;
   padding: 0;
 }
 
-.form-alert {
+.formAlert {
   overflow: hidden;
   margin-top: -2.5rem;
   margin-left: -5rem;
   margin-right: -5rem;
 }
 
-.form-controls {
+.formControls {
   display: flex;
   gap: var(--space-md);
 }

--- a/frontend/src/components/ui/FormField/FormField.module.css
+++ b/frontend/src/components/ui/FormField/FormField.module.css
@@ -1,4 +1,4 @@
-.form-field {
+.formField {
   position: relative;
   aside {
     position: absolute;
@@ -12,7 +12,7 @@
     }
   }
 
-  &:global(.has-warning) {
+  &:global(.hasWarning) {
     aside {
       svg {
         fill: var(--color-warning);
@@ -20,7 +20,7 @@
     }
   }
 
-  &:global(.has-error) {
+  &:global(.hasError) {
     input {
       padding-left: 3.5rem !important;
     }

--- a/frontend/src/components/ui/FormField/FormField.tsx
+++ b/frontend/src/components/ui/FormField/FormField.tsx
@@ -24,10 +24,10 @@ export function FormField({ id, children, hasError, hasWarning }: FormFieldProps
   return (
     <div
       id={id}
-      className={cn(cls["form-field"], {
-        "has-icon": !!icon,
-        "has-error": hasError,
-        "has-warning": hasWarning && !hasError,
+      className={cn(cls.formField, {
+        hasIcon: !!icon,
+        hasError: hasError,
+        hasWarning: hasWarning && !hasError,
       })}
     >
       <aside>{icon}</aside>

--- a/frontend/src/components/ui/IconButton/IconButton.module.css
+++ b/frontend/src/components/ui/IconButton/IconButton.module.css
@@ -1,4 +1,4 @@
-.iconbutton {
+.iconButton {
   color: var(--base-white);
   border-radius: 0.25rem;
   background: var(--base-white);

--- a/frontend/src/components/ui/IconButton/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton/IconButton.tsx
@@ -27,7 +27,7 @@ export function IconButton({
 }: IconButtonProps) {
   return (
     <button
-      className={cn(cls["iconbutton"], cls[variant], cls[size], {
+      className={cn(cls.iconButton, cls[variant], cls[size], {
         round: isRound,
       })}
       title={title}

--- a/frontend/src/components/ui/InputField/InputField.module.css
+++ b/frontend/src/components/ui/InputField/InputField.module.css
@@ -96,7 +96,7 @@
 
   /* Firefox */
   input[type="number"] {
-    -moz-appearance: textfield;
+    appearance: textfield;
   }
 
   input,

--- a/frontend/src/components/ui/InputGrid/InputGrid.module.css
+++ b/frontend/src/components/ui/InputGrid/InputGrid.module.css
@@ -1,4 +1,4 @@
-.input-grid {
+.inputGrid {
   margin-top: 1rem;
   width: 100%;
   border-spacing: 0;

--- a/frontend/src/components/ui/InputGrid/InputGrid.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.tsx
@@ -13,7 +13,7 @@ export function InputGrid({ zebra, children }: InputGridProps) {
   const ref = React.useRef<HTMLTableElement>(null);
 
   return (
-    <table role="none" ref={ref} className={cn(cls["input-grid"], { zebra: zebra })}>
+    <table role="none" ref={ref} className={cn(cls.inputGrid, { zebra: zebra })}>
       {children}
     </table>
   );

--- a/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.module.css
+++ b/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.module.css
@@ -1,4 +1,4 @@
-.keyboard-keys {
+.keyboardKeys {
   display: flex;
   gap: 0.25rem;
 
@@ -23,7 +23,7 @@
   }
 }
 
-.keyboard-keys-hint-text {
+.keyboardKeysHintText {
   display: flex;
   align-items: center;
   gap: 1rem;

--- a/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.tsx
+++ b/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.tsx
@@ -44,11 +44,9 @@ function renderKey(keyboardKey: KeyboardKey, index: number): React.JSX.Element {
 }
 
 export function KeyboardKeys({ keys }: KeyboardKeysProps) {
-  return (
-    <div className={cn(cls["keyboard-keys"])}>{keys.map((keyboardKey, index) => renderKey(keyboardKey, index))}</div>
-  );
+  return <div className={cn(cls.keyboardKeys)}>{keys.map((keyboardKey, index) => renderKey(keyboardKey, index))}</div>;
 }
 
 KeyboardKeys.HintText = function KeyboardKeysHintText({ children }: { children: React.ReactNode }) {
-  return <div className={cls["keyboard-keys-hint-text"]}>{children}</div>;
+  return <div className={cls.keyboardKeysHintText}>{children}</div>;
 };

--- a/frontend/src/components/ui/Modal/Modal.module.css
+++ b/frontend/src/components/ui/Modal/Modal.module.css
@@ -4,7 +4,7 @@
   background-color: rgba(0, 0, 0, 0.5);
   border: 0;
 
-  .modal-container {
+  .modalContainer {
     position: fixed;
     top: 50%;
     left: 50%;
@@ -32,7 +32,7 @@
     }
   }
 
-  .modal-body {
+  .modalBody {
     display: flex;
     flex-direction: column;
     background-color: var(--base-white);
@@ -62,7 +62,7 @@
   }
 }
 
-.no-flex {
+.noFlex {
   p {
     display: block;
     margin-bottom: 2rem;

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -58,7 +58,7 @@ export function Modal({ title, noFlex = false, onClose, children }: ModalProps):
 
   return (
     <dialog id="modal-dialog" className={cls.modal} ref={dialogRef}>
-      <div className={cls["modal-container"]}>
+      <div className={cls.modalContainer}>
         {onClose && (
           <IconButton
             onClick={() => {
@@ -73,11 +73,11 @@ export function Modal({ title, noFlex = false, onClose, children }: ModalProps):
             type="button"
           />
         )}
-        <div className={cls["modal-body"]}>
+        <div className={cls.modalBody}>
           <h2 id="modal-title" tabIndex={-1}>
             {title}
           </h2>
-          {noFlex ? <div className={cls["no-flex"]}>{children}</div> : children}
+          {noFlex ? <div className={cls.noFlex}>{children}</div> : children}
         </div>
       </div>
     </dialog>

--- a/frontend/src/components/ui/ProgressBar/ProgressBar.module.css
+++ b/frontend/src/components/ui/ProgressBar/ProgressBar.module.css
@@ -1,4 +1,4 @@
-.progressbar-container {
+.progressbarContainer {
   label {
     display: block;
     font-weight: bold;
@@ -24,7 +24,7 @@
   }
 }
 
-.progressbar-outer {
+.progressbarOuter {
   flex: 1 1 auto;
   height: 0.5rem;
   background-color: var(--color-hover);
@@ -35,7 +35,7 @@
   gap: 1px;
 }
 
-.progressbar-inner {
+.progressbarInner {
   height: 100%;
 }
 

--- a/frontend/src/components/ui/ProgressList/ProgressList.module.css
+++ b/frontend/src/components/ui/ProgressList/ProgressList.module.css
@@ -1,4 +1,4 @@
-.progress-list {
+.progressList {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -198,18 +198,18 @@ section.scroll {
     background: linear-gradient(to top, var(--bg-gray) 0%, rgba(249, 250, 251, 0) 100%);
   }
 
-  &:global(.show-top-gradient) {
+  &:global(.showTopGradient) {
     &::before {
       opacity: 1;
     }
   }
-  &:global(.show-bottom-gradient) {
+  &:global(.showBottomGradient) {
     &::after {
       opacity: 1;
     }
   }
 
-  &:global(.has-scrolling) {
+  &:global(.hasScrolling) {
     border-top: 1px solid var(--border-color-default);
     border-bottom: 1px solid var(--border-color-default);
 

--- a/frontend/src/components/ui/ProgressList/ProgressList.tsx
+++ b/frontend/src/components/ui/ProgressList/ProgressList.tsx
@@ -11,7 +11,7 @@ export interface ProgressListProps {
 }
 
 export function ProgressList({ children }: ProgressListProps) {
-  return <div className={cls["progress-list"]}>{children}</div>;
+  return <div className={cls.progressList}>{children}</div>;
 }
 
 ProgressList.Fixed = ({ children }: { children: React.ReactNode }) => (

--- a/frontend/src/components/ui/Table/Table.module.css
+++ b/frontend/src/components/ui/Table/Table.module.css
@@ -49,28 +49,28 @@
     margin-left: 0.5rem;
   }
 
-  td.number-cell {
+  td.numberCell {
     text-align: right;
     width: 6.5rem;
     line-height: 1.75rem;
   }
 
-  td.integer-cell {
+  td.integerCell {
     padding-right: 0;
     text-align: right;
   }
 
-  td.fraction-cell {
+  td.fractionCell {
     padding-left: 0.5rem;
     text-align: left;
     font-size: var(--font-size-xs);
   }
-  td.fraction-cell:empty {
+  td.fractionCell:empty {
     width: 0;
     padding-left: 0;
   }
 
-  tr.row-link {
+  tr.rowLink {
     cursor: pointer;
 
     &:hover {
@@ -87,7 +87,7 @@
     }
   }
 
-  tr.row-total {
+  tr.rowTotal {
     td {
       font-weight: bold;
       border-bottom: none;
@@ -95,7 +95,7 @@
   }
 }
 
-:where(.number-cell) {
+:where(.numberCell) {
   font-weight: bold;
   font-size: var(--font-size-body);
 }

--- a/frontend/src/components/ui/Toolbar/Toolbar.module.css
+++ b/frontend/src/components/ui/Toolbar/Toolbar.module.css
@@ -5,7 +5,7 @@
   min-height: 4.5rem;
 }
 
-.toolbar-section {
+.toolbarSection {
   display: flex;
   gap: var(--space-md-lg);
 

--- a/frontend/src/features/apportionment/components/Apportionment.module.css
+++ b/frontend/src/features/apportionment/components/Apportionment.module.css
@@ -6,11 +6,11 @@
   gap: 4rem;
 }
 
-.table-title {
+.tableTitle {
   margin-bottom: 2rem;
 }
 
-.table-information {
+.tableInformation {
   display: block;
   width: 39rem;
   margin-bottom: 2rem;
@@ -33,13 +33,13 @@
   }
 }
 
-.list-number-column {
+.listNumberColumn {
   min-width: 3.5rem;
   width: 3.5rem;
   max-width: 3.5rem;
 }
 
-.bt-1-gray {
+.bt1Gray {
   border-top: 1px solid var(--bg-gray-darkest);
 }
 
@@ -54,7 +54,7 @@
   background-color: var(--bg-gray);
 }
 
-.election-summary-table {
+.electionSummaryTable {
   tr {
     th {
       color: var(--base-black);
@@ -68,7 +68,7 @@
   }
 }
 
-.full-seats-table {
+.fullSeatsTable {
   tr {
     th {
       /* Signs (: and =) */
@@ -84,11 +84,11 @@
   }
 }
 
-.residual-seats-calculation-table {
+.residualSeatsCalculationTable {
   max-width: 34rem;
 }
 
-.residual-seats-19-or-more-seats-table {
+.residualSeats19OrMoreSeatsTable {
   max-width: 68rem;
   width: fit-content;
   tr {

--- a/frontend/src/features/data_entry_choice/components/DataEntryChoice.module.css
+++ b/frontend/src/features/data_entry_choice/components/DataEntryChoice.module.css
@@ -61,7 +61,7 @@
   }
 }
 
-.data-entry-list {
+.dataEntryList {
   details[open] {
     summary {
       display: none;

--- a/frontend/src/features/election_management/components/ElectionReportPage.module.css
+++ b/frontend/src/features/election_management/components/ElectionReportPage.module.css
@@ -1,4 +1,4 @@
-.report-info-section {
+.reportInfoSection {
   margin-bottom: 2rem;
   width: 37.5rem;
 

--- a/frontend/src/features/election_status/components/ElectionStatus.module.css
+++ b/frontend/src/features/election_status/components/ElectionStatus.module.css
@@ -6,7 +6,7 @@
   background-color: var(--bg-gray);
 }
 
-.status-title {
+.statusTitle {
   padding: 0;
   display: flex;
   justify-content: space-between;
@@ -31,7 +31,7 @@
   }
 }
 
-.status-section {
+.statusSection {
   display: flex;
   flex-direction: row;
   gap: 2rem;
@@ -42,7 +42,7 @@
   }
 }
 
-.status-article {
+.statusArticle {
   padding: 2rem;
   display: flex;
   flex-direction: column;

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -1,18 +1,18 @@
-.differences-table {
+.differencesTable {
   td {
     height: 4.5rem;
   }
 
-  td.gap-row {
+  td.gapRow {
     height: 2rem;
   }
 
-  td:not(.gap-row) {
+  td:not(.gapRow) {
     border-left: 1px solid var(--bg-gray-darkest);
   }
 }
 
-.zero-dash {
+.zeroDash {
   font-family: var(--font-text);
   color: var(--gray-300);
 }

--- a/frontend/vite-prod.config.ts
+++ b/frontend/vite-prod.config.ts
@@ -43,7 +43,6 @@ export default defineConfig(({ command }) => {
       emptyOutDir: true,
       sourcemap: true,
       minify: false,
-      // cssMinify: 'lightningcss',
       rollupOptions: {
         input: {
           app: "index.html",
@@ -53,7 +52,7 @@ export default defineConfig(({ command }) => {
     css: {
       transformer: "lightningcss",
       lightningcss: {
-        targets: browserslistToTargets(browserslist(">= 0.25%")),
+        targets: browserslistToTargets(browserslist(">= 0.25% and not dead")),
       },
     },
     define: {

--- a/frontend/vite-prod.config.ts
+++ b/frontend/vite-prod.config.ts
@@ -1,3 +1,5 @@
+import browserslist from "browserslist";
+import { browserslistToTargets } from "lightningcss";
 import { execSync } from "node:child_process";
 import path from "path";
 import { defineConfig, UserConfig } from "vite";
@@ -16,6 +18,7 @@ export default defineConfig(({ command }) => {
     __GIT_BRANCH__: undefined as string | undefined,
     __GIT_COMMIT__: undefined as string | undefined,
   };
+
   if (command == "build") {
     let gitDirty: boolean | undefined;
     let gitBranch: string | undefined;
@@ -40,6 +43,7 @@ export default defineConfig(({ command }) => {
       emptyOutDir: true,
       sourcemap: true,
       minify: false,
+      // cssMinify: 'lightningcss',
       rollupOptions: {
         input: {
           app: "index.html",
@@ -47,10 +51,9 @@ export default defineConfig(({ command }) => {
       },
     },
     css: {
-      modules: {
-        // Only dashes in class names will be converted to camelCase,
-        // the original class name will not to be removed from the locals
-        localsConvention: "dashes",
+      transformer: "lightningcss",
+      lightningcss: {
+        targets: browserslistToTargets(browserslist(">= 0.25%")),
       },
     },
     define: {


### PR DESCRIPTION
See discussion in #1324 

The postcss and autoprefixer dependencies add relatively many indirect dependencies and are not the fastest and modern options anymore. They are a bit of a burden.

[Lightning CSS](https://lightningcss.dev/) is a lot faster and only has a single dependency. This PR reduces the production dependencies from 62 to 41.

But there is a disadvantage: there is no localsConvention: "dashes" option, which means that css class names with dashes are not automatically converted to camelCase. This PR also converts all imported class names to camelCase.

