### PR TITLE
replace useParams with useNumericParam in DataEntryProgress

### DIFF
--- a/frontend/src/features/data_entry/components/DataEntryProgress.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import { Link, useParams } from "react-router";
+import { Link } from "react-router";
 
 import { useElection } from "@/api/election/useElection";
 import { ProgressList } from "@/components/ui/ProgressList/ProgressList";
+import { useNumericParam } from "@/hooks/useNumericParam";
 import { t } from "@/lib/i18n";
 import { FormSectionId } from "@/types/types";
 import { MenuStatus } from "@/types/ui";
@@ -12,7 +13,7 @@ import { FormSection } from "../types/types";
 import { isFormSectionEmpty } from "../utils/dataEntryUtils";
 
 export function DataEntryProgress() {
-  const { pollingStationId } = useParams();
+  const pollingStationId = useNumericParam("pollingStationId");
   const { election } = useElection();
 
   const { formState, pollingStationResults, entryNumber } = useDataEntryContext();


### PR DESCRIPTION
### Scope
While working on PR https://github.com/kiesraad/abacus/pull/1365, I noticed there was one last usage of `useParams()` that could be replaced with `useNumericParam()`, i.e. in `DataEntryProgress.tsx`. So I did that in this PR.
