### PR TITLE
Preview the differences resolve action in the tables

### DIFF
--- a/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "vitest";
 
 import { render, screen } from "@/testing/test-utils";
+import { ResolveAction } from "@/types/generated/openapi";
 
 import { DifferencesRow, DifferencesTable } from "./DifferencesTable";
+import cls from "./ResolveDifferences.module.css";
 
 const tableHeaders = ["Code", "First", "Second", "Description"];
 
-function renderTable(rows: DifferencesRow[]) {
-  render(<DifferencesTable title={"Differences"} headers={tableHeaders} rows={rows} />);
+function renderTable(rows: DifferencesRow[], action: ResolveAction | undefined = undefined) {
+  render(<DifferencesTable title={"Differences"} headers={tableHeaders} rows={rows} action={action} />);
 }
 
 describe("DifferencesTable", () => {
@@ -76,5 +78,49 @@ describe("DifferencesTable", () => {
       [""],
       ["H", "80", "88", "Skip two"],
     ]);
+  });
+
+  describe("show result of action in differences tables", () => {
+    const rows = [{ first: 10, second: 11 }];
+
+    test("keep_first_entry", async () => {
+      renderTable(rows, "keep_first_entry");
+      const [first, second] = await screen.findAllByRole("cell");
+
+      expect(first).toHaveClass(cls.keep!);
+      expect(first).not.toHaveClass(cls.discard!);
+      expect(second).toHaveClass(cls.discard!);
+      expect(second).not.toHaveClass(cls.keep!);
+    });
+
+    test("keep_second_entry", async () => {
+      renderTable(rows, "keep_second_entry");
+      const [first, second] = await screen.findAllByRole("cell");
+
+      expect(first).toHaveClass(cls.discard!);
+      expect(first).not.toHaveClass(cls.keep!);
+      expect(second).toHaveClass(cls.keep!);
+      expect(second).not.toHaveClass(cls.discard!);
+    });
+
+    test("discard_both_entries", async () => {
+      renderTable(rows, "discard_both_entries");
+      const [first, second] = await screen.findAllByRole("cell");
+
+      expect(first).toHaveClass(cls.discard!);
+      expect(first).not.toHaveClass(cls.keep!);
+      expect(second).toHaveClass(cls.discard!);
+      expect(second).not.toHaveClass(cls.keep!);
+    });
+
+    test("no action chosen", async () => {
+      renderTable(rows, undefined);
+      const [first, second] = await screen.findAllByRole("cell");
+
+      expect(first).not.toHaveClass(cls.keep!);
+      expect(first).not.toHaveClass(cls.discard!);
+      expect(second).not.toHaveClass(cls.discard!);
+      expect(second).not.toHaveClass(cls.keep!);
+    });
   });
 });

--- a/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
@@ -1,6 +1,8 @@
 import { Fragment, useId } from "react";
 
 import { Table } from "@/components/ui/Table/Table";
+import { ResolveAction } from "@/types/generated/openapi";
+import { cn } from "@/utils/classnames";
 
 import cls from "./ResolveDifferences.module.css";
 
@@ -8,6 +10,7 @@ interface DifferencesTableProps {
   title: string;
   headers: string[];
   rows: DifferencesRow[];
+  action?: ResolveAction;
 }
 
 const zeroDash = <span className={cls.zeroDash}>&mdash;</span>;
@@ -19,7 +22,9 @@ export interface DifferencesRow {
   description?: string;
 }
 
-export function DifferencesTable({ title, headers, rows }: DifferencesTableProps) {
+const CELL_CLASSES = ["text-align-r", "font-number", "bold"];
+
+export function DifferencesTable({ title, headers, rows, action }: DifferencesTableProps) {
   const id = useId();
   // An array of indices for rows that are different, also used to detect row gaps.
   // Two falsy values are considered equal (e.g. 0 and undefined)
@@ -32,9 +37,16 @@ export function DifferencesTable({ title, headers, rows }: DifferencesTableProps
     return null;
   }
 
+  const keepFirst = action === "keep_first_entry";
+  const keepSecond = action === "keep_second_entry";
+  const discardFirst = action === "keep_second_entry" || action === "discard_both_entries";
+  const discardSecond = action === "keep_first_entry" || action === "discard_both_entries";
+
   return (
     <section className="mt-lg mb-xl">
-      <h2 id={id}>{title}</h2>
+      <h3 className="heading-lg" id={id}>
+        {title}
+      </h3>
       <div>
         <Table className={cls.differencesTable} aria-labelledby={id}>
           <Table.Header>
@@ -60,10 +72,10 @@ export function DifferencesTable({ title, headers, rows }: DifferencesTableProps
                     <Table.HeaderCell scope="row" className="text-align-r normal">
                       {rows[rowIndex]?.code}
                     </Table.HeaderCell>
-                    <Table.Cell className="text-align-r font-number bold">
+                    <Table.Cell className={cn(...CELL_CLASSES, keepFirst && cls.keep, discardFirst && cls.discard)}>
                       {rows[rowIndex]?.first || zeroDash}
                     </Table.Cell>
-                    <Table.Cell className="text-align-r font-number bold">
+                    <Table.Cell className={cn(...CELL_CLASSES, keepSecond && cls.keep, discardSecond && cls.discard)}>
                       {rows[rowIndex]?.second || zeroDash}
                     </Table.Cell>
                     <Table.Cell>{rows[rowIndex]?.description}</Table.Cell>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -1,3 +1,13 @@
+.keep {
+  background-color: var(--color-success-bg);
+}
+
+.discard {
+  color: var(--gray-500);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cline x1='0' y1='0' x2='100' y2='100' stroke='%23D0D5DD' /%3E%3Cline x1='0' y1='100' x2='100' y2='0' stroke='%23D0D5DD' /%3E%3C/svg%3E");
+  background-size: 100% 100%;
+}
+
 .differencesTable {
   td {
     height: 4.5rem;

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -9,6 +9,7 @@
 }
 
 .differencesTable {
+  table-layout: fixed;
   td {
     height: 4.5rem;
   }

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -4,7 +4,7 @@
   }
 
   td.gapRow {
-    height: 2rem;
+    height: 1.5rem;
   }
 
   td:not(.gapRow) {

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.stories.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.stories.tsx
@@ -1,19 +1,43 @@
 import { Story } from "@ladle/react";
 
+import { Alert } from "@/components/ui/Alert/Alert";
 import { politicalGroupsMockData } from "@/testing/api-mocks/ElectionMockData";
+import { ResolveAction } from "@/types/generated/openapi";
 
 import { pollingStationResultsMockData } from "../testing/polling-station-results";
 import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
 
-export default {
-  title: "App / Resolve Differences",
+type Props = {
+  action: ResolveAction;
 };
 
-export const DefaultResolveDifferencesTables: Story = () => (
-  <ResolveDifferencesTables
-    first={pollingStationResultsMockData(true)}
-    second={pollingStationResultsMockData(false)}
-    politicalGroups={politicalGroupsMockData}
-  />
-);
+const actions: ResolveAction[] = ["keep_first_entry", "keep_second_entry", "discard_both_entries"];
+
+export default {
+  title: "App / Resolve Differences",
+  argTypes: {
+    action: {
+      options: actions,
+      control: { type: "radio" },
+    },
+  },
+};
+
+export const DefaultResolveDifferencesTables: Story<Props> = ({ action }) => {
+  return (
+    <>
+      <Alert type="notify" small>
+        <p>Previewing the result of an action can be seen using the Controls below</p>
+      </Alert>
+
+      <ResolveDifferencesTables
+        first={pollingStationResultsMockData(true)}
+        second={pollingStationResultsMockData(false)}
+        action={action}
+        politicalGroups={politicalGroupsMockData}
+      />
+    </>
+  );
+};
+
 DefaultResolveDifferencesTables.storyName = "ResolveDifferencesTables";

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
@@ -1,5 +1,5 @@
 import { t } from "@/lib/i18n";
-import { PoliticalGroup, PoliticalGroupVotes, PollingStationResults } from "@/types/generated/openapi";
+import { PoliticalGroup, PoliticalGroupVotes, PollingStationResults, ResolveAction } from "@/types/generated/openapi";
 import { getCandidateFullName } from "@/utils/candidate";
 
 import { DataEntrySection, getFromResults, sections } from "../utils/dataEntry";
@@ -9,13 +9,14 @@ export interface ResolveDifferencesTablesProps {
   first: PollingStationResults;
   second: PollingStationResults;
   politicalGroups: PoliticalGroup[];
+  action?: ResolveAction;
 }
 
-export function ResolveDifferencesTables({ first, second, politicalGroups }: ResolveDifferencesTablesProps) {
+export function ResolveDifferencesTables({ first, second, action, politicalGroups }: ResolveDifferencesTablesProps) {
   return (
     <>
       {sections.map((section) => (
-        <SectionTable key={section.id} section={section} first={first} second={second} />
+        <SectionTable key={section.id} section={section} first={first} second={second} action={action} />
       ))}
 
       {politicalGroups.map((politicalGroup, i) => (
@@ -24,6 +25,7 @@ export function ResolveDifferencesTables({ first, second, politicalGroups }: Res
           politicalGroup={politicalGroup}
           first={first.political_group_votes[i]}
           second={second.political_group_votes[i]}
+          action={action}
         />
       ))}
     </>
@@ -34,9 +36,10 @@ interface SectionTableProps {
   section: DataEntrySection;
   first: PollingStationResults;
   second: PollingStationResults;
+  action?: ResolveAction;
 }
 
-function SectionTable({ section, first, second }: SectionTableProps) {
+function SectionTable({ section, first, second, action }: SectionTableProps) {
   const title = t(`resolve_differences.section.${section.id}`);
 
   const headers = [
@@ -53,7 +56,7 @@ function SectionTable({ section, first, second }: SectionTableProps) {
     description: t(`polling_station_results.field.${field.path}`),
   }));
 
-  return <DifferencesTable title={title} headers={headers} rows={rows} />;
+  return <DifferencesTable title={title} headers={headers} rows={rows} action={action} />;
 }
 
 function yesno<T>(value: T) {
@@ -70,9 +73,10 @@ interface CandidatesTableProps {
   politicalGroup: PoliticalGroup;
   first?: PoliticalGroupVotes;
   second?: PoliticalGroupVotes;
+  action?: ResolveAction;
 }
 
-function CandidatesTable({ politicalGroup, first, second }: CandidatesTableProps) {
+function CandidatesTable({ politicalGroup, first, second, action }: CandidatesTableProps) {
   if (!first || !second) {
     return null;
   }
@@ -93,5 +97,5 @@ function CandidatesTable({ politicalGroup, first, second }: CandidatesTableProps
     description: getCandidateFullName(candidate),
   }));
 
-  return <DifferencesTable title={title} headers={headers} rows={rows} />;
+  return <DifferencesTable title={title} headers={headers} rows={rows} action={action} />;
 }


### PR DESCRIPTION
Resolves the table component part of #1247
Can be seen and played with in Ladle [here](https://308f9308.kiesraad-abacus.pages.dev/ladle/?story=app--resolve-differences--resolve-differences-tables)

- Add prop to tables for the action chosen
- Render first and second entry cells accordingly
- Fix gap row height issue noticed by @jorisleker 