### PR TITLE
disable import/namespace eslint rule

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -39,6 +39,7 @@ export default tseslint.config(
       reactHooks.configs["recommended-latest"],
     ],
     rules: {
+      "import/namespace": "off",
       "jsx-a11y/no-autofocus": "off",
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
       "@typescript-eslint/no-unsafe-type-assertion": "error",


### PR DESCRIPTION
part of #1524

The import/namespace eslint rule takes a significant amount of time to run, but standard type checking by TypeScript already covers this. Since we run `tsc` as part of our `npm run lint`, we can disable this eslint rule. (source: [typescrint eslint troubleshooting docs](https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import))

Disabling the `import/namespace` eslint rule makes eslint about 2.5 seconds faster on my machine. The table below suggests it should be 3 seconds, but that's because `import/namespace` does some stuff (technical term :tm:) that's also useful for other rules. For example, `import/no-unresolved` takes 359.028 ms without import/namespace and 17.131 ms with it.

### eslint with import/namespace
```
~/workspace/abacus/frontend (main =) $ TIMING=12 npx eslint .
Rule                                            | Time (ms) | Relative
:-----------------------------------------------|----------:|--------:
prettier/prettier                               |  3655.489 |    25.4%
import/namespace                                |  3132.660 |    21.8%
@typescript-eslint/no-deprecated                |  2482.314 |    17.3%
@typescript-eslint/no-unsafe-assignment         |  1016.359 |     7.1%
@typescript-eslint/no-misused-promises          |   950.150 |     6.6%
@typescript-eslint/no-floating-promises         |   827.255 |     5.8%
@typescript-eslint/no-unused-vars               |   658.470 |     4.6%
@typescript-eslint/no-unsafe-argument           |   176.208 |     1.2%
import/no-restricted-paths                      |   139.318 |     1.0%
@typescript-eslint/no-confusing-void-expression |   111.661 |     0.8%
@typescript-eslint/no-unsafe-return             |    98.580 |     0.7%
@typescript-eslint/unbound-method               |    84.283 |     0.6%
```

### eslint without  import/namespace
```
~/workspace/abacus/frontend (1524-disable-eslint-rule-import/namespace =) $ TIMING=12 npx eslint .
Rule                                            | Time (ms) | Relative
:-----------------------------------------------|----------:|--------:
prettier/prettier                               |  3693.964 |    30.7%
@typescript-eslint/no-deprecated                |  2535.481 |    21.1%
@typescript-eslint/no-unsafe-assignment         |  1037.640 |     8.6%
@typescript-eslint/no-misused-promises          |   922.376 |     7.7%
@typescript-eslint/no-floating-promises         |   860.351 |     7.2%
@typescript-eslint/no-unused-vars               |   633.501 |     5.3%
import/no-unresolved                            |   359.028 |     3.0%
@typescript-eslint/no-unsafe-argument           |   187.751 |     1.6%
@typescript-eslint/no-unsafe-return             |   182.266 |     1.5%
import/no-restricted-paths                      |   144.763 |     1.2%
import/export                                   |   106.936 |     0.9%
@typescript-eslint/no-confusing-void-expression |   104.167 |     0.9%
```

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->