### PR TITLE
Handle first_entry_has_errors in polling station choice form

### DIFF
--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -17,14 +17,18 @@ import { PollingStationChoiceForm } from "./PollingStationChoiceForm";
 
 vi.mock("@/hooks/user/useUser");
 
-function renderPollingStationChoiceForm() {
-  return renderReturningRouter(
+async function renderPollingStationChoiceForm() {
+  const router = renderReturningRouter(
     <ElectionProvider electionId={1}>
       <ElectionStatusProvider electionId={1}>
         <PollingStationChoiceForm />
       </ElectionStatusProvider>
     </ElectionProvider>,
   );
+
+  expect(await screen.findByRole("group", { name: "Welk stembureau ga je invoeren?" })).toBeVisible();
+
+  return router;
 }
 
 const testUser: LoginResponse = {
@@ -40,12 +44,13 @@ describe("Test PollingStationChoiceForm", () => {
     (useUser as Mock).mockReturnValue(testUser satisfies LoginResponse);
     server.use(ElectionStatusRequestHandler);
   });
+
   describe("Polling station choice form", () => {
     test("Form field entry", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
 
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       expect(await screen.findByRole("group", { name: "Welk stembureau ga je invoeren?" })).toBeVisible();
       const pollingStation = screen.getByTestId("pollingStation");
@@ -87,7 +92,7 @@ describe("Test PollingStationChoiceForm", () => {
     test("Selecting a valid polling station with leading zeros", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const pollingStation = await screen.findByTestId("pollingStation");
 
@@ -100,7 +105,7 @@ describe("Test PollingStationChoiceForm", () => {
     test("Selecting a non-existing polling station", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const pollingStation = await screen.findByTestId("pollingStation");
 
@@ -120,7 +125,7 @@ describe("Test PollingStationChoiceForm", () => {
     test("Submitting an empty or invalid polling station shows alert", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const pollingStation = await screen.findByTestId("pollingStation");
       const submitButton = screen.getByRole("button", { name: "Beginnen" });
@@ -222,7 +227,7 @@ describe("Test PollingStationChoiceForm", () => {
     test("Form displays message when searching", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const pollingStation = await screen.findByTestId("pollingStation");
 
@@ -254,7 +259,7 @@ describe("Test PollingStationChoiceForm", () => {
         ),
       );
 
-      const router = renderPollingStationChoiceForm();
+      const router = await renderPollingStationChoiceForm();
 
       const user = userEvent.setup();
       const pollingStation = await screen.findByTestId("pollingStation");
@@ -271,7 +276,7 @@ describe("Test PollingStationChoiceForm", () => {
       overrideOnce("get", "/api/elections/1/status", 200, statusResponseMock);
 
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       expect(await screen.findByText("Kies het stembureau")).not.toBeVisible();
       const openPollingStationList = screen.getByTestId("openPollingStationList");
@@ -292,7 +297,7 @@ describe("Test PollingStationChoiceForm", () => {
     test("Empty polling station list shows message", async () => {
       overrideOnce("get", "/api/elections/1", 200, { ...electionDetailsMockResponse, polling_stations: [] });
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const openPollingStationList = await screen.findByTestId("openPollingStationList");
       await user.click(openPollingStationList);
@@ -316,10 +321,13 @@ describe("Test PollingStationChoiceForm", () => {
         ],
       } satisfies ElectionStatusResponse);
 
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
-      const pollingStationList = await screen.findByTestId("polling_station_list");
-      expect(pollingStationList).not.toHaveTextContent(testPollingStation.name);
+      const pollingStationList = screen.queryByTestId("polling_station_list");
+      expect(pollingStationList).not.toBeInTheDocument();
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Er zijn voor jou geen stembureaus meer om in te voeren");
     });
 
     test("All data entries of polling stations are finished, polling station list shows message", async () => {
@@ -354,7 +362,7 @@ describe("Test PollingStationChoiceForm", () => {
       );
 
       const user = userEvent.setup();
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const openPollingStationList = await screen.findByTestId("openPollingStationList");
       await user.click(openPollingStationList);
@@ -385,7 +393,7 @@ describe("Test PollingStationChoiceForm", () => {
           ),
         ),
       );
-      const router = renderPollingStationChoiceForm();
+      const router = await renderPollingStationChoiceForm();
 
       // Open the polling station list
       const user = userEvent.setup();
@@ -422,7 +430,7 @@ describe("Test PollingStationChoiceForm", () => {
         ],
       } satisfies ElectionStatusResponse);
 
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       const alert = await screen.findByRole("alert");
       expect(await within(alert).findByRole("heading", { name: "Je hebt nog een openstaande invoer" })).toBeVisible();
@@ -456,7 +464,7 @@ describe("Test PollingStationChoiceForm", () => {
       );
 
       // Render the polling station choice page with the overridden server responses
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       // Search for polling station 2
       const user = userEvent.setup();
@@ -509,7 +517,7 @@ describe("Test PollingStationChoiceForm", () => {
       );
 
       // Render the polling station choice page with the overridden server responses
-      renderPollingStationChoiceForm();
+      await renderPollingStationChoiceForm();
 
       // Search for polling station 2
       const user = userEvent.setup();
@@ -539,7 +547,7 @@ describe("Test PollingStationChoiceForm", () => {
       ],
     } satisfies ElectionStatusResponse);
 
-    renderPollingStationChoiceForm();
+    await renderPollingStationChoiceForm();
 
     const list = await screen.findByTestId("unfinished-list");
     expect(list).toBeVisible();
@@ -548,6 +556,8 @@ describe("Test PollingStationChoiceForm", () => {
   });
 
   test("Show recent status when searching for polling station", async () => {
+    const testPollingStation = pollingStationMockData[0]!;
+
     server.use(ElectionRequestHandler);
     server.use(
       http.get("/api/elections/1/status", () =>
@@ -566,18 +576,7 @@ describe("Test PollingStationChoiceForm", () => {
       ),
     );
 
-    const testPollingStation = pollingStationMockData[0]!;
-    // Have the server return an in progress polling station that is owned by a logged-in user.
-    overrideOnce("get", "api/elections/1/status", 200, {
-      statuses: [
-        {
-          polling_station_id: testPollingStation.id,
-          status: "first_entry_not_started",
-        },
-      ],
-    } satisfies ElectionStatusResponse);
-
-    renderPollingStationChoiceForm();
+    await renderPollingStationChoiceForm();
 
     const user = userEvent.setup();
     const pollingStation = await screen.findByTestId("pollingStation");

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -198,7 +198,7 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
             <Alert type="error" small>
               <p>{t("polling_station_choice.no_polling_stations_found")}</p>
             </Alert>
-          ) : !available.length ? (
+          ) : !availableCurrentUser.length ? (
             <Alert type="notify" small>
               <p>{t("polling_station_choice.there_are_no_polling_stations_left_to_fill_in")}</p>
             </Alert>

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -17,7 +17,6 @@ import { parseIntUserInput } from "@/utils/strings";
 
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import {
-  finishedStatuses,
   getPollingStationWithStatusList,
   getUrlForDataEntry,
   PollingStationUserStatus,
@@ -108,10 +107,13 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
     void navigate(getUrlForDataEntry(election.id, pollingStation.id, pollingStation.statusEntry.status));
   };
 
+  const notAvailable = [
+    PollingStationUserStatus.Finished,
+    PollingStationUserStatus.SecondEntryNotAllowed,
+    PollingStationUserStatus.HasErrors,
+  ];
   const available = pollingStationsWithStatus.filter(
-    (pollingStation) =>
-      !finishedStatuses.includes(pollingStation.statusEntry.status) &&
-      pollingStation.userStatus !== PollingStationUserStatus.SecondEntryNotAllowed,
+    (pollingStation) => !notAvailable.includes(pollingStation.userStatus),
   );
   const availableCurrentUser = available.filter(
     (pollingStation) => pollingStation.userStatus !== PollingStationUserStatus.InProgressOtherUser,

--- a/frontend/src/features/data_entry_home/components/PollingStationSelector.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationSelector.tsx
@@ -88,6 +88,12 @@ export function PollingStationSelector({
               nr: currentPollingStation.number,
             }),
           );
+        case PollingStationUserStatus.HasErrors:
+          return renderWarningMessage(
+            tx("polling_station_choice.has_errors", undefined, {
+              nr: currentPollingStation.number,
+            }),
+          );
         case PollingStationUserStatus.Finished:
           return renderWarningMessage(
             tx("polling_station_choice.has_already_been_filled_twice", undefined, {

--- a/frontend/src/features/data_entry_home/utils/util.ts
+++ b/frontend/src/features/data_entry_home/utils/util.ts
@@ -10,6 +10,7 @@ export enum PollingStationUserStatus {
   InProgressCurrentUser,
   InProgressOtherUser,
   SecondEntryNotAllowed,
+  HasErrors,
   Finished,
 }
 
@@ -18,7 +19,7 @@ export type PollingStationWithStatus = PollingStation & {
   userStatus: PollingStationUserStatus;
 };
 
-export const finishedStatuses: DataEntryStatusName[] = ["entries_different", "definitive"];
+const finishedStatuses: DataEntryStatusName[] = ["entries_different", "definitive"];
 
 export function getPollingStationWithStatusList({
   pollingStations,
@@ -57,6 +58,8 @@ export function getPollingStationWithStatusList({
       }
     } else if (statusEntry.status === "second_entry_not_started" && statusEntry.first_entry_user_id === user?.user_id) {
       result.userStatus = PollingStationUserStatus.SecondEntryNotAllowed;
+    } else if (statusEntry.status === "first_entry_has_errors") {
+      result.userStatus = PollingStationUserStatus.HasErrors;
     }
 
     return result;

--- a/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
@@ -28,6 +28,7 @@ describe("PollingStationListPage", () => {
       ["34", "Testplek", "Bijzonder"],
       ["35", "Testschool", "Vaste locatie"],
       ["36", "Testbuurthuis", "Vaste locatie"],
+      ["37", "Dansschool Oeps nou deed ik het weer", "Bijzonder"],
     ]);
   });
 

--- a/frontend/src/i18n/locales/nl/polling_station_choice.json
+++ b/frontend/src/i18n/locales/nl/polling_station_choice.json
@@ -3,6 +3,7 @@
   "choose_polling_station": "Kies het stembureau",
   "enter_a_valid_number_to_start": "Voer een geldig nummer van een stembureau in om te beginnen",
   "has_already_been_filled_twice": "Stembureau {nr} <strong>({name})</strong> is al twee keer ingevoerd",
+  "has_errors": "Stembureau {nr} ligt ter beoordeling bij de coördinator",
   "insert_another": "Verder met een volgend stembureau?",
   "insert_number": "Voer het nummer in:",
   "insert_title": "Welk stembureau ga je invoeren?",

--- a/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
@@ -28,6 +28,12 @@ export const statusResponseMock: ElectionStatusResponse = {
       first_entry_progress: 100,
       second_entry_progress: 20,
     },
+    {
+      polling_station_id: 5,
+      status: "first_entry_has_errors",
+      first_entry_user_id: 1,
+      first_entry_progress: 100,
+    },
   ],
 };
 

--- a/frontend/src/testing/api-mocks/PollingStationMockData.ts
+++ b/frontend/src/testing/api-mocks/PollingStationMockData.ts
@@ -45,4 +45,15 @@ export const pollingStationMockData: PollingStation[] = [
     postal_code: "1234 WZ",
     locality: "Testplaats",
   },
+  {
+    id: 5,
+    election_id: 1,
+    name: "Dansschool Oeps nou deed ik het weer",
+    number: 37,
+    number_of_voters: 1000,
+    polling_station_type: "Special",
+    address: "Laan van Murphy 13",
+    postal_code: "4444 JP",
+    locality: "Twaalfsteden",
+  },
 ];


### PR DESCRIPTION
- Resolves https://github.com/kiesraad/abacus/issues/1548
- Fix issue where an empty list was shown instead of the "no stations available" message
- Show message when searching for first_entry_has_errors polling stations
- Filter first_entry_has_errors polling stations from list
- Add to mock for run frontend with MSW and tests

Can be tested by trying to start data entry for polling station number 37, using MSW
