### PR TITLE
Fix cache retrieval for `CandidatesVotesForm`

### DIFF
--- a/frontend/src/features/data_entry/components/candidates_votes/candidatesVotesValues.ts
+++ b/frontend/src/features/data_entry/components/candidates_votes/candidatesVotesValues.ts
@@ -8,7 +8,7 @@ export interface CandidateVotesFormValues extends Omit<PoliticalGroupVotes, "tot
 
 export type CandidateVotesValues = PoliticalGroupVotes;
 
-export function valuesToFormValues(values: PoliticalGroupVotes): CandidateVotesFormValues {
+export function valuesToFormValues(values: CandidateVotesValues): CandidateVotesFormValues {
   return {
     number: values.number,
     total: formatNumber(values.total),
@@ -16,7 +16,7 @@ export function valuesToFormValues(values: PoliticalGroupVotes): CandidateVotesF
   };
 }
 
-export function formValuesToValues(formData: CandidateVotesFormValues): PoliticalGroupVotes {
+export function formValuesToValues(formData: CandidateVotesFormValues): CandidateVotesValues {
   return {
     number: formData.number,
     total: deformatNumber(formData.total),

--- a/frontend/src/features/data_entry/components/candidates_votes/useCandidateVotes.ts
+++ b/frontend/src/features/data_entry/components/candidates_votes/useCandidateVotes.ts
@@ -12,12 +12,19 @@ import {
 export function useCandidateVotes(political_group_number: number) {
   const { onSubmit: _onSubmit, ...section } = useDataEntryFormSection<CandidateVotesFormValues>({
     section: `political_group_votes_${political_group_number}`,
-    getDefaultFormValues: (results, cache) =>
-      cache?.key === `political_group_votes_${political_group_number}`
-        ? valuesToFormValues(cache.data as CandidateVotesValues)
-        : valuesToFormValues(
-            results.political_group_votes.find((pg) => pg.number === political_group_number) as CandidateVotesValues,
-          ),
+    getDefaultFormValues: (results, cache) => {
+      let values;
+      if (cache?.key === `political_group_votes_${political_group_number}`) {
+        values = cache.data["political_group_votes"]?.find((pg) => pg.number === political_group_number);
+      }
+      values ??= results.political_group_votes.find((pg) => pg.number === political_group_number);
+      values ??= {
+        number: political_group_number,
+        total: 0,
+        candidate_votes: [],
+      };
+      return valuesToFormValues(values);
+    },
   });
 
   const [missingTotalError, setMissingTotalError] = React.useState(false);


### PR DESCRIPTION
Fixes #1391 by removing the type assertions (`as` keyword, also see https://github.com/kiesraad/abacus/issues/1391#issuecomment-2813154018). The `find` operation can technically return `undefined` (even though in practice it won't) so I also added an empty fallback value.

The function signatures in `candidatesVotesValues.ts` are updated to match the type alias in the same file.