### PR TITLE
Additional air-gap checks

### DIFF
--- a/backend/src/airgap/detect.rs
+++ b/backend/src/airgap/detect.rs
@@ -102,7 +102,7 @@ impl AirgapDetection {
             return;
         }
 
-        // persorm a DNS lookup using the default resolver
+        // perform a DNS lookup using the default resolver
         let dns_lookup_success = DOMAINS
             .iter()
             .map(|d| format!("{d}:{SECURE_PORT}").to_socket_addrs())

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()
-                .with_default_directive(LevelFilter::TRACE.into())
+                .with_default_directive(LevelFilter::INFO.into())
                 .from_env()?,
         )
         .init();

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
+                .with_default_directive(LevelFilter::TRACE.into())
                 .from_env()?,
         )
         .init();


### PR DESCRIPTION
In OSV2020 airgaps are detected using PING and by performing HTTP requests.

Performing a ping is not implemented in the Rust standard library. It also would involve root permissions if performed on a raw socket in a Linux system. Since including a external dependency for this is too much of a burden for this feature, we do not ping external systems.

Instead 3 types of simple checks are performed:

- A DNS resolve using the default resolver
- Establishing a TCP connection over IPv4
- Establishing a TCP connection over IPv6

Since the DNS query (usually) is performed over UDP these methods cover the two fundamental internet protocols.

Note that performing a HTTP request (like in OSV2020) has more points of failure than just establishing a TCP connection, while a HTTP request (apart form HTTP3) always starts of with a TCP connection. So only checking the final result of a HTTP request has a higher chance of false negative in a air-gap detection context.

To test:

Run abacus with the air-gap detection:

```shell
RUST_LOG=abacus=trace cargo run -- --airgap-detection
```

This should output the following:
```shell
ERROR abacus::airgap::detect: Airgap violation detected, abacus is connected to the internet!
TRACE abacus::airgap::detect: TCP IPv4 connections: 2
```

Bonus points for blocking TCP traffic in your firewall and seeing the  following output:
```shell
ERROR abacus::airgap::detect: Airgap violation detected, abacus is connected to the internet!
TRACE abacus::airgap::detect: DNS lookup success: 3
```

Code coverage is not perfect since, in a test , the detection will fail early.
