### PR TITLE
restore code coverage of CandidatesVotesPage

### DIFF
--- a/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesPage.test.tsx
+++ b/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesPage.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ElectionProvider } from "@/api/election/ElectionProvider";
+import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { ElectionRequestHandler, PollingStationDataEntryClaimHandler } from "@/testing/api-mocks/RequestHandlers";
+import { server } from "@/testing/server";
+import { render, screen, waitFor } from "@/testing/test-utils";
+
+import { DataEntryProvider } from "../DataEntryProvider";
+import { CandidatesVotesPage } from "./CandidatesVotesPage";
+
+function renderPage() {
+  return render(
+    <DataEntryProvider election={electionMockData} pollingStationId={1} entryNumber={1}>
+      <ElectionProvider electionId={1}>
+        <CandidatesVotesPage></CandidatesVotesPage>
+      </ElectionProvider>
+      )
+    </DataEntryProvider>,
+  );
+}
+
+const { mockedUseNumericParam } = vi.hoisted(() => {
+  return { mockedUseNumericParam: vi.fn() };
+});
+
+vi.mock(import("@/hooks/useNumericParam"), () => ({
+  useNumericParam: mockedUseNumericParam,
+}));
+
+describe("Test CandidatesVotesPage", () => {
+  beforeEach(() => {
+    server.use(ElectionRequestHandler, PollingStationDataEntryClaimHandler);
+  });
+
+  test("list not found shows error", async () => {
+    mockedUseNumericParam.mockReturnValue(123);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Geen lijst gevonden voor 123")).toBeVisible();
+    });
+  });
+
+  test("list found shows form", async () => {
+    mockedUseNumericParam.mockReturnValue(1);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("group", { name: "Lijst 1 - Vurige Vleugels Partij" })).toBeVisible();
+    });
+  });
+});

--- a/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesPage.tsx
+++ b/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesPage.tsx
@@ -1,21 +1,14 @@
-import { useParams } from "react-router";
-
 import { useElection } from "@/api/election/useElection";
+import { useNumericParam } from "@/hooks/useNumericParam";
 import { t } from "@/lib/i18n";
-import { parseIntStrict } from "@/lib/util/strings";
 
 import { CandidatesVotesForm } from "./CandidatesVotesForm";
 
 export function CandidatesVotesPage() {
-  const { listNumber } = useParams();
+  const listNumber = useNumericParam("listNumber");
   const { election } = useElection();
 
-  if (!listNumber) {
-    throw new Error("Missing 'listNumber' parameter");
-  }
-
-  const parsedListNumber = parseIntStrict(listNumber);
-  const group = election.political_groups.find((group) => group.number === parsedListNumber);
+  const group = election.political_groups.find((group) => group.number === listNumber);
 
   if (!group) {
     return <div>{t("data_entry.list.not_found", { listNumber })}</div>;


### PR DESCRIPTION
### Scope
- makes CandidatesVotesPage use `useNumericParam()` instead of `useParams()`
- adds two tests for CanidatesVotesPage, one for each return statement

Coverage is now [13 of 13 lines](https://app.codecov.io/gh/kiesraad/abacus/blob/1333-code-coverage-CandidatesVotesPage/frontend%2Fsrc%2Ffeatures%2Fdata_entry%2Fcomponents%2Fcandidates_votes%2FCandidatesVotesPage.tsx). Was 6 of 18.

### For a nex PR
The mock of `useNumericParam` can be made simpler by using a `__mocks__` directory. I'll submit a separate PR for this, so that any discussion does not block this PR.
