### PR TITLE
Validate and save endpoint for EML import

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -104,15 +104,73 @@
         }
       }
     },
-    "/api/elections/validate": {
+    "/api/elections/import": {
       "post": {
         "summary": "Uploads election definition, validates it and returns the associated election data and\na redacted hash, to be filled by the administrator",
+        "operationId": "election_import",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ElectionDefinitionImportRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Election imported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ElectionDefinitionImportResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/elections/import/validate": {
+      "post": {
+        "summary": "Uploads election definition, validates it and returns the associated election data and\na redacted hash, to be filled by the administrator.",
         "operationId": "election_import_validate",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ElectionDefinitionUploadRequest"
+                "$ref": "#/components/schemas/ElectionDefinitionValidateRequest"
               }
             }
           },
@@ -124,7 +182,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ElectionDefinitionUploadResponse"
+                  "$ref": "#/components/schemas/ElectionDefinitionValidateResponse"
                 }
               }
             }
@@ -3090,7 +3148,36 @@
           "Municipal"
         ]
       },
-      "ElectionDefinitionUploadRequest": {
+      "ElectionDefinitionImportRequest": {
+        "type": "object",
+        "required": [
+          "hash",
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "hash": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ElectionDefinitionImportResponse": {
+        "type": "object",
+        "required": [
+          "election"
+        ],
+        "properties": {
+          "election": {
+            "$ref": "#/components/schemas/Election"
+          }
+        }
+      },
+      "ElectionDefinitionValidateRequest": {
         "type": "object",
         "required": [
           "data"
@@ -3107,16 +3194,10 @@
             "items": {
               "type": "string"
             }
-          },
-          "save": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         }
       },
-      "ElectionDefinitionUploadResponse": {
+      "ElectionDefinitionValidateResponse": {
         "type": "object",
         "required": [
           "hash",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -112,7 +112,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NewElection"
+                "$ref": "#/components/schemas/ElectionDefinitionUploadRequest"
               }
             }
           },
@@ -3090,6 +3090,32 @@
           "Municipal"
         ]
       },
+      "ElectionDefinitionUploadRequest": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "hash": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "save": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
       "ElectionDefinitionUploadResponse": {
         "type": "object",
         "required": [
@@ -3385,6 +3411,7 @@
           "EntryNotUnique",
           "InternalServerError",
           "InvalidData",
+          "InvalidHash",
           "InvalidJson",
           "InvalidPassword",
           "InvalidPoliticalGroup",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -124,7 +124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ElectionDefinitionImportResponse"
+                  "$ref": "#/components/schemas/Election"
                 }
               }
             }
@@ -177,7 +177,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "Election validated",
             "content": {
               "application/json": {
@@ -3163,17 +3163,6 @@
             "items": {
               "type": "string"
             }
-          }
-        }
-      },
-      "ElectionDefinitionImportResponse": {
-        "type": "object",
-        "required": [
-          "election"
-        ],
-        "properties": {
-          "election": {
-            "$ref": "#/components/schemas/Election"
           }
         }
       },

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -198,7 +198,6 @@ pub async fn election_import(
 
     let new_election = EML110::from_str(&edu.data)?.as_abacus_election()?;
     let election = elections_repo.create(new_election).await?;
-
     Ok(Json(ElectionDefinitionImportResponse { election }))
 }
 

--- a/backend/src/eml/hash.rs
+++ b/backend/src/eml/hash.rs
@@ -2,7 +2,7 @@ use rand::rngs::SmallRng;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-const CHUNK_COUNT: usize = 16;
+pub const CHUNK_COUNT: usize = 16;
 
 #[derive(Debug, Deserialize, Serialize, Clone, ToSchema)]
 pub struct EmlHash {

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -7,7 +7,7 @@ mod eml_110;
 mod eml_230;
 mod eml_510;
 mod eml_520;
-mod hash;
+pub mod hash;
 mod util;
 
 pub use common::EMLImportError;

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -34,6 +34,7 @@ pub enum ErrorReference {
     EntryNotUnique,
     InternalServerError,
     InvalidData,
+    InvalidHash,
     InvalidJson,
     InvalidPassword,
     InvalidPoliticalGroup,
@@ -81,6 +82,7 @@ pub enum APIError {
     EmlImportError(EMLImportError),
     InvalidData(DataError),
     InvalidHeaderValue,
+    InvalidHashError,
     JsonRejection(JsonRejection),
     NotFound(String, ErrorReference),
     PdfGenError(PdfGenError),
@@ -180,6 +182,13 @@ impl IntoResponse for APIError {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     to_error("Internal server error", reference, false),
+                )
+            }
+            APIError::InvalidHashError => {
+                error!("Invalid hash");
+                (
+                    StatusCode::BAD_REQUEST,
+                    to_error("Invalid hash", ErrorReference::InvalidHash, false),
                 )
             }
             APIError::XmlError(err) => {

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -131,7 +131,7 @@ async fn test_election_import_save(pool: SqlitePool) {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::CREATED);
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -13,7 +13,7 @@ pub mod utils;
 async fn test_election_validate_valid(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
-    let url = format!("http://{addr}/api/elections/validate");
+    let url = format!("http://{addr}/api/elections/import/validate");
     let admin_cookie = shared::admin_login(&addr).await;
     let response = reqwest::Client::new()
         .post(&url)
@@ -33,7 +33,7 @@ async fn test_election_validate_valid(pool: SqlitePool) {
 async fn test_election_validate_invalid_election_subcategory(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
-    let url = format!("http://{addr}/api/elections/validate");
+    let url = format!("http://{addr}/api/elections/import/validate");
     let admin_cookie = shared::admin_login(&addr).await;
     let response = reqwest::Client::new()
         .post(&url)
@@ -53,7 +53,7 @@ async fn test_election_validate_invalid_election_subcategory(pool: SqlitePool) {
 async fn test_election_validate_invalid_election_number_of_seats(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
-    let url = format!("http://{addr}/api/elections/validate");
+    let url = format!("http://{addr}/api/elections/import/validate");
     let admin_cookie = shared::admin_login(&addr).await;
     let response = reqwest::Client::new()
         .post(&url)
@@ -73,7 +73,7 @@ async fn test_election_validate_invalid_election_number_of_seats(pool: SqlitePoo
 async fn test_election_validate_invalid_election_missing_region(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
-    let url = format!("http://{addr}/api/elections/validate");
+    let url = format!("http://{addr}/api/elections/import/validate");
     let admin_cookie = shared::admin_login(&addr).await;
     let response = reqwest::Client::new()
         .post(&url)
@@ -93,7 +93,7 @@ async fn test_election_validate_invalid_election_missing_region(pool: SqlitePool
 async fn test_election_validate_invalid_xml(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
-    let url = format!("http://{addr}/api/elections/validate");
+    let url = format!("http://{addr}/api/elections/import/validate");
     let admin_cookie = shared::admin_login(&addr).await;
     let response = reqwest::Client::new()
         .post(&url)
@@ -106,5 +106,80 @@ async fn test_election_validate_invalid_xml(pool: SqlitePool) {
         .unwrap();
 
     // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_import_save(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    let url = format!("http://{addr}/api/elections/import");
+    let admin_cookie = shared::admin_login(&addr).await;
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+            "hash": [
+                "84c9", "caba", "ff33", "6c42",
+                "9825", "b20c", "2ba9", "1ceb",
+                "3c61", "9b99", "8af1", "a57e",
+                "cf00", "8930", "9bce", "0c33"
+            ],
+            "data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_import_save_empty_stubs(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    let url = format!("http://{addr}/api/elections/import");
+    let admin_cookie = shared::admin_login(&addr).await;
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+            "hash": [
+                "84c9", "caba", "ff33", "6c42",
+                "", "b20c", "2ba9", "1ceb",
+                "3c61", "9b99", "", "a57e",
+                "cf00", "8930", "9bce", "0c33"
+            ],
+            "data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_import_save_wrong_hash(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    let url = format!("http://{addr}/api/elections/import");
+    let admin_cookie = shared::admin_login(&addr).await;
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+            "hash": [
+                "84c9", "caba", "ff33", "6c42",
+                "1234", "b20c", "2ba9", "1ceb",
+                "3c61", "9b99", "f0a6", "a57e",
+                "cf00", "8930", "9bce", "0c33"
+            ],
+            "data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+        }))
+        .send()
+        .await
+        .unwrap();
+
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/frontend/src/features/election_create/components/CheckElectionDefinition.tsx
+++ b/frontend/src/features/election_create/components/CheckElectionDefinition.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/Button/Button";
 import { Form } from "@/components/ui/Form/Form";
 import { InputField } from "@/components/ui/InputField/InputField";
 import { t, tx } from "@/i18n/translate";
-import { ElectionDefinitionUploadResponse } from "@/types/generated/openapi";
+import { ElectionDefinitionValidateResponse } from "@/types/generated/openapi";
 import { formatDateFull } from "@/utils/format";
 
 import { useElectionCheck } from "../hooks/useElectionCheck";
@@ -13,7 +13,7 @@ import { RedactedHash } from "./RedactedHash";
 
 interface CheckElectionDefinitionProps {
   file: File;
-  data: ElectionDefinitionUploadResponse;
+  data: ElectionDefinitionValidateResponse;
 }
 
 export function CheckElectionDefinition({ file, data }: CheckElectionDefinitionProps) {

--- a/frontend/src/features/election_create/components/CheckElectionDefinition.tsx
+++ b/frontend/src/features/election_create/components/CheckElectionDefinition.tsx
@@ -49,7 +49,7 @@ export function CheckElectionDefinition({ file, data }: CheckElectionDefinitionP
         </div>
       </Alert>
       <p>{t("election.check_eml.check_hash.description")}</p>
-      <Form onSubmit={handleSubmit}>
+      <Form onSubmit={(e) => void handleSubmit(e)}>
         {stubs.map((stub, stubIndex) => (
           <InputField
             key={stub.index}

--- a/frontend/src/features/election_create/components/CheckElectionDefinition.tsx
+++ b/frontend/src/features/election_create/components/CheckElectionDefinition.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { Form } from "@/components/ui/Form/Form";
@@ -15,12 +17,13 @@ interface CheckElectionDefinitionProps {
 }
 
 export function CheckElectionDefinition({ file, data }: CheckElectionDefinitionProps) {
-  const { stubs, highlightStub, handleSubmit } = useElectionCheck(data);
+  const [error, setError] = useState<string | undefined>();
+  const { stubs, highlightStub, handleSubmit } = useElectionCheck(file, data, setError);
 
   return (
     <section className="md">
       <h2>{t("election.check_eml.title")}</h2>
-      {stubs.some((stub) => stub.error.length > 0) && (
+      {(stubs.some((stub) => stub.error.length > 0) || error) && (
         <Alert type="error" title={t("election.check_eml.error.title")} inline>
           <p> {t("election.check_eml.error.description")} </p>
         </Alert>

--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -11,7 +11,7 @@ import { getRouter, Router } from "@/testing/router";
 import { overrideOnce, server } from "@/testing/server";
 import { screen, setupTestRouter } from "@/testing/test-utils";
 import { TestUserProvider } from "@/testing/TestUserProvider";
-import { ElectionDefinitionUploadResponse, NewElection } from "@/types/generated/openapi";
+import { ElectionDefinitionValidateResponse, NewElection } from "@/types/generated/openapi";
 
 import { electionCreateRoutes } from "../routes";
 
@@ -55,7 +55,7 @@ function renderWithRouter() {
   return router;
 }
 
-function electionValidateResponse(election: NewElection): ElectionDefinitionUploadResponse {
+function electionValidateResponse(election: NewElection): ElectionDefinitionValidateResponse {
   return {
     hash: {
       // NOTE: In actual data, the redacted version of the hash

--- a/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 
-import { ElectionDefinitionUploadResponse } from "@/types/generated/openapi";
+import { ElectionDefinitionValidateResponse } from "@/types/generated/openapi";
 
 import { ElectionCreateContext, IElectionCreateContext } from "../hooks/ElectionCreateContext";
 
 export function ElectionCreateContextProvider({ children }: { children: React.ReactNode }) {
   const [file, setFile] = useState<File | undefined>(undefined);
-  const [data, setData] = useState<ElectionDefinitionUploadResponse | undefined>(undefined);
+  const [data, setData] = useState<ElectionDefinitionValidateResponse | undefined>(undefined);
 
   const context: IElectionCreateContext = { file, setFile, data, setData };
   return <ElectionCreateContext.Provider value={context}>{children}</ElectionCreateContext.Provider>;

--- a/frontend/src/features/election_create/components/UploadElectionDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadElectionDefinition.tsx
@@ -5,16 +5,16 @@ import { useCrud } from "@/api/useCrud";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { FileInput } from "@/components/ui/FileInput/FileInput";
 import { t, tx } from "@/i18n/translate";
-import { ELECTION_IMPORT_VALIDATE_REQUEST_PATH, ElectionDefinitionUploadResponse } from "@/types/generated/openapi";
+import { ELECTION_IMPORT_VALIDATE_REQUEST_PATH, ElectionDefinitionValidateResponse } from "@/types/generated/openapi";
 
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 import { CheckElectionDefinition } from "./CheckElectionDefinition";
 
 export function UploadElectionDefinition() {
   const { file, setFile, data, setData } = useElectionCreateContext();
-  const path: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/validate`;
+  const path: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate`;
   const [error, setError] = useState<ReactElement | undefined>();
-  const { create } = useCrud<ElectionDefinitionUploadResponse>({ create: path });
+  const { create } = useCrud<ElectionDefinitionValidateResponse>({ create: path });
 
   const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const currentFile = e.target.files ? e.target.files[0] : undefined;

--- a/frontend/src/features/election_create/hooks/ElectionCreateContext.ts
+++ b/frontend/src/features/election_create/hooks/ElectionCreateContext.ts
@@ -1,12 +1,12 @@
 import { createContext } from "react";
 
-import { ElectionDefinitionUploadResponse } from "@/types/generated/openapi";
+import { ElectionDefinitionValidateResponse } from "@/types/generated/openapi";
 
 export interface IElectionCreateContext {
   file: File | undefined;
   setFile: (role: File | undefined) => void;
-  data: ElectionDefinitionUploadResponse | undefined;
-  setData: (data: ElectionDefinitionUploadResponse | undefined) => void;
+  data: ElectionDefinitionValidateResponse | undefined;
+  setData: (data: ElectionDefinitionValidateResponse | undefined) => void;
 }
 
 export const ElectionCreateContext = createContext<IElectionCreateContext | undefined>(undefined);

--- a/frontend/src/features/election_create/hooks/useElectionCheck.ts
+++ b/frontend/src/features/election_create/hooks/useElectionCheck.ts
@@ -6,16 +6,16 @@ import { useCrud } from "@/api/useCrud";
 import { t } from "@/i18n/translate";
 import {
   ELECTION_IMPORT_VALIDATE_REQUEST_PATH,
-  ElectionDefinitionUploadRequest,
-  ElectionDefinitionUploadResponse,
+  ElectionDefinitionValidateRequest,
+  ElectionDefinitionValidateResponse,
 } from "@/types/generated/openapi";
 
 import { Stub } from "../components/RedactedHash";
 
-export function useElectionCheck(file: File, data: ElectionDefinitionUploadResponse, setError: any) {
+export function useElectionCheck(file: File, data: ElectionDefinitionValidateResponse, setError: any) {
   const navigate = useNavigate();
-  const url: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = "/api/elections/validate";
-  const { create } = useCrud<ElectionDefinitionUploadRequest>(url);
+  const url: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = "/api/elections/import/validate";
+  const { create } = useCrud<ElectionDefinitionValidateRequest>(url);
 
   const [stubs, setStubs] = useState<Stub[]>(
     data.hash.redacted_indexes.map((redacted_index: number) => ({

--- a/frontend/src/features/election_create/hooks/useElectionCheck.ts
+++ b/frontend/src/features/election_create/hooks/useElectionCheck.ts
@@ -1,13 +1,22 @@
 import { FormEvent, useState } from "react";
 import { useNavigate } from "react-router";
 
+import { ApiError, isError, isSuccess } from "@/api/ApiResult";
+import { useCrud } from "@/api/useCrud";
 import { t } from "@/i18n/translate";
-import { ElectionDefinitionUploadResponse } from "@/types/generated/openapi";
+import {
+  ELECTION_IMPORT_VALIDATE_REQUEST_PATH,
+  ElectionDefinitionUploadRequest,
+  ElectionDefinitionUploadResponse,
+} from "@/types/generated/openapi";
 
 import { Stub } from "../components/RedactedHash";
 
-export function useElectionCheck(data: ElectionDefinitionUploadResponse) {
+export function useElectionCheck(file: File, data: ElectionDefinitionUploadResponse, setError: any) {
   const navigate = useNavigate();
+  const url: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = "/api/elections/validate";
+  const { create } = useCrud<ElectionDefinitionUploadRequest>(url);
+
   const [stubs, setStubs] = useState<Stub[]>(
     data.hash.redacted_indexes.map((redacted_index: number) => ({
       selected: false,
@@ -16,10 +25,12 @@ export function useElectionCheck(data: ElectionDefinitionUploadResponse) {
     })),
   );
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    setError(undefined);
 
     const formData = new FormData(event.currentTarget);
+    let completeHash = data.hash.chunks;
     stubs.forEach((stub, i) => {
       const value = formData.get(stub.index.toString());
       const newStubs = [...stubs];
@@ -28,6 +39,8 @@ export function useElectionCheck(data: ElectionDefinitionUploadResponse) {
         newStub.error = "";
         if (typeof value !== "string" || value.length !== 4) {
           newStub.error = t("election.check_eml.check_hash.hint");
+        } else {
+          completeHash[stub.index] = value;
         }
         setStubs(newStubs);
       }
@@ -35,7 +48,13 @@ export function useElectionCheck(data: ElectionDefinitionUploadResponse) {
 
     // Only submit when there a no errors
     if (stubs.every((stub) => stub.error === "")) {
-      void navigate("/elections/create/check-and-save");
+      void create({ data: await file.text(), hash: completeHash }).then((response) => {
+        if (isSuccess(response)) {
+          void navigate("/elections/create/check-and-save");
+        } else if (isError(response) && response instanceof ApiError && response.reference === "InvalidHash") {
+          setError(response.message);
+        }
+      });
     }
   }
 

--- a/frontend/src/features/election_create/hooks/useElectionCheck.ts
+++ b/frontend/src/features/election_create/hooks/useElectionCheck.ts
@@ -12,7 +12,11 @@ import {
 
 import { Stub } from "../components/RedactedHash";
 
-export function useElectionCheck(file: File, data: ElectionDefinitionValidateResponse, setError: any) {
+export function useElectionCheck(
+  file: File,
+  data: ElectionDefinitionValidateResponse,
+  setError: (error: string) => void,
+) {
   const navigate = useNavigate();
   const url: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = "/api/elections/import/validate";
   const { create } = useCrud<ElectionDefinitionValidateRequest>(url);
@@ -27,10 +31,10 @@ export function useElectionCheck(file: File, data: ElectionDefinitionValidateRes
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setError(undefined);
+    setError("");
 
     const formData = new FormData(event.currentTarget);
-    let completeHash = data.hash.chunks;
+    const completeHash = data.hash.chunks;
     stubs.forEach((stub, i) => {
       const value = formData.get(stub.index.toString());
       const newStubs = [...stubs];

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -25,6 +25,7 @@
     "InternalServerError": "Er is een interne fout opgetreden",
     "InvalidData": "De invoer is niet geldig",
     "InvalidJson": "De JSON is niet geldig",
+    "InvalidHash": "De hash is niet geldig",
     "InvalidXml": "De XML is niet geldig",
     "InvalidPassword": "Het opgegeven wachtwoord is onjuist",
     "InvalidPoliticalGroup": "De politieke partij is niet geldig",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -12,7 +12,7 @@ export type ELECTION_CREATE_REQUEST_BODY = NewElection;
 // /api/elections/validate
 export type ELECTION_IMPORT_VALIDATE_REQUEST_PARAMS = Record<string, never>;
 export type ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/validate`;
-export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = NewElection;
+export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = ElectionDefinitionUploadRequest;
 
 // /api/elections/{election_id}
 export interface ELECTION_DETAILS_REQUEST_PARAMS {
@@ -408,6 +408,12 @@ export interface ElectionApportionmentResponse {
  */
 export type ElectionCategory = "Municipal";
 
+export interface ElectionDefinitionUploadRequest {
+  data: string;
+  hash?: unknown[] | null;
+  save?: boolean | null;
+}
+
 export interface ElectionDefinitionUploadResponse {
   election: NewElection;
   hash: RedactedEmlHash;
@@ -528,6 +534,7 @@ export type ErrorReference =
   | "EntryNotUnique"
   | "InternalServerError"
   | "InvalidData"
+  | "InvalidHash"
   | "InvalidJson"
   | "InvalidPassword"
   | "InvalidPoliticalGroup"

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -418,10 +418,6 @@ export interface ElectionDefinitionImportRequest {
   hash: string[];
 }
 
-export interface ElectionDefinitionImportResponse {
-  election: Election;
-}
-
 export interface ElectionDefinitionValidateRequest {
   data: string;
   hash?: unknown[] | null;

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -9,10 +9,15 @@ export type ELECTION_CREATE_REQUEST_PARAMS = Record<string, never>;
 export type ELECTION_CREATE_REQUEST_PATH = `/api/elections`;
 export type ELECTION_CREATE_REQUEST_BODY = NewElection;
 
-// /api/elections/validate
+// /api/elections/import
+export type ELECTION_IMPORT_REQUEST_PARAMS = Record<string, never>;
+export type ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
+export type ELECTION_IMPORT_REQUEST_BODY = ElectionDefinitionImportRequest;
+
+// /api/elections/import/validate
 export type ELECTION_IMPORT_VALIDATE_REQUEST_PARAMS = Record<string, never>;
-export type ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/validate`;
-export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = ElectionDefinitionUploadRequest;
+export type ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate`;
+export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = ElectionDefinitionValidateRequest;
 
 // /api/elections/{election_id}
 export interface ELECTION_DETAILS_REQUEST_PARAMS {
@@ -408,13 +413,21 @@ export interface ElectionApportionmentResponse {
  */
 export type ElectionCategory = "Municipal";
 
-export interface ElectionDefinitionUploadRequest {
+export interface ElectionDefinitionImportRequest {
   data: string;
-  hash?: unknown[] | null;
-  save?: boolean | null;
+  hash: string[];
 }
 
-export interface ElectionDefinitionUploadResponse {
+export interface ElectionDefinitionImportResponse {
+  election: Election;
+}
+
+export interface ElectionDefinitionValidateRequest {
+  data: string;
+  hash?: unknown[] | null;
+}
+
+export interface ElectionDefinitionValidateResponse {
   election: NewElection;
   hash: RedactedEmlHash;
 }


### PR DESCRIPTION
Fixes #889 
Fixes #1480

- Verify endpoint now also verifies user provided hash
- Added endpoint that saves election
- CheckElectionDefinition now verifies the user provided hash by doing the backend call
- Tests

To test, you can test by uploading `src/eml/tests/eml110a_test.eml.xml`. The hash for that file is:
```
84c9 caba ff33 6c42 9825 b20c 2ba9 1ceb 3c61 9b99 8af1 a57e cf00 8930 9bce 0c33
```
This first stub should be `9825` and the second `8af1`.

You can also test with a different (valid) EML file and discovering the hash by executing `sha256sum path/to/file` in the command line.