### PR TITLE
1522 add field to election

### DIFF
--- a/backend/fixtures/election_1.sql
+++ b/backend/fixtures/election_1.sql
@@ -1,6 +1,6 @@
-INSERT INTO elections (id, name, location, number_of_voters, category, number_of_seats, election_date, nomination_date,
+INSERT INTO elections (id, name, election_id, location, domain_id, number_of_voters, category, number_of_seats, election_date, nomination_date,
                        status, political_groups)
-VALUES (1, 'Gemeenteraad 2026', 'Juinen', 3500, 'Municipal', 29, '2024-11-30', '2024-11-1', 'DataEntryInProgress', '[
+VALUES (1, 'Gemeenteraad 2026', 'Juinen_2024', 'Juinen', '0000', 3500, 'Municipal', 29, '2024-11-30', '2024-11-1', 'DataEntryInProgress', '[
          {
            "number": 1,
            "name": "Lijst Hekking",

--- a/backend/fixtures/election_2.sql
+++ b/backend/fixtures/election_2.sql
@@ -1,7 +1,7 @@
-INSERT INTO elections (id, name, location, number_of_voters, category, number_of_seats, election_date, nomination_date,
+INSERT INTO elections (id, name, election_id, location, domain_id, number_of_voters, category, number_of_seats, election_date, nomination_date,
                        status, political_groups)
 -- number_of_seats explicitly set to a value less than 19, to be used in elections with less than 19 seats
-VALUES (2, 'Municipal Election', 'Heemdamseburg', 100, 'Municipal', 15, '2024-11-30', '2024-11-1',
+VALUES (2, 'Municipal Election', 'Heemdamseburg_2024', 'Heemdamseburg', '0000', 100, 'Municipal', 15, '2024-11-30', '2024-11-1',
         'DataEntryInProgress',
         '[
           {

--- a/backend/fixtures/election_3.sql
+++ b/backend/fixtures/election_3.sql
@@ -1,6 +1,6 @@
-INSERT INTO elections (id, name, location, number_of_voters, category, number_of_seats, election_date, nomination_date,
+INSERT INTO elections (id, name, election_id, location, domain_id, number_of_voters, category, number_of_seats, election_date, nomination_date,
                        status, political_groups)
-VALUES (3, 'Municipal Re-election', 'Heemdamseburg', 100, 'Municipal', 29, '2024-12-31', '2024-12-1',
+VALUES (3, 'Municipal Re-election', 'Heemdamseburg_2024', 'Heemdamseburg', '0000', 100, 'Municipal', 29, '2024-12-31', '2024-12-1',
         'DataEntryInProgress',
         '[
           {

--- a/backend/fixtures/election_4.sql
+++ b/backend/fixtures/election_4.sql
@@ -1,6 +1,6 @@
-INSERT INTO elections (id, name, location, number_of_voters, category, number_of_seats, election_date, nomination_date,
+INSERT INTO elections (id, name, election_id, location, domain_id, number_of_voters, category, number_of_seats, election_date, nomination_date,
                        status, political_groups)
-VALUES (4, 'Test Election < 19 seats', 'Test Location', 2000, 'Municipal', 15, '2026-03-18', '2026-02-02',
+VALUES (4, 'Test Election < 19 seats', 'TestLocation_2026', 'Test Location', '0000', 2000, 'Municipal', 15, '2026-03-18', '2026-02-02',
         'DataEntryInProgress',
         '[
           {

--- a/backend/fixtures/election_5.sql
+++ b/backend/fixtures/election_5.sql
@@ -1,6 +1,6 @@
-INSERT INTO elections (id, name, location, number_of_voters, category, number_of_seats, election_date, nomination_date,
+INSERT INTO elections (id, name, election_id, location, domain_id, number_of_voters, category, number_of_seats, election_date, nomination_date,
                        status, political_groups)
-VALUES (5, 'Test Election >= 19 seats', 'Grote Stad', 2000, 'Municipal', 23, '2026-03-18', '2026-02-02',
+VALUES (5, 'Test Election >= 19 seats', 'GroteStad_2026', 'Grote Stad', '0000', 2000, 'Municipal', 23, '2026-03-18', '2026-02-02',
         'DataEntryInProgress',
         '[
           {
@@ -306,6 +306,6 @@ VALUES (5, 'Test Election >= 19 seats', 'Grote Stad', 2000, 'Municipal', 23, '20
           }
         ]');
 
-INSERT INTO polling_stations (id, election_id, name, number, number_of_voters, polling_station_type, address, 
+INSERT INTO polling_stations (id, election_id, name, number, number_of_voters, polling_station_type, address,
                               postal_code, locality)
 VALUES (8, 5, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad');

--- a/backend/migrations/1_elections.sql
+++ b/backend/migrations/1_elections.sql
@@ -2,7 +2,9 @@ CREATE TABLE elections
 (
     id               INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name             TEXT                              NOT NULL,
+    election_id      TEXT                              NOT NULL,
     location         TEXT                              NOT NULL,
+    domain_id        TEXT                              NOT NULL,
     number_of_voters INTEGER                           NOT NULL,
     category         TEXT                              NOT NULL,
     number_of_seats  INTEGER                           NOT NULL,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -54,7 +54,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ElectionRequest"
+                "$ref": "#/components/schemas/NewElection"
               }
             }
           },
@@ -112,7 +112,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ElectionRequest"
+                "$ref": "#/components/schemas/NewElection"
               }
             }
           },
@@ -2977,7 +2977,9 @@
         "required": [
           "id",
           "name",
+          "election_id",
           "location",
+          "domain_id",
           "number_of_voters",
           "category",
           "number_of_seats",
@@ -2989,9 +2991,15 @@
           "category": {
             "$ref": "#/components/schemas/ElectionCategory"
           },
+          "domain_id": {
+            "type": "string"
+          },
           "election_date": {
             "type": "string",
             "format": "date"
+          },
+          "election_id": {
+            "type": "string"
           },
           "id": {
             "type": "integer",
@@ -3064,7 +3072,7 @@
         ],
         "properties": {
           "election": {
-            "$ref": "#/components/schemas/Election"
+            "$ref": "#/components/schemas/NewElection"
           },
           "hash": {
             "$ref": "#/components/schemas/RedactedEmlHash"
@@ -3076,7 +3084,9 @@
         "required": [
           "electionId",
           "electionName",
+          "electionElectionId",
           "electionLocation",
+          "electionDomainId",
           "electionNumberOfVoters",
           "electionCategory",
           "electionNumberOfSeats",
@@ -3088,9 +3098,15 @@
           "electionCategory": {
             "type": "string"
           },
+          "electionDomainId": {
+            "type": "string"
+          },
           "electionElectionDate": {
             "type": "string",
             "format": "date"
+          },
+          "electionElectionId": {
+            "type": "string"
           },
           "electionId": {
             "type": "integer",
@@ -3153,59 +3169,6 @@
             "items": {
               "$ref": "#/components/schemas/Election"
             }
-          }
-        }
-      },
-      "ElectionRequest": {
-        "type": "object",
-        "description": "Election request",
-        "required": [
-          "name",
-          "location",
-          "number_of_voters",
-          "category",
-          "number_of_seats",
-          "election_date",
-          "nomination_date",
-          "status",
-          "political_groups"
-        ],
-        "properties": {
-          "category": {
-            "$ref": "#/components/schemas/ElectionCategory"
-          },
-          "election_date": {
-            "type": "string",
-            "format": "date"
-          },
-          "location": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "nomination_date": {
-            "type": "string",
-            "format": "date"
-          },
-          "number_of_seats": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          "number_of_voters": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          "political_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PoliticalGroup"
-            }
-          },
-          "status": {
-            "$ref": "#/components/schemas/ElectionStatus"
           }
         }
       },
@@ -3628,6 +3591,67 @@
           },
           "username": {
             "type": "string"
+          }
+        }
+      },
+      "NewElection": {
+        "type": "object",
+        "description": "Election request",
+        "required": [
+          "name",
+          "election_id",
+          "location",
+          "domain_id",
+          "number_of_voters",
+          "category",
+          "number_of_seats",
+          "election_date",
+          "nomination_date",
+          "status",
+          "political_groups"
+        ],
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/ElectionCategory"
+          },
+          "domain_id": {
+            "type": "string"
+          },
+          "election_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "election_id": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nomination_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "number_of_seats": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "number_of_voters": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "political_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PoliticalGroup"
+            }
+          },
+          "status": {
+            "$ref": "#/components/schemas/ElectionStatus"
           }
         }
       },

--- a/backend/src/audit_log/audit_event.rs
+++ b/backend/src/audit_log/audit_event.rs
@@ -36,7 +36,9 @@ pub struct UserDetails {
 pub struct ElectionDetails {
     pub election_id: u32,
     pub election_name: String,
+    pub election_election_id: String,
     pub election_location: String,
+    pub election_domain_id: String,
     pub election_number_of_voters: u32,
     pub election_category: String,
     pub election_number_of_seats: u32,

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -671,7 +671,9 @@ mod tests {
         Election {
             id: 1,
             name: "Test election".to_string(),
+            election_id: "Test_2025".to_string(),
             location: "Test location".to_string(),
+            domain_id: "0000".to_string(),
             number_of_voters: 100,
             category: ElectionCategory::Municipal,
             number_of_seats: 18,

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use super::{ElectionRequest, repository::Elections, structs::Election};
+use super::{NewElection, repository::Elections, structs::Election};
 #[cfg(feature = "dev-database")]
 use crate::audit_log::{AuditEvent, AuditService};
 use crate::{APIError, eml::EMLImportError};
@@ -97,7 +97,7 @@ pub async fn election_details(
 #[utoipa::path(
     post,
     path = "/api/elections",
-    request_body = ElectionRequest,
+    request_body = NewElection,
     responses(
         (status = 201, description = "Election created", body = Election),
         (status = 400, description = "Bad request", body = ErrorResponse),
@@ -110,7 +110,7 @@ pub async fn election_create(
     _user: Admin,
     State(elections_repo): State<Elections>,
     audit_service: AuditService,
-    Json(new_election): Json<ElectionRequest>,
+    Json(new_election): Json<NewElection>,
 ) -> Result<(StatusCode, Election), APIError> {
     let election = elections_repo.create(new_election).await?;
 
@@ -129,7 +129,7 @@ pub struct ElectionDefinitionUploadRequest {
 #[derive(Debug, Deserialize, Serialize, Clone, ToSchema)]
 pub struct ElectionDefinitionUploadResponse {
     hash: RedactedEmlHash,
-    election: Election,
+    election: NewElection,
 }
 
 /// Uploads election definition, validates it and returns the associated election data and
@@ -137,7 +137,7 @@ pub struct ElectionDefinitionUploadResponse {
 #[utoipa::path(
     post,
     path = "/api/elections/validate",
-    request_body = ElectionRequest,
+    request_body = NewElection,
     responses(
         (status = 201, description = "Election validated", body = ElectionDefinitionUploadResponse),
         (status = 400, description = "Bad request", body = ErrorResponse),
@@ -152,7 +152,7 @@ pub async fn election_import_validate(
     let eml = EML110::from_str(&edu.data)?;
     Ok(Json(ElectionDefinitionUploadResponse {
         hash: RedactedEmlHash::from(edu.data.as_bytes()),
-        election: eml.as_crate_election()?,
+        election: eml.as_abacus_election()?,
     }))
 }
 

--- a/backend/src/election/repository.rs
+++ b/backend/src/election/repository.rs
@@ -1,11 +1,9 @@
 use axum::extract::FromRef;
-#[cfg(feature = "dev-database")]
 use sqlx::types::Json;
 use sqlx::{Error, SqlitePool, query_as};
 
 use super::Election;
-#[cfg(feature = "dev-database")]
-use super::ElectionRequest;
+use super::NewElection;
 use crate::AppState;
 
 pub struct Elections(SqlitePool);
@@ -18,7 +16,7 @@ impl Elections {
 
     pub async fn list(&self) -> Result<Vec<Election>, Error> {
         let elections: Vec<Election> = query_as(
-            "SELECT id, name, location, number_of_voters, category, number_of_seats, election_date, nomination_date, status FROM elections",
+            "SELECT id, name, election_id, location, domain_id, number_of_voters, category, number_of_seats, election_date, nomination_date, status FROM elections",
         )
         .fetch_all(&self.0)
         .await?;
@@ -33,13 +31,14 @@ impl Elections {
         Ok(election)
     }
 
-    #[cfg(feature = "dev-database")]
-    pub async fn create(&self, election: ElectionRequest) -> Result<Election, Error> {
+    pub async fn create(&self, election: NewElection) -> Result<Election, Error> {
         query_as(
             r#"
             INSERT INTO elections (
               name,
+              election_id,
               location,
+              domain_id,
               number_of_voters,
               category,
               number_of_seats,
@@ -47,11 +46,13 @@ impl Elections {
               nomination_date,
               status,
               political_groups
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING
               id,
               name,
+              election_id,
               location,
+              domain_id,
               number_of_voters,
               category,
               number_of_seats,
@@ -62,7 +63,9 @@ impl Elections {
             "#,
         )
         .bind(election.name)
+        .bind(election.election_id)
         .bind(election.location)
+        .bind(election.domain_id)
         .bind(election.number_of_voters)
         .bind(election.category)
         .bind(election.number_of_seats)

--- a/backend/src/election/structs.rs
+++ b/backend/src/election/structs.rs
@@ -14,7 +14,9 @@ use crate::audit_log::ElectionDetails;
 pub struct Election {
     pub id: u32,
     pub name: String,
+    pub election_id: String,
     pub location: String,
+    pub domain_id: String,
     pub number_of_voters: u32,
     pub category: ElectionCategory,
     pub number_of_seats: u32,
@@ -34,7 +36,9 @@ impl From<Election> for ElectionDetails {
         Self {
             election_id: value.id,
             election_name: value.name,
+            election_election_id: value.election_id,
             election_location: value.location,
+            election_domain_id: value.domain_id,
             election_number_of_voters: value.number_of_voters,
             election_category: value.category.to_string(),
             election_number_of_seats: value.number_of_seats,
@@ -53,9 +57,11 @@ impl IntoResponse for Election {
 
 /// Election request
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
-pub struct ElectionRequest {
+pub struct NewElection {
     pub name: String,
+    pub election_id: String,
     pub location: String,
+    pub domain_id: String,
     pub number_of_voters: u32,
     pub category: ElectionCategory,
     pub number_of_seats: u32,
@@ -176,7 +182,9 @@ pub(crate) mod tests {
         Election {
             id: 1,
             name: "Test".to_string(),
+            election_id: "Test_2023".to_string(),
             location: "Test".to_string(),
+            domain_id: "0000".to_string(),
             number_of_voters: 100,
             category: ElectionCategory::Municipal,
             number_of_seats,

--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -160,6 +160,8 @@ pub enum EMLImportError {
     MissingPreferenceThreshold,
     MissingRegion,
     MissingSubcategory,
+    MissingElectionTree,
+    MissingElectionDomain,
     Needs101a,
     NumberOfSeatsNotInRange,
     OnlyMunicipalSupported,

--- a/backend/src/eml/eml_510.rs
+++ b/backend/src/eml/eml_510.rs
@@ -1,11 +1,11 @@
-use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
 use super::{
     EMLBase,
     common::{
         AffiliationIdentifier, AuthorityAddress, AuthorityIdentifier, ContestIdentifier,
-        ElectionCategory, ElectionIdentifier, ElectionSubcategory, ManagingAuthority,
+        ElectionCategory, ElectionDomain, ElectionIdentifier, ElectionSubcategory,
+        ManagingAuthority,
     },
 };
 use crate::{
@@ -36,7 +36,7 @@ impl EML510 {
         summary: &ElectionSummary,
         creation_date_time: &chrono::DateTime<chrono::Local>,
     ) -> EML510 {
-        let authority_id = "0000".to_string(); // TODO: replace with actual authority id from election definition (i.e. data from election tree)
+        let authority_id = election.domain_id.clone(); // TODO: replace with election tree when that is available
         let total_votes = TotalVotes::from_summary(election, summary);
         let reporting_unit_votes = results
             .iter()
@@ -45,24 +45,20 @@ impl EML510 {
             })
             .collect();
         let contest = Contest {
-            contest_identifier: ContestIdentifier::new(
-                election.id.to_string(),     // TODO: set contest id from election definition
-                Some(election.name.clone()), // TODO: set contest name in contest id from election definition (optional value)
-            ),
+            contest_identifier: ContestIdentifier::new("geen".to_string(), None),
             total_votes,
             reporting_unit_votes,
         };
         let election_eml = Election {
             election_identifier: ElectionIdentifier {
-                id: format!(
-                    "{}{}",
-                    election.category.to_eml_code(),
-                    election.election_date.year()
-                ), // TODO: set election id from election definition instead of this generated id
+                id: election.election_id.clone(),
                 election_name: election.name.clone(),
                 election_category: ElectionCategory::from(election.category),
                 election_subcategory: election_subcategory(election),
-                election_domain: None, // TODO: set election domain from election definition
+                election_domain: Some(ElectionDomain {
+                    id: election.domain_id.clone(),
+                    name: election.location.clone(),
+                }),
                 election_date: election.election_date.format("%Y-%m-%d").to_string(),
                 nomination_date: None,
             },

--- a/backend/src/eml/tests/eml110a_invalid_election_missing_election_domain.eml.xml
+++ b/backend/src/eml/tests/eml110a_invalid_election_missing_election_domain.eml.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2022-02-04</IssueDate>
+    <kr:CreationDateTime>2022-02-04T11:16:26.827</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="GR2022_Amsterdam">
+                <ElectionName>Gemeenteraad Amsterdam 2022</ElectionName>
+                <ElectionCategory>GR</ElectionCategory>
+                <kr:ElectionSubcategory>GR2</kr:ElectionSubcategory>
+                <kr:ElectionDate>2022-03-16</kr:ElectionDate>
+                <kr:NominationDate>2022-01-31</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="geen"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>45</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="363" RegionCategory="GEMEENTE">
+                    <kr:RegionName>Amsterdam</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GROENLINKS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>D66</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Arbeid (P.v.d.A.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>SP (Socialistische Partij)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Dieren</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>DENK</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Forum voor Democratie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>CDA</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Ouderen (P.v.d.O.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ChristenUnie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Amsterdam BIJ1</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>50PLUS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>De Groenen Basis Piraten</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ST3M</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Hart voor Vrijheid Amsterdam</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>DE FEESTPARTIJ (DFP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Staatkundig Gereformeerde Partij (SGP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JA21</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Belang van Nederland (BVNL)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>LEF - Voor de Nieuwe Generatie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Volt</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GO</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>De Republikeinse Politieke Partij</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Democratisch Socialisten Amsterdam</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/backend/src/eml/tests/eml110a_invalid_election_missing_election_tree.eml.xml
+++ b/backend/src/eml/tests/eml110a_invalid_election_missing_election_tree.eml.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2022-02-04</IssueDate>
+    <kr:CreationDateTime>2022-02-04T11:16:26.827</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="GR2022_Amsterdam">
+                <ElectionName>Gemeenteraad Amsterdam 2022</ElectionName>
+                <ElectionCategory>GR</ElectionCategory>
+                <kr:ElectionSubcategory>GR2</kr:ElectionSubcategory>
+                <kr:ElectionDomain Id="0363">Amsterdam</kr:ElectionDomain>
+                <kr:ElectionDate>2022-03-16</kr:ElectionDate>
+                <kr:NominationDate>2022-01-31</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="geen"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>45</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GROENLINKS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>D66</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Arbeid (P.v.d.A.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>SP (Socialistische Partij)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Dieren</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>DENK</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Forum voor Democratie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>CDA</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Ouderen (P.v.d.O.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ChristenUnie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Amsterdam BIJ1</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>50PLUS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>De Groenen Basis Piraten</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ST3M</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Hart voor Vrijheid Amsterdam</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>DE FEESTPARTIJ (DFP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Staatkundig Gereformeerde Partij (SGP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JA21</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Belang van Nederland (BVNL)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>LEF - Voor de Nieuwe Generatie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Volt</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GO</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>De Republikeinse Politieke Partij</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Democratisch Socialisten Amsterdam</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -61,7 +61,9 @@ pub(crate) mod tests {
             election: Election {
                 id: 1,
                 name: "Municipal Election".to_string(),
+                election_id: "MunicipalElection_2025".to_string(),
                 location: "Heemdamseburg".to_string(),
+                domain_id: "0000".to_string(),
                 number_of_voters: 100,
                 category: ElectionCategory::Municipal,
                 number_of_seats: 29,

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -223,7 +223,9 @@ async fn test_election_apportionment_error_apportionment_not_available_no_pollin
         .header("cookie", cookie.clone())
         .json(&serde_json::json!({
             "name": "Test Election",
+            "election_id": "TestElection_2026",
             "location": "Test Location",
+            "domain_id": "0000",
             "number_of_voters": 100,
             "category": "Municipal",
             "number_of_seats": 29,

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -68,7 +68,9 @@ async fn test_election_create_works(pool: SqlitePool) {
         .header("cookie", admin_cookie)
         .json(&serde_json::json!({
             "name": "Test Election",
+            "election_id": "TestElection_2026",
             "location": "Test Location",
+            "domain_id": "0000",
             "number_of_voters": 100,
             "category": "Municipal",
             "number_of_seats": 29,

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -1,15 +1,17 @@
 import {
   ClaimDataEntryResponse,
   DataEntry,
-  ElectionRequest,
+  NewElection,
   PollingStationRequest,
   PollingStationResults,
   SaveDataEntryResponse,
 } from "@/types/generated/openapi";
 
-export const electionRequest: ElectionRequest = {
+export const electionRequest: NewElection = {
   name: "Test Election",
+  election_id: "TestLocation_2026",
   location: "Test Location",
+  domain_id: "0000",
   number_of_voters: 100,
   category: "Municipal",
   number_of_seats: 29,

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
@@ -2007,7 +2007,9 @@ export const election_summary: ElectionSummary = {
 export const election: Election = {
   id: 5,
   name: "Test Election >= 19 seats & Absolute Majority Change",
+  election_id: "TestLocation_2026",
   location: "Test Location",
+  domain_id: "0000",
   number_of_voters: 20000,
   category: "Municipal",
   number_of_seats: 24,

--- a/frontend/src/features/apportionment/testing/gte-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats.ts
@@ -1324,7 +1324,9 @@ export const election_summary: ElectionSummary = {
 export const election: Election = {
   id: 2,
   name: "Test Election >= 19 seats",
+  election_id: "TestLocation_2026",
   location: "Test Location",
+  domain_id: "0000",
   number_of_voters: 2000,
   category: "Municipal",
   number_of_seats: 23,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
@@ -839,7 +839,9 @@ export const election_summary: ElectionSummary = {
 export const election: Election = {
   id: 6,
   name: "Test Election < 19 seats & List Exhaustion",
+  election_id: "TestLocation_2026",
   location: "Test Location",
+  domain_id: "0000",
   number_of_voters: 100,
   category: "Municipal",
   number_of_seats: 6,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
@@ -1523,7 +1523,9 @@ export const election_summary: ElectionSummary = {
 export const election: Election = {
   id: 4,
   name: "Test Election Absolute Majority Change and List Exhaustion",
+  election_id: "TestLocation_2026",
   location: "Test Location",
+  domain_id: "0000",
   number_of_voters: 6000,
   category: "Municipal",
   number_of_seats: 15,

--- a/frontend/src/features/apportionment/testing/lt-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats.ts
@@ -1659,7 +1659,9 @@ export const political_group_1: PoliticalGroup = {
 export const election: Election = {
   id: 3,
   name: "Test Election < 19 seats",
+  election_id: "TestLocation_2026",
   location: "Test Location",
+  domain_id: "0000",
   number_of_voters: 2000,
   category: "Municipal",
   number_of_seats: 15,

--- a/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesForm.test.tsx
+++ b/frontend/src/features/data_entry/components/candidates_votes/CandidatesVotesForm.test.tsx
@@ -288,7 +288,9 @@ describe("Test CandidatesVotesForm", () => {
       const electionMockData: Required<Election> = {
         id: 1,
         name: "Gemeenteraadsverkiezingen 2026",
+        election_id: "Heemdamseburg_2024",
         location: "Heemdamseburg",
+        domain_id: "0000",
         number_of_voters: 100,
         category: "Municipal",
         number_of_seats: 29,

--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -5,13 +5,13 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ApiProvider } from "@/api/ApiProvider";
-import { getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { newElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { ElectionRequestHandler } from "@/testing/api-mocks/RequestHandlers";
 import { getRouter, Router } from "@/testing/router";
 import { overrideOnce, server } from "@/testing/server";
 import { screen, setupTestRouter } from "@/testing/test-utils";
 import { TestUserProvider } from "@/testing/TestUserProvider";
-import { Election, ElectionDefinitionUploadResponse } from "@/types/generated/openapi";
+import { ElectionDefinitionUploadResponse, NewElection } from "@/types/generated/openapi";
 
 import { electionCreateRoutes } from "../routes";
 
@@ -55,7 +55,7 @@ function renderWithRouter() {
   return router;
 }
 
-function electionValidateResponse(election: Election): ElectionDefinitionUploadResponse {
+function electionValidateResponse(election: NewElection): ElectionDefinitionUploadResponse {
   return {
     hash: {
       // NOTE: In actual data, the redacted version of the hash
@@ -123,8 +123,7 @@ describe("Election create pages", () => {
   });
 
   test("Shows and validates hash when uploading valid file", async () => {
-    const election = getElectionMockData().election;
-    overrideOnce("post", "/api/elections/validate", 200, electionValidateResponse(election));
+    overrideOnce("post", "/api/elections/validate", 200, electionValidateResponse(newElectionMockData));
 
     const router = renderWithRouter();
     const user = userEvent.setup();
@@ -143,7 +142,7 @@ describe("Election create pages", () => {
     await user.upload(input, file);
 
     // Wait for the page to be loaded and expect the election name to be present
-    expect(await screen.findByText(election.name)).toBeInTheDocument();
+    expect(await screen.findByText(newElectionMockData.name)).toBeInTheDocument();
 
     // Expect parts of the hash to be shown
     expect(screen.getByText("asdf")).toBeInTheDocument();
@@ -174,8 +173,7 @@ describe("Election create pages", () => {
   });
 
   test("Shows error on invalid input", async () => {
-    const election = getElectionMockData().election;
-    overrideOnce("post", "/api/elections/validate", 200, electionValidateResponse(election));
+    overrideOnce("post", "/api/elections/validate", 200, electionValidateResponse(newElectionMockData));
 
     const router = renderWithRouter();
     const user = userEvent.setup();
@@ -190,7 +188,7 @@ describe("Election create pages", () => {
     await user.upload(input, file);
 
     // Wait for the page to be loaded and expect the election name to be present
-    expect(await screen.findByText(election.name)).toBeInTheDocument();
+    expect(await screen.findByText(newElectionMockData.name)).toBeInTheDocument();
     const inputPart1 = screen.getByLabelText("Controle deel 1");
     await user.type(inputPart1, "zxcv");
     const inputPart2 = screen.getByLabelText("Controle deel 2");

--- a/frontend/src/testing/api-mocks/ElectionMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionMockData.ts
@@ -1,4 +1,10 @@
-import { Election, ElectionDetailsResponse, ElectionListResponse, PoliticalGroup } from "@/types/generated/openapi";
+import {
+  Election,
+  ElectionDetailsResponse,
+  ElectionListResponse,
+  NewElection,
+  PoliticalGroup,
+} from "@/types/generated/openapi";
 
 import { pollingStationMockData } from "./PollingStationMockData";
 
@@ -242,7 +248,9 @@ export const electionListMockResponse: ElectionListResponse = {
     {
       id: 1,
       name: "Gemeenteraadsverkiezingen 2026",
+      election_id: "Heemdamseburg_2024",
       location: "Heemdamseburg",
+      domain_id: "0000",
       number_of_voters: 100,
       category: "Municipal",
       number_of_seats: 29,
@@ -266,3 +274,7 @@ export const getElectionMockData = (election: Partial<Election> = {}): Required<
 
 export const electionDetailsMockResponse: Required<ElectionDetailsResponse> = getElectionMockData();
 export const electionMockData = electionDetailsMockResponse.election as Required<Election>;
+export const newElectionMockData = {
+  ...electionDetailsMockResponse.election,
+  polling_stations: pollingStationMockData,
+} as Required<NewElection>;

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -7,12 +7,12 @@ export type ELECTION_LIST_REQUEST_PARAMS = Record<string, never>;
 export type ELECTION_LIST_REQUEST_PATH = `/api/elections`;
 export type ELECTION_CREATE_REQUEST_PARAMS = Record<string, never>;
 export type ELECTION_CREATE_REQUEST_PATH = `/api/elections`;
-export type ELECTION_CREATE_REQUEST_BODY = ElectionRequest;
+export type ELECTION_CREATE_REQUEST_BODY = NewElection;
 
 // /api/elections/validate
 export type ELECTION_IMPORT_VALIDATE_REQUEST_PARAMS = Record<string, never>;
 export type ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/validate`;
-export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = ElectionRequest;
+export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = NewElection;
 
 // /api/elections/{election_id}
 export interface ELECTION_DETAILS_REQUEST_PARAMS {
@@ -379,7 +379,9 @@ export interface DifferencesCounts {
  */
 export interface Election {
   category: ElectionCategory;
+  domain_id: string;
   election_date: string;
+  election_id: string;
   id: number;
   location: string;
   name: string;
@@ -405,13 +407,15 @@ export interface ElectionApportionmentResponse {
 export type ElectionCategory = "Municipal";
 
 export interface ElectionDefinitionUploadResponse {
-  election: Election;
+  election: NewElection;
   hash: RedactedEmlHash;
 }
 
 export interface ElectionDetails {
   electionCategory: string;
+  electionDomainId: string;
   electionElectionDate: string;
+  electionElectionId: string;
   electionId: number;
   electionLocation: string;
   electionName: string;
@@ -436,21 +440,6 @@ export interface ElectionDetailsResponse {
  */
 export interface ElectionListResponse {
   elections: Election[];
-}
-
-/**
- * Election request
- */
-export interface ElectionRequest {
-  category: ElectionCategory;
-  election_date: string;
-  location: string;
-  name: string;
-  nomination_date: string;
-  number_of_seats: number;
-  number_of_voters: number;
-  political_groups: PoliticalGroup[];
-  status: ElectionStatus;
 }
 
 /**
@@ -630,6 +619,23 @@ export interface LoginResponse {
   role: Role;
   user_id: number;
   username: string;
+}
+
+/**
+ * Election request
+ */
+export interface NewElection {
+  category: ElectionCategory;
+  domain_id: string;
+  election_date: string;
+  election_id: string;
+  location: string;
+  name: string;
+  nomination_date: string;
+  number_of_seats: number;
+  number_of_voters: number;
+  political_groups: PoliticalGroup[];
+  status: ElectionStatus;
 }
 
 /**


### PR DESCRIPTION
Fixes #1522

- Adds two fields to the election struct for election id (different from the id field in election, this is the election id from the EML) and domain_id (used for identifier of region and prefix of polling station id in exported data
- The `ElectionRequest` struct was renamed to `NewElection` to reflect its new usage better
- The validate endpoint now returns a `NewElection` instead of `Election` (without the id) to indicate that the election wasn't saved yet
- Some small associated changes in the frontend as well to fix type errors
- Renamed `as_crate_election` to `as_abacus_election` to better reflect what it is doing