### PR TITLE
Add second admin and coordinator to backend fixtures

### DIFF
--- a/backend/fixtures/users.sql
+++ b/backend/fixtures/users.sql
@@ -1,10 +1,14 @@
 INSERT INTO users (id, username, fullname, role, password_hash, needs_password_change)
 -- Passwords:
 -- admin: 'AdminPassword01'
+-- admin2: 'Admin2Password01'
 -- coordinator: 'CoordinatorPassword01'
+-- coordinator: 'Coordinator2Password01'
 -- typist: 'TypistPassword01'
 -- typist2: 'Typist2Password01'
 VALUES (1, 'admin', 'Sanne Molenaar', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$QUKK7UVINt+ORMFA+7egeQ$iWQBzhaWH5NupuTSJA5jzxC20y/SH8j53rdz5YTema4', false),
-       (2, 'coordinator', 'Mohammed van der Velden', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$M3/ivnARZ5AHMGIAIc+hpA$AUNjzm2yEWIkMlaam8BKFxr4gv3TbU+nyiAcSZrmfoM', false),
-       (3, 'typist', 'Sam Kuijpers', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$Er+VXYLcGjIJL8i1aCUofA$fjT6Cp1tNr0HhI+LUE+hZG8GnvZI+m9qNXr6mcyJzQM', false),
-       (4, 'typist2', 'Aliyah van den Berg', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$wQphZULq5ttINkUDRTSzow$vUVBCYFJOaEMWUYiI0kYLgtlPACYXwikuxWfj+0QM9o', false);
+       (2, 'admin2', 'Jef van Reybrouck', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$T3GsSA2b0DoADC99nNvUiQ$aFbvgSyHJwEly0s88XypgceNNXtJVhBmCD5Eu9/xD7I', false),
+       (3, 'coordinator', 'Mohammed van der Velden', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$M3/ivnARZ5AHMGIAIc+hpA$AUNjzm2yEWIkMlaam8BKFxr4gv3TbU+nyiAcSZrmfoM', false),
+       (4, 'coordinator2', 'Mei Chen', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$wgaSTPo3hhk3RTR9eDf/TQ$2wi/gsHEDslt1cqoWzL1zS07Y+5tlYg4V/lp2ZYcS5g', false),
+       (5, 'typist', 'Sam Kuijpers', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$Er+VXYLcGjIJL8i1aCUofA$fjT6Cp1tNr0HhI+LUE+hZG8GnvZI+m9qNXr6mcyJzQM', false),
+       (6, 'typist2', 'Aliyah van den Berg', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$wQphZULq5ttINkUDRTSzow$vUVBCYFJOaEMWUYiI0kYLgtlPACYXwikuxWfj+0QM9o', false);

--- a/backend/fixtures/users.sql
+++ b/backend/fixtures/users.sql
@@ -3,7 +3,7 @@ INSERT INTO users (id, username, fullname, role, password_hash, needs_password_c
 -- admin: 'AdminPassword01'
 -- admin2: 'Admin2Password01'
 -- coordinator: 'CoordinatorPassword01'
--- coordinator: 'Coordinator2Password01'
+-- coordinator2: 'Coordinator2Password01'
 -- typist: 'TypistPassword01'
 -- typist2: 'Typist2Password01'
 VALUES (1, 'admin1', 'Sanne Molenaar', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$trZGY1jE5OSpt+NG9NvY1w$vofrcEyML5A70ZR6EhwdqfLsv81DjkYMJvgXeKFLqQ4', false),

--- a/backend/fixtures/users.sql
+++ b/backend/fixtures/users.sql
@@ -6,9 +6,9 @@ INSERT INTO users (id, username, fullname, role, password_hash, needs_password_c
 -- coordinator: 'Coordinator2Password01'
 -- typist: 'TypistPassword01'
 -- typist2: 'Typist2Password01'
-VALUES (1, 'admin', 'Sanne Molenaar', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$QUKK7UVINt+ORMFA+7egeQ$iWQBzhaWH5NupuTSJA5jzxC20y/SH8j53rdz5YTema4', false),
+VALUES (1, 'admin1', 'Sanne Molenaar', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$trZGY1jE5OSpt+NG9NvY1w$vofrcEyML5A70ZR6EhwdqfLsv81DjkYMJvgXeKFLqQ4', false),
        (2, 'admin2', 'Jef van Reybrouck', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$T3GsSA2b0DoADC99nNvUiQ$aFbvgSyHJwEly0s88XypgceNNXtJVhBmCD5Eu9/xD7I', false),
-       (3, 'coordinator', 'Mohammed van der Velden', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$M3/ivnARZ5AHMGIAIc+hpA$AUNjzm2yEWIkMlaam8BKFxr4gv3TbU+nyiAcSZrmfoM', false),
+       (3, 'coordinator1', 'Mohammed van der Velden', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$D6QmytaEld06P+sZ1p5osg$RqPv1nE7sosIeEoAl9wA96dC1R9RTO9om9aOYZPi3iw', false),
        (4, 'coordinator2', 'Mei Chen', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$wgaSTPo3hhk3RTR9eDf/TQ$2wi/gsHEDslt1cqoWzL1zS07Y+5tlYg4V/lp2ZYcS5g', false),
-       (5, 'typist', 'Sam Kuijpers', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$Er+VXYLcGjIJL8i1aCUofA$fjT6Cp1tNr0HhI+LUE+hZG8GnvZI+m9qNXr6mcyJzQM', false),
+       (5, 'typist1', 'Sam Kuijpers', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$xQo7+6SEm9qRdViNg3/hsg$nA926/HWrQfih8xx5NPR5PXvtE2DqndImHiPWP7HDdQ', false),
        (6, 'typist2', 'Aliyah van den Berg', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$wQphZULq5ttINkUDRTSzow$vUVBCYFJOaEMWUYiI0kYLgtlPACYXwikuxWfj+0QM9o', false);

--- a/backend/src/audit_log/api.rs
+++ b/backend/src/audit_log/api.rs
@@ -156,7 +156,7 @@ mod tests {
 
     async fn create_log_entries(pool: SqlitePool) {
         let user = Users::new(pool.clone())
-            .get_by_username("admin")
+            .get_by_username("admin1")
             .await
             .unwrap()
             .unwrap();
@@ -265,6 +265,6 @@ mod tests {
         let result: Vec<AuditLogUser> = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].username, "admin");
+        assert_eq!(result[0].username, "admin1");
     }
 }

--- a/backend/src/audit_log/service.rs
+++ b/backend/src/audit_log/service.rs
@@ -88,7 +88,7 @@ mod test {
         let service = AuditService {
             log: AuditLog::new(pool.clone()),
             ip: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 0))),
-            user: Users::new(pool).get_by_username("admin").await.unwrap(),
+            user: Users::new(pool).get_by_username("admin1").await.unwrap(),
         };
 
         let audit_event = AuditEvent::UserLoggedIn(UserLoggedInDetails {
@@ -109,7 +109,7 @@ mod test {
         assert_eq!(event.event_level(), &AuditEventLevel::Success);
         assert_eq!(event.message(), Some(&"User logged in".to_string()));
         assert_eq!(event.user_id(), 1);
-        assert_eq!(event.username(), "admin");
+        assert_eq!(event.username(), "admin1");
         assert_eq!(event.ip(), Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 0))));
     }
 

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -504,7 +504,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let result: UserListResponse = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result.users.len(), 4);
+        assert_eq!(result.users.len(), 6);
     }
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -65,7 +65,7 @@ mod tests {
             .with_state(state)
     }
 
-    async fn login(app: Router) -> HeaderValue {
+    async fn login_as_admin(app: Router) -> HeaderValue {
         let response = app
             .oneshot(
                 Request::builder()
@@ -74,8 +74,8 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
-                            password: "AdminPassword01".to_string(),
+                            username: "admin1".to_string(),
+                            password: "Admin1Password01".to_string(),
                         })
                         .unwrap(),
                     ))
@@ -99,8 +99,8 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
-                            password: "AdminPassword01".to_string(),
+                            username: "admin1".to_string(),
+                            password: "Admin1Password01".to_string(),
                         })
                         .unwrap(),
                     ))
@@ -116,7 +116,7 @@ mod tests {
         let result: LoginResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(result.user_id, 1);
-        assert_eq!(result.username, "admin");
+        assert_eq!(result.username, "admin1");
     }
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
@@ -157,8 +157,8 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
-                            password: "AdminPassword01".to_string(),
+                            username: "admin1".to_string(),
+                            password: "Admin1Password01".to_string(),
                         })
                         .unwrap(),
                     ))
@@ -180,7 +180,7 @@ mod tests {
         let result: LoginResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(result.user_id, 1);
-        assert_eq!(result.username, "admin");
+        assert_eq!(result.username, "admin1");
 
         let response = app
             .clone()
@@ -245,8 +245,8 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
-                            password: "AdminPassword01".to_string(),
+                            username: "admin1".to_string(),
+                            password: "Admin1Password01".to_string(),
                         })
                         .unwrap(),
                     ))
@@ -268,7 +268,7 @@ mod tests {
         let result: LoginResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(result.user_id, 1);
-        assert_eq!(result.username, "admin");
+        assert_eq!(result.username, "admin1");
 
         let response = app
             .clone()
@@ -289,7 +289,7 @@ mod tests {
         let result: LoginResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(result.user_id, 1);
-        assert_eq!(result.username, "admin");
+        assert_eq!(result.username, "admin1");
 
         // logout the current user
         let response = app
@@ -352,8 +352,8 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
-                            password: "AdminPassword01".to_string(),
+                            username: "admin1".to_string(),
+                            password: "Admin1Password01".to_string(),
                         })
                         .unwrap(),
                     ))
@@ -384,7 +384,7 @@ mod tests {
                     .header("cookie", &cookie)
                     .body(Body::from(
                         serde_json::to_vec(&AccountUpdateRequest {
-                            username: "admin".to_string(),
+                            username: "admin1".to_string(),
                             password: "TotallyValidNewP4ssW0rd".to_string(),
                             fullname: None,
                         })
@@ -399,7 +399,7 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let result: LoginResponse = serde_json::from_slice(&body).unwrap();
 
-        assert_eq!(result.username, "admin");
+        assert_eq!(result.username, "admin1");
 
         let response = app
             .oneshot(
@@ -409,7 +409,7 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
+                            username: "admin1".to_string(),
                             password: "TotallyValidNewP4ssW0rd".to_string(),
                         })
                         .unwrap(),
@@ -435,8 +435,8 @@ mod tests {
                     .header(CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         serde_json::to_vec(&Credentials {
-                            username: "admin".to_string(),
-                            password: "AdminPassword01".to_string(),
+                            username: "admin1".to_string(),
+                            password: "Admin1Password01".to_string(),
                         })
                         .unwrap(),
                     ))
@@ -565,7 +565,7 @@ mod tests {
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_create(pool: SqlitePool) {
         let app = create_app(pool.clone());
-        let cookie = login(app.clone()).await;
+        let cookie = login_as_admin(app.clone()).await;
         let response = app
             .clone()
             .oneshot(
@@ -599,7 +599,7 @@ mod tests {
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_update_user(pool: SqlitePool) {
         let app = create_app(pool.clone());
-        let cookie = login(app.clone()).await;
+        let cookie = login_as_admin(app.clone()).await;
         let response = app
             .clone()
             .oneshot(
@@ -623,7 +623,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let result: user::User = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result.username(), "admin");
+        assert_eq!(result.username(), "admin1");
         assert_eq!(result.fullname().unwrap(), "Test Full Name".to_string());
         assert_eq!(result.role(), Role::Administrator);
     }

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -84,6 +84,9 @@ mod tests {
             .await
             .unwrap();
 
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get("set-cookie").is_some());
+
         response.headers().get("set-cookie").unwrap().clone()
     }
 
@@ -148,39 +151,7 @@ mod tests {
     async fn test_logout(pool: SqlitePool) {
         let app = create_app(pool);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/api/user/login")
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&Credentials {
-                            username: "admin1".to_string(),
-                            password: "Admin1Password01".to_string(),
-                        })
-                        .unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let cookie = response
-            .headers()
-            .get("set-cookie")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let result: LoginResponse = serde_json::from_slice(&body).unwrap();
-
-        assert_eq!(result.user_id, 1);
-        assert_eq!(result.username, "admin1");
+        let cookie = login_as_admin(app.clone()).await;
 
         let response = app
             .clone()
@@ -236,39 +207,7 @@ mod tests {
     async fn test_whoami(pool: SqlitePool) {
         let app = create_app(pool);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/api/user/login")
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&Credentials {
-                            username: "admin1".to_string(),
-                            password: "Admin1Password01".to_string(),
-                        })
-                        .unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let cookie = response
-            .headers()
-            .get("set-cookie")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let result: LoginResponse = serde_json::from_slice(&body).unwrap();
-
-        assert_eq!(result.user_id, 1);
-        assert_eq!(result.username, "admin1");
+        let cookie = login_as_admin(app.clone()).await;
 
         let response = app
             .clone()
@@ -343,35 +282,7 @@ mod tests {
     async fn test_update_password(pool: SqlitePool) {
         let app = create_app(pool);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/api/user/login")
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&Credentials {
-                            username: "admin1".to_string(),
-                            password: "Admin1Password01".to_string(),
-                        })
-                        .unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert!(response.headers().get("set-cookie").is_some());
-
-        let cookie = response
-            .headers()
-            .get("set-cookie")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
+        let cookie = login_as_admin(app.clone()).await;
 
         // Call the account update endpoint
         let response = app
@@ -426,35 +337,7 @@ mod tests {
     async fn test_update_password_fail(pool: SqlitePool) {
         let app = create_app(pool);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/api/user/login")
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&Credentials {
-                            username: "admin1".to_string(),
-                            password: "Admin1Password01".to_string(),
-                        })
-                        .unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert!(response.headers().get("set-cookie").is_some());
-
-        let cookie = response
-            .headers()
-            .get("set-cookie")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
+        let cookie = login_as_admin(app.clone()).await;
 
         // Call the account update endpoint with incorrect user
         let response = app

--- a/backend/tests/account_integration_test.rs
+++ b/backend/tests/account_integration_test.rs
@@ -19,7 +19,7 @@ async fn test_account_update(pool: SqlitePool) {
     let response = reqwest::Client::new()
         .put(&url)
         .json(&json!({
-            "username": "admin",
+            "username": "admin1",
             "fullname": "Saartje Molenaar",
             "password": "MyLongPassword13"
         }))
@@ -35,7 +35,7 @@ async fn test_account_update(pool: SqlitePool) {
     );
 
     let body: Value = response.json().await.unwrap();
-    assert_eq!(body["username"], "admin");
+    assert_eq!(body["username"], "admin1");
     assert_eq!(body["fullname"], "Saartje Molenaar");
     assert_eq!(body["needs_password_change"], false);
 }

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -367,9 +367,9 @@ async fn get_statuses(
 async fn test_election_details_status(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let typist_cookie = shared::typist_login(&addr).await;
-    let typist_user_id = 3;
+    let typist_user_id = 5;
     let typist2_cookie = shared::typist2_login(&addr).await;
-    let typist2_user_id = 4;
+    let typist2_user_id = 6;
     let coordinator_cookie = shared::coordinator_login(&addr).await;
 
     // Ensure the statuses are "NotStarted"

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -268,17 +268,17 @@ pub async fn create_result_with_non_example_data_entry(
 
 /// Calls the login endpoint for an Admin user and returns the session cookie
 pub async fn admin_login(addr: &SocketAddr) -> HeaderValue {
-    login(addr, "admin", "AdminPassword01").await
+    login(addr, "admin1", "Admin1Password01").await
 }
 
 /// Calls the login endpoint for a Coordinator user and returns the session cookie
 pub async fn coordinator_login(addr: &SocketAddr) -> HeaderValue {
-    login(addr, "coordinator", "CoordinatorPassword01").await
+    login(addr, "coordinator1", "Coordinator1Password01").await
 }
 
 /// Calls the login endpoint for a Typist user and returns the session cookie
 pub async fn typist_login(addr: &SocketAddr) -> HeaderValue {
-    login(addr, "typist", "TypistPassword01").await
+    login(addr, "typist1", "Typist1Password01").await
 }
 
 /// Calls the login endpoint for a Typist user and returns the session cookie

--- a/backend/tests/user_integration_test.rs
+++ b/backend/tests/user_integration_test.rs
@@ -83,11 +83,18 @@ async fn test_user_listing(pool: SqlitePool) {
         "Unexpected response status"
     );
     let body: UserListResponse = response.json().await.unwrap();
-    assert_eq!(body.users.len(), 4);
+    assert_eq!(body.users.len(), 6);
     assert!(body.users.iter().any(|ps| {
-        ["admin", "coordinator", "typist"]
-            .iter()
-            .any(|u| ps.username() == *u)
+        [
+            "admin1",
+            "admin2",
+            "coordinator1",
+            "coordinator2",
+            "typist1",
+            "typist2",
+        ]
+        .iter()
+        .any(|u| ps.username() == *u)
     }))
 }
 
@@ -250,8 +257,8 @@ async fn test_user_change_to_same_password_fails(pool: SqlitePool) {
     let response = reqwest::Client::new()
         .put(&url)
         .json(&json!({
-            "username": "typist",
-            "password": "TypistPassword01",
+            "username": "typist1",
+            "password": "Typist1Password01",
         }))
         .header("cookie", typist_cookie)
         .send()
@@ -280,7 +287,7 @@ async fn test_user_get(pool: SqlitePool) {
 
     assert_eq!(body["id"], 1);
     assert_eq!(body["role"], "administrator");
-    assert_eq!(body["username"], "admin");
+    assert_eq!(body["username"], "admin1");
     assert_eq!(body["fullname"], "Sanne Molenaar");
 }
 
@@ -342,7 +349,7 @@ async fn test_can_delete_logged_in_user(pool: SqlitePool) {
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_1", "users"))))]
 async fn test_cant_do_anything_when_password_needs_change(pool: SqlitePool) {
     let addr = serve_api(pool).await;
-    let url = format!("http://{addr}/api/user/3");
+    let url = format!("http://{addr}/api/user/5");
     let admin_cookie = shared::admin_login(&addr).await;
     let typist_cookie = shared::typist_login(&addr).await;
 
@@ -368,15 +375,15 @@ async fn test_cant_do_anything_when_password_needs_change(pool: SqlitePool) {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     // Login again with the temporary password
-    let typist_cookie = shared::login(&addr, "typist", "TotallyValidTempP4ssW0rd").await;
+    let typist_cookie = shared::login(&addr, "typist1", "TotallyValidTempP4ssW0rd").await;
 
     // User sets password
     let url = format!("http://{addr}/api/user/account");
     let response = reqwest::Client::new()
         .put(&url)
         .json(&json!({
-            "username": "typist",
-            "password": "TypistPassword02",
+            "username": "typist1",
+            "password": "Typist1Password02",
         }))
         .header("cookie", &typist_cookie)
         .send()

--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -56,7 +56,7 @@ type Fixtures = {
 async function completePollingStationDataEntries(request: APIRequestContext, pollingStationId: number) {
   for (const entryNumber of [1, 2]) {
     if (entryNumber === 1) {
-      await loginAs(request, "typist");
+      await loginAs(request, "typist1");
     } else if (entryNumber === 2) {
       await loginAs(request, "typist2");
     }
@@ -69,7 +69,7 @@ async function completePollingStationDataEntries(request: APIRequestContext, pol
 }
 
 async function completePollingStationDataEntriesWithDifferences(request: APIRequestContext, pollingStationId: number) {
-  await loginAs(request, "typist");
+  await loginAs(request, "typist1");
   const firstDataEntry = new DataEntryApiClient(request, pollingStationId, 1);
   await firstDataEntry.claim();
   await firstDataEntry.save(noRecountNoDifferencesRequest);
@@ -106,14 +106,14 @@ export const test = base.extend<Fixtures>({
   },
   pollingStationFirstEntryClaimed: async ({ typistOne, pollingStation }, use) => {
     const { request } = typistOne;
-    await loginAs(request, "typist");
+    await loginAs(request, "typist1");
 
     const firstDataEntry = new DataEntryApiClient(request, pollingStation.id, 1);
     await firstDataEntry.claim();
     await use(pollingStation);
   },
   emptyElection: async ({ request }, use) => {
-    await loginAs(request, "admin");
+    await loginAs(request, "admin1");
     // override the current storage state
     // create an election with no polling stations
     const url: ELECTION_CREATE_REQUEST_PATH = `/api/elections`;
@@ -124,7 +124,7 @@ export const test = base.extend<Fixtures>({
     await use(election);
   },
   election: async ({ request, emptyElection }, use) => {
-    await loginAs(request, "admin");
+    await loginAs(request, "admin1");
     // create polling stations in the existing emptyElection
     const url: POLLING_STATION_CREATE_REQUEST_PATH = `/api/elections/${emptyElection.id}/polling_stations`;
     for (const pollingStationRequest of pollingStationRequests) {
@@ -141,7 +141,7 @@ export const test = base.extend<Fixtures>({
     await use(election);
   },
   pollingStation: async ({ request, election }, use) => {
-    await loginAs(request, "admin");
+    await loginAs(request, "admin1");
     // get the first polling station of the existing election
     const url: POLLING_STATION_GET_REQUEST_PATH = `/api/elections/${election.election.id}/polling_stations/${election.polling_stations[0]?.id ?? 0}`;
     const response = await request.get(url);
@@ -151,7 +151,7 @@ export const test = base.extend<Fixtures>({
     await use(pollingStation);
   },
   pollingStationFirstEntryDone: async ({ request, pollingStation }, use) => {
-    await loginAs(request, "typist");
+    await loginAs(request, "typist1");
 
     const firstDataEntry = new DataEntryApiClient(request, pollingStation.id, 1);
     await firstDataEntry.claim();
@@ -178,7 +178,7 @@ export const test = base.extend<Fixtures>({
     await use(election.election);
   },
   newTypist: async ({ request }, use) => {
-    await loginAs(request, "admin");
+    await loginAs(request, "admin1");
     // create a new user
     const url: USER_CREATE_REQUEST_PATH = "/api/user";
     const data: USER_CREATE_REQUEST_BODY = {

--- a/frontend/e2e-tests/setup.ts
+++ b/frontend/e2e-tests/setup.ts
@@ -15,13 +15,13 @@ async function globalSetup(config: FullConfig) {
   const baseUrl = config.projects[0]?.use.baseURL;
   const session = await request.newContext({ baseURL: baseUrl });
 
-  await loginAs(session, "admin");
+  await loginAs(session, "admin1");
   await session.storageState({ path: "e2e-tests/state/admin.json" });
 
-  await loginAs(session, "coordinator");
+  await loginAs(session, "coordinator1");
   await session.storageState({ path: "e2e-tests/state/coordinator.json" });
 
-  await loginAs(session, "typist");
+  await loginAs(session, "typist1");
   await session.storageState({ path: "e2e-tests/state/typist.json" });
 
   await loginAs(session, "typist2");

--- a/frontend/e2e-tests/tests/authentication.e2e.ts
+++ b/frontend/e2e-tests/tests/authentication.e2e.ts
@@ -10,8 +10,8 @@ test.describe("authentication", () => {
     await page.goto("/account/login");
 
     const loginPage = new LoginPgObj(page);
-    await loginPage.username.fill("admin");
-    await loginPage.password.fill("AdminPassword01");
+    await loginPage.username.fill("admin1");
+    await loginPage.password.fill("Admin1Password01");
     await loginPage.loginBtn.click();
 
     await page.waitForURL("/elections");

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -154,7 +154,7 @@ test.describe("resume data entry flow", () => {
       await expect(dataEntryHomePage.fieldset).toBeVisible();
       await expect(dataEntryHomePage.resumeDataEntry).toBeVisible();
 
-      await loginAs(request, "typist");
+      await loginAs(request, "typist1");
       const dataEntryResponse = await request.post(`/api/polling_stations/${pollingStation.id}/data_entries/1/claim`);
       expect(dataEntryResponse.status()).toBe(200);
       expect(await dataEntryResponse.json()).toMatchObject({
@@ -228,7 +228,7 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await loginAs(request, "typist");
+      await loginAs(request, "typist1");
       const dataEntryResponse = await request.post(`/api/polling_stations/${pollingStation.id}/data_entries/1/claim`);
       expect(dataEntryResponse.status()).toBe(200);
       expect(await dataEntryResponse.json()).toMatchObject({
@@ -381,7 +381,7 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await loginAs(request, "typist");
+      await loginAs(request, "typist1");
       const claimResponse = await request.post(`/api/polling_stations/${pollingStation.id}/data_entries/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject(emptyDataEntryResponse);
@@ -423,7 +423,7 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await loginAs(request, "typist");
+      await loginAs(request, "typist1");
       const claimResponse = await request.post(`/api/polling_stations/${pollingStation.id}/data_entries/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject(emptyDataEntryResponse);

--- a/frontend/src/features/dev/components/DevHomePage.tsx
+++ b/frontend/src/features/dev/components/DevHomePage.tsx
@@ -95,10 +95,10 @@ function DevLinks() {
           <Link
             to="/dev"
             onClick={() => {
-              void login("admin", "AdminPassword01");
+              void login("admin1", "Admin1Password01");
             }}
           >
-            {t("administrator")}
+            {t("administrator")} 1
           </Link>
         </li>
         <li>
@@ -115,10 +115,10 @@ function DevLinks() {
           <Link
             to="/dev"
             onClick={() => {
-              void login("coordinator", "CoordinatorPassword01");
+              void login("coordinator1", "Coordinator1Password01");
             }}
           >
-            {t("coordinator")}
+            {t("coordinator")} 1
           </Link>
         </li>
         <li>
@@ -135,10 +135,10 @@ function DevLinks() {
           <Link
             to="/dev"
             onClick={() => {
-              void login("typist", "TypistPassword01");
+              void login("typist1", "Typist1Password01");
             }}
           >
-            {t("typist")}
+            {t("typist")} 1
           </Link>
         </li>
         <li>

--- a/frontend/src/features/dev/components/DevHomePage.tsx
+++ b/frontend/src/features/dev/components/DevHomePage.tsx
@@ -105,10 +105,30 @@ function DevLinks() {
           <Link
             to="/dev"
             onClick={() => {
+              void login("admin2", "Admin2Password01");
+            }}
+          >
+            {t("administrator")} 2
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/dev"
+            onClick={() => {
               void login("coordinator", "CoordinatorPassword01");
             }}
           >
             {t("coordinator")}
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/dev"
+            onClick={() => {
+              void login("coordinator2", "Coordinator2Password01");
+            }}
+          >
+            {t("coordinator")} 2
           </Link>
         </li>
         <li>


### PR DESCRIPTION
Motivation for this change is me wondering what happens if two coordinators try to resolve differences between data entries 1 and 2 at the same time. So I want to have two coordinators and two admins in our backend fixtures.

### Scope
- add second admin to backend fixtures and dev page
- add second coordinator to backend fixtures and dev page
- update `admin`, `coordinator` and `typist` fixtures to have `1` in their name and password
- fix tests: backend tests and e2e tests
- more `let cookie = login_as_admin(app.clone()).await;` in `backend/src/authentication/mod.rs`
