### PR TITLE
Added inline Alert component

### DIFF
--- a/frontend/src/components/ui/Alert/Alert.module.css
+++ b/frontend/src/components/ui/Alert/Alert.module.css
@@ -27,6 +27,7 @@
   header {
     display: flex;
     gap: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
   > button {

--- a/frontend/src/components/ui/Alert/Alert.module.css
+++ b/frontend/src/components/ui/Alert/Alert.module.css
@@ -6,14 +6,40 @@
   display: flex;
   gap: 1rem;
 
-  a:visited {
-    color: var(--link-default);
-  }
-
   > button {
     position: absolute;
     right: 2rem;
     top: 2rem;
+  }
+}
+
+.inlineAlert {
+  border: 1px solid;
+  border-radius: var(--rounded-default);
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  position: relative;
+
+  svg {
+    width: 1.5rem;
+  }
+
+  header {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  > button {
+    position: absolute;
+    right: 1.5rem;
+    top: 1.5rem;
+  }
+}
+
+.alert,
+.inlineAlert {
+  a:visited {
+    color: var(--link-default);
   }
 
   aside {
@@ -30,10 +56,6 @@
     max-width: 48rem;
     word-break: break-word;
 
-    h2 {
-      margin-bottom: 0;
-    }
-
     p {
       line-height: 1.5rem;
       margin: 0;
@@ -41,6 +63,13 @@
 
     button {
       width: fit-content;
+    }
+  }
+
+  section,
+  header {
+    h2 {
+      margin-bottom: 0;
     }
   }
 

--- a/frontend/src/components/ui/Alert/Alert.stories.tsx
+++ b/frontend/src/components/ui/Alert/Alert.stories.tsx
@@ -31,6 +31,30 @@ export const SmallAlert: Story<Props> = ({ type, text }) => (
   </Alert>
 );
 
+export const NoIconAlert: Story<Props> = ({ type, text }) => (
+  <Alert type={type} variant="no-icon">
+    <p>{text}</p>
+  </Alert>
+);
+
+export const InlineAlert: Story<Props> = ({ type, title, text }) => (
+  <Alert type={type} inline title={title}>
+    <p>{text}</p>
+  </Alert>
+);
+
+export const InlineClosableAlert: Story<Props> = ({ type, title, text, onClose }) => (
+  <Alert type={type} inline title={title} onClose={onClose}>
+    <p>{text}</p>
+  </Alert>
+);
+
+export const InlineNoIconAlert: Story<Props> = ({ type, title, text }) => (
+  <Alert type={type} inline variant="no-icon" title={title}>
+    <p>{text}</p>
+  </Alert>
+);
+
 export default {
   args: {
     title: "Nog niet ingesteld",

--- a/frontend/src/components/ui/Alert/Alert.stories.tsx
+++ b/frontend/src/components/ui/Alert/Alert.stories.tsx
@@ -43,6 +43,12 @@ export const InlineAlert: Story<Props> = ({ type, title, text }) => (
   </Alert>
 );
 
+export const InlineSmall: Story<Props> = ({ type, title, text }) => (
+  <Alert type={type} inline variant="small" title={title}>
+    <p>{text}</p>
+  </Alert>
+);
+
 export const InlineClosableAlert: Story<Props> = ({ type, title, text, onClose }) => (
   <Alert type={type} inline title={title} onClose={onClose}>
     <p>{text}</p>

--- a/frontend/src/components/ui/Alert/Alert.tsx
+++ b/frontend/src/components/ui/Alert/Alert.tsx
@@ -8,22 +8,34 @@ import { cn } from "@kiesraad/util";
 import cls from "./Alert.module.css";
 
 export interface AlertProps {
+  title?: string;
   type: AlertType;
   variant?: "default" | "small" | "no-icon";
+  inline?: boolean;
   margin?: "mb-md" | "mb-md-lg" | "mb-lg";
   children: React.ReactNode;
   onClose?: () => void;
 }
 
-export function Alert({ type, onClose, children, margin, variant = "default" }: AlertProps) {
+export function Alert({ type, onClose, children, margin, title, inline, variant = "default" }: AlertProps) {
   const id = React.useId();
-
   return (
-    <div className={cn(cls.alert, cls[type], margin, variant)} role="alert" aria-describedby={id}>
+    <div
+      className={cn(inline ? cls.inlineAlert : cls.alert, cls[type], margin, variant)}
+      role="alert"
+      aria-describedby={id}
+    >
       {onClose && (
         <IconButton icon={<IconCross />} title={t("close_message")} variant="tertiary" size="lg" onClick={onClose} />
       )}
-      {variant !== "no-icon" && <aside>{renderIconForType(type)}</aside>}
+      {inline ? (
+        <header>
+          {variant !== "no-icon" && <aside>{renderIconForType(type)}</aside>}
+          {title && <h2>{title}</h2>}
+        </header>
+      ) : (
+        variant !== "no-icon" && <aside>{renderIconForType(type)}</aside>
+      )}
       <section id={id}>{children}</section>
     </div>
   );

--- a/frontend/src/components/ui/Alert/Alert.tsx
+++ b/frontend/src/components/ui/Alert/Alert.tsx
@@ -28,6 +28,7 @@ export function Alert({ type, onClose, children, margin, title, inline, variant 
       {onClose && (
         <IconButton icon={<IconCross />} title={t("close_message")} variant="tertiary" size="lg" onClick={onClose} />
       )}
+
       {inline ? (
         <header>
           {variant !== "no-icon" && <aside>{renderIconForType(type)}</aside>}


### PR DESCRIPTION
Added attribute to Alert component to render an inline variant of it.
Opted for an attribute instead of a variant, so it we get inline versions of all variants "for free".

PR is best reviewed by viewing the component in Ladle

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->