### PR TITLE
Improve utoipa audit log documentation

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -844,8 +844,83 @@
     },
     "/api/log": {
       "get": {
-        "summary": "Lists all users",
+        "summary": "List audit events",
         "operationId": "audit_log_list",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number, default 1",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "description": "Number of items per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "description": "Filter by log level",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "event",
+            "in": "query",
+            "description": "Filter by event type",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "user",
+            "in": "query",
+            "description": "Filter by user ID",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Only show events since the specified timestamp",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Audit log event list",
@@ -882,7 +957,7 @@
     },
     "/api/log-users": {
       "get": {
-        "summary": "Lists all users",
+        "summary": "Lists all users that appear in the audit log",
         "operationId": "audit_log_list_users",
         "responses": {
           "200": {

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -1,7 +1,7 @@
 use axum::{Json, extract::State};
 use axum_extra::extract::Query;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
@@ -36,27 +36,34 @@ fn default_per_page() -> u32 {
     200
 }
 
-#[derive(Debug, Deserialize, ToSchema)]
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
 #[serde(rename_all = "camelCase")]
 pub struct LogFilterQuery {
+    /// Page number, default 1
     #[serde(default = "default_page")]
     pub page: u32,
+    /// Number of items per page
     #[serde(default = "default_per_page")]
     pub per_page: u32,
+    /// Filter by log level
     #[serde(default)]
     pub level: Vec<String>,
+    /// Filter by event type
     #[serde(default)]
     pub event: Vec<String>,
+    /// Filter by user ID
     #[serde(default)]
     pub user: Vec<u32>,
+    /// Only show events since the specified timestamp
     #[serde(default)]
     pub since: Option<i64>,
 }
 
-/// Lists all users
+/// List audit events
 #[utoipa::path(
     get,
     path = "/api/log",
+    params(LogFilterQuery),
     responses(
         (status = 200, description = "Audit log event list", body = AuditLogListResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
@@ -94,7 +101,7 @@ pub struct AuditLogUser {
     pub role: Role,
 }
 
-/// Lists all users
+/// Lists all users that appear in the audit log
 #[utoipa::path(
     get,
     path = "/api/log-users",

--- a/frontend/src/api/gen/openapi.ts
+++ b/frontend/src/api/gen/openapi.ts
@@ -75,7 +75,14 @@ export interface ELECTION_STATUS_REQUEST_PARAMS {
 export type ELECTION_STATUS_REQUEST_PATH = `/api/elections/${number}/status`;
 
 // /api/log
-export type AUDIT_LOG_LIST_REQUEST_PARAMS = Record<string, never>;
+export interface AUDIT_LOG_LIST_REQUEST_PARAMS {
+  page: number;
+  perPage: number;
+  level: string[];
+  event: string[];
+  user: number[];
+  since: number | null;
+}
 export type AUDIT_LOG_LIST_REQUEST_PATH = `/api/log`;
 
 // /api/log-users


### PR DESCRIPTION
Add parameters for `/api/log` endpoint in the Open API documentation.