### PR TITLE
More verbose file uploads from github actions

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -189,7 +189,7 @@ jobs:
         run: strip abacus
       - name: Upload binary to test server
         run: |
-          curl -s \
+          curl -s -v \
           --fail \
           -H "Authorization: Bearer ${{ secrets.ABACUS_TEST_API_KEY }}" \
           -T ./abacus \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           name: abacus-ubuntu-latest
       - name: Upload binary to test server
         run: |
-          curl -s \
+          curl -s -v \
           --fail \
           -H "Authorization: Bearer ${{ secrets.ABACUS_TEST_API_KEY }}" \
           -T ./abacus \


### PR DESCRIPTION
This will show the request and response for uploads to abacus-test.

Note that we still pass the `-s` silent flag to hide the progress bar etc.