### PR TITLE
Moved impls for ApiError to respective modules

### DIFF
--- a/backend/src/apportionment/api.rs
+++ b/backend/src/apportionment/api.rs
@@ -1,9 +1,17 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use super::{
+    ApportionmentError, CandidateNominationResult, SeatAssignmentResult, candidate_nomination,
+    get_total_seats_from_apportionment_result, seat_assignment,
+};
 use crate::{
     APIError, AppState, ErrorResponse,
-    apportionment::{
-        ApportionmentError, CandidateNominationResult, SeatAssignmentResult, candidate_nomination,
-        get_total_seats_from_apportionment_result, seat_assignment,
-    },
     audit_log::{AuditEvent, AuditService},
     authentication::Coordinator,
     data_entry::{
@@ -14,14 +22,12 @@ use crate::{
     polling_station::repository::PollingStations,
     summary::ElectionSummary,
 };
-use axum::{
-    Json,
-    extract::{Path, State},
-};
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
+impl From<ApportionmentError> for APIError {
+    fn from(err: ApportionmentError) -> Self {
+        APIError::Apportionment(err)
+    }
+}
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default().routes(routes!(election_apportionment))
 }

--- a/backend/src/apportionment/candidate_nomination.rs
+++ b/backend/src/apportionment/candidate_nomination.rs
@@ -315,6 +315,8 @@ pub fn candidate_numbers(candidates: &[Candidate]) -> Vec<CandidateNumber> {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use crate::{
         apportionment::{
             ApportionmentError, Fraction, PoliticalGroupCandidateNomination, candidate_nomination,
@@ -327,7 +329,6 @@ mod tests {
             tests::election_fixture_with_given_number_of_seats,
         },
     };
-    use test_log::test;
 
     fn check_political_group_candidate_nomination(
         nomination: &PoliticalGroupCandidateNomination,

--- a/backend/src/apportionment/candidate_nomination.rs
+++ b/backend/src/apportionment/candidate_nomination.rs
@@ -1,12 +1,13 @@
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+use utoipa::ToSchema;
+
+use super::{ApportionmentError, Fraction};
 use crate::{
-    apportionment::{ApportionmentError, Fraction},
     data_entry::CandidateVotes,
     election::{Candidate, CandidateNumber, Election, PGNumber, PoliticalGroup},
     summary::ElectionSummary,
 };
-use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
-use utoipa::ToSchema;
 
 /// Contains information about the chosen candidates and the candidate list ranking
 /// for a specific political group.

--- a/backend/src/apportionment/fraction.rs
+++ b/backend/src/apportionment/fraction.rs
@@ -1,9 +1,10 @@
-use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result},
     ops::{Add, Div, Mul, Sub},
 };
+
+use serde::{Deserialize, Serialize};
 use utoipa::{
     PartialSchema, ToSchema,
     openapi::{RefOr, schema::Schema},
@@ -199,11 +200,12 @@ impl From<DisplayFraction> for Fraction {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use crate::{
         apportionment::{DisplayFraction, Fraction},
         data_entry::Count,
     };
-    use test_log::test;
 
     #[test]
     fn test_from_count() {

--- a/backend/src/apportionment/seat_assignment.rs
+++ b/backend/src/apportionment/seat_assignment.rs
@@ -3,10 +3,8 @@ use std::cmp::Ordering;
 use tracing::{debug, info};
 use utoipa::ToSchema;
 
-use crate::{
-    APIError, apportionment::Fraction, data_entry::PoliticalGroupVotes, election::PGNumber,
-    summary::ElectionSummary,
-};
+use super::Fraction;
+use crate::{data_entry::PoliticalGroupVotes, election::PGNumber, summary::ElectionSummary};
 
 /// The result of the seat assignment procedure. This contains the number of seats and the quota
 /// that was used. It then contains the initial standing after full seats were assigned,
@@ -302,12 +300,6 @@ pub enum ApportionmentError {
     ApportionmentNotAvailableUntilDataEntryFinalised,
     DrawingOfLotsNotImplemented,
     ZeroVotesCast,
-}
-
-impl From<ApportionmentError> for APIError {
-    fn from(err: ApportionmentError) -> Self {
-        APIError::Apportionment(err)
-    }
 }
 
 /// Initial construction of the data required per political group

--- a/backend/src/apportionment/seat_assignment.rs
+++ b/backend/src/apportionment/seat_assignment.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 use utoipa::ToSchema;
 
@@ -1039,11 +1040,12 @@ mod tests {
 
     /// Tests apportionment for councils with less than 19 seats
     mod lt_19_seats {
+        use test_log::test;
+
         use crate::apportionment::{
             ApportionmentError, get_total_seats_from_apportionment_result, seat_assignment,
             test_helpers::election_summary_fixture_with_default_50_candidates,
         };
-        use test_log::test;
 
         /// Apportionment without remainder seats
         ///
@@ -1222,11 +1224,12 @@ mod tests {
         }
 
         mod drawing_of_lots {
+            use test_log::test;
+
             use crate::apportionment::{
                 ApportionmentError, seat_assignment,
                 test_helpers::election_summary_fixture_with_default_50_candidates,
             };
-            use test_log::test;
 
             /// Apportionment with residual seats assigned with largest remainders method  
             /// This test triggers Kieswet Article P 9
@@ -1277,11 +1280,12 @@ mod tests {
         }
 
         mod list_exhaustion {
+            use test_log::test;
+
             use crate::apportionment::{
                 ApportionmentError, get_total_seats_from_apportionment_result, seat_assignment,
                 test_helpers::election_summary_fixture_with_given_candidate_votes,
             };
-            use test_log::test;
 
             /// Apportionment with no residual seats  
             /// This test triggers Kieswet Article P 10
@@ -1746,11 +1750,12 @@ mod tests {
 
     /// Tests apportionment for councils with 19 or more seats
     mod gte_19_seats {
+        use test_log::test;
+
         use crate::apportionment::{
             ApportionmentError, get_total_seats_from_apportionment_result, seat_assignment,
             test_helpers::election_summary_fixture_with_default_50_candidates,
         };
-        use test_log::test;
 
         /// Apportionment without remainder seats
         ///
@@ -1868,11 +1873,12 @@ mod tests {
         }
 
         mod drawing_of_lots {
+            use test_log::test;
+
             use crate::apportionment::{
                 ApportionmentError, seat_assignment,
                 test_helpers::election_summary_fixture_with_default_50_candidates,
             };
-            use test_log::test;
 
             /// Apportionment with residual seats assigned with highest averages method  
             /// This test triggers Kieswet Article P 9
@@ -1910,11 +1916,12 @@ mod tests {
         }
 
         mod list_exhaustion {
+            use test_log::test;
+
             use crate::apportionment::{
                 ApportionmentError, get_total_seats_from_apportionment_result, seat_assignment,
                 test_helpers::election_summary_fixture_with_given_candidate_votes,
             };
-            use test_log::test;
 
             /// Apportionment with no residual seats  
             /// This test triggers Kieswet Article P 10

--- a/backend/src/apportionment/seat_assignment.rs
+++ b/backend/src/apportionment/seat_assignment.rs
@@ -4,7 +4,7 @@ use tracing::{debug, info};
 use utoipa::ToSchema;
 
 use crate::{
-    apportionment::Fraction, data_entry::PoliticalGroupVotes, election::PGNumber,
+    APIError, apportionment::Fraction, data_entry::PoliticalGroupVotes, election::PGNumber,
     summary::ElectionSummary,
 };
 
@@ -302,6 +302,12 @@ pub enum ApportionmentError {
     ApportionmentNotAvailableUntilDataEntryFinalised,
     DrawingOfLotsNotImplemented,
     ZeroVotesCast,
+}
+
+impl From<ApportionmentError> for APIError {
+    fn from(err: ApportionmentError) -> Self {
+        APIError::Apportionment(err)
+    }
 }
 
 /// Initial construction of the data required per political group

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -121,6 +121,8 @@ async fn audit_log_list_users(
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use axum::{
         Router,
         body::Body,
@@ -131,7 +133,6 @@ mod tests {
     use chrono::TimeDelta;
     use http_body_util::BodyExt;
     use sqlx::SqlitePool;
-    use std::net::Ipv4Addr;
     use test_log::test;
     use tower::ServiceExt;
 

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -4,12 +4,11 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use super::{AuditLog, AuditLogEvent, LogFilter};
 use crate::{
     APIError, AppState, ErrorResponse,
     authentication::{AdminOrCoordinator, Role},
 };
-
-use super::{AuditLog, AuditLogEvent, LogFilter};
 
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()

--- a/backend/src/audit_log/audit_log_events.rs
+++ b/backend/src/audit_log/audit_log_events.rs
@@ -1,9 +1,10 @@
+use std::net::IpAddr;
+
 use axum::extract::FromRef;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::{SqlitePool, Type, prelude::FromRow};
-use std::net::IpAddr;
 use strum::VariantNames;
 use utoipa::ToSchema;
 

--- a/backend/src/audit_log/audit_log_events.rs
+++ b/backend/src/audit_log/audit_log_events.rs
@@ -7,12 +7,11 @@ use std::net::IpAddr;
 use strum::VariantNames;
 use utoipa::ToSchema;
 
+use super::{AuditEvent, AuditLogUser, LogFilterQuery};
 use crate::{
     APIError, AppState,
     authentication::{Role, User},
 };
-
-use super::{AuditEvent, AuditLogUser, LogFilterQuery};
 
 #[derive(
     Serialize, Deserialize, VariantNames, Clone, Copy, Debug, PartialEq, Eq, Hash, ToSchema, Type,

--- a/backend/src/audit_log/service.rs
+++ b/backend/src/audit_log/service.rs
@@ -4,12 +4,11 @@ use axum::{
 };
 use std::net::{IpAddr, SocketAddr};
 
+use super::{AuditEvent, AuditLog, AuditLogEvent};
 use crate::{
     APIError,
     authentication::{User, Users, error::AuthenticationError},
 };
-
-use super::{AuditEvent, AuditLog, AuditLogEvent};
 
 #[derive(Clone)]
 pub struct AuditService {

--- a/backend/src/audit_log/service.rs
+++ b/backend/src/audit_log/service.rs
@@ -1,8 +1,9 @@
+use std::net::{IpAddr, SocketAddr};
+
 use axum::{
     extract::{ConnectInfo, FromRef, FromRequestParts},
     http::request::Parts,
 };
-use std::net::{IpAddr, SocketAddr};
 
 use super::{AuditEvent, AuditLog, AuditLogEvent};
 use crate::{
@@ -74,12 +75,13 @@ impl AuditService {
 // write some tests
 #[cfg(test)]
 mod test {
-    use crate::audit_log::{AuditEventLevel, UserLoggedInDetails};
-    use sqlx::SqlitePool;
     use std::net::Ipv4Addr;
+
+    use sqlx::SqlitePool;
     use test_log::test;
 
     use super::*;
+    use crate::audit_log::{AuditEventLevel, UserLoggedInDetails};
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_log_event(pool: SqlitePool) {

--- a/backend/src/authentication/api.rs
+++ b/backend/src/authentication/api.rs
@@ -1,3 +1,15 @@
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Json},
+};
+use axum_extra::{TypedHeader, extract::CookieJar, headers::UserAgent};
+use cookie::{Cookie, SameSite};
+use hyper::StatusCode;
+use serde::{Deserialize, Serialize};
+use sqlx::Error;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
 use super::{
     Admin, AdminOrCoordinator, SECURE_COOKIES, SESSION_COOKIE_NAME, SESSION_LIFE_TIME,
     error::AuthenticationError,
@@ -10,17 +22,12 @@ use crate::{
     audit_log::{AuditEvent, AuditService, UserDetails, UserLoggedInDetails, UserLoggedOutDetails},
     error::ErrorReference,
 };
-use axum::{
-    extract::{Path, State},
-    response::{IntoResponse, Json},
-};
-use axum_extra::{TypedHeader, extract::CookieJar, headers::UserAgent};
-use cookie::{Cookie, SameSite};
-use hyper::StatusCode;
-use serde::{Deserialize, Serialize};
-use sqlx::Error;
-use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
+
+impl From<AuthenticationError> for APIError {
+    fn from(err: AuthenticationError) -> Self {
+        APIError::Authentication(err)
+    }
+}
 
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -1,3 +1,5 @@
+use crate::APIError;
+
 #[derive(Debug)]
 pub enum AuthenticationError {
     UserNotFound,
@@ -23,5 +25,11 @@ impl From<password_hash::Error> for AuthenticationError {
 impl From<sqlx::Error> for AuthenticationError {
     fn from(err: sqlx::Error) -> Self {
         AuthenticationError::Database(err)
+    }
+}
+
+impl From<AuthenticationError> for APIError {
+    fn from(err: AuthenticationError) -> Self {
+        APIError::Authentication(err)
     }
 }

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -1,5 +1,3 @@
-use crate::APIError;
-
 #[derive(Debug)]
 pub enum AuthenticationError {
     UserNotFound,
@@ -25,11 +23,5 @@ impl From<password_hash::Error> for AuthenticationError {
 impl From<sqlx::Error> for AuthenticationError {
     fn from(err: sqlx::Error) -> Self {
         AuthenticationError::Database(err)
-    }
-}
-
-impl From<AuthenticationError> for APIError {
-    fn from(err: AuthenticationError) -> Self {
-        APIError::Authentication(err)
     }
 }

--- a/backend/src/authentication/middleware.rs
+++ b/backend/src/authentication/middleware.rs
@@ -1,7 +1,3 @@
-use crate::{
-    audit_log::{AuditEvent, AuditService},
-    authentication::{SESSION_COOKIE_NAME, User, set_default_cookie_properties},
-};
 use axum::{
     extract::{Request, State},
     http::HeaderValue,
@@ -15,6 +11,10 @@ use tracing::{debug, error, info};
 use super::{
     SESSION_MIN_LIFE_TIME, Users,
     session::{Session, Sessions},
+};
+use crate::{
+    audit_log::{AuditEvent, AuditService},
+    authentication::{SESSION_COOKIE_NAME, User, set_default_cookie_properties},
 };
 
 /// Inject user and session

--- a/backend/src/authentication/middleware.rs
+++ b/backend/src/authentication/middleware.rs
@@ -103,6 +103,8 @@ pub async fn extend_session(
 
 #[cfg(test)]
 mod test {
+    use std::{net::Ipv4Addr, str::FromStr};
+
     use axum::{
         body::Body,
         extract::{Request, State},
@@ -113,11 +115,9 @@ mod test {
     use cookie::Cookie;
     use hyper::header::SET_COOKIE;
     use sqlx::SqlitePool;
-    use std::{net::Ipv4Addr, str::FromStr};
     use test_log::test;
 
     use super::{extend_session, inject_user};
-
     use crate::{
         audit_log::{AuditLog, AuditService},
         authentication::{Role, SESSION_LIFE_TIME, SESSION_MIN_LIFE_TIME, Sessions, User, Users},

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -1,11 +1,11 @@
 use chrono::TimeDelta;
+pub use middleware::*;
+pub use role::{Admin, AdminOrCoordinator, Coordinator, Role, Typist};
+pub use user::{User, Users};
 
 pub use self::api::*;
 #[cfg(test)]
 pub use self::session::Sessions;
-pub use middleware::*;
-pub use role::{Admin, AdminOrCoordinator, Coordinator, Role, Typist};
-pub use user::{User, Users};
 
 pub mod api;
 pub mod error;
@@ -31,7 +31,6 @@ pub const SECURE_COOKIES: bool = false;
 
 #[cfg(test)]
 mod tests {
-    use super::role::Role;
     use api::{AccountUpdateRequest, Credentials, UserListResponse};
     use axum::{
         Router,
@@ -45,6 +44,7 @@ mod tests {
     use test_log::test;
     use tower::ServiceExt;
 
+    use super::role::Role;
     use crate::{
         AppState,
         authentication::{middleware::extend_session, session::Sessions, *},

--- a/backend/src/authentication/password.rs
+++ b/backend/src/authentication/password.rs
@@ -1,11 +1,10 @@
-use std::ops::Deref;
-
 use argon2::{
     Algorithm, Argon2, Params, Version,
     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
 use serde::Deserialize;
 use sqlx::Type;
+use std::ops::Deref;
 
 use super::error::AuthenticationError;
 

--- a/backend/src/authentication/password.rs
+++ b/backend/src/authentication/password.rs
@@ -1,10 +1,11 @@
+use std::ops::Deref;
+
 use argon2::{
     Algorithm, Argon2, Params, Version,
     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
 use serde::Deserialize;
 use sqlx::Type;
-use std::ops::Deref;
 
 use super::error::AuthenticationError;
 
@@ -93,8 +94,9 @@ pub(super) fn verify_password(password: &str, password_hash: &HashedPassword) ->
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_hash_password_and_verify() {

--- a/backend/src/authentication/role.rs
+++ b/backend/src/authentication/role.rs
@@ -6,12 +6,11 @@ use serde::{Deserialize, Serialize};
 use sqlx::Type;
 use utoipa::ToSchema;
 
-use crate::APIError;
-
 use super::{
     error::AuthenticationError,
     user::{User, Users},
 };
+use crate::APIError;
 
 #[derive(
     Serialize, Deserialize, strum::Display, Clone, Copy, Debug, PartialEq, Eq, Hash, ToSchema, Type,

--- a/backend/src/authentication/session.rs
+++ b/backend/src/authentication/session.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use axum::{
     extract::{FromRef, OptionalFromRequestParts},
     http::request::Parts,
@@ -9,14 +7,14 @@ use chrono::{DateTime, TimeDelta, Utc};
 use cookie::CookieBuilder;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, SqlitePool};
-
-use crate::{APIError, AppState};
+use std::time::Duration;
 
 use super::{
     SESSION_COOKIE_NAME, SESSION_LIFE_TIME,
     error::AuthenticationError,
     util::{create_new_session_key, get_expires_at},
 };
+use crate::{APIError, AppState};
 
 /// A session object, corresponds to a row in the sessions table
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, FromRow)]

--- a/backend/src/authentication/session.rs
+++ b/backend/src/authentication/session.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use axum::{
     extract::{FromRef, OptionalFromRequestParts},
     http::request::Parts,
@@ -7,7 +9,6 @@ use chrono::{DateTime, TimeDelta, Utc};
 use cookie::CookieBuilder;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, SqlitePool};
-use std::time::Duration;
 
 use super::{
     SESSION_COOKIE_NAME, SESSION_LIFE_TIME,

--- a/backend/src/authentication/user.rs
+++ b/backend/src/authentication/user.rs
@@ -7,13 +7,12 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Error, FromRow, SqlitePool, query, query_as};
 use utoipa::ToSchema;
 
-use crate::{APIError, AppState, audit_log::UserDetails};
-
 use super::{
     error::AuthenticationError,
     password::{HashedPassword, ValidatedPassword, hash_password, verify_password},
     role::Role,
 };
+use crate::{APIError, AppState, audit_log::UserDetails};
 
 const MIN_UPDATE_LAST_ACTIVITY_AT_SECS: i64 = 60; // 1 minute
 

--- a/backend/src/authentication/util.rs
+++ b/backend/src/authentication/util.rs
@@ -22,8 +22,9 @@ pub(super) fn get_expires_at(duration: TimeDelta) -> DateTime<Utc> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_create_new_session_key() {

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -1,13 +1,14 @@
-#[cfg(feature = "dev-database")]
-use abacus::fixtures;
-use abacus::start_server;
-use clap::Parser;
-use sqlx::{SqlitePool, sqlite::SqliteConnectOptions};
 use std::{
     error::Error,
     net::{Ipv4Addr, SocketAddr},
     str::FromStr,
 };
+
+#[cfg(feature = "dev-database")]
+use abacus::fixtures;
+use abacus::start_server;
+use clap::Parser;
+use sqlx::{SqlitePool, sqlite::SqliteConnectOptions};
 use tokio::net::TcpListener;
 #[cfg(feature = "dev-database")]
 use tracing::info;

--- a/backend/src/bin/gen-openapi.rs
+++ b/backend/src/bin/gen-openapi.rs
@@ -18,8 +18,9 @@ fn get_openapi_json() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn generated_openapi_json_is_up_to_date() {

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -491,13 +491,12 @@ pub mod tests {
     use sqlx::{SqlitePool, query};
     use test_log::test;
 
+    use super::*;
     use crate::{
         audit_log::AuditLog,
         authentication::Role,
         data_entry::{DifferencesCounts, PoliticalGroupVotes, VotersCounts, VotesCounts},
     };
-
-    use super::*;
 
     pub fn example_data_entry() -> DataEntry {
         DataEntry {

--- a/backend/src/data_entry/entry_number.rs
+++ b/backend/src/data_entry/entry_number.rs
@@ -1,6 +1,7 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 use sqlx::Sqlite;
-use std::fmt::Display;
 
 #[derive(Debug, Copy, Clone, Serialize, PartialEq, Eq)]
 pub enum EntryNumber {

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -1,7 +1,8 @@
+use std::fmt::Display;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::Type;
-use std::fmt::Display;
 use utoipa::ToSchema;
 
 use super::{
@@ -622,13 +623,14 @@ impl Default for DataEntryStatus {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::{
         data_entry::{CandidateVotes, PoliticalGroupVotes, VotersCounts, VotesCounts},
         election::{Candidate, Election, ElectionCategory, ElectionStatus, PoliticalGroup},
         polling_station::{PollingStation, PollingStationType},
     };
-    use test_log::test;
 
     fn polling_station_result() -> PollingStationResults {
         PollingStationResults {

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -1,15 +1,13 @@
-use std::fmt::Display;
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::Type;
+use std::fmt::Display;
 use utoipa::ToSchema;
 
-use super::{DataError, ValidationResults, validate_polling_station_results};
-use crate::{
-    APIError, data_entry::PollingStationResults, election::Election, error::ErrorReference,
-    polling_station::PollingStation,
+use super::{
+    DataError, PollingStationResults, ValidationResults, validate_polling_station_results,
 };
+use crate::{election::Election, polling_station::PollingStation};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DataEntryTransitionError {
@@ -35,22 +33,6 @@ impl From<DataError> for DataEntryTransitionError {
 impl From<ValidationResults> for DataEntryTransitionError {
     fn from(err: ValidationResults) -> Self {
         Self::ValidationError(err)
-    }
-}
-
-impl From<DataEntryTransitionError> for APIError {
-    fn from(err: DataEntryTransitionError) -> Self {
-        match err {
-            DataEntryTransitionError::FirstEntryAlreadyClaimed
-            | DataEntryTransitionError::SecondEntryAlreadyClaimed => {
-                APIError::Conflict(err.to_string(), ErrorReference::DataEntryAlreadyClaimed)
-            }
-            DataEntryTransitionError::FirstEntryAlreadyFinalised
-            | DataEntryTransitionError::SecondEntryAlreadyFinalised => {
-                APIError::Conflict(err.to_string(), ErrorReference::DataEntryAlreadyFinalised)
-            }
-            _ => APIError::Conflict(err.to_string(), ErrorReference::InvalidStateTransition),
-        }
     }
 }
 

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -1,15 +1,16 @@
-use crate::{
-    APIError,
-    audit_log::DataEntryDetails,
-    data_entry::status::DataEntryStatus,
-    election::{CandidateNumber, PGNumber, PoliticalGroup},
-    error::ErrorReference,
-};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, types::Json};
 use std::ops::AddAssign;
 use utoipa::ToSchema;
+
+use super::status::DataEntryStatus;
+use crate::{
+    APIError,
+    audit_log::DataEntryDetails,
+    election::{CandidateNumber, PGNumber, PoliticalGroup},
+    error::ErrorReference,
+};
 
 #[derive(Serialize, Deserialize, Clone, ToSchema, Debug, FromRow, Default)]
 pub struct PollingStationDataEntry {

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -1,7 +1,8 @@
+use std::ops::AddAssign;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, types::Json};
-use std::ops::AddAssign;
 use utoipa::ToSchema;
 
 use super::status::DataEntryStatus;
@@ -267,8 +268,9 @@ pub struct CandidateVotes {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_votes_addition() {

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -1,17 +1,12 @@
-use crate::{
-    APIError,
-    data_entry::{
-        CandidateVotes, Count, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
-        VotersCounts, VotesCounts,
-    },
-    election::Election,
-    polling_station::PollingStation,
-};
-
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use utoipa::ToSchema;
+
+use super::{
+    CandidateVotes, Count, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
+    VotersCounts, VotesCounts,
+};
+use crate::{election::Election, polling_station::PollingStation};
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Default, PartialEq, Eq)]
 pub struct ValidationResults {
@@ -154,12 +149,6 @@ impl DataError {
 impl fmt::Display for DataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Data error: {}", self.message)
-    }
-}
-
-impl From<DataError> for APIError {
-    fn from(err: DataError) -> Self {
-        APIError::InvalidData(err)
     }
 }
 

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -1,4 +1,5 @@
 use crate::{
+    APIError,
     data_entry::{
         CandidateVotes, Count, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
         VotersCounts, VotesCounts,
@@ -153,6 +154,12 @@ impl DataError {
 impl fmt::Display for DataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Data error: {}", self.message)
+    }
+}
+
+impl From<DataError> for APIError {
+    fn from(err: DataError) -> Self {
+        APIError::InvalidData(err)
     }
 }
 

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::{
@@ -892,11 +893,12 @@ impl Validate for CandidateVotes {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::{
         election::tests::election_fixture, polling_station::structs::tests::polling_station_fixture,
     };
-    use test_log::test;
 
     #[test]
     fn test_validation_result_append() {

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-database")]
+use axum::http::StatusCode;
 use axum::{
     Json,
     extract::{Path, State},
@@ -5,6 +7,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use self::repository::Elections;
 pub use self::structs::*;
@@ -13,15 +16,11 @@ use crate::{
     authentication::User,
     polling_station::{repository::PollingStations, structs::PollingStation},
 };
-
 #[cfg(feature = "dev-database")]
-use crate::audit_log::{AuditEvent, AuditService};
-#[cfg(feature = "dev-database")]
-use crate::authentication::Admin;
-#[cfg(feature = "dev-database")]
-use axum::http::StatusCode;
-use utoipa_axum::{router::OpenApiRouter, routes};
-
+use crate::{
+    audit_log::{AuditEvent, AuditService},
+    authentication::Admin,
+};
 pub(crate) mod repository;
 pub mod structs;
 

--- a/backend/src/election/repository.rs
+++ b/backend/src/election/repository.rs
@@ -1,4 +1,3 @@
-use crate::AppState;
 use axum::extract::FromRef;
 #[cfg(feature = "dev-database")]
 use sqlx::types::Json;
@@ -7,6 +6,7 @@ use sqlx::{Error, SqlitePool, query_as};
 use super::Election;
 #[cfg(feature = "dev-database")]
 use super::ElectionRequest;
+use crate::AppState;
 
 pub struct Elections(SqlitePool);
 

--- a/backend/src/election/structs.rs
+++ b/backend/src/election/structs.rs
@@ -131,9 +131,8 @@ pub enum CandidateGender {
 pub(crate) mod tests {
     use chrono::NaiveDate;
 
-    use crate::election::{Candidate, CandidateGender::X, ElectionCategory, PoliticalGroup};
-
     use super::*;
+    use crate::election::{Candidate, CandidateGender::X, ElectionCategory, PoliticalGroup};
 
     /// Create a test election with some political groups and a given number of seats.
     /// The number of political groups is the length of the `political_groups_candidates` slice.

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -1,10 +1,9 @@
-use std::io::BufRead;
-
 use quick_xml::{
     DeError, SeError,
     se::{Serializer, WriteResult},
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::io::BufRead;
 
 /// Base EML XML document that contains all the mostly irrelevant for our logic
 /// XML tags and setup.

--- a/backend/src/eml/base.rs
+++ b/backend/src/eml/base.rs
@@ -1,9 +1,10 @@
+use std::io::BufRead;
+
 use quick_xml::{
     DeError, SeError,
     se::{Serializer, WriteResult},
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::io::BufRead;
 
 /// Base EML XML document that contains all the mostly irrelevant for our logic
 /// XML tags and setup.
@@ -86,8 +87,9 @@ pub trait EMLDocument: Sized + DeserializeOwned + Serialize {
 }
 
 pub fn eml_document_hash(input: &str, chunked: bool) -> String {
-    use sha2::Digest;
     use std::fmt::Write;
+
+    use sha2::Digest;
     let digest = sha2::Sha256::digest(input.as_bytes());
 
     let mut res = String::new();
@@ -102,8 +104,9 @@ pub fn eml_document_hash(input: &str, chunked: bool) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[derive(Debug, Serialize, Deserialize)]
     struct EmptyDoc {

--- a/backend/src/eml/eml_510.rs
+++ b/backend/src/eml/eml_510.rs
@@ -487,10 +487,10 @@ impl CandidateIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::eml::{EMLDocument, common::ElectionDomain};
+    use test_log::test;
 
     use super::*;
-    use test_log::test;
+    use crate::eml::{EMLDocument, common::ElectionDomain};
 
     #[test]
     fn test_eml510b() {

--- a/backend/src/eml/eml_510.rs
+++ b/backend/src/eml/eml_510.rs
@@ -1,18 +1,17 @@
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    data_entry::{PoliticalGroupVotes, PollingStationResults},
-    polling_station::PollingStation,
-    summary::ElectionSummary,
-};
-
 use super::{
     EMLBase,
     common::{
         AffiliationIdentifier, AuthorityAddress, AuthorityIdentifier, ContestIdentifier,
         ElectionCategory, ElectionIdentifier, ElectionSubcategory, ManagingAuthority,
     },
+};
+use crate::{
+    data_entry::{PoliticalGroupVotes, PollingStationResults},
+    polling_station::PollingStation,
+    summary::ElectionSummary,
 };
 
 /// Vote count data for EML_NL 510

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use axum::{
     Json,
     extract::rejection::JsonRejection,
@@ -8,7 +10,6 @@ use hyper::header::InvalidHeaderValue;
 use quick_xml::SeError;
 use serde::{Deserialize, Serialize};
 use sqlx::Error::RowNotFound;
-use std::error::Error;
 use tracing::error;
 use utoipa::ToSchema;
 use zip::result::ZipError;

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -350,12 +350,6 @@ impl From<SeError> for APIError {
     }
 }
 
-impl From<ZipError> for APIError {
-    fn from(err: ZipError) -> Self {
-        APIError::ZipError(err)
-    }
-}
-
 impl From<Box<dyn Error>> for APIError {
     fn from(err: Box<dyn Error>) -> Self {
         APIError::StdError(err)

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -14,10 +14,8 @@ use utoipa::ToSchema;
 use zip::result::ZipError;
 
 use crate::{
-    apportionment::ApportionmentError,
-    authentication::error::AuthenticationError,
-    data_entry::{DataError, status::DataEntryTransitionError},
-    pdf_gen::PdfGenError,
+    apportionment::ApportionmentError, authentication::error::AuthenticationError,
+    data_entry::DataError, pdf_gen::PdfGenError,
 };
 
 /// Error reference used to show the corresponding error message to the end-user
@@ -339,12 +337,6 @@ impl From<sqlx::Error> for APIError {
     }
 }
 
-impl From<DataError> for APIError {
-    fn from(err: DataError) -> Self {
-        APIError::InvalidData(err)
-    }
-}
-
 impl From<InvalidHeaderValue> for APIError {
     fn from(_: InvalidHeaderValue) -> Self {
         APIError::InvalidHeaderValue
@@ -357,37 +349,9 @@ impl From<SeError> for APIError {
     }
 }
 
-impl From<DataEntryTransitionError> for APIError {
-    fn from(err: DataEntryTransitionError) -> Self {
-        match err {
-            DataEntryTransitionError::FirstEntryAlreadyClaimed
-            | DataEntryTransitionError::SecondEntryAlreadyClaimed => {
-                APIError::Conflict(err.to_string(), ErrorReference::DataEntryAlreadyClaimed)
-            }
-            DataEntryTransitionError::FirstEntryAlreadyFinalised
-            | DataEntryTransitionError::SecondEntryAlreadyFinalised => {
-                APIError::Conflict(err.to_string(), ErrorReference::DataEntryAlreadyFinalised)
-            }
-            _ => APIError::Conflict(err.to_string(), ErrorReference::InvalidStateTransition),
-        }
-    }
-}
-
-impl From<AuthenticationError> for APIError {
-    fn from(err: AuthenticationError) -> Self {
-        APIError::Authentication(err)
-    }
-}
-
 impl From<ZipError> for APIError {
     fn from(err: ZipError) -> Self {
         APIError::ZipError(err)
-    }
-}
-
-impl From<ApportionmentError> for APIError {
-    fn from(err: ApportionmentError) -> Self {
-        APIError::Apportionment(err)
     }
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,8 +1,9 @@
+use std::{error::Error, net::SocketAddr};
+
 #[cfg(feature = "memory-serve")]
 use axum::http::StatusCode;
 use axum::{Router, extract::FromRef, middleware, serve::ListenerExt};
 use sqlx::SqlitePool;
-use std::{error::Error, net::SocketAddr};
 use tokio::{net::TcpListener, signal};
 use tower_http::trace::{self, TraceLayer};
 use tracing::{Level, info, trace};

--- a/backend/src/pdf_gen/embedded/mod.rs
+++ b/backend/src/pdf_gen/embedded/mod.rs
@@ -1,6 +1,7 @@
 mod world;
 
 use std::time::Instant;
+
 use tracing::{debug, info, warn};
 use typst::{diag::SourceDiagnostic, ecow::EcoVec};
 use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};

--- a/backend/src/pdf_gen/embedded/mod.rs
+++ b/backend/src/pdf_gen/embedded/mod.rs
@@ -1,13 +1,12 @@
 mod world;
 
 use std::time::Instant;
-
-use super::{PdfGenResult, models::PdfModel};
 use tracing::{debug, info, warn};
 use typst::{diag::SourceDiagnostic, ecow::EcoVec};
-
-use crate::APIError;
 use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
+
+use super::{PdfGenResult, models::PdfModel};
+use crate::APIError;
 
 pub fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
     let start = Instant::now();

--- a/backend/src/pdf_gen/embedded/world.rs
+++ b/backend/src/pdf_gen/embedded/world.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-
-use super::super::models::PdfModel;
 use typst::{
     Library, World,
     diag::{FileError, FileResult},
@@ -9,6 +7,8 @@ use typst::{
     text::{Font, FontBook},
     utils::LazyHash,
 };
+
+use super::super::models::PdfModel;
 
 /// Contains the context for rendering PDFs.
 pub struct PdfWorld {

--- a/backend/src/pdf_gen/embedded/world.rs
+++ b/backend/src/pdf_gen/embedded/world.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+
 use typst::{
     Library, World,
     diag::{FileError, FileResult},

--- a/backend/src/pdf_gen/external.rs
+++ b/backend/src/pdf_gen/external.rs
@@ -1,10 +1,8 @@
+use rand::{Rng, distr::Alphanumeric};
 use std::{path::PathBuf, process::Command};
 
-use rand::{Rng, distr::Alphanumeric};
-
-use crate::APIError;
-
 use super::{PdfGenResult, models::PdfModel};
+use crate::APIError;
 
 pub fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
     generate_pdf_internal(model).map_err(APIError::PdfGenError)

--- a/backend/src/pdf_gen/external.rs
+++ b/backend/src/pdf_gen/external.rs
@@ -1,5 +1,6 @@
-use rand::{Rng, distr::Alphanumeric};
 use std::{path::PathBuf, process::Command};
+
+use rand::{Rng, distr::Alphanumeric};
 
 use super::{PdfGenResult, models::PdfModel};
 use crate::APIError;

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -8,7 +8,6 @@ mod external;
 
 #[cfg(feature = "embed-typst")]
 pub use embedded::{PdfGenError, generate_pdf};
-
 #[cfg(not(feature = "embed-typst"))]
 pub use external::{PdfGenError, generate_pdf};
 

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -1,11 +1,3 @@
-use self::repository::PollingStations;
-pub use self::structs::*;
-use crate::{
-    APIError, AppState, ErrorResponse,
-    audit_log::{AuditEvent, AuditService},
-    authentication::{AdminOrCoordinator, User},
-    election::repository::Elections,
-};
 use axum::{
     Json,
     extract::{Path, State},
@@ -15,6 +7,15 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
+
+use self::repository::PollingStations;
+pub use self::structs::*;
+use crate::{
+    APIError, AppState, ErrorResponse,
+    audit_log::{AuditEvent, AuditService},
+    authentication::{AdminOrCoordinator, User},
+    election::repository::Elections,
+};
 
 pub mod repository;
 pub mod structs;

--- a/backend/src/polling_station/repository.rs
+++ b/backend/src/polling_station/repository.rs
@@ -1,10 +1,8 @@
 use axum::extract::FromRef;
 use sqlx::{SqlitePool, query, query_as};
 
-use crate::{
-    AppState,
-    polling_station::structs::{PollingStation, PollingStationRequest},
-};
+use super::structs::{PollingStation, PollingStationRequest};
+use crate::AppState;
 
 pub struct PollingStations(SqlitePool);
 

--- a/backend/src/polling_station/structs.rs
+++ b/backend/src/polling_station/structs.rs
@@ -90,9 +90,8 @@ impl From<String> for PollingStationType {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::election::tests::election_fixture;
-
     use super::*;
+    use crate::election::tests::election_fixture;
 
     /// Create a test polling station.
     pub fn polling_station_fixture(number_of_voters: Option<i64>) -> PollingStation {

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -17,6 +17,12 @@ use crate::{
     summary::ElectionSummary,
 };
 
+impl From<ZipError> for APIError {
+    fn from(err: ZipError) -> Self {
+        APIError::ZipError(err)
+    }
+}
+
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(election_download_zip_results))

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -1,3 +1,8 @@
+use axum::extract::{Path, State};
+use axum_extra::response::Attachment;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use zip::{result::ZipError, write::SimpleFileOptions};
+
 use crate::{
     APIError, AppState, ErrorResponse,
     authentication::Coordinator,
@@ -11,10 +16,6 @@ use crate::{
     polling_station::{repository::PollingStations, structs::PollingStation},
     summary::ElectionSummary,
 };
-use axum::extract::{Path, State};
-use axum_extra::response::Attachment;
-use utoipa_axum::{router::OpenApiRouter, routes};
-use zip::{result::ZipError, write::SimpleFileOptions};
 
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()

--- a/backend/src/summary/mod.rs
+++ b/backend/src/summary/mod.rs
@@ -225,9 +225,10 @@ impl SumCount {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::{election::tests::election_fixture, pdf_gen::tests::polling_stations_fixture};
-    use test_log::test;
 
     fn polling_station_results_fixture_a() -> PollingStationResults {
         PollingStationResults {

--- a/backend/tests/account_integration_test.rs
+++ b/backend/tests/account_integration_test.rs
@@ -4,7 +4,8 @@ use hyper::StatusCode;
 use serde_json::{Value, json};
 use sqlx::SqlitePool;
 use test_log::test;
-use utils::serve_api;
+
+use crate::utils::serve_api;
 
 pub mod shared;
 pub mod utils;

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -1,12 +1,5 @@
 #![cfg(test)]
 
-use crate::{
-    shared::{
-        create_and_finalise_data_entry, create_result, create_result_with_non_example_data_entry,
-        differences_counts_zero, political_group_votes_from_test_data_auto,
-    },
-    utils::serve_api,
-};
 use abacus::{
     ErrorResponse,
     apportionment::{
@@ -20,6 +13,14 @@ use abacus::{
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
+
+use crate::{
+    shared::{
+        create_and_finalise_data_entry, create_result, create_result_with_non_example_data_entry,
+        differences_counts_zero, political_group_votes_from_test_data_auto,
+    },
+    utils::serve_api,
+};
 
 pub mod shared;
 pub mod utils;

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -1,15 +1,5 @@
 #![cfg(test)]
 
-use abacus::{
-    ErrorResponse,
-    apportionment::{
-        ElectionApportionmentResponse, Fraction, get_total_seats_from_apportionment_result,
-    },
-    data_entry::{
-        DataEntry, PollingStationResults, VotersCounts, VotesCounts, status::ClientState,
-    },
-    election::Election,
-};
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
@@ -20,6 +10,16 @@ use crate::{
         differences_counts_zero, political_group_votes_from_test_data_auto,
     },
     utils::serve_api,
+};
+use abacus::{
+    ErrorResponse,
+    apportionment::{
+        ElectionApportionmentResponse, Fraction, get_total_seats_from_apportionment_result,
+    },
+    data_entry::{
+        DataEntry, PollingStationResults, VotersCounts, VotesCounts, status::ClientState,
+    },
+    election::Election,
 };
 
 pub mod shared;

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -1,22 +1,23 @@
 #![cfg(test)]
 
-use axum::http::HeaderValue;
-use reqwest::{Response, StatusCode};
-use serde_json::json;
-use sqlx::SqlitePool;
 use std::{collections::BTreeMap, net::SocketAddr};
-use test_log::test;
 
-use crate::{
-    shared::{claim_data_entry, create_and_finalise_data_entry, save_data_entry},
-    utils::serve_api,
-};
 use abacus::{
     ErrorResponse,
     data_entry::{
         ClaimDataEntryResponse, ElectionStatusResponse, ElectionStatusResponseEntry,
         SaveDataEntryResponse, ValidationResultCode, status::DataEntryStatusName::*,
     },
+};
+use axum::http::HeaderValue;
+use reqwest::{Response, StatusCode};
+use serde_json::json;
+use sqlx::SqlitePool;
+use test_log::test;
+
+use crate::{
+    shared::{claim_data_entry, create_and_finalise_data_entry, save_data_entry},
+    utils::serve_api,
 };
 
 pub mod shared;

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -2,13 +2,6 @@
 
 use std::{collections::BTreeMap, net::SocketAddr};
 
-use abacus::{
-    ErrorResponse,
-    data_entry::{
-        ClaimDataEntryResponse, ElectionStatusResponse, ElectionStatusResponseEntry,
-        SaveDataEntryResponse, ValidationResultCode, status::DataEntryStatusName::*,
-    },
-};
 use axum::http::HeaderValue;
 use reqwest::{Response, StatusCode};
 use serde_json::json;
@@ -18,6 +11,13 @@ use test_log::test;
 use crate::{
     shared::{claim_data_entry, create_and_finalise_data_entry, save_data_entry},
     utils::serve_api,
+};
+use abacus::{
+    ErrorResponse,
+    data_entry::{
+        ClaimDataEntryResponse, ElectionStatusResponse, ElectionStatusResponseEntry,
+        SaveDataEntryResponse, ValidationResultCode, status::DataEntryStatusName::*,
+    },
 };
 
 pub mod shared;

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -1,13 +1,13 @@
 #![cfg(test)]
 
+#[cfg(feature = "dev-database")]
+use abacus::election::Election;
+use abacus::election::{ElectionDetailsResponse, ElectionListResponse};
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
 
 use crate::{shared::create_result, utils::serve_api};
-#[cfg(feature = "dev-database")]
-use abacus::election::Election;
-use abacus::election::{ElectionDetailsResponse, ElectionListResponse};
 
 pub mod shared;
 pub mod utils;

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -1,13 +1,12 @@
 #![cfg(test)]
 
 #[cfg(feature = "dev-database")]
-use abacus::election::Election;
-use abacus::election::{ElectionDetailsResponse, ElectionListResponse};
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
 
 use crate::{shared::create_result, utils::serve_api};
+use abacus::election::{Election, ElectionDetailsResponse, ElectionListResponse};
 
 pub mod shared;
 pub mod utils;

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -1,12 +1,13 @@
 #![cfg(test)]
 
-#[cfg(feature = "dev-database")]
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
 
 use crate::{shared::create_result, utils::serve_api};
-use abacus::election::{Election, ElectionDetailsResponse, ElectionListResponse};
+#[cfg(feature = "dev-database")]
+use abacus::election::Election;
+use abacus::election::{ElectionDetailsResponse, ElectionListResponse};
 
 pub mod shared;
 pub mod utils;

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -1,11 +1,5 @@
 #![cfg(test)]
 
-use abacus::{
-    ErrorResponse,
-    polling_station::{
-        PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
-    },
-};
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
@@ -13,6 +7,12 @@ use test_log::test;
 use crate::{
     shared::{claim_data_entry, create_result, save_data_entry},
     utils::serve_api,
+};
+use abacus::{
+    ErrorResponse,
+    polling_station::{
+        PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
+    },
 };
 
 pub mod shared;

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -1,5 +1,11 @@
 #![cfg(test)]
 
+use abacus::{
+    ErrorResponse,
+    polling_station::{
+        PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
+    },
+};
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
@@ -7,12 +13,6 @@ use test_log::test;
 use crate::{
     shared::{claim_data_entry, create_result, save_data_entry},
     utils::serve_api,
-};
-use abacus::{
-    ErrorResponse,
-    polling_station::{
-        PollingStation, PollingStationListResponse, PollingStationRequest, PollingStationType,
-    },
 };
 
 pub mod shared;

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -2,6 +2,12 @@
 
 use std::net::SocketAddr;
 
+use axum::http::{HeaderValue, StatusCode};
+use hyper::header::CONTENT_TYPE;
+use reqwest::{Body, Client};
+use serde_json::json;
+use tracing::trace;
+
 use abacus::{
     data_entry::{
         CandidateVotes, Count, DataEntry, DifferencesCounts, ElectionStatusResponse,
@@ -11,11 +17,6 @@ use abacus::{
     },
     election::{CandidateNumber, PGNumber},
 };
-use axum::http::{HeaderValue, StatusCode};
-use hyper::header::CONTENT_TYPE;
-use reqwest::{Body, Client};
-use serde_json::json;
-use tracing::trace;
 
 pub fn differences_counts_zero() -> DifferencesCounts {
     DifferencesCounts {

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use std::net::SocketAddr;
+
 use abacus::{
     data_entry::{
         CandidateVotes, Count, DataEntry, DifferencesCounts, ElectionStatusResponse,
@@ -13,7 +15,6 @@ use axum::http::{HeaderValue, StatusCode};
 use hyper::header::CONTENT_TYPE;
 use reqwest::{Body, Client};
 use serde_json::json;
-use std::net::SocketAddr;
 use tracing::trace;
 
 pub fn differences_counts_zero() -> DifferencesCounts {

--- a/backend/tests/user_integration_test.rs
+++ b/backend/tests/user_integration_test.rs
@@ -1,11 +1,12 @@
 #![cfg(test)]
 
-use abacus::authentication::UserListResponse;
 use hyper::StatusCode;
 use serde_json::{Value, json};
 use sqlx::SqlitePool;
 use test_log::test;
-use utils::serve_api;
+
+use crate::utils::serve_api;
+use abacus::authentication::UserListResponse;
 
 pub mod shared;
 pub mod utils;

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
-use sqlx::SqlitePool;
 use std::net::SocketAddr;
-use tokio::net::TcpListener;
 
 use abacus::start_server;
+use sqlx::SqlitePool;
+use tokio::net::TcpListener;
 
 pub async fn serve_api(pool: SqlitePool) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -2,9 +2,10 @@
 
 use std::net::SocketAddr;
 
-use abacus::start_server;
 use sqlx::SqlitePool;
 use tokio::net::TcpListener;
+
+use abacus::start_server;
 
 pub async fn serve_api(pool: SqlitePool) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
- Moved impls for ApiError to respective modules
- Reordered imports in all Rust files where not consistent into 3 groups:
1.    `std`, `core` and `alloc`,
2.    external crates,
3.    `self`, `super` and `crate` imports.
- Moved imports from crate to super where possible

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->