### PR TITLE
restore code coverage of dataEntryUtils

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -89,7 +89,7 @@ module.exports = {
       },
     },
     {
-      files: ["*.test.tsx", "src/testing/**/*.ts"],
+      files: ["*.test.ts{,x}", "src/testing/**/*.ts"],
       rules: {
         "@typescript-eslint/no-non-null-assertion": "off",
       },

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, test } from "vitest";
 
-import { errorWarningMocks, getDefaultDataEntryState, getInitialValues } from "../testing/mock-data";
-import { formSectionComplete, getDataEntrySummary, getNextSectionID, resetFormSectionState } from "./dataEntryUtils";
+import { PollingStationResults } from "@/api";
+
+import {
+  errorWarningMocks,
+  getDefaultDataEntryState,
+  getDefaultFormSection,
+  getInitialValues,
+} from "../testing/mock-data";
+import {
+  formSectionComplete,
+  getDataEntrySummary,
+  getNextSectionID,
+  isFormSectionEmpty,
+  resetFormSectionState,
+} from "./dataEntryUtils";
 import { ValidationResultSet } from "./ValidationResults";
 
 describe("formSectionComplete", () => {
@@ -54,6 +67,84 @@ describe("getNextSectionID", () => {
     const nextSection = getNextSectionID(formState);
 
     expect(nextSection).toBe("voters_votes_counts");
+  });
+});
+
+describe("isFormSectionEmpty", () => {
+  test("political group form is empty", () => {
+    const section = getDefaultFormSection("political_group_votes_1", 0);
+    const values: PollingStationResults = getInitialValues();
+
+    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+  });
+
+  test("political group form: total is not empty", () => {
+    const section = getDefaultFormSection("political_group_votes_1", 0);
+    const values: PollingStationResults = getInitialValues();
+    values.political_group_votes[0]!.total = 100;
+
+    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+  });
+
+  test("political group formL: candidate votes is not empty", () => {
+    const section = getDefaultFormSection("political_group_votes_1", 0);
+    const values: PollingStationResults = getInitialValues();
+    values.political_group_votes[0]!.candidate_votes[0]!.votes = 100;
+
+    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+  });
+
+  test("voters and votes form is empty", () => {
+    const section = getDefaultFormSection("political_group_votes_1", 0);
+    const values: PollingStationResults = getInitialValues();
+
+    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+  });
+
+  test("voters and votes form: votes is not empty", () => {
+    const section = getDefaultFormSection("voters_votes_counts", 0);
+    const values: PollingStationResults = getInitialValues();
+    values.votes_counts.invalid_votes_count = 3;
+
+    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+  });
+
+  test("voters and votes form: voters is not empty", () => {
+    const section = getDefaultFormSection("voters_votes_counts", 0);
+    const values: PollingStationResults = getInitialValues();
+    values.voters_counts.total_admitted_voters_count = 6;
+
+    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+  });
+
+  test("differences form is empty", () => {
+    const section = getDefaultFormSection("differences_counts", 0);
+    const values: PollingStationResults = getInitialValues();
+
+    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+  });
+
+  test("differences form is not empty", () => {
+    const section = getDefaultFormSection("differences_counts", 0);
+    const values: PollingStationResults = getInitialValues();
+    values.differences_counts.more_ballots_count = 5;
+
+    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+  });
+
+  test("recounted form is empty", () => {
+    const section = getDefaultFormSection("recounted", 0);
+    const values: PollingStationResults = getInitialValues();
+
+    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+  });
+
+  test("recounted form is not empty", () => {
+    const section = getDefaultFormSection("recounted", 0);
+    const values: PollingStationResults = getInitialValues();
+    values.recounted = false;
+
+    expect(isFormSectionEmpty(section, values)).toBeFalsy();
   });
 });
 

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "vitest";
 
-import { PollingStationResults } from "@/api";
-
 import {
   errorWarningMocks,
   getDefaultDataEntryState,
@@ -73,14 +71,14 @@ describe("getNextSectionID", () => {
 describe("isFormSectionEmpty", () => {
   test("political group form is empty", () => {
     const section = getDefaultFormSection("political_group_votes_1", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
 
     expect(isFormSectionEmpty(section, values)).toBeTruthy();
   });
 
   test("political group form: total is not empty", () => {
     const section = getDefaultFormSection("political_group_votes_1", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
     values.political_group_votes[0]!.total = 100;
 
     expect(isFormSectionEmpty(section, values)).toBeFalsy();
@@ -88,7 +86,7 @@ describe("isFormSectionEmpty", () => {
 
   test("political group formL: candidate votes is not empty", () => {
     const section = getDefaultFormSection("political_group_votes_1", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
     values.political_group_votes[0]!.candidate_votes[0]!.votes = 100;
 
     expect(isFormSectionEmpty(section, values)).toBeFalsy();
@@ -96,14 +94,14 @@ describe("isFormSectionEmpty", () => {
 
   test("voters and votes form is empty", () => {
     const section = getDefaultFormSection("political_group_votes_1", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
 
     expect(isFormSectionEmpty(section, values)).toBeTruthy();
   });
 
   test("voters and votes form: votes is not empty", () => {
     const section = getDefaultFormSection("voters_votes_counts", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
     values.votes_counts.invalid_votes_count = 3;
 
     expect(isFormSectionEmpty(section, values)).toBeFalsy();
@@ -111,7 +109,7 @@ describe("isFormSectionEmpty", () => {
 
   test("voters and votes form: voters is not empty", () => {
     const section = getDefaultFormSection("voters_votes_counts", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
     values.voters_counts.total_admitted_voters_count = 6;
 
     expect(isFormSectionEmpty(section, values)).toBeFalsy();
@@ -119,14 +117,14 @@ describe("isFormSectionEmpty", () => {
 
   test("differences form is empty", () => {
     const section = getDefaultFormSection("differences_counts", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
 
     expect(isFormSectionEmpty(section, values)).toBeTruthy();
   });
 
   test("differences form is not empty", () => {
     const section = getDefaultFormSection("differences_counts", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
     values.differences_counts.more_ballots_count = 5;
 
     expect(isFormSectionEmpty(section, values)).toBeFalsy();
@@ -134,14 +132,14 @@ describe("isFormSectionEmpty", () => {
 
   test("recounted form is empty", () => {
     const section = getDefaultFormSection("recounted", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
 
     expect(isFormSectionEmpty(section, values)).toBeTruthy();
   });
 
   test("recounted form is not empty", () => {
     const section = getDefaultFormSection("recounted", 0);
-    const values: PollingStationResults = getInitialValues();
+    const values = getInitialValues();
     values.recounted = false;
 
     expect(isFormSectionEmpty(section, values)).toBeFalsy();


### PR DESCRIPTION
partial https://github.com/kiesraad/abacus/issues/1333 Restore front-end test coverage after replacing RTL integration test with e2e test

### Scope
test all branches of `isFormSectionEmpty()` in `dataEntryUtils.ts`

Coverage is now [243 of 250](https://app.codecov.io/gh/kiesraad/abacus/blob/1333-code-coverage-dataEntryUtils/frontend%2Fsrc%2Ffeatures%2Fdata_entry%2Futils%2FdataEntryUtils.ts). Was 221 of 250.