### PR TITLE
Add NumberInput Playwright test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "test:e2e-dev": "cross-env RUST_LOG=tower_http-warning playwright test -c playwright.e2e.config.ts",
     "test:e2e-ui": "cross-env LOCAL_CI=true playwright test -c playwright.e2e.config.ts --ui",
     "test:ladle": "playwright test -c playwright.ladle.config.ts",
+    "test:ladle-ui": "playwright test -c playwright.ladle.config.ts --ui",
     "ladle": "ladle serve",
     "build:ladle": "ladle build",
     "start:msw": "cross-env API_MODE=mock vite",

--- a/frontend/src/components/ui/NumberInput/NumberInput.e2e.ts
+++ b/frontend/src/components/ui/NumberInput/NumberInput.e2e.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("NumberInput", () => {
+  test("number formatting", async ({ page }) => {
+    await page.goto("/?story=number-input--default-number-input");
+    await page.waitForSelector("[data-storyloaded]");
+
+    const input = page.getByTestId("test");
+    await expect(input).toBeVisible();
+    await expect(input).toHaveValue("12.300");
+
+    await input.focus();
+    await expect(input).toHaveValue("12300");
+
+    await input.blur();
+    await expect(input).toHaveValue("12.300");
+
+    // BUG: Playwright with Chrome will append the new value instead of replacing the old value
+    // without `clear()` or `selectText()` or `focus()`
+    await input.clear();
+
+    await input.fill("9999");
+    await expect(input).toHaveValue("9999");
+
+    await input.blur();
+    await expect(input).toHaveValue("9.999");
+  });
+});

--- a/frontend/src/components/ui/NumberInput/NumberInput.e2e.ts
+++ b/frontend/src/components/ui/NumberInput/NumberInput.e2e.ts
@@ -14,10 +14,22 @@ test.describe("NumberInput", () => {
 
     await input.blur();
     await expect(input).toHaveValue("12.300");
+  });
+
+  test("change formatted number", async ({ page, browserName }) => {
+    await page.goto("/?story=number-input--default-number-input");
+    await page.waitForSelector("[data-storyloaded]");
+
+    const input = page.getByTestId("test");
+    await expect(input).toBeVisible();
+    await expect(input).toHaveValue("12.300");
 
     // BUG: Playwright with Chrome will append the new value instead of replacing the old value
     // without `clear()` or `selectText()` or `focus()`
-    await input.clear();
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (browserName == "chromium") {
+      await input.clear();
+    }
 
     await input.fill("9999");
     await expect(input).toHaveValue("9999");


### PR DESCRIPTION
Added a Playwright test to reproduce https://github.com/kiesraad/abacus/issues/1487

A workaround is to clear the input before using `fill()`, and it seems to be Chrome only. Firefox and Safari work just fine without the workaround.

If anybody has a solution to fix this within the NumberInput itself that would be preferable, the issue does not occur if `input.value = newValue;` is not changing the value, which is the reason this only occurs for numbers > 999.

