### PR TITLE
fix two instances of identical test names

### DIFF
--- a/frontend/src/features/apportionment/components/list_details/CandidatesWithVotesTable.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/CandidatesWithVotesTable.test.tsx
@@ -10,7 +10,7 @@ import {
 import { CandidatesWithVotesTable } from "./CandidatesWithVotesTable";
 
 describe("CandidatesWithVotesTable", () => {
-  test("renders a table with the candidates, localities and number of votes", async () => {
+  test("renders a table with the candidates and localities", async () => {
     render(
       <CandidatesWithVotesTable
         id="test-table"
@@ -37,7 +37,7 @@ describe("CandidatesWithVotesTable", () => {
     ]);
   });
 
-  test("renders a table with the candidates, localities and number of votes", async () => {
+  test("renders a table with the candidates and number of votes", async () => {
     render(
       <CandidatesWithVotesTable
         id="test-table"

--- a/frontend/src/features/users/components/UserListPage.test.tsx
+++ b/frontend/src/features/users/components/UserListPage.test.tsx
@@ -27,7 +27,7 @@ describe("PollingStationListPage", () => {
     ]);
   });
 
-  test("Show users", async () => {
+  test("Show users - table sorts data by default", async () => {
     const users = [userMockData[2], userMockData[1], userMockData[4], userMockData[0], userMockData[3]];
     overrideOnce("get", "/api/user", 200, { users });
     render(<UserListPage />);


### PR DESCRIPTION
Discovered by running eslint-plugin-vitest.

It found two others kinds of issues:
- Test has no assertions: this are mostly (all?) false positives, because the only assert of the test is defined in a separate function
- Expect must have a corresponding matcher call: quite a few cases where we omit the [`toBeVisible()`](https://github.com/testing-library/jest-dom?tab=readme-ov-file#tobevisible).

Addressing those can be done later and/or as part of adopting eslint-plugin-vitest.