### PR TITLE
restore code coverage of ErrorModal.tsx

### DIFF
--- a/frontend/src/components/error/ErrorModal.stories.tsx
+++ b/frontend/src/components/error/ErrorModal.stories.tsx
@@ -2,7 +2,7 @@ import { Story } from "@ladle/react";
 
 import { ErrorModal } from "@/components/error/ErrorModal";
 
-import { ApiError, ApiResponseStatus } from "@kiesraad/api";
+import { ApiError, ApiResponseStatus, NetworkError } from "@kiesraad/api";
 
 export const ServerErrorModal: Story = () => {
   return (
@@ -10,4 +10,19 @@ export const ServerErrorModal: Story = () => {
       error={new ApiError(ApiResponseStatus.ServerError, 500, "Internal Server Error", "InternalServerError")}
     />
   );
+};
+
+export const UnknownServerErrorModal: Story = () => {
+  return (
+    <ErrorModal
+      // we need to disable the linter to test the method with an unknown translation key
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      error={new ApiError(ApiResponseStatus.ServerError, 543, "Unknown Server Error", "UnknownServerError")}
+    />
+  );
+};
+
+export const NetworkErrorModal: Story = () => {
+  return <ErrorModal error={new NetworkError("Network errors are the worst")} />;
 };

--- a/frontend/src/components/error/ErrorModal.stories.tsx
+++ b/frontend/src/components/error/ErrorModal.stories.tsx
@@ -7,13 +7,7 @@ import { ApiError, ApiResponseStatus } from "@kiesraad/api";
 export const ServerErrorModal: Story = () => {
   return (
     <ErrorModal
-      error={
-        {
-          status: ApiResponseStatus.ServerError,
-          code: 500,
-          message: "Internal Server Error",
-        } as ApiError
-      }
+      error={new ApiError(ApiResponseStatus.ServerError, 500, "Internal Server Error", "InternalServerError")}
     />
   );
 };

--- a/frontend/src/components/error/ErrorModal.test.tsx
+++ b/frontend/src/components/error/ErrorModal.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import { describe, expect, test } from "vitest";
 
 import { render, screen, within } from "@/testing";
@@ -5,35 +6,47 @@ import { render, screen, within } from "@/testing";
 import { NetworkErrorModal, ServerErrorModal, UnknownServerErrorModal } from "./ErrorModal.stories";
 
 describe("Component: ErrorModal", () => {
-  test("Server error has expected children", () => {
+  test("Server error modal is shown and can be closed", async () => {
     render(<ServerErrorModal />);
 
-    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Sorry, er ging iets mis");
+    expect(screen.getByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).toBeVisible();
 
     const modalBody = screen.getByTestId("error-modal");
     expect(modalBody).toHaveTextContent("Er is een interne fout opgetreden");
     expect(modalBody).not.toHaveTextContent("Foutcode: 500");
     expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
+
+    const user = userEvent.setup();
+    await user.click(within(modalBody).getByRole("button", { name: "Melding sluiten" }));
+    expect(screen.queryByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).not.toBeInTheDocument();
   });
 
-  test("Unknown server error has expected children", () => {
+  test("Unknown server modal is shown and can be closed", async () => {
     render(<UnknownServerErrorModal />);
 
-    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Sorry, er ging iets mis");
+    expect(screen.getByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).toBeVisible();
 
     const modalBody = screen.getByTestId("error-modal");
     expect(modalBody).toHaveTextContent("Foutcode: 543");
     expect(modalBody).toHaveTextContent("Unknown Server Error");
     expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
+
+    const user = userEvent.setup();
+    await user.click(within(modalBody).getByRole("button", { name: "Melding sluiten" }));
+    expect(screen.queryByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).not.toBeInTheDocument();
   });
 
-  test("Network error has expected children", () => {
+  test("Network error modal is shown and can be closed", async () => {
     render(<NetworkErrorModal />);
 
-    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Sorry, er ging iets mis");
+    expect(screen.getByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).toBeVisible();
 
     const modalBody = screen.getByTestId("error-modal");
     expect(modalBody).toHaveTextContent("Network errors are the worst");
     expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
+
+    const user = userEvent.setup();
+    await user.click(within(modalBody).getByRole("button", { name: "Melding sluiten" }));
+    expect(screen.queryByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/error/ErrorModal.test.tsx
+++ b/frontend/src/components/error/ErrorModal.test.tsx
@@ -21,7 +21,7 @@ describe("Component: ErrorModal", () => {
     expect(screen.queryByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).not.toBeInTheDocument();
   });
 
-  test("Unknown server modal is shown and can be closed", async () => {
+  test("Unknown server error modal is shown and can be closed", async () => {
     render(<UnknownServerErrorModal />);
 
     expect(screen.getByRole("heading", { level: 2, name: "Sorry, er ging iets mis" })).toBeVisible();

--- a/frontend/src/components/error/ErrorModal.test.tsx
+++ b/frontend/src/components/error/ErrorModal.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { render, screen, within } from "@/testing";
 
-import { ServerErrorModal } from "./ErrorModal.stories";
+import { NetworkErrorModal, ServerErrorModal, UnknownServerErrorModal } from "./ErrorModal.stories";
 
 describe("Component: ErrorModal", () => {
   test("Server error has expected children", () => {
@@ -13,6 +13,27 @@ describe("Component: ErrorModal", () => {
     const modalBody = screen.getByTestId("error-modal");
     expect(modalBody).toHaveTextContent("Er is een interne fout opgetreden");
     expect(modalBody).not.toHaveTextContent("Foutcode: 500");
+    expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
+  });
+
+  test("Unknown server error has expected children", () => {
+    render(<UnknownServerErrorModal />);
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Sorry, er ging iets mis");
+
+    const modalBody = screen.getByTestId("error-modal");
+    expect(modalBody).toHaveTextContent("Foutcode: 543");
+    expect(modalBody).toHaveTextContent("Unknown Server Error");
+    expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
+  });
+
+  test("Network error has expected children", () => {
+    render(<NetworkErrorModal />);
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Sorry, er ging iets mis");
+
+    const modalBody = screen.getByTestId("error-modal");
+    expect(modalBody).toHaveTextContent("Network errors are the worst");
     expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
   });
 });

--- a/frontend/src/components/error/ErrorModal.test.tsx
+++ b/frontend/src/components/error/ErrorModal.test.tsx
@@ -1,14 +1,18 @@
 import { describe, expect, test } from "vitest";
 
-import { render } from "@kiesraad/test";
+import { render, screen, within } from "@/testing";
 
 import { ServerErrorModal } from "./ErrorModal.stories";
 
 describe("Component: ErrorModal", () => {
   test("Server error has expected children", () => {
-    const { getByText } = render(<ServerErrorModal />);
+    render(<ServerErrorModal />);
 
-    expect(getByText("Sorry, er ging iets mis")).toBeInTheDocument();
-    expect(getByText("Er is een interne fout opgetreden")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Sorry, er ging iets mis");
+
+    const modalBody = screen.getByTestId("error-modal");
+    expect(modalBody).toHaveTextContent("Er is een interne fout opgetreden");
+    expect(modalBody).not.toHaveTextContent("Foutcode: 500");
+    expect(within(modalBody).getByRole("button")).toHaveTextContent("Melding sluiten");
   });
 });

--- a/frontend/src/components/error/ErrorModal.test.tsx
+++ b/frontend/src/components/error/ErrorModal.test.tsx
@@ -9,5 +9,6 @@ describe("Component: ErrorModal", () => {
     const { getByText } = render(<ServerErrorModal />);
 
     expect(getByText("Sorry, er ging iets mis")).toBeInTheDocument();
+    expect(getByText("Er is een interne fout opgetreden")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
partial #1333 Restore front-end test coverage after replacing RTL integration test with e2e test

### Scope
- cover all three variations of the ErrorModal
  - ApiError of which the `reference` has a translation in `error.api_error`
  - ApiError of which the `reference` does not have a translation in `error.api_error`
  - not-an-ApiError error

Coverage is now [41 of 41 lines](https://app.codecov.io/gh/kiesraad/abacus/blob/1333-code-coverage-ErrorModal/frontend%2Fsrc%2Fcomponents%2Ferror%2FErrorModal.tsx). Was: 26 of 41 lines.
