### PR TITLE
Use cases: overzicht input-/output-bestanden abacus

### DIFF
--- a/documentatie/use-cases/gsb-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-eerste-zitting.md
@@ -137,7 +137,7 @@ __Niveau:__ gebruikersdoel, zee, 🌊
 
 __Hoofdscenario:__  
 1. De applicatie stelt vast dat alle stembureaus definitieve invoer hebben en dat invoer is afgesloten.
-2. De coördinator GSB genereert het [PV](./input-output-bestanden.md#output-voor-csb) en het [digitale bestand](./input-output-bestanden.md#output-voor-csb).
+2. De coördinator GSB genereert het [PV](./input-output-bestanden.md#gsb) en het [digitale bestand](./input-output-bestanden.md#gsb).
 3. De coördinator GSB voegt "Bijlage 2: Bezwaren van aanwezigen op stembureaus" toe aan het PV.
 
 __Uitbreidingen:__  

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -1,31 +1,43 @@
 # Input- en output-bestanden Abacus
 
 TODO: check/fix links to this doc
-TODO: .zip met EML_NL en pdf?
-TODO: s/PV/Tellingen want een Bijlage is geen PV
-TODO: EML_NL bestanden van GSB en CSB
-TODO: vermelden niet in scope: csv met tellingen in digitaal bestand (doet uitwisselplatform)
 
 ---
 
 Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig mogelijk met pen op de PV's moet worden geschreven. 
 
-
 ## Open punten
+
+### Vragen
+
 - Klopt het dat de Na 14-1 versie 1 (DSO) gegenereerd moeten worden door Abacus?
-- Modellen nalopen: wat moet door Abacus worden ingevuld (blauwe tekst)? wat niet?
+- Hoe worden modellen die door Abacus worden gegenereerd afgedrukt? Waar staat de printer?
+- Filteren we welke modellen gegenereerd kunnen worden o.b.v. DSO/CSO?
+- Wordt Telling 510a (telling SB) ergens gebruikt of gegenereerd?
+- Is de kandidatenlijst altijd een EML_NL 230b? Of is de kandidatenlijst voor sommige verkiezingen een EML_NL 210?
+- Hoe stellen we de adresgegevens van de (verkozen) kandidaten beschikbaar, makkelijker dan d.m.v. totaallijst (EML_NL 230c)?
+
+### Te doen
+
+- Modellen nalopen: wat moet door Abacus worden ingevuld (blauwe tekst)? Wat niet?
 - EML_NL bestanden nalopen: hebben we alle data voor de EML_NL bestanden?
 - Titels/Namen van modellen bijwerken o.b.v. voorstel voor OSV.
 - Welke bestanden genereert OSV? Klopt dat met wat we van plan zijn met Abacus?
-- Hoe worden modellen die door Abacus worden gegenereerd afgedrukt? Waar staat de printer?
-- Filteren we welke modellen gegenereerd kunnen worden o.b.v. DSO/CSO?
+  - Leeg EML_NL-bestand: Telling 510b
 
+---
 
 ## Verkiezingsgegevens
 
-- verkiezingsdefinitie (EML_NL)
-- kandidatenlijst (EML_NL)
-- stembureaus (EML_NL)
+- verkiezingsdefinitie (EML_NL 110a)
+  - wordt geïmporteerd in Abacus
+- stembureaus (EML_NL 110b)
+  - wordt geïmporteerd in Abacus
+- kandidatenlijst (EML_NL 230b)
+  - wordt geïmporteerd in Abacus
+- totaallijst (EML_NL 230c)
+  - niet gebruikt door Abacus
+  - zie open punt over beschikbaar stellen van adresgegevens voor benoemings- en geloofsbrieven
 
 ## GSB
 
@@ -34,7 +46,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 | Model(onderdeel)  | DSO  | CSO  | Doel                          | 'template' uit Abacus | input voor Abacus | output van Abacus |
 | ----------------- | :--: | :--: | ----------------------------- | :-------------------: | :---------------: | :---------------: |
 | N 10-1            |  X   |      | PV SB                         |                       |         X         |                   |
-| Na 14-1 versie 1  |  X   |      | Corrigendum SB - 1ste zitting |         X (?)         |         X         |                   |
+| Na 14-1 versie 1  |  X   |      | Corrigendum SB - 1ste zitting |         X(?)          |         X         |                   |
 | N 10-2            |      |  X   | PV SB                         |                       |         X         |                   |
 | Na 31-2 Bijlage 1 |      |  X   | PV SB                         |                       |         X         |                   |
 | Na 31-2 Bijlage 2 |      |  X   | Bezwaren SB's                 |                       |                   |                   |
@@ -42,10 +54,14 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 | Na 31-2           |      |  X   | PV GSB - 1ste zitting         |                       |                   |         X         |
 | Na 14-1 versie 2  |  X   |      | Corrigendum SB - 2de zitting  |           X           |         X         |                   |
 | Na 14-2 Bijlage 1 |      |  X   | Corrigendum SB - 2de zitting  |           X           |         X         |                   |
-| Na 14-2           |  X   |  X   | Corrigendum GSB - 2de zitting |                       |                   |         X         |
-| P 2a              |  X   |  X   | Verslag 2de zitting           |                       |                   |         X         |
+| Na 14-2[^1]       |  X   |  X   | Corrigendum GSB - 2de zitting |                       |                   |         X         |
+| P 2a[^2]          |  X   |  X   | Verslag 2de zitting           |                       |                   |         X         |
+
+[^1]: NA 14-2 wordt alleen aangemaakt als hertellingen tot een ander resultaat leiden.
+[^2]: P 2a wordt alleen aangemaakt als er een tweede zitting is.
 
 #### N 10-1 (DSO) en N 10-2 (CSO): PV op SB-niveau
+
 - door gemeente ruim op voorhand aangemaakt met eigen huisstijl, voorblad, etc.
 - worden met de hand ingevuld en dan ingevoerd in Abacus
 
@@ -83,11 +99,6 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - gegenereerd door Abacus, alleen als hertellingen tot een ander resultaat leidden
 - input voor CSB
 
-- structuur
-  - Deel 1 – Gecorrigeerde telresultaten van de gemeente/het openbaar lichaam
-  - Deel 2 – Ondertekening
-  - Bijlage 1 Verslagen van tellingen van stembureaus die zijn herteld door het gemeentelijk stembureau/stembureau voor het openbaar lichaam
-
 
 #### P 2a (DSO en CSO): Verslag tweede zitting
 - gegenereerd door Abacus
@@ -97,26 +108,45 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 
 #### EML_NL
 
-#### CSV
+- Telling 510b
+  - tellingen GSB en SB's
 
-niet in scope
+#### CSV-bestand met tellingen
 
+- niet in scope Abacus
+- tellingen GSB en SB's
+- Uitwisselplatform zal EML_NLs omzetten naar CSVs
+
+---
 
 ## CSB
 
 ### Modellen
 
+| Model(onderdeel) | DSO  | CSO  | Doel                          | input voor Abacus | output van Abacus |
+| ---------------- | :--: | :--: | ----------------------------- | :---------------: | :---------------: |
+| Na 31-1          |  X   |      | PV GSB - 1ste zitting         |         X         |                   |
+| Na 31-2          |      |  X   | PV GSB - 1ste zitting         |         X         |                   |
+| Na 14-2[^3]      |  X   |  X   | Corrigendum GSB - 2de zitting |         X         |                   |
+| P 2a[^4]         |  X   |  X   | Verslag 2de zitting           |        ???        |                   |
+| P 22-2           |  X   |  X   |                               |                   |         X         |
+
+[^3]: NA 14-2 wordt alleen aangemaakt als hertellingen tot een ander resultaat leiden.
+[^4]: P 2a wordt alleen aangemaakt als er een tweede zitting is.
+
 #### P 22-2
 
 - gegenereerd  door Abacus
 
-### Benoemingsbrieven etc.
+### Benoemingsbrieven en geloofsbrieven
 
-- niet uit Abacus
-- hoe adresgegevens uit totaallijst (EML_NL) naar csv o.i.d.?
-  - technische oplossing nog te bepalen
-  - issue 288
+- niet in scope Abacus
 
 ### Tellingsbestanden
 
 #### EML_NL
+
+- Totaaltelling 510d
+  - tellingen GSB
+- Resultaat 520
+  - verkozen kandidaten

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -24,6 +24,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - Titels/Namen van modellen bijwerken o.b.v. voorstel voor OSV.
 - Welke bestanden genereert OSV? Klopt dat met wat we van plan zijn met Abacus?
   - Leeg EML_NL-bestand: Telling 510b
+  - Totaaltelling 510d lijkt output van GSB, niet CSB. (te verifiëren)
 
 ---
 
@@ -110,6 +111,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 
 - Telling 510b
   - tellingen GSB en SB's
+  - output van Abacus - GSB, input voor Abacus - CSB
 
 #### CSV-bestand met tellingen
 
@@ -146,7 +148,12 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 
 #### EML_NL
 
+- Telling 510b
+  - tellingen GSB en SB's
+  - output van Abacus - GSB, input voor Abacus - CSB
 - Totaaltelling 510d
   - tellingen GSB
+  - output van Abacus - CSB
 - Resultaat 520
   - verkozen kandidaten
+  - output van Abacus - CSB

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -1,5 +1,15 @@
 # Input- en output-bestanden applicatie
 
+TODO: afstemmen met Lodewijk Melanie
+
+TODO: modellen nalopen op de afzonderlijke elementen, controleren: uit software is blauw, ergens anders vandaan is groen
+
+​	! zoveel mogelijk door Abacus laten invullen
+
+TODO: namen worden anders, zie mail met Excel in bijlage
+
+
+
 ## Input - verkiezing
 
 - verkiezingsdefinitie (EML_NL)
@@ -8,6 +18,61 @@
 
 
 ## GSB
+
+- 'lege' PVs op SB-niveau
+  - N 10-1 (DSO) en N10-2 (CSO)
+  - weinig of zelfs niet gebruikt
+  - zelf maken met toolkit, aan leverancier/drukkers vragen
+  - gemeentehuisstijl, voorblad, etc dus door Abacus genereren is altijd sub-optimaal
+  - OSV genereert dit waarschijnlijk wel, want tabel namen (TODO: bevestigen)
+  - niet kern van software, dus niet doen zelfs als OSV dit wel doet
+  - worden ingevuld en dan ingevoerd in Abacus
+- 'leeg' SB-corrigendum eerste zitting (Na 14-1 versie 1)
+  - genereren door Abacus, afrdukken, invullen, invoeren in Abacus
+  - hoe afdrukken? printer aan Abacus-server?
+  - TODO: of elders genereren obv toolkit? -> technisch projectleider DSO-gemeente of Lodewijk
+  - moet wel zeker kunnen, OSV doet het ook, alleen zichtbaar voor CSO-gemeentes?
+- 'leeg' SB-corrigendum nieuwe zitting (Na 14-1 versie 2 of Na 14-2 bijlage 1)
+  - genereren door Abacus
+  - versie 2 en bijlage 1 met aantallen oorspr. telling, opdracht
+  - worden ingevuld en dan ingevoerd in Abacus
+- CSO: Bijlage 1 van Na 31-2
+  - niet uit Abacus
+  - groene tekst! ipv blauw
+  - voorbereid door gemeentes
+  - zelfde 'functie' als N 10-1 van DSO
+  - ingevuld en ingevoerd in Abacus
+  - wordt samengevoegd met Na31-2 die gegenereerd wordt door Abacus en met Bijlage 2
+- CSO: Bijlage 2 van Na 31-2
+  - overgenomen van SB PV's door typist (niet invoerder)
+  - maakt bijlage zelf
+- PVs op GSB-niveau eerste zitting
+  - gegenereerd door Abacus obv invoer
+  - Na 31-1 (DSO) en Na 31-2 (CSO)
+  - CSO: Bijlage 1 bij Na 31-2 met resultaten SB komen uit Abacus ???
+  - gaat naar CSB
+- GSB-corrigendum
+  - gegenereerd door Abacus obv invoer van Na14-1 versie 2 (DSO) of Na 14-2 bijlage 1 (CSO)
+  - optioneel, alleen als SBs met ander resultaat
+  - Na 14-2
+  - gaat naar CSB
+- verslag tweede zitting
+  - gegenereerd door Abacus obv invoer
+  - P 2a
+  - gaan naar CSB
+- EML_NL bestanden
+
+
+
+## CSB
+
+- P 22-2
+  - gegenereerd  door Abacus
+- EML_NL bestanden
+
+
+
+---
 
 ### Input voor GSB
 
@@ -35,6 +100,10 @@
 
 
 ## CSB
+
+- van totaallijst (EML_NL) naar csv o.i.d. voor benoemingsbrieven e.d.
+  - technische oplossing nog te bepalen
+  - issue 288
 
 ### Input voor CSB
 

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -1,9 +1,5 @@
 # Input- en output-bestanden Abacus
 
-TODO: check/fix links to this doc
-
----
-
 Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig mogelijk met pen op de PV's moet worden geschreven. 
 
 ## Open punten
@@ -39,6 +35,8 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - totaallijst (EML_NL 230c)
   - niet gebruikt door Abacus
   - zie open punt over beschikbaar stellen van adresgegevens voor benoemings- en geloofsbrieven
+
+---
 
 ## GSB
 
@@ -84,6 +82,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 #### Na 31-1 (DSO) en Na 31-2 (CSO): PV op GSB-niveau voor eerste zitting
 - gegenereerd door Abacus
 
+
 #### Na 14-1 versie 2 (DSO): Corrigendum op SB-niveau
 - gegenereerd door Abacus met resultaten vorige telling ingevuld
 - opdracht invoeren, genereren, handmatig invullen, resultaten (wel of niet hertelling), in Abacus invoeren
@@ -105,6 +104,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - gegenereerd door Abacus
 - input voor CSB (?)
 
+
 ### Tellingsbestanden
 
 #### EML_NL
@@ -112,6 +112,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - Telling 510b
   - tellingen GSB en SB's
   - output van Abacus - GSB, input voor Abacus - CSB
+
 
 #### CSV-bestand met tellingen
 
@@ -140,9 +141,11 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 
 - gegenereerd  door Abacus
 
+
 ### Benoemingsbrieven en geloofsbrieven
 
 - niet in scope Abacus
+
 
 ### Tellingsbestanden
 

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -1,118 +1,122 @@
-# Input- en output-bestanden applicatie
+# Input- en output-bestanden Abacus
 
-TODO: afstemmen met Lodewijk Melanie
+TODO: check/fix links to this doc
+TODO: .zip met EML_NL en pdf?
+TODO: s/PV/Tellingen want een Bijlage is geen PV
+TODO: EML_NL bestanden van GSB en CSB
+TODO: vermelden niet in scope: csv met tellingen in digitaal bestand (doet uitwisselplatform)
 
-TODO: modellen nalopen op de afzonderlijke elementen, controleren: uit software is blauw, ergens anders vandaan is groen
+---
 
-​	! zoveel mogelijk door Abacus laten invullen
-
-TODO: namen worden anders, zie mail met Excel in bijlage
+Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig mogelijk met pen op de PV's moet worden geschreven. 
 
 
+## Open punten
+- Klopt het dat de Na 14-1 versie 1 (DSO) gegenereerd moeten worden door Abacus?
+- Modellen nalopen: wat moet door Abacus worden ingevuld (blauwe tekst)? wat niet?
+- EML_NL bestanden nalopen: hebben we alle data voor de EML_NL bestanden?
+- Titels/Namen van modellen bijwerken o.b.v. voorstel voor OSV.
+- Welke bestanden genereert OSV? Klopt dat met wat we van plan zijn met Abacus?
+- Hoe worden modellen die door Abacus worden gegenereerd afgedrukt? Waar staat de printer?
+- Filteren we welke modellen gegenereerd kunnen worden o.b.v. DSO/CSO?
 
-## Input - verkiezing
+
+## Verkiezingsgegevens
 
 - verkiezingsdefinitie (EML_NL)
 - kandidatenlijst (EML_NL)
 - stembureaus (EML_NL)
 
-
 ## GSB
 
-- 'lege' PVs op SB-niveau
-  - N 10-1 (DSO) en N10-2 (CSO)
-  - weinig of zelfs niet gebruikt
-  - zelf maken met toolkit, aan leverancier/drukkers vragen
-  - gemeentehuisstijl, voorblad, etc dus door Abacus genereren is altijd sub-optimaal
-  - OSV genereert dit waarschijnlijk wel, want tabel namen (TODO: bevestigen)
-  - niet kern van software, dus niet doen zelfs als OSV dit wel doet
-  - worden ingevuld en dan ingevoerd in Abacus
-- 'leeg' SB-corrigendum eerste zitting (Na 14-1 versie 1)
-  - genereren door Abacus, afrdukken, invullen, invoeren in Abacus
-  - hoe afdrukken? printer aan Abacus-server?
-  - TODO: of elders genereren obv toolkit? -> technisch projectleider DSO-gemeente of Lodewijk
-  - moet wel zeker kunnen, OSV doet het ook, alleen zichtbaar voor CSO-gemeentes?
-- 'leeg' SB-corrigendum nieuwe zitting (Na 14-1 versie 2 of Na 14-2 bijlage 1)
-  - genereren door Abacus
-  - versie 2 en bijlage 1 met aantallen oorspr. telling, opdracht
-  - worden ingevuld en dan ingevoerd in Abacus
-- CSO: Bijlage 1 van Na 31-2
-  - niet uit Abacus
-  - groene tekst! ipv blauw
-  - voorbereid door gemeentes
-  - zelfde 'functie' als N 10-1 van DSO
-  - ingevuld en ingevoerd in Abacus
-  - wordt samengevoegd met Na31-2 die gegenereerd wordt door Abacus en met Bijlage 2
-- CSO: Bijlage 2 van Na 31-2
-  - overgenomen van SB PV's door typist (niet invoerder)
-  - maakt bijlage zelf
-- PVs op GSB-niveau eerste zitting
-  - gegenereerd door Abacus obv invoer
-  - Na 31-1 (DSO) en Na 31-2 (CSO)
-  - CSO: Bijlage 1 bij Na 31-2 met resultaten SB komen uit Abacus ???
-  - gaat naar CSB
-- GSB-corrigendum
-  - gegenereerd door Abacus obv invoer van Na14-1 versie 2 (DSO) of Na 14-2 bijlage 1 (CSO)
-  - optioneel, alleen als SBs met ander resultaat
-  - Na 14-2
-  - gaat naar CSB
-- verslag tweede zitting
-  - gegenereerd door Abacus obv invoer
-  - P 2a
-  - gaan naar CSB
-- EML_NL bestanden
+### Modellen
+
+| Model(onderdeel)  | DSO  | CSO  | Doel                          | 'template' uit Abacus | input voor Abacus | output van Abacus |
+| ----------------- | :--: | :--: | ----------------------------- | :-------------------: | :---------------: | :---------------: |
+| N 10-1            |  X   |      | PV SB                         |                       |         X         |                   |
+| Na 14-1 versie 1  |  X   |      | Corrigendum SB - 1ste zitting |         X (?)         |         X         |                   |
+| N 10-2            |      |  X   | PV SB                         |                       |         X         |                   |
+| Na 31-2 Bijlage 1 |      |  X   | PV SB                         |                       |         X         |                   |
+| Na 31-2 Bijlage 2 |      |  X   | Bezwaren SB's                 |                       |                   |                   |
+| Na 31-1           |  X   |      | PV GSB - 1ste zitting         |                       |                   |         X         |
+| Na 31-2           |      |  X   | PV GSB - 1ste zitting         |                       |                   |         X         |
+| Na 14-1 versie 2  |  X   |      | Corrigendum SB - 2de zitting  |           X           |         X         |                   |
+| Na 14-2 Bijlage 1 |      |  X   | Corrigendum SB - 2de zitting  |           X           |         X         |                   |
+| Na 14-2           |  X   |  X   | Corrigendum GSB - 2de zitting |                       |                   |         X         |
+| P 2a              |  X   |  X   | Verslag 2de zitting           |                       |                   |         X         |
+
+#### N 10-1 (DSO) en N 10-2 (CSO): PV op SB-niveau
+- door gemeente ruim op voorhand aangemaakt met eigen huisstijl, voorblad, etc.
+- worden met de hand ingevuld en dan ingevoerd in Abacus
 
 
-
-## CSB
-
-- P 22-2
-  - gegenereerd  door Abacus
-- EML_NL bestanden
+#### Na 14-1 versie 1 (DSO): Corrigendum eerste zitting
+- wordt gegenereerd door Abacus, met de hand ingevuld, dan ingevoerd in Abacus
 
 
+#### Na 31-2 Bijlage 1 (CSO): PV op SB-niveau
+- door gemeente ruim op voorhand aangemaakt met eigen huisstijl, voorblad, etc.
+- worden met de hand ingevuld en dan ingevoerd in Abacus
 
----
 
-### Input voor GSB
+#### Na 31-2 Bijlage 2 (CSO): Bezwaren SB's
+- niet gegenereerd door Abacus; uit toolkit?
+- typist (niet invoerder) neemt deze over van SB PV's, buiten Abacus om
 
-- CSO: ...
-- DSO: ...
 
-### Output voor eigen proces (GSB)
+#### Na 31-1 (DSO) en Na 31-2 (CSO): PV op GSB-niveau voor eerste zitting
+- gegenereerd door Abacus
 
-- DSO: 'leeg' corrigendum PV SB (Na 14-1)
-  - minimale optie: gemeente, stembureau en kandidatenlijsten (keuze welke lijsten)
-  - uitgebreide optie: ook oorspronkelijke telresultaten PV SB
-- ...
+#### Na 14-1 versie 2 (DSO): Corrigendum op SB-niveau
+- gegenereerd door Abacus met resultaten vorige telling ingevuld
+- opdracht invoeren, genereren, handmatig invullen, resultaten (wel of niet hertelling), in Abacus invoeren
+- worden ingevuld en dan ingevoerd in Abacus
 
-### Output voor CSB
 
-- PV
-  - ... (nog aan te vullen)
-  - Bijlage voor ondertekenen PV
-- Digitaal bestand (`.zip`-bestand)
-  - EML_NL (enige verplichte onderdeel), PV als pdf
+#### Na 14-2 Bijlage 1 (CSO): Corrigendum op SB-niveau
+- gegenereerd door Abacus met resultaten vorige telling ingevuld
+- opdracht invoeren, genereren, handmatig invullen, resultaten (wel of niet hertelling), in Abacus invoeren
+- worden ingevuld en dan ingevoerd in Abacus
 
-### Niet in scope
 
-- csv met tellingen in digitaal bestand (doet uitwisselplatform)
+#### Na 14-2 (DSO en CSO): Corrigendum op GSB-niveau voor tweede zitting
+- gegenereerd door Abacus, alleen als hertellingen tot een ander resultaat leidden
+- input voor CSB
+
+- structuur
+  - Deel 1 – Gecorrigeerde telresultaten van de gemeente/het openbaar lichaam
+  - Deel 2 – Ondertekening
+  - Bijlage 1 Verslagen van tellingen van stembureaus die zijn herteld door het gemeentelijk stembureau/stembureau voor het openbaar lichaam
+
+
+#### P 2a (DSO en CSO): Verslag tweede zitting
+- gegenereerd door Abacus
+- input voor CSB (?)
+
+### Tellingsbestanden
+
+#### EML_NL
+
+#### CSV
+
+niet in scope
 
 
 ## CSB
 
-- van totaallijst (EML_NL) naar csv o.i.d. voor benoemingsbrieven e.d.
+### Modellen
+
+#### P 22-2
+
+- gegenereerd  door Abacus
+
+### Benoemingsbrieven etc.
+
+- niet uit Abacus
+- hoe adresgegevens uit totaallijst (EML_NL) naar csv o.i.d.?
   - technische oplossing nog te bepalen
   - issue 288
 
-### Input voor CSB
+### Tellingsbestanden
 
-- ...
-
-### Output voor eigen proces (CSB)
-
-- ...
-
-### Output voor gemeenteraad
-
-- ...
+#### EML_NL


### PR DESCRIPTION
### Scope
- adds contents to the document that provides an overview of all input and output files

### Not in scope
- linking to this document from the use cases themselves. Reasons: (1) The structure of this document needs to be 'final' first. (2) I'm not sure if those linkes are necessary. It might be better to mention the input/output file by name in the use case and link to either the GSB or CSB section of the document.
- anything mentioned in "Open punten"