### PR TITLE
Allow string interpolation variables for "not found" errors

### DIFF
--- a/frontend/src/api/ApiResult.ts
+++ b/frontend/src/api/ApiResult.ts
@@ -46,6 +46,7 @@ export class NetworkError extends FatalError {
 export class NotFoundError extends FatalError {
   path: string;
   message: TranslationPath;
+  vars?: Record<string, string | number>;
 
   constructor(message?: TranslationPath) {
     super(message || "error.not_found");
@@ -53,8 +54,9 @@ export class NotFoundError extends FatalError {
     this.path = window.location.pathname;
   }
 
-  withMessage(message: TranslationPath): this {
+  withMessage(message: TranslationPath, vars?: Record<string, string | number>): this {
     this.message = message;
+    this.vars = vars;
 
     return this;
   }

--- a/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/src/app/ErrorBoundary.tsx
@@ -18,7 +18,7 @@ export function ErrorBoundary() {
   console.error(error);
 
   if (error instanceof NotFoundError) {
-    return <NotFoundPage message={error.message} path={error.path} />;
+    return <NotFoundPage message={error.message} vars={error.vars} path={error.path} />;
   }
 
   if (error instanceof NetworkError) {

--- a/frontend/src/app/NotFoundPage.tsx
+++ b/frontend/src/app/NotFoundPage.tsx
@@ -7,14 +7,15 @@ import { t, TranslationPath, tx } from "@/lib/i18n";
 export interface NotFoundPageProps {
   message: TranslationPath;
   path: string;
+  vars?: Record<string, string | number>;
 }
 
-export function NotFoundPage({ message, path }: NotFoundPageProps) {
+export function NotFoundPage({ message, vars, path }: NotFoundPageProps) {
   return (
     <AppLayout>
       {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
       <NavBar location={{ pathname: "/" }} />
-      <Error title={t(message)}>
+      <Error title={t(message, vars)}>
         {path && <p>{tx("error.page_not_found", undefined, { path })}</p>}
         <p>{t("error.not_found_feedback")}</p>
       </Error>


### PR DESCRIPTION
Enable thronging a `NotFoundError` with translation variables. This enables rendering more specific error messages.