### PR TITLE
Fix styling for resolve differences tables

### DIFF
--- a/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
@@ -56,6 +56,20 @@ describe("DifferencesTable", () => {
     expect(table).toHaveTableContent([tableHeaders, ["A", "10", "\u2014", "Some value"]]);
   });
 
+  test("Render a string value as-is", async () => {
+    renderTable([{ code: "A", first: "Ja", second: "Nee", description: "Some value" }]);
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveTableContent([tableHeaders, ["A", "Ja", "Nee", "Some value"]]);
+  });
+
+  test("Render a big number with thousands separator", async () => {
+    renderTable([{ code: "A", first: 10_120_334, second: 9_344_042, description: "Some value" }]);
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveTableContent([tableHeaders, ["A", "10.120.334", "9.344.042", "Some value"]]);
+  });
+
   test("Render gap rows between rows with differences", async () => {
     renderTable([
       { code: "A", first: 10, second: 10, description: "Same" },

--- a/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useId } from "react";
+import { Fragment, ReactElement, useId } from "react";
 
 import { Table } from "@/components/ui/Table/Table";
 import { ResolveAction } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
+import { formatNumber } from "@/utils/format";
 
 import cls from "./ResolveDifferences.module.css";
 
@@ -13,7 +14,15 @@ interface DifferencesTableProps {
   action?: ResolveAction;
 }
 
-const zeroDash = <span className={cls.zeroDash}>&mdash;</span>;
+function formatValue(value: string | number | undefined): string | ReactElement {
+  if (!value) {
+    return <span className={cls.zeroDash}>&mdash;</span>;
+  } else if (typeof value === "string") {
+    return value;
+  } else {
+    return formatNumber(value);
+  }
+}
 
 export interface DifferencesRow {
   code?: number | string;
@@ -73,10 +82,10 @@ export function DifferencesTable({ title, headers, rows, action }: DifferencesTa
                       {rows[rowIndex]?.code}
                     </Table.HeaderCell>
                     <Table.Cell className={cn(...CELL_CLASSES, keepFirst && cls.keep, discardFirst && cls.discard)}>
-                      {rows[rowIndex]?.first || zeroDash}
+                      {formatValue(rows[rowIndex]?.first)}
                     </Table.Cell>
                     <Table.Cell className={cn(...CELL_CLASSES, keepSecond && cls.keep, discardSecond && cls.discard)}>
-                      {rows[rowIndex]?.second || zeroDash}
+                      {formatValue(rows[rowIndex]?.second)}
                     </Table.Cell>
                     <Table.Cell>{rows[rowIndex]?.description}</Table.Cell>
                   </Table.Row>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -18,6 +18,7 @@
 }
 
 .keep {
+  color: black;
   background-color: var(--color-success-bg);
 }
 

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
@@ -51,12 +51,13 @@ describe("ResolveDifferencesTables", () => {
     expect(fieryWingsPartyTable).toBeVisible();
     expect(fieryWingsPartyTable).toHaveTableContent([
       ["Nummer", "Eerste invoer", "Tweede invoer", "Kandidaat"],
+      ["1", "1.256", "1.258", "Zilverlicht, E. (Eldor)"],
+      [""],
       ["3", "65", "63", "Fluisterwind, S. (Seraphina)"],
       ["4", "26", "28", "Nachtschaduw, V. (Vesper)"],
       [""],
       ["12", "4", "—", "Groenhart, T. (Timo)"],
       ["13", "2", "4", "Veldbloem, N. (Naima)"],
-      ["14", "—", "2", "IJzeren, V. (Vincent)"],
     ]);
 
     const wiseOfWaterAndWindTable = screen.queryByRole("table", {

--- a/frontend/src/features/resolve_differences/testing/polling-station-results.ts
+++ b/frontend/src/features/resolve_differences/testing/polling-station-results.ts
@@ -39,9 +39,9 @@ export function pollingStationResultsMockData(first: boolean): PollingStationRes
     political_group_votes: [
       {
         number: 1,
-        total: first ? 512 : 481,
+        total: first ? 1512 : 1481,
         candidate_votes: [
-          { number: 1, votes: 256 },
+          { number: 1, votes: first ? 1256 : 1258 },
           { number: 2, votes: 128 },
           { number: 3, votes: first ? 65 : 63 },
           { number: 4, votes: first ? 26 : 28 },
@@ -54,7 +54,7 @@ export function pollingStationResultsMockData(first: boolean): PollingStationRes
           { number: 9, votes: 0 },
           { number: 10, votes: first ? 4 : 0 },
           { number: 11, votes: first ? 2 : 4 },
-          { number: 12, votes: first ? 0 : 2 },
+          { number: 12, votes: 0 },
         ],
       },
       {


### PR DESCRIPTION
- Fix formatting big numbers with thousands separator
- Fix text black for values with a green "keep" background

Both can be seen in updated [Ladle deployment](https://579b7721.kiesraad-abacus.pages.dev/ladle/?arg-action=keep_first_entry&story=app--resolve-differences--resolve-differences-tables)