### PR TITLE
updates apportionment and seat assignment use case

### DIFF
--- a/documentatie/use-cases/csb-zitting.md
+++ b/documentatie/use-cases/csb-zitting.md
@@ -56,6 +56,8 @@ __Niveau:__ hoog-over, vlieger, 🪁
 
 ### Hoofdscenario en uitbreidingen
 
+Zie ook [Zetelverdeling en aanwijzing kandidaten bij gemeenteraadsverkiezingen](../verkiezingsproces/zetelverdeling-GR.md)
+
 __Hoofdscenario:__
 
 1. Het CSB markeert overleden kandidaten.
@@ -64,16 +66,24 @@ __Hoofdscenario:__
 
 __Uitbreidingen:__
 
-2a. Er zijn minder beschikbare restzetels dan lijsten met gelijke overschotten of gemiddelden:  
-&emsp;2a1. De restzetel wordt bij loting toegekend.
+2b. Er zijn minder beschikbare restzetels dan lijsten met gelijke overschotten of gemiddelden:  
+&emsp;2b1. De restzetel wordt bij loting toegekend.
+
+2a. Er zijn geen geldige stemmen uitgebracht op kandidaten:  
+&emsp; 2a1. De applicatie toont een foutmelding om contact op te nemen met de Kiesraad.
+
+2c. (art P 9) Een lijst heeft een meerderheid van stemmen, maar geen meerderheid van zetels:  
+&emsp; 2c1. De laatst toegewezen restzetel wordt toegekend aan die lijst.  
+&emsp; 2c1a. De laatst toegewezen restzetel was toegekend op basis van een gelijk gemiddelde of overschot:  
+&emsp;&emsp; 2c1a1. Er wordt bij loting bepaald bij welke lijst de restzetel wordt weggehaald.
+
+2d. (art P 10 lijstuitputting) Er zijn meer zetels aan een lijst toegekend dan dat er kandidaten op de lijst staan:  
+&emsp; 2d1. De zetelverdeling wordt opnieuw berekend met inachtneming van de lijstuitputting.  
+&emsp; 2d1a. Er zijn te weinig kandidaten om alle aan lijsten toegewezen zetels te vullen:  
+&emsp;&emsp; 2d1a1. De applicatie toont een foutmelding om contact op te nemen met de Kiesraad.
 
 3a. Er zijn minder beschikbare zetels dan kandidaten met gelijke behaalde (voorkeur)stemmen:  
 &emsp;3a1. De zetel wordt bij loting toegekend.
-
-3b. Er zijn meer zetels aan een lijst toegekend dan dat er kandidaten op de lijst staan (lijstuitputting):  
-&emsp; 3b1. De zetelverdeling wordt opnieuw berekend met inachtneming van de lijstuitputting.  
-&emsp; 3b2. De kandidaten worden o.b.v. de nieuwe zetelverdeling aangewezen.
-
 
 ### Buiten scope
 - Er is een voorgestelde wetswijziging dat lijsten de kiesdeler moeten halen om een restzetel te kunnen krijgen. De minister is voornemens de vragen in het verslag wetsvoorstel te beantwoorden na de gemeenteraadsverkiezingen van 2026. Deze wetswijziging gaat dus niet in vóór GR 2026.


### PR DESCRIPTION
### Scope
Updates apportionment and seat assignment use case. The most important extentions are now mentioned. For more details we refer readers to the separate document with the full description.

Indicating a candidate is deceased, has not been built yet (epic #797), so that step may need to be edited as part of that epic.