### PR TITLE
Add e2e test for election creation

### DIFF
--- a/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
@@ -4,11 +4,13 @@ import { NavBar } from "../NavBarPgObj";
 
 export class OverviewPgObj {
   readonly navBar: NavBar;
+  readonly header: Locator;
   readonly alert: Locator;
   readonly create: Locator;
 
   constructor(protected readonly page: Page) {
     this.navBar = new NavBar(page);
+    this.header = page.getByRole("heading", { name: "Beheer verkiezingen" });
     this.alert = page.getByRole("heading", { name: "Je account is ingesteld" });
     this.create = page.getByRole("link", { name: "Verkiezing toevoegen" });
   }

--- a/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
@@ -7,11 +7,23 @@ export class OverviewPgObj {
   readonly header: Locator;
   readonly alert: Locator;
   readonly create: Locator;
+  readonly importedElections: Locator;
+  readonly readyStates: Locator;
 
   constructor(protected readonly page: Page) {
     this.navBar = new NavBar(page);
     this.header = page.getByRole("heading", { name: "Beheer verkiezingen" });
     this.alert = page.getByRole("heading", { name: "Je account is ingesteld" });
     this.create = page.getByRole("link", { name: "Verkiezing toevoegen" });
+    this.importedElections = page.getByText("Gemeenteraad Amsterdam 2022");
+    this.readyStates = page.getByText("Klaar voor invoer");
+  }
+
+  async electionCount(): Promise<number> {
+    return await this.importedElections.count();
+  }
+
+  async readyStateCount(): Promise<number> {
+    return await this.readyStates.count();
   }
 }

--- a/frontend/e2e-tests/page-objects/election/create/CheckAndSavePgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckAndSavePgObj.ts
@@ -1,0 +1,11 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class CheckAndSavePgObj {
+  readonly header: Locator;
+  readonly save: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.header = page.getByRole("heading", { level: 2, name: "Controleren en opslaan" });
+    this.save = page.getByRole("button", { name: "Opslaan" });
+  }
+}

--- a/frontend/e2e-tests/page-objects/election/create/CheckDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckDefinitionPgObj.ts
@@ -1,11 +1,17 @@
 import { type Locator, type Page } from "@playwright/test";
 
-export class ElectionCheckDefinitionPgObj {
+export class CheckDefinitionPgObj {
   readonly header: Locator;
   readonly hash: Locator;
+  readonly hashInput1: Locator;
+  readonly hashInput2: Locator;
+  readonly next: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Controleer verkiezingsdefinitie" });
     this.hash = page.getByTestId("hash");
+    this.hashInput1 = page.getByLabel("Controle deel 1");
+    this.hashInput2 = page.getByLabel("Controle deel 2");
+    this.next = page.getByRole("button", { name: "Volgende" });
   }
 }

--- a/frontend/e2e-tests/page-objects/election/create/CheckDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckDefinitionPgObj.ts
@@ -6,6 +6,7 @@ export class CheckDefinitionPgObj {
   readonly hashInput1: Locator;
   readonly hashInput2: Locator;
   readonly next: Locator;
+  readonly error: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Controleer verkiezingsdefinitie" });
@@ -13,5 +14,6 @@ export class CheckDefinitionPgObj {
     this.hashInput1 = page.getByLabel("Controle deel 1");
     this.hashInput2 = page.getByLabel("Controle deel 2");
     this.next = page.getByRole("button", { name: "Volgende" });
+    this.error = page.getByRole("heading", { level: 3, name: "Controle digitale vingerafdruk niet gelukt" });
   }
 }

--- a/frontend/e2e-tests/page-objects/election/create/UploadDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/UploadDefinitionPgObj.ts
@@ -2,10 +2,12 @@ import { type Locator, type Page } from "@playwright/test";
 
 export class UploadDefinitionPgObj {
   readonly header: Locator;
+  readonly error: Locator;
   readonly upload: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Importeer verkiezingsdefinitie" });
+    this.error = page.getByRole("heading", { level: 3, name: "Ongeldige verkiezingsdefinitie" });
     this.upload = page.getByRole("button", { name: "Bestand kiezen" });
   }
 

--- a/frontend/e2e-tests/page-objects/election/create/UploadDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/UploadDefinitionPgObj.ts
@@ -1,6 +1,6 @@
 import { type Locator, type Page } from "@playwright/test";
 
-export class ElectionUploadDefinitionPgObj {
+export class UploadDefinitionPgObj {
   readonly header: Locator;
   readonly upload: Locator;
 

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -47,4 +47,33 @@ test.describe("Election creation", () => {
     // Check if the amount of "Klaar voor invoer states" is one more than before the import
     expect(await overviewPage.readyStateCount()).toBe(initialReadyStateCount + 1);
   });
+
+  test("it fails on incorrect hash", async ({ page }) => {
+    await page.goto("/elections");
+    const overviewPage = new OverviewPgObj(page);
+    await overviewPage.create.click();
+
+    const uploadDefinitionPage = new UploadDefinitionPgObj(page);
+    await expect(uploadDefinitionPage.header).toBeVisible();
+    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+
+    const checkDefinitionPage = new CheckDefinitionPgObj(page);
+    await expect(checkDefinitionPage.hashInput1).toBeFocused();
+    // Wrong hash
+    await checkDefinitionPage.hashInput1.fill("1234");
+    await checkDefinitionPage.hashInput2.fill("asdf");
+    await checkDefinitionPage.next.click();
+    await expect(checkDefinitionPage.error).toBeVisible();
+  });
+
+  test("it fails on valid, but incorrect file", async ({ page }) => {
+    await page.goto("/elections");
+    const overviewPage = new OverviewPgObj(page);
+    await overviewPage.create.click();
+
+    const uploadDefinitionPage = new UploadDefinitionPgObj(page);
+    await expect(uploadDefinitionPage.header).toBeVisible();
+    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110b_test.eml.xml");
+    await expect(uploadDefinitionPage.error).toBeVisible();
+  });
 });

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
-import { ElectionCheckDefinitionPgObj } from "e2e-tests/page-objects/election/ElectionCheckDefinitionPgObj";
-import { ElectionUploadDefinitionPgObj } from "e2e-tests/page-objects/election/ElectionUploadDefinitionPgObj";
+import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckAndSavePgObj";
+import { CheckDefinitionPgObj } from "e2e-tests/page-objects/election/create/CheckDefinitionPgObj";
+import { UploadDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadDefinitionPgObj";
 import { OverviewPgObj } from "e2e-tests/page-objects/election/OverviewPgObj";
 
 import { test } from "../fixtures";
@@ -15,15 +16,32 @@ test.describe("Election creation", () => {
     const overviewPage = new OverviewPgObj(page);
     await overviewPage.create.click();
 
-    const uploadDefinitionPage = new ElectionUploadDefinitionPgObj(page);
+    const uploadDefinitionPage = new UploadDefinitionPgObj(page);
     await expect(uploadDefinitionPage.header).toBeVisible();
     await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
 
-    const checkDefinitionPage = new ElectionCheckDefinitionPgObj(page);
+    const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
     // Check that the uploaded file name is present somewhere on the page
     await expect(page.getByText("eml110a_test.eml.xml")).toBeVisible();
     // Election date
     await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+
+    await expect(checkDefinitionPage.hashInput1).toBeFocused();
+    await checkDefinitionPage.hashInput1.fill("9825");
+    await checkDefinitionPage.hashInput2.fill("8af1");
+    await checkDefinitionPage.next.click();
+
+    const checkAndSavePage = new CheckAndSavePgObj(page);
+    await expect(checkAndSavePage.header).toBeVisible();
+    await checkAndSavePage.save.click();
+
+    //await page.goto("/elections");
+
+    // Redefine the Overview page, so we can locate the newly
+    // added objects
+    await expect(overviewPage.header).toBeVisible();
+    await expect(page.getByText("Gemeenteraad Amsterdam 2022")).toBeVisible();
+    await expect(page.getByText("Klaar voor invoer")).toBeVisible();
   });
 });

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -14,6 +14,9 @@ test.describe("Election creation", () => {
   test("it uploads a file", async ({ page }) => {
     await page.goto("/elections");
     const overviewPage = new OverviewPgObj(page);
+    const initialElectionCount = await overviewPage.electionCount();
+    const initialReadyStateCount = await page.getByText("Klaar voor invoer").count();
+
     await overviewPage.create.click();
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
@@ -36,12 +39,12 @@ test.describe("Election creation", () => {
     await expect(checkAndSavePage.header).toBeVisible();
     await checkAndSavePage.save.click();
 
-    //await page.goto("/elections");
-
     // Redefine the Overview page, so we can locate the newly
     // added objects
     await expect(overviewPage.header).toBeVisible();
-    await expect(page.getByText("Gemeenteraad Amsterdam 2022")).toBeVisible();
-    await expect(page.getByText("Klaar voor invoer")).toBeVisible();
+    // Check if the amount of elections by this title is one more than before the import
+    expect(await overviewPage.electionCount()).toBe(initialElectionCount + 1);
+    // Check if the amount of "Klaar voor invoer states" is one more than before the import
+    expect(await overviewPage.readyStateCount()).toBe(initialReadyStateCount + 1);
   });
 });


### PR DESCRIPTION
Fixes #1415

Adds e2e tests for election definition uploading, hash checking, and saving a new election
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->