### PR TITLE
Use cases corrigenda

### DIFF
--- a/documentatie/use-cases/gsb-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-eerste-zitting.md
@@ -25,8 +25,8 @@ __Uitbreidingen:__
 
 3a. (CSO) Het GSB gebruikt de applicatie om het SB PV te controleren:
 
-3b. Het GSB stelt vast dat de tellingen van het stembureau mogelijk niet kloppen:  
-&emsp; 3b1. het GSB doet een (gedeeltelijke) hertelling van het stembureau.  
+3b. (DSO) Het GSB stelt vast dat de tellingen van het stembureau mogelijk niet kloppen:  
+&emsp; 3b1. Het GSB doet een (gedeeltelijke) hertelling van het stembureau.  
 &emsp; 3b1. Het GSB noteert de wijzigingen in een corrigendum Na 14-1.
 
 7a. Het GSB stelt verschillen vast d.m.v. het controleprotocol (handmatige controle optellingen software):  

--- a/documentatie/use-cases/gsb-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-eerste-zitting.md
@@ -11,7 +11,7 @@ __Hoofdscenario:__
 2. (gedurende de zitting) Het GSB houdt tijd en locatie bij van de aanwezigheid van elk lid van het GSB.
 3. Voor elk stembureau:
     - (CSO) Het GSB doet de telling op lijst- en kandidaatsniveau en vult Na 31-2 Bijlage 1 in.
-    - (DSO) Het GSB stelt met de hand vast dat de tellingen die het stembureau heeft vastgesteld in N 10-1, kloppen.
+    - (DSO) Het GSB stelt vast dat de tellingen die het stembureau heeft vastgesteld in N 10-1, kloppen.
 4. De coördinator GSB geeft in de applicatie aan dat de zitting is geopend en voert de locatie en starttijd in.
 5. [De coördinator GSB en de invoerders voeren alle gegevens in de applicatie in.](./gsb-invoer-eerste-zitting.md#de-coördinator-gsb-en-de-invoerders-voeren-alle-gegevens-in-de-applicatie-in-vlieger)
 6. [De coördinator GSB maakt het PV en het digitale bestand aan.](#de-coördinator-gsb-maakt-het-pv-en-het-digitale-bestand-aan-zee)
@@ -23,7 +23,7 @@ __Hoofdscenario:__
 
 __Uitbreidingen:__  
 
-3a. Het GSB gebruikt de applicatie om het SB PV te controleren:
+3a. (CSO) Het GSB gebruikt de applicatie om het SB PV te controleren:
 
 3b. Het GSB stelt vast dat de tellingen van het stembureau mogelijk niet kloppen:  
 &emsp; 3b1. het GSB doet een (gedeeltelijke) hertelling van het stembureau.  

--- a/documentatie/use-cases/gsb-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-eerste-zitting.md
@@ -1,6 +1,6 @@
 # GSB: Eerste zitting
 
-## Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting d.m.v. CSO (wolk)
+## Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting (wolk)
 
 _Niveau:_ hoog-over, wolk, ☁️
 
@@ -11,7 +11,9 @@ Voor DSO zie [Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting
 __Hoofdscenario:__  
 1. Het GSB opent de zitting.
 2. (gedurende de zitting) Het GSB houdt tijd en locatie bij van de aanwezigheid van elk lid van het GSB.
-3. (voor elk stembureau) Het GSB doet de telling op lijst- en kandidaatsniveau en vult Na 31-2 Bijlage 1 in.
+3. Voor elk stembureau:
+    - (CSO) Het GSB doet de telling op lijst- en kandidaatsniveau en vult Na 31-2 Bijlage 1 in.
+    - (DSO) Het GSB stelt met de hand vast dat de tellingen die het stembureau heeft vastgesteld in N 10-1, kloppen.
 4. De coördinator GSB geeft in de applicatie aan dat de zitting is geopend en voert de locatie en starttijd in.
 5. [De coördinator GSB en de invoerders voeren alle gegevens in de applicatie in.](./gsb-invoer-eerste-zitting.md#de-coördinator-gsb-en-de-invoerders-voeren-alle-gegevens-in-de-applicatie-in-vlieger)
 6. [De coördinator GSB maakt het PV en het digitale bestand aan.](#de-coördinator-gsb-maakt-het-pv-en-het-digitale-bestand-aan-zee)
@@ -22,6 +24,13 @@ __Hoofdscenario:__
 11. De burgemeester publiceert het PV GSB (inc. bijlagen) en brengt het over naar het CSB.
 
 __Uitbreidingen:__  
+
+3a. Het GSB gebruikt de applicatie om het SB PV te controleren:
+
+3b. Het GSB stelt vast dat de tellingen van het stembureau mogelijk niet kloppen:  
+&emsp; 3b1. het GSB doet een (gedeeltelijke) hertelling van het stembureau.  
+&emsp; 3b1. Het GSB noteert de wijzigingen in een corrigendum Na 14-1.
+
 7a. Het GSB stelt verschillen vast d.m.v. het controleprotocol (handmatige controle optellingen software):  
 &emsp; 7a1. Het GSB controleert de resultaten van het controleprotocol.  
 &emsp; 7a2. Het GSB vindt een fout in de resultaten van het controleprotocol en corrigeert deze.  
@@ -55,40 +64,6 @@ __Uitbreidingen:__
 - Kunnen we het mogelijk maken om bezwaren en bijzonderheden in te voeren in de applicatie tijdens het voorlezen van het PV?
 - Moet de applicatie een preview van het te genereren PV tonen, zodat de coördinator GSB die kan controleren en eventuele fouten kan herstellen?
   - Preview: bestand genereren met "concept" in watermerk en in bestandsnaam.
-
-
-## Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting d.m.v. DSO (wolk)
-
-__Niveau:__ hoog-over, wolk, ☁️
-
-Voor CSO zie [Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting d.m.v. CSO (wolk)](#gemeentelijk-stembureau-gsb-stelt-uitslag-vast-in-eerste-zitting-dmv-cso-wolk).
-
-### Hoofdscenario en uitbreidingen
-
-__Hoofdscenario:__
-
-1. Het GSB opent de zitting.
-2. (gedurende de zitting) Het GSB houdt tijd en locatie bij van de aanwezigheid van elk lid van het GSB.
-3. (voor elk stembureau) Het GSB stelt met de hand vast dat de tellingen die het stembureau heeft vastgesteld in N 10-1, kloppen.
-4. De coördinator GSB geeft in de applicatie aan dat de zitting is geopend.
-5. [De coördinator GSB en de invoerders voeren alle gegevens in de applicatie in](./gsb-invoer-eerste-zitting.md#de-coördinator-gsb-en-de-invoerders-voeren-alle-gegevens-in-de-applicatie-in-vlieger)
-6. [De coördinator GSB maakt het PV en het digitale bestand aan.](#de-coördinator-gsb-maakt-het-pv-en-het-digitale-bestand-aan-zee)
-7. Het GSB voert het controleprotocol (handmatige controle optellingen software) uit en stelt geen verschillen vast.
-8. Het GSB stelt de gemeentelijke totalen vast o.b.v. het PV: controleren op compleetheid, voorlezen, geen additionele bezwaren en bijzonderheden, ondertekenen. En sluit daarmee de zitting.
-9. Het GSB stelt de benodigde EML_NL bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
-10. Het GSB stelt het PV GSB (inclusief bijlagen) beschikbaar aan de burgemeester.
-11. De burgemeester publiceert het PV GSB (inclusief bijlagen) en brengt het over naar het CSB.
-
-__Uitbreidingen:__
-
-3a. Het GSB gebruikt de applicatie om het SB PV te controleren:
-
-3b. Het GSB stelt vast dat de tellingen van het stembureau mogelijk niet kloppen:  
-&emsp; 3b1. het GSB doet een (gedeeltelijke) hertelling van het stembureau.  
-&emsp; 3b1. Het GSB noteert de wijzigingen in een corrigendum Na 14-1.
-
-#### Open punten
-
 - Zijn de invoervelden voor de tellingen van een stembureau voor DSO gelijk aan die van CSO?
   - Waarschijnlijk niet, bijvoorbeeld geen "Is er herteld?" op SB PV.
   - Nieuwe modellen op nalopen.

--- a/documentatie/use-cases/gsb-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-eerste-zitting.md
@@ -4,8 +4,6 @@
 
 _Niveau:_ hoog-over, wolk, ☁️
 
-Voor DSO zie [Gemeentelijk stembureau (GSB) stelt uitslag vast in eerste zitting d.m.v. DSO (wolk)](#gemeentelijk-stembureau-gsb-stelt-uitslag-vast-in-eerste-zitting-dmv-dso-wolk).
-
 ### Hoofdscenario en uitbreidingen
 
 __Hoofdscenario:__  

--- a/documentatie/use-cases/gsb-invoer-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-invoer-eerste-zitting.md
@@ -27,7 +27,7 @@ __Uitbreidingen:__
 &emsp; 2-3a1. De coördinator GSB pauzeert de invoer.  
 &emsp; 2-3a2. De applicatie blokkeert verdere invoer.
 
-2-3b. Nadat een stembureau twee keer is ingevoerd, wordt de telling van dat stembureau gecorrigeerd:  
+2-3b. De telling van het stembureau moet worden gecorrigeerd nadat deze al twee keer was ingevoerd:  
 &emsp; 2-3b1. De coördinator GSB verwijdert de invoer van het stembureau.  
 &emsp; 2-3b2. De coördinator GSB laat het stembureau twee keer invoeren.  
 

--- a/documentatie/use-cases/gsb-invoer-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-invoer-eerste-zitting.md
@@ -27,6 +27,10 @@ __Uitbreidingen:__
 &emsp; 2-3a1. De coördinator GSB pauzeert de invoer.  
 &emsp; 2-3a2. De applicatie blokkeert verdere invoer.
 
+2-3b. Nadat een stembureau twee keer is ingevoerd, wordt de telling van dat stembureau gecorrigeerd:  
+&emsp; 2-3b1. De coördinator GSB verwijdert de invoer van het stembureau.  
+&emsp; 2-3b2. De coördinator GSB laat het stembureau twee keer invoeren.  
+
 5a. De applicatie stelt vast dat niet voor alle stembureaus resultaten zijn ingevoerd:
 
 6a. De applicatie stelt vast dat er stembureaus met geaccepteerde waarschuwingen zijn:

--- a/documentatie/use-cases/gsb-invoer-tweede-zitting.md
+++ b/documentatie/use-cases/gsb-invoer-tweede-zitting.md
@@ -2,7 +2,7 @@
 
 N.B.: Alle use cases voor de tweede zitting gelden ook voor elke latere zitting (derde, etc.).
 
-## De invoerders voeren de uitkomst van het onderzoek en de hertelling in de applicatie in (vlieger)
+## De invoerders voeren de hertelling in de applicatie in (vlieger)
 
 __Niveau:__ hoog-over, vlieger, 🪁
 
@@ -18,7 +18,7 @@ __Trigger:__ Er is een corrigendum PV opgesteld.
 __Hoofdscenario:__  
 
 1. De coördinator GSB stelt invoer open voor het stembureau met corrigendum.
-2. De invoerders vullen de uitkomst van het onderzoek en de resultaten van de gecorrigeerde tellingen (alleen gewijzigde aantallen) in.
+2. De invoerders vullen de resultaten van de gecorrigeerde tellingen (alleen de gewijzigde aantallen) in.
 
 __Uitbreidingen:__  
 2a. Er zijn verschillen tussen de eerste en de tweede invoer:  

--- a/documentatie/use-cases/gsb-tweede-zitting.md
+++ b/documentatie/use-cases/gsb-tweede-zitting.md
@@ -61,7 +61,8 @@ __Hoofdscenario:__
 6. Het GSB besluit dat er een hertelling nodig is.
 7. De coördinator GSB drukt de overige bladzijdes van het 'leeg' corrigendum af.
 8. Het GSB stelt een ander resultaat vast in de hertelling.
-9. [De invoerders voeren de uitkomst van het onderzoek en de hertelling in de applicatie in.](./gsb-invoer-tweede-zitting.md#de-invoerders-voeren-de-uitkomst-van-het-onderzoek-en-de-hertelling-in-de-applicatie-in-vlieger)
+9. De coördinator voert de uitkomst van het onderzoek in de applicatie in.
+10. [De invoerders voeren de hertelling in de applicatie in.](./gsb-invoer-tweede-zitting.md#de-invoerders-voeren-de-hertelling-in-de-applicatie-in-vlieger)
 11. Het GSB voegt het corrigendum toe aan de PV's van de zitting.
 
 
@@ -85,3 +86,4 @@ __Uitbreidingen:__
 - 'leeg' corrigendum is geen heel goede term
     - Moet je kunnen selecteren welke lijsten er opgenomen moeten worden in het 'lege' corrigendum? Nee, want nieuwe modellen: corrigendum bevat aantallen modellen vorige zitting (niet: eerste zitting tenzij dat de vorige zitting is), dus handig om alle lijsten in corrigendum te hebben.
 - Hoe expliciet willen we zijn over de verschillende momenten waarop welke onderdelen van het corrigendum afgedrukt kunnen worden?
+- Als de coördinator GSB de overige bladzijdes afrdukt, vult deze dan op dat moment ook al de resultaten van het onderzoek in?


### PR DESCRIPTION
closes https://github.com/kiesraad/abacus-internal/issues/212
closes https://github.com/kiesraad/abacus-internal/issues/272

### Scope
- samenvoegen eerste zitting CSO en DSO, want te weinig verschillen
- uitbreiding toevoegen over aanpassen telling na definitief maken invoer
- aanpassen dat coördinator GSB het resultaat van het onderzoek invoert en de invoerders alleen de hertelling