### PR TITLE
Allow inlined images in CSP

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -135,7 +135,7 @@ pub fn router(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
         ))
         .layer(SetResponseHeaderLayer::overriding(
             header::CONTENT_SECURITY_POLICY,
-            HeaderValue::from_static("default-src 'self'"),
+            HeaderValue::from_static("default-src 'self'; img-src 'self' data:"),
         ))
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-permitted-cross-domain-policies"),
@@ -267,7 +267,7 @@ mod test {
             assert_eq!(response.headers()["x-content-type-options"], "nosniff");
             assert_eq!(
                 response.headers()["content-security-policy"],
-                "default-src 'self'"
+                "default-src 'self'; img-src 'self' data:"
             );
             assert_eq!(
                 response.headers()["x-permitted-cross-domain-policies"],

--- a/frontend/src/assets/icons/times.svg
+++ b/frontend/src/assets/icons/times.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none">
-    <line x1="0" y1="0" x2="100" y2="100" stroke="#D0D5DD" />
-    <line x1="0" y1="100" x2="100" y2="0" stroke="#D0D5DD" />
-</svg>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -24,7 +24,7 @@
 
 .discard {
   color: var(--gray-500);
-  background-image: url("../../../assets/icons/times.svg");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cline x1='0' y1='0' x2='100' y2='100' stroke='%23D0D5DD' /%3E%3Cline x1='0' y1='100' x2='100' y2='0' stroke='%23D0D5DD' /%3E%3C/svg%3E");
   background-size: 100% 100%;
 }
 


### PR DESCRIPTION
Vite automatically inlines images to `data:` URLs, which was broken by the strict CSP in #1466. This PR fixes this by explicitly allowing inlined images from `data:` URLs. The (insufficient) fix in #1481 is undone.