### PR TITLE
Fixed typo in comment and fixed docstring copy/pasta

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -106,7 +106,7 @@
     },
     "/api/elections/import": {
       "post": {
-        "summary": "Uploads election definition, validates it and returns the associated election data and\na redacted hash, to be filled by the administrator",
+        "summary": "Uploads election definition, validates it, saves it to the database, and returns the created election",
         "operationId": "election_import",
         "requestBody": {
           "content": {

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -170,8 +170,7 @@ pub struct ElectionDefinitionImportRequest {
     data: String,
 }
 
-/// Uploads election definition, validates it and returns the associated election data and
-/// a redacted hash, to be filled by the administrator
+/// Uploads election definition, validates it, saves it to the database, and returns the created election
 #[utoipa::path(
     post,
     path = "/api/elections/import",

--- a/frontend/src/features/election_create/components/CheckHash.tsx
+++ b/frontend/src/features/election_create/components/CheckHash.tsx
@@ -57,7 +57,7 @@ export function CheckHash({ date, title, fileName, redactedHash, error, onSubmit
       }
     });
 
-    // Only submit when there a no errors
+    // Only submit when there are no errors
     if (stubs.every((stub) => stub.error === "")) {
       onSubmit(completeHash);
     }


### PR DESCRIPTION
Fixes #1573 

Gets the list of elections after navigating from `CheckAndSave`. I'm not sure if this is the best implementation, I've looked at how it's done when creating users.

Tested by importing an election and verifying it's added without refreshing the page, or navigating away from the election listing first. 

Also fixed a comment and a docstring.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->