### PR TITLE
Remove inline images

### DIFF
--- a/frontend/src/assets/icons/times.svg
+++ b/frontend/src/assets/icons/times.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+    <line x1="0" y1="0" x2="100" y2="100" stroke="#D0D5DD" />
+    <line x1="0" y1="100" x2="100" y2="0" stroke="#D0D5DD" />
+</svg>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -23,7 +23,7 @@
 
 .discard {
   color: var(--gray-500);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cline x1='0' y1='0' x2='100' y2='100' stroke='%23D0D5DD' /%3E%3Cline x1='0' y1='100' x2='100' y2='0' stroke='%23D0D5DD' /%3E%3C/svg%3E");
+  background-image: url("../../../assets/icons/times.svg");
   background-size: 100% 100%;
 }
 


### PR DESCRIPTION
Our new security headers do not permit inline images, this removes the only inline image I could find (an moves it to a file).