### PR TITLE
Capitalize "gemeentelijk stembureau" and "centraal stembureau" in front-end

### DIFF
--- a/frontend/src/lib/i18n/locales/nl/election_report.json
+++ b/frontend/src/lib/i18n/locales/nl/election_report.json
@@ -1,7 +1,7 @@
 {
   "finish_data_entry_phase": "Invoerfase afronden?",
   "about_to_stop_data_entry": "Je staat op het punt het invoeren van stemmen te stoppen.",
-  "data_entry_finish_steps_explanation": "<ul><li>In de volgende stap kan je het proces-verbaal van deze zitting opmaken en de officiële telbestanden downloaden.</li><li>Zolang het concept proces-verbaal nog niet is ondertekend en gedeeld met het centraal stembureau, kan je nog terug naar de steminvoer.</li></ul>",
+  "data_entry_finish_steps_explanation": "<ul><li>In de volgende stap kan je het proces-verbaal van deze zitting opmaken en de officiële telbestanden downloaden.</li><li>Zolang het concept proces-verbaal nog niet is ondertekend en gedeeld met het Centraal Stembureau, kan je nog terug naar de steminvoer.</li></ul>",
   "for_recount_new_session_needed": "Als er na het afronden van de zitting nog stemmen herteld worden, moet dan in een nieuwe zitting van het gemeentelijke stembureau.",
   "download_report": "Download los proces-verbaal",
   "download_zip": "Download proces-verbaal met telbestand"

--- a/frontend/src/lib/i18n/locales/nl/recounted.json
+++ b/frontend/src/lib/i18n/locales/nl/recounted.json
@@ -1,6 +1,6 @@
 {
   "recounted_form_title": "Is het selectievakje op de eerste pagina aangevinkt?",
-  "message": "Was er een onverklaard verschil tussen het aantal toegelaten kiezers en het aantal uitgebrachte stemmen? Is er op basis daarvan herteld door het gemeentelijk stembureau? Dan is het selectievakje op de eerste pagina van het papieren formulier aangevinkt.",
+  "message": "Was er een onverklaard verschil tussen het aantal toegelaten kiezers en het aantal uitgebrachte stemmen? Is er op basis daarvan herteld door het Gemeentelijk Stembureau? Dan is het selectievakje op de eerste pagina van het papieren formulier aangevinkt.",
   "recounted_yes": "Ja, er was een hertelling",
   "recounted_no": "Nee, er was geen hertelling"
 }

--- a/frontend/src/lib/i18n/locales/nl/voters_and_votes.json
+++ b/frontend/src/lib/i18n/locales/nl/voters_and_votes.json
@@ -1,5 +1,5 @@
 {
-  "admitted_voters_after_recount": "Toegelaten kiezers na hertelling door gemeentelijk stembureau",
+  "admitted_voters_after_recount": "Toegelaten kiezers na hertelling door Gemeentelijk Stembureau",
   "blank_votes_count": "Blanco stemmen",
   "form_accept_warnings": "Ik heb de aantallen gecontroleerd met het papier en correct overgenomen.",
   "form_title": "Toegelaten kiezers en uitgebrachte stemmen",


### PR DESCRIPTION
### Scope

Searched for "gemeentelijk stembureau" and "centraal stembureau" in our nl json files and capitalized the starting letters where they weren't yet.