### PR TITLE
1333 code coverage api client

### DIFF
--- a/frontend/src/api/ApiClient.test.ts
+++ b/frontend/src/api/ApiClient.test.ts
@@ -6,132 +6,136 @@ import { ApiClient } from "./ApiClient";
 import { ApiError, ApiResponseStatus, FatalApiError } from "./ApiResult";
 
 describe("ApiClient", () => {
-  test("200 response is parsed as success", async () => {
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, { fizz: "buzz" });
+  describe("Responses with json body", () => {
+    test("Get request returns expected data", async () => {
+      overrideOnce("get", "/api/test/1", 200, { fizz: "buzz" });
 
-    const client = new ApiClient();
-    const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
-      data: null,
+      const client = new ApiClient();
+      const parsedResponse = await client.getRequest("/api/test/1");
+
+      expect(parsedResponse).toStrictEqual({
+        status: ApiResponseStatus.Success,
+        code: 200,
+        data: { fizz: "buzz" },
+      });
     });
 
-    expect(parsedResponse).toStrictEqual({
-      status: ApiResponseStatus.Success,
-      code: 200,
-      data: { fizz: "buzz" },
-    });
-  });
+    test("200 response is parsed as success", async () => {
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, { fizz: "buzz" });
 
-  test("422 response is parsed as client error", async () => {
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 422, {
-      error: "Error message",
-      fatal: true,
-      reference: "InternalServerError",
-    });
+      const client = new ApiClient();
+      const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
+        data: null,
+      });
 
-    const client = new ApiClient();
-    const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", undefined);
-
-    const expectedResponse = new FatalApiError(ApiResponseStatus.ClientError, 422, "Error message");
-    expect(parsedResponse).toStrictEqual(expectedResponse);
-  });
-
-  test("fatal 500 response is parsed as fatal server error", async () => {
-    const responseBody = {
-      error: "foo",
-      fatal: true,
-      reference: "InternalServerError",
-    };
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, responseBody);
-
-    const client = new ApiClient();
-    const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
-      data: null,
+      expect(parsedResponse).toStrictEqual({
+        status: ApiResponseStatus.Success,
+        code: 200,
+        data: { fizz: "buzz" },
+      });
     });
 
-    expect(parsedResponse).toStrictEqual(new FatalApiError(ApiResponseStatus.ServerError, 500, responseBody.error));
-  });
+    test("422 response is parsed as client error", async () => {
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", 422, {
+        error: "Error message",
+        fatal: true,
+        reference: "InternalServerError",
+      });
 
-  test("non-fatal 500 response is parsed as server error", async () => {
-    const responseBody = {
-      error: "foo",
-      fatal: false,
-      reference: "InternalServerError",
-    };
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, responseBody);
+      const client = new ApiClient();
+      const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", undefined);
 
-    const client = new ApiClient();
-    const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
-      data: null,
+      const expectedResponse = new FatalApiError(ApiResponseStatus.ClientError, 422, "Error message");
+      expect(parsedResponse).toStrictEqual(expectedResponse);
     });
 
-    expect(parsedResponse).toStrictEqual(new ApiError(ApiResponseStatus.ServerError, 500, responseBody.error));
-  });
+    test("fatal 500 response is parsed as fatal server error", async () => {
+      const responseBody = {
+        error: "foo",
+        fatal: true,
+        reference: "InternalServerError",
+      };
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, responseBody);
 
-  test("300 response with body is parsed as fatal server error", async () => {
-    const responseBody = {
-      error: "foo",
-      fatal: false,
-      reference: "MultipleChoices",
-    };
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", 300, responseBody);
+      const client = new ApiClient();
+      const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
+        data: null,
+      });
 
-    const client = new ApiClient();
-    const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
-      data: null,
+      expect(parsedResponse).toStrictEqual(new FatalApiError(ApiResponseStatus.ServerError, 500, responseBody.error));
     });
 
-    expect(parsedResponse).toStrictEqual(
-      new FatalApiError(ApiResponseStatus.ServerError, 300, "Unexpected response status: 300", "InvalidData"),
-    );
-  });
+    test("non-fatal 500 response is parsed as server error", async () => {
+      const responseBody = {
+        error: "foo",
+        fatal: false,
+        reference: "InternalServerError",
+      };
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", 500, responseBody);
 
-  test("318 response returns an error", async () => {
-    const responseStatus = 318;
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1", responseStatus, "");
+      const client = new ApiClient();
+      const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
+        data: null,
+      });
 
-    const client = new ApiClient();
+      expect(parsedResponse).toStrictEqual(new ApiError(ApiResponseStatus.ServerError, 500, responseBody.error));
+    });
 
-    const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", { data: null });
+    test("300 response with body is parsed as fatal server error", async () => {
+      const responseBody = {
+        error: "foo",
+        fatal: false,
+        reference: "MultipleChoices",
+      };
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", 300, responseBody);
 
-    const expectedResponse = new FatalApiError(
-      ApiResponseStatus.ServerError,
-      responseStatus,
-      `Unexpected response status: ${responseStatus}`,
-      "InvalidData",
-    );
-    expect(parsedResponse).toStrictEqual(expectedResponse);
-  });
+      const client = new ApiClient();
+      const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", {
+        data: null,
+      });
 
-  test("Get request returns expected data", async () => {
-    overrideOnce("get", "/api/test/1", 200, { fizz: "buzz" });
-
-    const client = new ApiClient();
-    const parsedResponse = await client.getRequest("/api/test/1");
-
-    expect(parsedResponse).toStrictEqual({
-      status: ApiResponseStatus.Success,
-      code: 200,
-      data: { fizz: "buzz" },
+      expect(parsedResponse).toStrictEqual(
+        new FatalApiError(ApiResponseStatus.ServerError, 300, "Unexpected response status: 300", "InvalidData"),
+      );
     });
   });
 
-  test("Invalid server response returns an error", async () => {
-    overrideOnce("get", "/api/test/1", 200, "invalid");
+  describe("Responses with non-json body", () => {
+    test("318 response returns an error", async () => {
+      const responseStatus = 318;
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", responseStatus, "");
 
-    const client = new ApiClient();
+      const client = new ApiClient();
 
-    // error is expected
-    vi.spyOn(console, "error").mockImplementation(() => {});
+      const parsedResponse = await client.postRequest("/api/polling_stations/1/data_entries/1", { data: null });
 
-    const parsedResponse = await client.getRequest("/api/test/1");
+      const expectedResponse = new FatalApiError(
+        ApiResponseStatus.ServerError,
+        responseStatus,
+        `Unexpected response status: ${responseStatus}`,
+        "InvalidData",
+      );
+      expect(parsedResponse).toStrictEqual(expectedResponse);
+    });
 
-    const expectedResponse = new FatalApiError(
-      ApiResponseStatus.ServerError,
-      200,
-      "Unexpected data from server: invalid",
-    );
-    expect(parsedResponse).toStrictEqual(expectedResponse);
+    test("Invalid server response returns an error", async () => {
+      overrideOnce("get", "/api/test/1", 200, "invalid");
 
-    expect(console.error).toHaveBeenCalledWith("Unexpected data from server:", expect.any(String));
+      const client = new ApiClient();
+
+      // error is expected
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const parsedResponse = await client.getRequest("/api/test/1");
+
+      const expectedResponse = new FatalApiError(
+        ApiResponseStatus.ServerError,
+        200,
+        "Unexpected data from server: invalid",
+      );
+      expect(parsedResponse).toStrictEqual(expectedResponse);
+
+      expect(console.error).toHaveBeenCalledWith("Unexpected data from server:", expect.any(String));
+    });
   });
 });

--- a/frontend/src/api/ApiClient.ts
+++ b/frontend/src/api/ApiClient.ts
@@ -123,7 +123,7 @@ export class ApiClient extends EventTarget {
   }
 
   // handle a response without a body, and return an error when there is a non-2xx status or a non-empty body
-  async handleEmptyBody<T>(response: Response): Promise<ApiResult<T>> {
+  async handleEmptyOrNonJsonBody<T>(response: Response): Promise<ApiResult<T>> {
     const body = await response.text();
 
     if (response.status === 404) {
@@ -185,7 +185,7 @@ export class ApiClient extends EventTarget {
       // handle the response, and return an error when state there is a non-2xx status
       const apiResult: ApiResult<T> = isJson
         ? await this.handleJsonBody<T>(response)
-        : await this.handleEmptyBody(response);
+        : await this.handleEmptyOrNonJsonBody(response);
 
       // dispatch error events to subscribers
       if (apiResult instanceof ApiError) {


### PR DESCRIPTION
partial https://github.com/kiesraad/abacus/issues/1333 Restore front-end test coverage after replacing RTL integration test with e2e test

### Scope
Each in a separate commit:
- add tests for non-fatal 500 and 300 with json body responses
- split tests in two groups: json response and non-json response (separate commit)
- change method name `handleEmptyBody()` to `handleEmptyOrNonJsonBody()`

Code coverage of ApiClient can be improved a little further. Decided to not do that in this PR, because there's still plenty of other coverage to restore for #1333.
