### PR TITLE
Add e2e test for second data entry user being different

### DIFF
--- a/frontend/e2e-tests/tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry.e2e.ts
@@ -946,19 +946,13 @@ test.describe("api error responses", () => {
     await expect(dataEntryHomePage.fieldset).toBeVisible();
   });
 
-  test("UI Error: Second data entry user must be different from first entry", async ({ page, pollingStation }) => {
-    await page.route(`*/**/api/polling_stations/${pollingStation.id}/data_entries/1/claim`, async (route) => {
-      await route.fulfill({
-        status: 409,
-        json: {
-          error: "Conflict",
-          fatal: false,
-          reference: "SecondEntryNeedsDifferentUser",
-        },
-      });
-    });
-
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1/recounted`);
+  test("UI Error: Second data entry user must be different from first entry", async ({
+    page,
+    pollingStationFirstEntryDone,
+  }) => {
+    await page.goto(
+      `/elections/${pollingStationFirstEntryDone.election_id}/data-entry/${pollingStationFirstEntryDone.id}/1/recounted`,
+    );
     const recountedPage = new RecountedPage(page);
 
     // Data entry currently returns "null" for all responses without results

--- a/frontend/e2e-tests/tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry.e2e.ts
@@ -946,7 +946,7 @@ test.describe("api error responses", () => {
     await expect(dataEntryHomePage.fieldset).toBeVisible();
   });
 
-  test("Second data entry user must be different from first entry", async ({ page, pollingStation }) => {
+  test("UI Error: Second data entry user must be different from first entry", async ({ page, pollingStation }) => {
     await page.route(`*/**/api/polling_stations/${pollingStation.id}/data_entries/1/claim`, async (route) => {
       await route.fulfill({
         status: 409,
@@ -963,5 +963,19 @@ test.describe("api error responses", () => {
 
     // Data entry currently returns "null" for all responses without results
     await expect(recountedPage.next).toBeHidden();
+  });
+
+  test("UI Warning: Second data entry user must be different from first entry", async ({
+    page,
+    pollingStationFirstEntryDone,
+  }) => {
+    await page.goto(`/elections/${pollingStationFirstEntryDone.election_id}/data-entry`);
+    const dataEntryHomePage = new DataEntryHomePage(page);
+
+    await dataEntryHomePage.pollingStationNumber.fill(pollingStationFirstEntryDone.number.toString());
+
+    await expect(dataEntryHomePage.pollingStationFeedback).toContainText(
+      `Je mag stembureau ${pollingStationFirstEntryDone.number} niet nog een keer invoeren`,
+    );
   });
 });

--- a/frontend/e2e-tests/tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry.e2e.ts
@@ -945,4 +945,23 @@ test.describe("api error responses", () => {
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
   });
+
+  test("Second data entry user must be different from first entry", async ({ page, pollingStation }) => {
+    await page.route(`*/**/api/polling_stations/${pollingStation.id}/data_entries/1/claim`, async (route) => {
+      await route.fulfill({
+        status: 409,
+        json: {
+          error: "Conflict",
+          fatal: false,
+          reference: "SecondEntryNeedsDifferentUser",
+        },
+      });
+    });
+
+    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1/recounted`);
+    const recountedPage = new RecountedPage(page);
+
+    // Data entry currently returns "null" for all responses without results
+    await expect(recountedPage.next).toBeHidden();
+  });
 });

--- a/frontend/e2e-tests/tests/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry.e2e.ts
@@ -956,7 +956,7 @@ test.describe("api error responses", () => {
     const recountedPage = new RecountedPage(page);
 
     // Data entry currently returns "null" for all responses without results
-    await expect(recountedPage.next).toBeHidden();
+    await expect(recountedPage.fieldset).toBeHidden();
   });
 
   test("UI Warning: Second data entry user must be different from first entry", async ({


### PR DESCRIPTION
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->

Add e2e test for data entries requiring first and second data entry to have different users.

Note:
Has slightly empty test for starting data entry when this is the case.

closes #1151