### PR TITLE
vitest `__mocks__` directory for easier mocking of useParams

### DIFF
--- a/frontend/__mocks__/react-router.ts
+++ b/frontend/__mocks__/react-router.ts
@@ -1,0 +1,6 @@
+import { vi } from "vitest";
+
+/* eslint-disable import/export */
+export * from "react-router";
+
+export const useParams = vi.fn();

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -1,3 +1,5 @@
+import { useParams } from "react-router";
+
 import { render as rtlRender } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
@@ -14,13 +16,7 @@ import { candidate_nomination, election, election_summary, seat_assignment } fro
 import { ApportionmentProvider } from "../ApportionmentProvider";
 import { ApportionmentListDetailsPage } from "./ApportionmentListDetailsPage";
 
-const { mockedUseNumericParam } = vi.hoisted(() => {
-  return { mockedUseNumericParam: vi.fn() };
-});
-
-vi.mock(import("@/hooks/useNumericParam"), () => ({
-  useNumericParam: mockedUseNumericParam,
-}));
+vi.mock("react-router");
 
 const renderApportionmentPage = () =>
   render(
@@ -33,7 +29,7 @@ const renderApportionmentPage = () =>
 
 describe("ApportionmentListDetailsPage", () => {
   test("All tables visible", async () => {
-    mockedUseNumericParam.mockReturnValue(1);
+    vi.mocked(useParams).mockReturnValue({ pgNumber: "1" });
     overrideOnce("get", "/api/elections/1", 200, getElectionMockData(election));
     overrideOnce("post", "/api/elections/1/apportionment", 200, {
       seat_assignment: seat_assignment,
@@ -125,7 +121,7 @@ describe("ApportionmentListDetailsPage", () => {
   });
 
   test("No tables visible because 0 seats assigned", async () => {
-    mockedUseNumericParam.mockReturnValue(5);
+    vi.mocked(useParams).mockReturnValue({ pgNumber: "5" });
     overrideOnce("get", "/api/elections/1", 200, getElectionMockData(election));
     overrideOnce("post", "/api/elections/1/apportionment", 200, {
       seat_assignment: seat_assignment,
@@ -174,7 +170,7 @@ describe("ApportionmentListDetailsPage", () => {
 
   describe("Apportionment not yet available", () => {
     test("Not available until data entry is finalised", async () => {
-      mockedUseNumericParam.mockReturnValue(1);
+      vi.mocked(useParams).mockReturnValue({ pgNumber: "1" });
       overrideOnce("get", "/api/elections/1", 200, getElectionMockData(election));
       overrideOnce("post", "/api/elections/1/apportionment", 412, {
         error: "Election data entry first needs to be finalised",
@@ -199,7 +195,7 @@ describe("ApportionmentListDetailsPage", () => {
     });
 
     test("Not possible because drawing of lots is not implemented yet", async () => {
-      mockedUseNumericParam.mockReturnValue(1);
+      vi.mocked(useParams).mockReturnValue({ pgNumber: "1" });
       overrideOnce("get", "/api/elections/1", 200, getElectionMockData(election));
       overrideOnce("post", "/api/elections/1/apportionment", 422, {
         error: "Drawing of lots is required",
@@ -224,7 +220,7 @@ describe("ApportionmentListDetailsPage", () => {
     });
 
     test("Not possible because all lists are exhausted", async () => {
-      mockedUseNumericParam.mockReturnValue(1);
+      vi.mocked(useParams).mockReturnValue({ pgNumber: "1" });
       overrideOnce("get", "/api/elections/1", 200, getElectionMockData(election));
       overrideOnce("post", "/api/elections/1/apportionment", 422, {
         error: "All lists are exhausted, not enough candidates to fill all seats",
@@ -251,7 +247,7 @@ describe("ApportionmentListDetailsPage", () => {
     });
 
     test("Internal Server Error renders error page", async () => {
-      mockedUseNumericParam.mockReturnValue(1);
+      vi.mocked(useParams).mockReturnValue({ pgNumber: "1" });
       // Since we test what happens after an error, we want vitest to ignore them
       vi.spyOn(console, "error").mockImplementation(() => {
         /* do nothing */

--- a/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesPage.test.tsx
+++ b/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesPage.test.tsx
@@ -1,3 +1,5 @@
+import { useParams } from "react-router";
+
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ElectionProvider } from "@/api/election/ElectionProvider";
@@ -8,6 +10,8 @@ import { render, screen, waitFor } from "@/testing/test-utils";
 
 import { DataEntryProvider } from "../DataEntryProvider";
 import { CandidatesVotesPage } from "./CandidatesVotesPage";
+
+vi.mock("react-router");
 
 function renderPage() {
   return render(
@@ -20,21 +24,13 @@ function renderPage() {
   );
 }
 
-const { mockedUseNumericParam } = vi.hoisted(() => {
-  return { mockedUseNumericParam: vi.fn() };
-});
-
-vi.mock(import("@/hooks/useNumericParam"), () => ({
-  useNumericParam: mockedUseNumericParam,
-}));
-
 describe("Test CandidatesVotesPage", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, PollingStationDataEntryClaimHandler);
   });
 
   test("list not found shows error", async () => {
-    mockedUseNumericParam.mockReturnValue(123);
+    vi.mocked(useParams).mockReturnValue({ listNumber: "123" });
     renderPage();
 
     await waitFor(() => {
@@ -43,7 +39,7 @@ describe("Test CandidatesVotesPage", () => {
   });
 
   test("list found shows form", async () => {
-    mockedUseNumericParam.mockReturnValue(1);
+    vi.mocked(useParams).mockReturnValue({ listNumber: "1" });
     renderPage();
 
     await waitFor(() => {

--- a/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
@@ -1,3 +1,5 @@
+import { useParams } from "react-router";
+
 import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -14,9 +16,7 @@ import { render, renderReturningRouter, screen, spyOnHandler, waitFor, within } 
 
 import { PollingStationUpdatePage } from "./PollingStationUpdatePage";
 
-vi.mock(import("@/hooks/useNumericParam"), () => ({
-  useNumericParam: () => 1,
-}));
+vi.mock("react-router");
 
 describe("PollingStationUpdatePage", () => {
   const testPollingStation: PollingStation = {
@@ -33,6 +33,7 @@ describe("PollingStationUpdatePage", () => {
 
   beforeEach(() => {
     server.use(ElectionRequestHandler, PollingStationGetHandler, PollingStationUpdateHandler);
+    vi.mocked(useParams).mockReturnValue({ pollingStationId: "1" });
   });
 
   test("Shows form", async () => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -37,6 +37,7 @@
     "vite.config.ts",
     "vite-prod.config.ts",
     "vitest.config.ts",
+    "__mocks__/**/*",
     "e2e-tests/**/*"
   ]
 }


### PR DESCRIPTION
closes #1369 

### Scope
- add `frontend/__mocks__/react-router.ts` so we can mock `useParams()` with less code in the tests
- apply this way of setting up the mock in almost all other test files that mock `useParams()`

Note that until recently we could not mock `useParams()`. Instead we mock `useNumericParam()`. Since the frontend refactoring now allows us to mock `useParams()`, scope of this PR includes changing these mocks accordingly.

### Not in scope
- `UserUpdatePage.test.tsx`: it also mocks `useNavigate()` and I wasn't able to figure out in a reasonable amount of time how to add a mock for that to `frontend/__mocks__/react-router.ts`
- Using "import/no-restricted-paths" from eslint-plugin-import or [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest) to lint on imports from `frontend/__mocks__/`.

### Help needed
If someone can figure out how to refactor `UserUpdatePage.test.tsx`, that would be great. If no one has time, let's merge the PR as is.
