### PR TITLE
remove eslint-plugin-prettier

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,7 +3,6 @@ import tsParser from "@typescript-eslint/parser";
 import importPlugin from "eslint-plugin-import";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import playwright from "eslint-plugin-playwright";
-import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import { readdirSync } from "fs";
@@ -35,7 +34,6 @@ export default tseslint.config(
       importPlugin.flatConfigs.typescript,
       reactRefresh.configs.recommended,
       jsxA11y.flatConfigs.recommended,
-      eslintPluginPrettierRecommended,
       reactHooks.configs["recommended-latest"],
     ],
     rules: {
@@ -93,7 +91,7 @@ export default tseslint.config(
   {
     files: ["**/*.js"],
     ignores: ["!.ladle/**"],
-    extends: [eslint.configs.recommended, importPlugin.flatConfigs.recommended, eslintPluginPrettierRecommended],
+    extends: [eslint.configs.recommended, importPlugin.flatConfigs.recommended],
     languageOptions: {
       ecmaVersion: 2020,
       globals: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,6 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-playwright": "^2.2.0",
-        "eslint-plugin-prettier": "^5.4.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -2018,19 +2017,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@pkgr/core": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
-      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@playwright/test": {
@@ -5678,37 +5664,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
-      "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -6082,13 +6037,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -10366,19 +10314,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -11757,23 +11692,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/synckit": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
-      "integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.2.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -12031,7 +11949,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,6 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-playwright": "^2.2.0",
-    "eslint-plugin-prettier": "^5.4.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",


### PR DESCRIPTION
part of https://github.com/kiesraad/abacus/issues/1524

eslint-plugin-prettier runs prettier as an eslint rule. However, both in our pre-commit hook and in our pipeline we run prettier on its own. So there's no need to also make eslint run prettier. (source: [typescrint eslint troubleshooting docs]( https://typescript-eslint.io/troubleshooting/typed-linting/performance/#eslint-plugin-prettier))

Removing eslint-plugin-prettier makes eslint about 3.7 seconds faster on my machine.

### eslint with eslint-plugin-prettier
```
~/workspace/abacus/frontend (main =) $ TIMING=12 npx eslint .
Rule                                            | Time (ms) | Relative
:-----------------------------------------------|----------:|--------:
prettier/prettier                               |  3744.021 |    25.3%
import/namespace                                |  3207.331 |    21.7%
@typescript-eslint/no-deprecated                |  2497.644 |    16.9%
@typescript-eslint/no-unsafe-assignment         |  1051.256 |     7.1%
@typescript-eslint/no-misused-promises          |  1005.266 |     6.8%
@typescript-eslint/no-floating-promises         |   861.130 |     5.8%
@typescript-eslint/no-unused-vars               |   697.528 |     4.7%
@typescript-eslint/no-unsafe-argument           |   186.742 |     1.3%
import/no-restricted-paths                      |   155.210 |     1.0%
@typescript-eslint/no-confusing-void-expression |   113.730 |     0.8%
@typescript-eslint/no-unsafe-return             |   108.337 |     0.7%
@typescript-eslint/unbound-method               |    98.183 |     0.7%
```

### eslint without eslint-plugin-prettier
```
~/workspace/abacus/frontend (1524-remove-eslint-plugin-prettier =) $ TIMING=12 npx eslint .
Rule                                            | Time (ms) | Relative
:-----------------------------------------------|----------:|--------:
import/namespace                                |  2971.794 |    28.9%
@typescript-eslint/no-deprecated                |  2367.133 |    23.0%
@typescript-eslint/no-unsafe-assignment         |   934.698 |     9.1%
@typescript-eslint/no-floating-promises         |   864.318 |     8.4%
@typescript-eslint/no-misused-promises          |   838.156 |     8.2%
@typescript-eslint/no-unused-vars               |   597.991 |     5.8%
@typescript-eslint/no-unsafe-return             |   198.707 |     1.9%
@typescript-eslint/no-unsafe-argument           |   166.110 |     1.6%
import/no-restricted-paths                      |   140.691 |     1.4%
@typescript-eslint/no-confusing-void-expression |   108.495 |     1.1%
@typescript-eslint/unbound-method               |    79.265 |     0.8%
@typescript-eslint/no-unsafe-member-access      |    65.421 |     0.6%
```