### PR TITLE
adds matchers to RTL expects that didn't have one

### DIFF
--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -43,9 +43,9 @@ describe("ApportionmentPage", () => {
 
     const router = renderApportionmentPage(true) as Router;
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" })).toBeVisible();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Kengetallen" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Kengetallen" })).toBeVisible();
     const election_summary_table = await screen.findByTestId("election-summary-table");
     expect(election_summary_table).toBeVisible();
     expect(election_summary_table).toHaveTableContent([
@@ -59,7 +59,7 @@ describe("ApportionmentPage", () => {
       ["Voorkeursdrempel", "40", "50% van de kiesdeler"],
     ]);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Zetelverdeling" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Zetelverdeling" })).toBeVisible();
     const apportionment_table = await screen.findByTestId("apportionment-table");
     expect(apportionment_table).toBeVisible();
     expect(apportionment_table).toHaveTableContent([
@@ -88,7 +88,7 @@ describe("ApportionmentPage", () => {
       "/details-residual-seats",
     );
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Gekozen kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Gekozen kandidaten" })).toBeVisible();
     const chosen_candidates_table = await screen.findByTestId("chosen-candidates-table");
     expect(chosen_candidates_table).toBeVisible();
     expect(chosen_candidates_table).toHaveTableContent([
@@ -130,7 +130,7 @@ describe("ApportionmentPage", () => {
       renderApportionmentPage(false);
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
@@ -153,7 +153,7 @@ describe("ApportionmentPage", () => {
       renderApportionmentPage(false);
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(
@@ -176,7 +176,7 @@ describe("ApportionmentPage", () => {
       renderApportionmentPage(false);
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(
@@ -201,7 +201,7 @@ describe("ApportionmentPage", () => {
       renderApportionmentPage(false);
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
@@ -34,9 +34,11 @@ describe("ApportionmentFullSeatsPage", () => {
 
     renderApportionmentFullSeatsPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" })).toBeVisible();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Hoe vaak haalde elke partij de kiesdeler?" }));
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Hoe vaak haalde elke partij de kiesdeler?" }),
+    ).toBeVisible();
     const full_seats_table = await screen.findByTestId("full-seats-table");
     expect(full_seats_table).toBeVisible();
     expect(full_seats_table).toHaveTableContent([
@@ -51,7 +53,9 @@ describe("ApportionmentFullSeatsPage", () => {
       ["8", "Political Group H", "52", ":", "80", "", "=", "0"],
     ]);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Hoeveel restzetels zijn er te verdelen?" }));
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Hoeveel restzetels zijn er te verdelen?" }),
+    ).toBeVisible();
     const residual_seats_calculation_table = await screen.findByTestId("residual-seats-calculation-table");
     expect(residual_seats_calculation_table).toBeVisible();
     expect(residual_seats_calculation_table).toHaveTableContent([
@@ -73,7 +77,7 @@ describe("ApportionmentFullSeatsPage", () => {
       renderApportionmentFullSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
@@ -95,7 +99,7 @@ describe("ApportionmentFullSeatsPage", () => {
       renderApportionmentFullSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(
@@ -117,7 +121,7 @@ describe("ApportionmentFullSeatsPage", () => {
       renderApportionmentFullSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(
@@ -141,7 +145,7 @@ describe("ApportionmentFullSeatsPage", () => {
       renderApportionmentFullSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -43,14 +43,14 @@ describe("ApportionmentListDetailsPage", () => {
 
     renderApportionmentPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" })).toBeVisible();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Toegewezen aantal zetels" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Toegewezen aantal zetels" })).toBeVisible();
     expect(await screen.findByTestId("text-political-group-assigned-nr-seats")).toHaveTextContent(
       "Lijst 1 - Political Group A heeft 12 zetels toegewezen gekregen.",
     );
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Met voorkeur gekozen kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Met voorkeur gekozen kandidaten" })).toBeVisible();
     expect(await screen.findByTestId("text-preferentially-chosen-candidates")).toHaveTextContent(
       "De volgende kandidaten zijn met voorkeursstemmen gekozen. Deze kandidaten hebben meer dan 50% van de kiesdeler gehaald.",
     );
@@ -69,7 +69,7 @@ describe("ApportionmentListDetailsPage", () => {
       ["Bakker, S. (Sophie) (v)", "Test Location", "40"],
     ]);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Overige gekozen kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Overige gekozen kandidaten" })).toBeVisible();
     expect(await screen.findByTestId("text-other-chosen-candidates")).toHaveTextContent(
       "De overige aan de lijst toegewezen zetels gaan naar de volgende kandidaten.",
     );
@@ -82,7 +82,7 @@ describe("ApportionmentListDetailsPage", () => {
       ["van den Berg, M. (Marijke) (v)", "Test Location", "20"],
     ]);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Rangschikking kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Rangschikking kandidaten" })).toBeVisible();
     expect(await screen.findByTestId("text-ranking-candidates")).toHaveTextContent(
       "De kandidaten zijn gerangschikt in de volgorde zoals hieronder aangegeven.",
     );
@@ -104,7 +104,7 @@ describe("ApportionmentListDetailsPage", () => {
       ["van den Berg, M. (Marijke) (v)", "Test Location"],
     ]);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Totaal aantal stemmen per kandidaat" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Totaal aantal stemmen per kandidaat" })).toBeVisible();
     const total_votes_per_candidate_table = await screen.findByTestId("total-votes-per-candidate-table");
     expect(total_votes_per_candidate_table).toBeVisible();
     expect(total_votes_per_candidate_table).toHaveTableContent([
@@ -135,32 +135,32 @@ describe("ApportionmentListDetailsPage", () => {
 
     renderApportionmentPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Lijst 5 - Political Group E" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Lijst 5 - Political Group E" })).toBeVisible();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Toegewezen aantal zetels" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Toegewezen aantal zetels" })).toBeVisible();
     expect(await screen.findByTestId("text-political-group-assigned-nr-seats")).toHaveTextContent(
       "Lijst 5 - Political Group E heeft 0 zetels toegewezen gekregen.",
     );
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Met voorkeur gekozen kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Met voorkeur gekozen kandidaten" })).toBeVisible();
     expect(await screen.findByTestId("text-preferentially-chosen-candidates")).toHaveTextContent(
       "Geen van de kandidaten heeft meer dan 50% van de kiesdeler gehaald. Niemand is met voorkeursstemmen gekozen.",
     );
     expect(screen.queryByTestId("preferentially-chosen-candidates-table")).not.toBeInTheDocument();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Overige gekozen kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Overige gekozen kandidaten" })).toBeVisible();
     expect(await screen.findByTestId("text-other-chosen-candidates")).toHaveTextContent(
       "Er zijn geen andere kandidaten gekozen.",
     );
     expect(screen.queryByTestId("other-chosen-candidates-table")).not.toBeInTheDocument();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Rangschikking kandidaten" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Rangschikking kandidaten" })).toBeVisible();
     expect(await screen.findByTestId("text-ranking-candidates")).toHaveTextContent(
       "De kandidaten zijn gerangschikt in de volgorde zoals ze op de lijst stonden.",
     );
     expect(screen.queryByTestId("candidates-ranking-table")).not.toBeInTheDocument();
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Totaal aantal stemmen per kandidaat" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Totaal aantal stemmen per kandidaat" })).toBeVisible();
     const total_votes_per_candidate_table = await screen.findByTestId("total-votes-per-candidate-table");
     expect(total_votes_per_candidate_table).toBeVisible();
     expect(total_votes_per_candidate_table).toHaveTableContent([
@@ -185,7 +185,7 @@ describe("ApportionmentListDetailsPage", () => {
       renderApportionmentPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
@@ -210,7 +210,7 @@ describe("ApportionmentListDetailsPage", () => {
       renderApportionmentPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(
@@ -235,7 +235,7 @@ describe("ApportionmentListDetailsPage", () => {
       renderApportionmentPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -36,14 +36,14 @@ describe("ApportionmentResidualSeatsPage", () => {
 
     renderApportionmentResidualSeatsPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
     expect(
       await screen.findByRole("heading", {
         level: 2,
         name: "De restzetels gaan naar de partijen met de grootste gemiddelden",
       }),
-    );
+    ).toBeVisible();
     const highest_averages_for_19_or_more_seats_table = await screen.findByTestId(
       "highest-averages-for-19-or-more-seats-table",
     );
@@ -73,14 +73,14 @@ describe("ApportionmentResidualSeatsPage", () => {
 
     renderApportionmentResidualSeatsPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
     expect(
       await screen.findByRole("heading", {
         level: 2,
         name: "De restzetels gaan naar de partijen met de grootste overschotten",
       }),
-    );
+    ).toBeVisible();
     const largest_remainders_table = await screen.findByTestId("largest-remainders-table");
     expect(largest_remainders_table).toBeVisible();
     expect(largest_remainders_table).toHaveTableContent([
@@ -89,7 +89,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       ["2", "Political Group B", "0", "60", "", "1"],
     ]);
 
-    expect(await screen.findByRole("heading", { level: 2, name: "Verdeling overige restzetels" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Verdeling overige restzetels" })).toBeVisible();
     const highest_averages_for_less_than_19_seats_table = await screen.findByTestId(
       "highest-averages-for-less-than-19-seats-table",
     );
@@ -123,14 +123,14 @@ describe("ApportionmentResidualSeatsPage", () => {
 
     renderApportionmentResidualSeatsPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
     expect(
       await screen.findByRole("heading", {
         level: 2,
         name: "De restzetels gaan naar de partijen met de grootste overschotten",
       }),
-    );
+    ).toBeVisible();
     const largest_remainders_table = await screen.findByTestId("largest-remainders-table");
     expect(largest_remainders_table).toBeVisible();
     expect(largest_remainders_table).toHaveTableContent([
@@ -154,14 +154,14 @@ describe("ApportionmentResidualSeatsPage", () => {
 
     renderApportionmentResidualSeatsPage();
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
     expect(
       await screen.findByRole("heading", {
         level: 2,
         name: "De restzetels gaan naar de partijen met de grootste overschotten",
       }),
-    );
+    ).toBeVisible();
     const largest_remainders_table = await screen.findByTestId("largest-remainders-table");
     expect(largest_remainders_table).toBeVisible();
     expect(largest_remainders_table).toHaveTableContent([
@@ -178,7 +178,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         level: 2,
         name: "Verdeling overige restzetels",
       }),
-    );
+    ).toBeVisible();
     const highest_averages_table = await screen.findByTestId("highest-averages-for-less-than-19-seats-table");
     expect(highest_averages_table).toBeVisible();
     expect(highest_averages_table).toHaveTableContent([
@@ -218,7 +218,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       renderApportionmentResidualSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
@@ -242,7 +242,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       renderApportionmentResidualSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(
@@ -266,7 +266,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       renderApportionmentResidualSeatsPage();
 
       // Wait for the page to be loaded
-      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" }));
+      expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
       expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
       expect(

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -87,7 +87,7 @@ describe("Test CheckAndSaveForm", () => {
     renderForm();
     const finalise = spyOnHandler(PollingStationDataEntryFinaliseHandler);
 
-    expect(await screen.findByRole("group", { name: "Controleren en opslaan" }));
+    expect(await screen.findByRole("group", { name: "Controleren en opslaan" })).toBeVisible();
 
     const user = userEvent.setup();
 
@@ -105,7 +105,7 @@ describe("Test CheckAndSaveForm", () => {
     renderForm();
 
     // Wait for the page to be loaded and check that the save button is not visible
-    expect(await screen.findByRole("group", { name: "Controleren en opslaan" }));
+    expect(await screen.findByRole("group", { name: "Controleren en opslaan" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "Opslaan" })).not.toBeInTheDocument();
 
     expect(screen.getByTestId("section-status-voters_votes_counts")).toHaveTextContent("heeft blokkerende fouten");
@@ -120,7 +120,7 @@ describe("Test CheckAndSaveForm", () => {
     renderForm();
 
     // Wait for the page to be loaded and check that the save button is not visible
-    expect(await screen.findByRole("group", { name: "Controleren en opslaan" }));
+    expect(await screen.findByRole("group", { name: "Controleren en opslaan" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "Opslaan" })).not.toBeInTheDocument();
 
     expect(screen.getByTestId("section-status-voters_votes_counts")).toHaveTextContent("Controleer waarschuwingen bij");

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -185,7 +185,7 @@ describe("getPollingStationSummary", () => {
       summary.notableFormSections.some(
         (item) => item.formSection.id === "differences_counts" && item.status === "accepted-warnings",
       ),
-    );
+    ).toBeTruthy();
 
     state.sections.voters_votes_counts.errors = new ValidationResultSet([errorWarningMocks.F201]);
 
@@ -199,7 +199,7 @@ describe("getPollingStationSummary", () => {
       summary.notableFormSections.some(
         (item) => item.formSection.id === "voters_votes_counts" && item.status === "errors",
       ),
-    );
+    ).toBeTruthy();
 
     state.sections.differences_counts.acceptWarnings = false;
 
@@ -213,6 +213,6 @@ describe("getPollingStationSummary", () => {
       summary.notableFormSections.some(
         (item) => item.formSection.id == "differences_counts" && item.status === "unaccepted-warnings",
       ),
-    );
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/features/data_entry_choice/components/DataEntryChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_choice/components/DataEntryChoiceForm.test.tsx
@@ -46,7 +46,7 @@ describe("Test DataEntryChoiceForm", () => {
 
       renderDataEntryChoicePage();
 
-      expect(await screen.findByRole("group", { name: "Welk stembureau ga je invoeren?" }));
+      expect(await screen.findByRole("group", { name: "Welk stembureau ga je invoeren?" })).toBeVisible();
       const pollingStation = screen.getByTestId("pollingStation");
 
       // Test if the feedback field shows an error
@@ -74,7 +74,7 @@ describe("Test DataEntryChoiceForm", () => {
         </ElectionProvider>,
       );
 
-      expect(await screen.findByRole("group", { name: "Verder met een volgend stembureau?" }));
+      expect(await screen.findByRole("group", { name: "Verder met een volgend stembureau?" })).toBeVisible();
       const pollingStation = screen.getByTestId("pollingStation");
 
       // Test if the polling station name is shown

--- a/frontend/src/features/data_entry_choice/components/DataEntryChoicePage.test.tsx
+++ b/frontend/src/features/data_entry_choice/components/DataEntryChoicePage.test.tsx
@@ -54,7 +54,7 @@ describe("DataEntryHomePage", () => {
         level: 1,
         name: electionDetailsMockResponse.election.name,
       }),
-    );
+    ).toBeVisible();
   });
 
   test("Alert not visible when not finished", async () => {
@@ -66,7 +66,7 @@ describe("DataEntryHomePage", () => {
         level: 1,
         name: electionDetailsMockResponse.election.name,
       }),
-    );
+    ).toBeVisible();
 
     // Test that the message doesn't exist
     expect(screen.queryByText("Alle stembureaus zijn ingevoerd")).not.toBeInTheDocument();
@@ -126,7 +126,7 @@ describe("DataEntryHomePage", () => {
         level: 1,
         name: electionDetailsMockResponse.election.name,
       }),
-    );
+    ).toBeVisible();
 
     // Expect the alert to not be visible
     const alertHeading = "Je invoer is opgeslagen";
@@ -156,7 +156,7 @@ describe("DataEntryHomePage", () => {
         level: 1,
         name: electionDetailsMockResponse.election.name,
       }),
-    );
+    ).toBeVisible();
 
     const alertHeading = "Je kan stembureau 33 niet invoeren.";
     expect(screen.queryByText(alertHeading)).not.toBeInTheDocument();

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -30,7 +30,7 @@ describe("ElectionHomePage", () => {
     );
 
     // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Gemeenteraadsverkiezingen 2026" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Gemeenteraadsverkiezingen 2026" })).toBeVisible();
     const list = await screen.findByTestId("election-pages");
     expect(list).toBeVisible();
     expect(list.childElementCount).toBe(2);

--- a/frontend/src/features/election_management/components/ElectionReportPage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionReportPage.test.tsx
@@ -55,8 +55,8 @@ describe("ElectionReportPage", () => {
     );
 
     // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Steminvoer eerste zitting afronden" }));
-    expect(await screen.findByRole("heading", { level: 2, name: "Invoerfase afronden?" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Steminvoer eerste zitting afronden" })).toBeVisible();
+    expect(await screen.findByRole("heading", { level: 2, name: "Invoerfase afronden?" })).toBeVisible();
     expect(await screen.findByRole("button", { name: "Download los proces-verbaal" })).toBeVisible();
     expect(await screen.findByRole("button", { name: "Download proces-verbaal met telbestand" })).toBeVisible();
   });

--- a/frontend/src/features/election_status/components/ElectionStatus.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.test.tsx
@@ -10,7 +10,7 @@ describe("ElectionStatus", () => {
     render(<PollingStationStatus navigate={navigate} />);
 
     // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 2, name: "Statusoverzicht steminvoer" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Statusoverzicht steminvoer" })).toBeVisible();
 
     const items = [...screen.getByTestId("polling-stations-per-status").children];
     expect(items[0]).toEqual(screen.getByRole("heading", { level: 3, name: "Stembureaus per status" }));

--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -67,7 +67,7 @@ describe("ElectionStatusPage", () => {
     renderElectionStatusPage();
 
     // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
 
     expect(await screen.findByText("Alle stembureaus zijn twee keer ingevoerd")).toBeVisible();
     expect(screen.getByRole("button", { name: "Invoerfase afronden" })).toBeVisible();
@@ -85,7 +85,7 @@ describe("ElectionStatusPage", () => {
     renderElectionStatusPage();
 
     // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
 
     expect(screen.queryByText("Alle stembureaus zijn twee keer ingevoerd")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Invoerfase afronden" })).not.toBeInTheDocument();


### PR DESCRIPTION
Discovered by running eslint-plugin-vitest. Addresses an issue also mentioned in https://github.com/kiesraad/abacus/pull/1379.

There were quite some RTL tests where an `expect()` didn't have a matcher call, e.g. `toBeVisible()`. This PR adds those.