### PR TITLE
Add status FirstEntryHasErrors

### DIFF
--- a/backend/.sqlx/query-1f17b6083878ff250d57a8843412bd1fd83fe9c1effc346af769d63bdd69dc86.json
+++ b/backend/.sqlx/query-1f17b6083878ff250d57a8843412bd1fd83fe9c1effc346af769d63bdd69dc86.json
@@ -1,0 +1,86 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM audit_log ORDER BY id DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "event",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "event_name",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "event_level",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "message",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "workstation",
+        "ordinal": 5,
+        "type_info": "Integer"
+      },
+      {
+        "name": "ip",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "user_id",
+        "ordinal": 7,
+        "type_info": "Integer"
+      },
+      {
+        "name": "username",
+        "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "user_fullname",
+        "ordinal": 9,
+        "type_info": "Text"
+      },
+      {
+        "name": "user_role",
+        "ordinal": 10,
+        "type_info": "Text"
+      },
+      {
+        "name": "time",
+        "ordinal": 11,
+        "type_info": "Datetime"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1f17b6083878ff250d57a8843412bd1fd83fe9c1effc346af769d63bdd69dc86"
+}

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1471,7 +1471,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Data entry finalised successfully"
+            "description": "Data entry finalised successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataEntryStatus"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -2811,6 +2818,24 @@
             ],
             "properties": {
               "state": {
+                "$ref": "#/components/schemas/FirstEntryHasErrors"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "FirstEntryHasErrors"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "state",
+              "status"
+            ],
+            "properties": {
+              "state": {
                 "$ref": "#/components/schemas/SecondEntryNotStarted"
               },
               "status": {
@@ -2882,6 +2907,7 @@
         "enum": [
           "first_entry_not_started",
           "first_entry_in_progress",
+          "first_entry_has_errors",
           "second_entry_not_started",
           "second_entry_in_progress",
           "entries_different",
@@ -3432,6 +3458,30 @@
           },
           "reference": {
             "$ref": "#/components/schemas/ErrorReference"
+          }
+        }
+      },
+      "FirstEntryHasErrors": {
+        "type": "object",
+        "required": [
+          "first_entry_user_id",
+          "finalised_first_entry",
+          "first_entry_finished_at"
+        ],
+        "properties": {
+          "finalised_first_entry": {
+            "$ref": "#/components/schemas/PollingStationResults",
+            "description": "First data entry for a polling station"
+          },
+          "first_entry_finished_at": {
+            "type": "string",
+            "description": "When the first data entry was finalised"
+          },
+          "first_entry_user_id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "User who did the first data entry",
+            "minimum": 0
           }
         }
       },

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -316,7 +316,7 @@ async fn polling_station_data_entry_delete(
     post,
     path = "/api/polling_stations/{polling_station_id}/data_entries/{entry_number}/finalise",
     responses(
-        (status = 200, description = "Data entry finalised successfully"),
+        (status = 200, description = "Data entry finalised successfully", body = DataEntryStatus),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),
         (status = 409, description = "Request cannot be completed", body = ErrorResponse),
@@ -335,7 +335,7 @@ async fn polling_station_data_entry_finalise(
     State(polling_stations_repo): State<PollingStations>,
     audit_service: AuditService,
     Path((id, entry_number)): Path<(u32, EntryNumber)>,
-) -> Result<(), APIError> {
+) -> Result<Json<DataEntryStatus>, APIError> {
     let state = polling_station_data_entries.get_or_default(id).await?;
 
     let polling_station = polling_stations_repo.get(id).await?;
@@ -371,10 +371,13 @@ async fn polling_station_data_entry_finalise(
     let data_entry = polling_station_data_entries.get_row(id).await?;
 
     audit_service
-        .log(&AuditEvent::DataEntryFinalised(data_entry.into()), None)
+        .log(
+            &AuditEvent::DataEntryFinalised(data_entry.clone().into()),
+            None,
+        )
         .await?;
 
-    Ok(())
+    Ok(Json(data_entry.state.0))
 }
 
 /// Resolve data entry differences by providing a `ResolveAction`
@@ -672,7 +675,7 @@ pub mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_cannot_finalise_with_errors(pool: SqlitePool) {
+    async fn test_first_entry_finalise_with_errors(pool: SqlitePool) {
         let mut request_body = example_data_entry();
         request_body.data.voters_counts.poll_card_count = 100; // incorrect value
 
@@ -681,9 +684,24 @@ pub mod tests {
         let response = save(pool.clone(), request_body.clone(), EntryNumber::FirstEntry).await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        // Check that we cannot finalise with errors
+        // Check that finalise with errors results in FirstEntryHasErrors
         let response = finalise(pool.clone(), EntryNumber::FirstEntry).await;
-        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let status: DataEntryStatus = serde_json::from_slice(&body).unwrap();
+
+        assert!(matches!(status, DataEntryStatus::FirstEntryHasErrors(_)));
+
+        // Check that it has been logged in the audit log
+        let audit_log_row = query!("SELECT * FROM audit_log ORDER BY id DESC LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .expect("should have audit log row");
+        assert_eq!(audit_log_row.event_name, "DataEntryFinalised");
+
+        let event: serde_json::Value = serde_json::from_str(&audit_log_row.event).unwrap();
+        assert_eq!(event["dataEntryStatus"], "first_entry_has_errors");
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]

--- a/frontend/src/components/ui/Badge/Badge.module.css
+++ b/frontend/src/components/ui/Badge/Badge.module.css
@@ -67,7 +67,8 @@
 }
 
 .first_entry_not_started,
-.first_entry_in_progress {
+.first_entry_in_progress,
+.first_entry_has_errors {
   background: var(--badge-first-entry-bg);
   color: var(--badge-first-entry);
 }

--- a/frontend/src/components/ui/Badge/Badge.stories.tsx
+++ b/frontend/src/components/ui/Badge/Badge.stories.tsx
@@ -7,6 +7,7 @@ import { Badge, BadgeProps } from "./Badge";
 const badgeTypes: DataEntryStatusName[] = [
   "first_entry_not_started",
   "first_entry_in_progress",
+  "first_entry_has_errors",
   "second_entry_not_started",
   "second_entry_in_progress",
   "entries_different",

--- a/frontend/src/components/ui/Badge/Badge.test.tsx
+++ b/frontend/src/components/ui/Badge/Badge.test.tsx
@@ -40,6 +40,14 @@ test("The first entry in progress badge is visible", () => {
   expect(badgeElementImg).toBeVisible();
 });
 
+test("The first entry has errors badge is visible", () => {
+  render(<Badge type="first_entry_has_errors" />);
+
+  const badgeElement = screen.getByText("1e invoer");
+
+  expect(badgeElement).toBeVisible();
+});
+
 test("The second entry badge is visible", () => {
   render(<Badge type="second_entry_not_started" />);
 

--- a/frontend/src/components/ui/Badge/Badge.tsx
+++ b/frontend/src/components/ui/Badge/Badge.tsx
@@ -10,6 +10,7 @@ import cls from "./Badge.module.css";
 const typeToLabel: { [S in DataEntryStatusName]: { label: string; icon?: ReactElement } } = {
   first_entry_not_started: { label: t("data_entry.first_entry") },
   first_entry_in_progress: { label: t("data_entry.first_entry"), icon: <Icon size="sm" icon={<IconPencil />} /> },
+  first_entry_has_errors: { label: t("data_entry.first_entry") },
   second_entry_not_started: { label: t("data_entry.second_entry") },
   second_entry_in_progress: { label: t("data_entry.second_entry"), icon: <Icon size="sm" icon={<IconPencil />} /> },
   entries_different: { label: t("data_entry.entries_different") },

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -332,6 +332,7 @@ export interface DataEntryDetails {
 export type DataEntryStatus =
   | { status: "FirstEntryNotStarted" }
   | { state: FirstEntryInProgress; status: "FirstEntryInProgress" }
+  | { state: FirstEntryHasErrors; status: "FirstEntryHasErrors" }
   | { state: SecondEntryNotStarted; status: "SecondEntryNotStarted" }
   | { state: SecondEntryInProgress; status: "SecondEntryInProgress" }
   | { state: EntriesDifferent; status: "EntriesDifferent" }
@@ -340,6 +341,7 @@ export type DataEntryStatus =
 export type DataEntryStatusName =
   | "first_entry_not_started"
   | "first_entry_in_progress"
+  | "first_entry_has_errors"
   | "second_entry_not_started"
   | "second_entry_in_progress"
   | "entries_different"
@@ -562,6 +564,15 @@ export interface ErrorResponse {
   error: string;
   fatal: boolean;
   reference: ErrorReference;
+}
+
+export interface FirstEntryHasErrors {
+  /** First data entry for a polling station */
+  finalised_first_entry: PollingStationResults;
+  /** When the first data entry was finalised */
+  first_entry_finished_at: string;
+  /** User who did the first data entry */
+  first_entry_user_id: number;
 }
 
 export interface FirstEntryInProgress {


### PR DESCRIPTION
- Add new data entry state`FirstEntryHasErrors`
- Incoming state transitions as documented in our [state diagram](https://github.com/kiesraad/abacus/blob/main/documentatie/flowcharts/data-entry-state.md)
  - When we finalise a `FirstEntryInProgress` and it still contains errors, go to `FirstEntryHasErrors` instead of `SecondEntryNotStarted`, 
  - When keep_second_entry is called with a second data entry that has errors, go to `FirstEntryHasErrors`
- Update tests accordingly
- Update Badge component that handles all possible states

This PR is not testable through the UI currently but is an integral part of [the epic "foutopsporing"](https://github.com/kiesraad/abacus/issues/1421) and will be tested through the other issues
The Badge can be seen in Ladle

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->
