### PR TITLE
use cases: P 22-2 sectie 2.11 Hertelling

### DIFF
--- a/documentatie/use-cases/csb-zitting.md
+++ b/documentatie/use-cases/csb-zitting.md
@@ -36,11 +36,14 @@ __Uitbreidingen:__
 &emsp;11a1. Het CSB neemt de bezwaren op in het PV.  
 &emsp;11a2. Het CSB besluit dat geen van de bezwaren reden zijn tot een hertelling.  
 &emsp;&emsp; 11a2a. Het CSB besluit dat een aantal stembureaus herteld moet worden:  
-&emsp;&emsp;&emsp;11a2a1. De hertelling wordt gedaan door het GSB.  
+&emsp;&emsp;&emsp;11a2a1. De hertelling wordt gedaan door het GSB d.m.v. de corrigendum-flow.  
 &emsp;&emsp;&emsp;11a2a2. Het CSB stelt de nieuwe uitslag vast.  
-&emsp;&emsp;&emsp;11a2a3. Het CSB neemt de nieuwe uitslag op in het PV.
+&emsp;&emsp;&emsp;11a2a3. Het CSB voegt de sectie "Hertelling" toe aan het oorspronkelijke PV.
 
-13a. De gemeenteraad besluit dat een hertelling nodig is (art V 4a):
+13a. De gemeenteraad besluit dat een hertelling nodig is (art V 4a):  
+&emsp; 13a1. De hertelling wordt gedaan door het GSB d.m.v. de corrigendum-flow.  
+&emsp; 13a2. De CSB stelt de nieuwe uitslag vast.  
+&emsp; 13a3. Het CSB maakt een nieuw PV aan met alleen de nieuwe uitslag.
 
 ### Niet in scope
 
@@ -56,7 +59,7 @@ __Uitbreidingen:__
     - Hoe faciliteren we gemeentes in het bepalen van de layout (bijv. gebruik huisstijl gemeente).
     - Als de applicatie deze moet genereren, dan moeten we ook de totalenlijst i.p.v. de kandidatenlijst importeren.
 - Overzicht bijlages toevoegen? Komen niet uit de software. (P22-2)
-- Moet de applicatie Sectie 2.11 Hertelling van de P22-2 genereren? (hertelling n.a.v. bezwaren tijdens zitting CSB)
+- Moet de applicatie Sectie 2.11 Hertelling van de P22-2 genereren, inclusief extra secties 2.3 t/m 2.5 of 2.10 o.b.v. de hertelling?
 
 
 ## Het CSB stelt de zetelverdeling vast en wijst de gekozen kandidaten aan (vlieger)

--- a/documentatie/use-cases/csb-zitting.md
+++ b/documentatie/use-cases/csb-zitting.md
@@ -40,7 +40,7 @@ __Uitbreidingen:__
 &emsp;&emsp;&emsp;11a2a2. Het CSB stelt de nieuwe uitslag vast.  
 &emsp;&emsp;&emsp;11a2a3. Het CSB voegt de sectie "Hertelling" toe aan het oorspronkelijke PV.
 
-13a. De gemeenteraad besluit dat een hertelling nodig is (art V 4a):  
+13a. De gemeenteraad besluit dat een hertelling nodig is ([Artikel V 4a Kieswet](https://wetten.overheid.nl/jci1.3:c:BWBR0004627&afdeling=IV&hoofdstuk=V&paragraaf=1&artikel=V_4a&z=2025-02-12&g=2025-02-12)):  
 &emsp; 13a1. De hertelling wordt gedaan door het GSB d.m.v. de corrigendum-flow.  
 &emsp; 13a2. De CSB stelt de nieuwe uitslag vast.  
 &emsp; 13a3. Het CSB maakt een nieuw PV aan met alleen de nieuwe uitslag.

--- a/documentatie/use-cases/csb-zitting.md
+++ b/documentatie/use-cases/csb-zitting.md
@@ -32,7 +32,7 @@ __Uitbreidingen:__
 4-11a. Het CSB moet nieuwe aantallen invoeren ter correctie van de eerder ingevoerde tellingen:  
 &emsp; 4-11a1. Het CSB corrigeert de eerder ingevoerde aantallen in de applicatie. Er is dus geen tweede zitting.
 
-11a. Er zijn bezwaren tijdens de zitting (kan alleen tijdens zitting):  
+11a. Er zijn bezwaren tijdens de zitting:  
 &emsp;11a1. Het CSB neemt de bezwaren op in het PV.  
 &emsp;11a2. Het CSB besluit dat geen van de bezwaren reden zijn tot een hertelling.  
 &emsp;&emsp; 11a2a. Het CSB besluit dat een aantal stembureaus herteld moet worden:  

--- a/documentatie/use-cases/csb-zitting.md
+++ b/documentatie/use-cases/csb-zitting.md
@@ -32,7 +32,15 @@ __Uitbreidingen:__
 4-11a. Het CSB moet nieuwe aantallen invoeren ter correctie van de eerder ingevoerde tellingen:  
 &emsp; 4-11a1. Het CSB corrigeert de eerder ingevoerde aantallen in de applicatie. Er is dus geen tweede zitting.
 
-11a. Er zijn bezwaren (kan alleen tijdens zitting):
+11a. Er zijn bezwaren tijdens de zitting (kan alleen tijdens zitting):  
+&emsp;11a1. Het CSB neemt de bezwaren op in het PV.  
+&emsp;11a2. Het CSB besluit dat geen van de bezwaren reden zijn tot een hertelling.  
+&emsp;&emsp; 11a2a. Het CSB besluit dat een aantal stembureaus herteld moet worden:  
+&emsp;&emsp;&emsp;11a2a1. De hertelling wordt gedaan door het GSB.  
+&emsp;&emsp;&emsp;11a2a2. Het CSB stelt de nieuwe uitslag vast.  
+&emsp;&emsp;&emsp;11a2a3. Het CSB neemt de nieuwe uitslag op in het PV.
+
+13a. De gemeenteraad besluit dat een hertelling nodig is (art V 4a):
 
 ### Niet in scope
 
@@ -48,6 +56,7 @@ __Uitbreidingen:__
     - Hoe faciliteren we gemeentes in het bepalen van de layout (bijv. gebruik huisstijl gemeente).
     - Als de applicatie deze moet genereren, dan moeten we ook de totalenlijst i.p.v. de kandidatenlijst importeren.
 - Overzicht bijlages toevoegen? Komen niet uit de software. (P22-2)
+- Moet de applicatie Sectie 2.11 Hertelling van de P22-2 genereren? (hertelling n.a.v. bezwaren tijdens zitting CSB)
 
 
 ## Het CSB stelt de zetelverdeling vast en wijst de gekozen kandidaten aan (vlieger)

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -7,14 +7,12 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - Hoe stellen we de adresgegevens van de (verkozen) kandidaten beschikbaar, makkelijker dan d.m.v. de totaallijst (EML_NL 230c)? Deze gegevens zijn nodig voor het opstellen van de benoemings- en geloofsbrieven.
 - Als er een hertelling gebeurt n.a.v. een verzoek van het CSB of op vraag van de Commissie voor het Onderzoek van de Geloofsbrieven, leidt dit dan op stembureau-niveau tot een corrigendum of tot een volledig nieuw tellings-PV?
   - Wie vervult de rol van de Commissie voor het Onderzoek van de Geloofsbrieven (Tweede Kamerverkiezingen) bij gemeenteraadsverkiezingen?
+- Moet Abacus Sectie 2.11 Hertelling van de P22-2 genereren? Deze sectie wordt alleen gebruikt bij een hertelling n.a.v. een bezwaar tijdens de CSB-zitting.
 
 
 ## Genereren van modellen door Abacus
 
-- Abacus moet alle modellen kunnen genereren. Ofwel als 'leeg' model (in te vullen met de hand) of als ingevuld model (ingevuld door Abacus).
-- In de tabellen hieronder
-  - 'leeg' model uit Abacus
-  - output van Abacus
+- Abacus moet alle modellen kunnen genereren. Ofwel als 'leeg' model (in te vullen met de hand) of als ingevuld model (ingevuld door Abacus). In de tabellen hieronder zijn dit respectievelijk de kolommen *'leeg' model uit Abacus* en *output van Abacus*.
 - Alleen de modellen die overeenkomen met het ingestelde type stemopneming (DSO of CSO) kunnen gegenereerd worden voor een verkiezing.
 - Het is niet noodzakelijk om te beperken op welk moment bepaalde 'lege' modellen gegenereerd kunnen worden, zolang het onderscheid tussen de verschillende modellen duidelijk is voor gebruikers.
 - Het is niet noodzakelijk om onderscheid te maken tussen beheerders, coördinatoren GSB en coördinatoren CSB voor wie welke 'lege' modellen mag genereren.
@@ -131,17 +129,25 @@ EML_NL 510a (tellingsbestand stembureau) wordt niet gebruikt.
 
 ### Modellen
 
-| Model(onderdeel) | DSO  | CSO  | Doel                          | input voor Abacus | output van Abacus |
-| ---------------- | :--: | :--: | ----------------------------- | :---------------: | :---------------: |
-| Na 31-1          |  X   |      | PV GSB - 1ste zitting         |         X         |                   |
-| Na 31-2          |      |  X   | PV GSB - 1ste zitting         |         X         |                   |
-| Na 14-2          |  X   |  X   | Corrigendum GSB - 2de zitting |         X         |                   |
-| P 2a             |  X   |  X   | Verslag 2de zitting GSB       |                   |                   |
-| P 22-2           |  X   |  X   | PV CSB - einduitslag          |                   |         X         |
+| Model(onderdeel)   | DSO  | CSO  | Doel                               | input voor Abacus | output van Abacus |
+| ------------------ | :--: | :--: | ---------------------------------- | :---------------: | :---------------: |
+| Na 31-1            |  X   |      | PV GSB - 1ste zitting              |         X         |                   |
+| Na 31-2            |      |  X   | PV GSB - 1ste zitting              |         X         |                   |
+| Na 14-2            |  X   |  X   | Corrigendum GSB - 2de zitting      |         X         |                   |
+| P 2a               |  X   |  X   | Verslag 2de zitting GSB            |                   |                   |
+| P 22-2             |  X   |  X   | PV CSB - einduitslag               |                   |         X         |
+| P 22-2 sectie 2.11 |  X   |  X   | PV CSB - hertelling n.a.v. bezwaar |                   |        ???        |
 
 #### P 22-2: einduitslag CSB
 
 - gegenereerd  door Abacus
+
+#### P22-2 sectie 2.11 Hertelling
+
+- open punt of gegenereerd door Abacus
+- alleen relevant bij een hertelling n.a.v. bezwaar tijdens zitting CSB
+  - dus niet bij terugverwijzing door CSB vóór invoer in Abacus
+  - dus niet bij hertelling op verzoek van gemeenteraad (art V 4a)
 
 
 ### Benoemingsbrieven en geloofsbrieven

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -7,7 +7,7 @@ Het doel is dat Abacus zoveel mogelijk in de modellen invult en er dus zo weinig
 - Hoe stellen we de adresgegevens van de (verkozen) kandidaten beschikbaar, makkelijker dan d.m.v. de totaallijst (EML_NL 230c)? Deze gegevens zijn nodig voor het opstellen van de benoemings- en geloofsbrieven.
 - Als er een hertelling gebeurt n.a.v. een verzoek van het CSB of op vraag van de Commissie voor het Onderzoek van de Geloofsbrieven, leidt dit dan op stembureau-niveau tot een corrigendum of tot een volledig nieuw tellings-PV?
   - Wie vervult de rol van de Commissie voor het Onderzoek van de Geloofsbrieven (Tweede Kamerverkiezingen) bij gemeenteraadsverkiezingen?
-- Moet Abacus Sectie 2.11 Hertelling van de P22-2 genereren? Deze sectie wordt alleen gebruikt bij een hertelling n.a.v. een bezwaar tijdens de CSB-zitting.
+- Moet Abacus Sectie 2.11 Hertelling van de P22-2 genereren, inclusief extra secties 2.3 t/m 2.5 of 2.10 o.b.v. de hertelling? Deze sectie wordt alleen gebruikt bij een hertelling n.a.v. een bezwaar tijdens de CSB-zitting.
 
 
 ## Genereren van modellen door Abacus
@@ -145,6 +145,9 @@ EML_NL 510a (tellingsbestand stembureau) wordt niet gebruikt.
 #### P22-2 sectie 2.11 Hertelling
 
 - open punt of gegenereerd door Abacus
+- twee varianten:
+  - hertelling maar geen wijziging in zetelverdeling: aangevuld met 2.3 t/m 2.5 o.b.v nieuwe telling
+  - hertelling en wijziging in zetelverdeling: aangevuld met 2.3 t/m 2.10 o.b.v nieuwe telling
 - alleen relevant bij een hertelling n.a.v. bezwaar tijdens zitting CSB
   - dus niet bij terugverwijzing door CSB vóór invoer in Abacus
   - dus niet bij hertelling op verzoek van gemeenteraad (art V 4a)

--- a/documentatie/use-cases/input-output-bestanden.md
+++ b/documentatie/use-cases/input-output-bestanden.md
@@ -150,7 +150,7 @@ EML_NL 510a (tellingsbestand stembureau) wordt niet gebruikt.
   - hertelling en wijziging in zetelverdeling: aangevuld met 2.3 t/m 2.10 o.b.v nieuwe telling
 - alleen relevant bij een hertelling n.a.v. bezwaar tijdens zitting CSB
   - dus niet bij terugverwijzing door CSB vóór invoer in Abacus
-  - dus niet bij hertelling op verzoek van gemeenteraad (art V 4a)
+  - dus niet bij hertelling op verzoek van gemeenteraad ([Artikel V 4a Kieswet](https://wetten.overheid.nl/jci1.3:c:BWBR0004627&afdeling=IV&hoofdstuk=V&paragraaf=1&artikel=V_4a&z=2025-02-12&g=2025-02-12))
 
 
 ### Benoemingsbrieven en geloofsbrieven


### PR DESCRIPTION
### Scope

Expliciet maken wat de drie mogelijkheden tot hertelling zijn:
- terugverwijzing door CSB voordat CSB start met invoer -> corrigenda-flow en dus nieuwe P22-2
- terugverwijzing door CSB nav bezwaar in CSB-zitting -> P22-2 sectie 2.11 Hertelling
- terugverwijzing door gemeenteraad (art V 4a) -> corrigenda-flow en dus nieuwe P22-2

Open vraag is of Abacus de P22-2 sectie 2.11 Hertelling moet genereren.