### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   TZ: "Europe/Amsterdam"
 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -50,7 +50,7 @@ jobs:
           rustup default stable &&
           rustup target add x86_64-unknown-linux-musl
       - name: Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           workspaces: "backend -> target"
       - name: Check rustfmt
@@ -115,7 +115,7 @@ jobs:
         run: npm run test:ladle
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: "Playwright Ladle ubuntu-latest"
@@ -159,7 +159,7 @@ jobs:
           retention-days: 30
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: "Playwright e2e"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
         uses: kiesraad/cla-bot@1101706b8b4299832da758b53d64bd59b20b1cec # main
 
       - if: failure() && steps.check.outputs.missing
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 #v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
         with:
           message: |
             Hi ${{steps.check.outputs.missing}}!
@@ -28,6 +28,6 @@ jobs:
             Please [review the CLA](https://github.com/kiesraad/abacus/blob/main/CLA.md), and send your signed copy to abacus[@]kiesraad.nl. Thanks!
 
       - if: success()
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 #v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
         with:
           delete: true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: check
-        uses: kiesraad/cla-bot@main
+        uses: kiesraad/cla-bot@1101706b8b4299832da758b53d64bd59b20b1cec # main
 
       - if: failure() && steps.check.outputs.missing
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 #v2
         with:
           message: |
             Hi ${{steps.check.outputs.missing}}!
@@ -28,6 +28,6 @@ jobs:
             Please [review the CLA](https://github.com/kiesraad/abacus/blob/main/CLA.md), and send your signed copy to abacus[@]kiesraad.nl. Thanks!
 
       - if: success()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 #v2
         with:
           delete: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   TZ: "Europe/Amsterdam"
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,12 +36,12 @@ jobs:
           rustup update nightly &&
           rustup default nightly
       - name: Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           workspaces: "backend -> target"
           cache-bin: "false"
       - name: Install Binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@a803508dbf9c51e6ba0a3a68aa5bcb3b8fc6f4e2 # main
       - name: Install cargo-llvm-cov
         run: cargo binstall cargo-llvm-cov
       - name: Install Nextest
@@ -50,7 +50,7 @@ jobs:
         run: cargo llvm-cov nextest --branch --profile ci --features embed-typst
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Backend Nextest Results
@@ -60,7 +60,7 @@ jobs:
       - name: Create code coverage report
         run: cargo llvm-cov report --cobertura --output-path ./target/llvm-cov-target/codecov.json
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Backend Nextest Coverage
@@ -93,7 +93,7 @@ jobs:
         run: npx vitest run --coverage --reporter=junit --outputFile=test-report.junit.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Frontend Vitest Results
@@ -101,7 +101,7 @@ jobs:
           disable_search: true
           fail_ci_if_error: true
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Frontend Vitest Coverage

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,13 +2,17 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   merge_group:
     types: [checks_requested]
   schedule:
-    - cron: '27 7 * * 2'
+    - cron: "27 7 * * 2"
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   analyze:
@@ -21,20 +25,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-        - language: javascript-typescript
+          - language: actions
+          - language: javascript-typescript
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,12 +12,17 @@ on:
 
 jobs:
   analyze:
-    name: Analyze JavaScript/TypeScript
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    timeout-minutes: 360
     permissions:
       security-events: write
-      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+        - language: javascript-typescript
 
     steps:
     - name: Checkout repository
@@ -26,10 +31,10 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: javascript-typescript
-        queries: security-and-quality
-        
+        languages: ${{ matrix.language }}
+        queries: security-extended,security-and-quality
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
-        category: "/language:javascript-typescript"
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run build:ladle
       - name: Deploy
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.API_TOKEN }}
           accountId: ${{ secrets.ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
   # Run every Sunday at 12:00 UTC
   schedule:
-    - cron: '0 12 * * 0'
+    - cron: "0 12 * * 0"
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -151,7 +155,6 @@ jobs:
           files: release/*
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Version ${{ env.TAG }}
-
 
   deploy:
     name: Deploy to abacus-test.nl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Push git tag
         run: git push origin $TAG
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2
         with:
           body: This is an alpha release of Abacus, commit ${{ github.sha }} on ${{ env.BUILD_DATE }}
           tag_name: ${{ env.TAG }}

--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -1,6 +1,11 @@
 name: Sigrid PR Feedback
+
 on:
   pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   sigridci:

--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Sigrid CI
-        uses: Software-Improvement-Group/sigridci@main
+        uses: Software-Improvement-Group/sigridci@1df84f0d4ac24bd66bc46a3b7f8ade6b083c0672 # main
         with:
           customer: kiesraad
           system: abacus
@@ -27,7 +27,7 @@ jobs:
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
       - name: "Sigrid PR feedback"
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
         if: always()
         with:
           message-id: sigrid

--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Sigrid CI
-        uses: Software-Improvement-Group/sigridci@main
+        uses: Software-Improvement-Group/sigridci@1df84f0d4ac24bd66bc46a3b7f8ade6b083c0672 # main
         with:
           customer: kiesraad
           system: abacus

--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -1,4 +1,8 @@
 name: Sigrid Publish
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Analyse GitHub Actions workflows using CodeQL, see https://github.blog/changelog/2025-04-22-github-actions-workflow-security-analysis-with-codeql-is-now-generally-available/ for more information.

Also fix alerts reported by CodeQL:
- Add permissions to GitHub Actions workflows
- Pin commit hashes for third party actions
  https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions