### PR TITLE
Airgap error dialog

### DIFF
--- a/frontend/src/api/ApiClient.ts
+++ b/frontend/src/api/ApiClient.ts
@@ -192,7 +192,7 @@ export class ApiClient extends EventTarget {
         : await this.handleEmptyOrNonJsonBody(response);
 
       // dispatch error events to subscribers
-      if (apiResult instanceof ApiError) {
+      if (apiResult instanceof ApiError || apiResult instanceof FatalApiError) {
         this.dispatchEvent(new ApiErrorEvent(apiResult));
       }
 

--- a/frontend/src/api/ApiEvents.ts
+++ b/frontend/src/api/ApiEvents.ts
@@ -1,7 +1,7 @@
-import { ApiError } from "./ApiResult";
+import { ApiError, FatalApiError } from "./ApiResult";
 
 export class ApiErrorEvent extends Event {
-  constructor(public error: ApiError) {
+  constructor(public error: ApiError | FatalApiError) {
     super("apiError");
     this.error = error;
   }

--- a/frontend/src/api/ApiProvider.tsx
+++ b/frontend/src/api/ApiProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 import { ApiClient } from "./ApiClient";
 import { ApiProviderContext, ApiState } from "./ApiProviderContext";
@@ -13,18 +13,12 @@ export interface ApiProviderProps {
 const client = new ApiClient();
 
 export function ApiProvider({ children, fetchInitialUser = true }: ApiProviderProps) {
-  const {
-    user,
-    loading,
-    setUser,
-    login,
-    logout,
-    expiration,
-    setExpiration,
-    extendSession,
-    airGapError,
-    setAirGapError,
-  } = useSessionState(client, fetchInitialUser);
+  const { user, loading, setUser, login, logout, expiration, setExpiration, extendSession } = useSessionState(
+    client,
+    fetchInitialUser,
+  );
+
+  const [airGapError, setAirGapError] = useState<boolean>(false);
 
   // Unset the current user when the API returns an invalid session error
   // indicating that the sessions has expired or the user is not authenticated anymore

--- a/frontend/src/api/ApiProviderContext.tsx
+++ b/frontend/src/api/ApiProviderContext.tsx
@@ -14,6 +14,7 @@ export interface ApiState {
   loading: boolean;
   expiration: Date | null;
   extendSession: () => Promise<void>;
+  airGapError: boolean;
 }
 
 export const ApiProviderContext = createContext<ApiState | null>(null);

--- a/frontend/src/api/useSessionState.ts
+++ b/frontend/src/api/useSessionState.ts
@@ -20,6 +20,8 @@ export interface SessionState {
   expiration: Date | null;
   setExpiration: (expiration: Date | null) => void;
   extendSession: () => Promise<void>;
+  airGapError: boolean;
+  setAirGapError: (error: boolean) => void;
 }
 
 // Keep track of the currently logged-in user
@@ -29,6 +31,7 @@ export default function useSessionState(client: ApiClient, fetchInitialUser: boo
   const [user, setUser] = useState<LoginResponse | null>(null);
   const [expiration, setExpiration] = useState<Date | null>(null);
   const [loading, setLoading] = useState(true);
+  const [airGapError, setAirGapError] = useState<boolean>(false);
 
   // Log out the current user
   const logout = async () => {
@@ -71,7 +74,6 @@ export default function useSessionState(client: ApiClient, fetchInitialUser: boo
 
       void (async () => {
         const path: WHOAMI_REQUEST_PATH = "/api/user/whoami";
-        const client = new ApiClient();
         const response = await client.getRequest<LoginResponse>(path, abortController);
 
         if (!abortController.signal.aborted) {
@@ -89,7 +91,7 @@ export default function useSessionState(client: ApiClient, fetchInitialUser: boo
         abortController.abort(DEFAULT_CANCEL_REASON);
       };
     }
-  }, [fetchInitialUser]);
+  }, [fetchInitialUser, client]);
 
   return {
     expiration,
@@ -100,5 +102,7 @@ export default function useSessionState(client: ApiClient, fetchInitialUser: boo
     setUser,
     user,
     extendSession,
+    airGapError,
+    setAirGapError,
   };
 }

--- a/frontend/src/api/useSessionState.ts
+++ b/frontend/src/api/useSessionState.ts
@@ -20,8 +20,6 @@ export interface SessionState {
   expiration: Date | null;
   setExpiration: (expiration: Date | null) => void;
   extendSession: () => Promise<void>;
-  airGapError: boolean;
-  setAirGapError: (error: boolean) => void;
 }
 
 // Keep track of the currently logged-in user
@@ -31,7 +29,6 @@ export default function useSessionState(client: ApiClient, fetchInitialUser: boo
   const [user, setUser] = useState<LoginResponse | null>(null);
   const [expiration, setExpiration] = useState<Date | null>(null);
   const [loading, setLoading] = useState(true);
-  const [airGapError, setAirGapError] = useState<boolean>(false);
 
   // Log out the current user
   const logout = async () => {
@@ -102,7 +99,5 @@ export default function useSessionState(client: ApiClient, fetchInitialUser: boo
     setUser,
     user,
     extendSession,
-    airGapError,
-    setAirGapError,
   };
 }

--- a/frontend/src/app/RootLayout.tsx
+++ b/frontend/src/app/RootLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, ScrollRestoration } from "react-router";
 
+import { AirGapViolationDialog } from "@/components/error/AirGapviolationDialog";
 import { AppFrame } from "@/components/ui/AppFrame/AppFrame";
 
 import { AuthorizationDialog } from "./AuthorizationDialog";
@@ -9,6 +10,7 @@ export function RootLayout() {
     <AppFrame>
       <AuthorizationDialog />
       <ScrollRestoration />
+      <AirGapViolationDialog />
       <Outlet />
     </AppFrame>
   );

--- a/frontend/src/app/routes.test.tsx
+++ b/frontend/src/app/routes.test.tsx
@@ -14,7 +14,7 @@ import { routes } from "./routes";
 
 const renderWithRouter = () => {
   const router = setupTestRouter(routes);
-  rtlRender(<Providers router={createTestRouter(router)} />);
+  rtlRender(<Providers router={router} />);
   return router;
 };
 

--- a/frontend/src/app/routes.test.tsx
+++ b/frontend/src/app/routes.test.tsx
@@ -14,7 +14,7 @@ import { routes } from "./routes";
 
 const renderWithRouter = () => {
   const router = setupTestRouter(routes);
-  rtlRender(<Providers router={router} />);
+  rtlRender(<Providers router={createTestRouter(router)} />);
   return router;
 };
 

--- a/frontend/src/components/error/AirGapViolationDialog.test.tsx
+++ b/frontend/src/components/error/AirGapViolationDialog.test.tsx
@@ -1,0 +1,36 @@
+import { render as rtlRender, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { Providers } from "@/testing/Providers";
+import { overrideOnce } from "@/testing/server";
+import { screen, setupTestRouter } from "@/testing/test-utils";
+import { routes } from "@/app/routes";
+
+describe("AirGapViolationDialog", () => {
+  test("Error dialog when air-gap violation is detected", async () => {
+
+    // Since we test what happens after an error, we want vitest to ignore them
+    vi.spyOn(console, "warn").mockImplementation(() => {
+      /* do nothing */
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {
+      /* do nothing */
+    });
+
+    overrideOnce("get", "/api/whoami", 503, {
+        error: "Blocking request due to airgap violation",
+        fatal: true,
+        reference: "AirgapViolation"
+    });
+
+    const router = setupTestRouter(routes);
+    rtlRender(<Providers router={router} fetchInitialUser={true} />);
+
+    // Wait for the modal to be loaded
+    await waitFor(() => {
+        expect(screen.queryByTestId("modal-title")).toBeVisible();
+    });
+
+    expect(screen.queryByTestId("modal-title")).toHaveTextContent("Abacus is niet beschikbaar");
+  });
+});

--- a/frontend/src/components/error/AirGapViolationDialog.test.tsx
+++ b/frontend/src/components/error/AirGapViolationDialog.test.tsx
@@ -1,14 +1,14 @@
 import { render as rtlRender, waitFor } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 
-import { Providers } from "@/testing/Providers";
+import { ApiProvider } from "@/api/ApiProvider";
 import { overrideOnce } from "@/testing/server";
-import { screen, setupTestRouter } from "@/testing/test-utils";
-import { routes } from "@/app/routes";
+import { screen } from "@/testing/test-utils";
+
+import { AirGapViolationDialog } from "./AirGapviolationDialog";
 
 describe("AirGapViolationDialog", () => {
   test("Error dialog when air-gap violation is detected", async () => {
-
     // Since we test what happens after an error, we want vitest to ignore them
     vi.spyOn(console, "warn").mockImplementation(() => {
       /* do nothing */
@@ -17,20 +17,21 @@ describe("AirGapViolationDialog", () => {
       /* do nothing */
     });
 
-    overrideOnce("get", "/api/whoami", 503, {
-        error: "Blocking request due to airgap violation",
-        fatal: true,
-        reference: "AirgapViolation"
+    overrideOnce("get", "/api/user/whoami", 503, {
+      error: "Blocking request due to airgap violation",
+      fatal: true,
+      reference: "AirgapViolation",
     });
 
-    const router = setupTestRouter(routes);
-    rtlRender(<Providers router={router} fetchInitialUser={true} />);
+    rtlRender(
+      <ApiProvider fetchInitialUser={true}>
+        <AirGapViolationDialog />
+      </ApiProvider>,
+    );
 
     // Wait for the modal to be loaded
     await waitFor(() => {
-        expect(screen.queryByTestId("modal-title")).toBeVisible();
+      expect(screen.queryByTestId("modal-title")).toHaveTextContent("Abacus is niet beschikbaar");
     });
-
-    expect(screen.queryByTestId("modal-title")).toHaveTextContent("Abacus is niet beschikbaar");
   });
 });

--- a/frontend/src/components/error/AirGapViolationDialog.test.tsx
+++ b/frontend/src/components/error/AirGapViolationDialog.test.tsx
@@ -1,5 +1,5 @@
 import { render as rtlRender, waitFor } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { ApiProvider } from "@/api/ApiProvider";
 import { overrideOnce } from "@/testing/server";
@@ -9,14 +9,6 @@ import { AirGapViolationDialog } from "./AirGapviolationDialog";
 
 describe("AirGapViolationDialog", () => {
   test("Error dialog when air-gap violation is detected", async () => {
-    // Since we test what happens after an error, we want vitest to ignore them
-    vi.spyOn(console, "warn").mockImplementation(() => {
-      /* do nothing */
-    });
-    vi.spyOn(console, "error").mockImplementation(() => {
-      /* do nothing */
-    });
-
     overrideOnce("get", "/api/user/whoami", 503, {
       error: "Blocking request due to airgap violation",
       fatal: true,

--- a/frontend/src/components/error/AirGapviolationDialog.tsx
+++ b/frontend/src/components/error/AirGapviolationDialog.tsx
@@ -1,0 +1,30 @@
+import { useApiState } from "@/api/useApiState";
+import { t } from "@/i18n/translate";
+
+import { Button } from "../ui/Button/Button";
+import { Modal } from "../ui/Modal/Modal";
+
+export function AirGapViolationDialog() {
+  const { airGapError } = useApiState();
+
+  if (!airGapError) {
+    return null;
+  }
+
+  return (
+    <Modal title={t("error.airgap_violation.title")} noFlex={true}>
+      <p>{t("error.airgap_violation.content")}</p>
+      <nav>
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          {t("error.airgap_violation.reload")}
+        </Button>
+      </nav>
+    </Modal>
+  );
+}

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -12,6 +12,11 @@
     "title": "Komt het probleem terug?",
     "content": "Neem contact op met de ontwikkelaars of rapporteer een bug via <link>https://github.com/kiesraad/abacus</link>"
   },
+  "airgap_violation": {
+    "title": "Abacus is niet beschikbaar",
+    "content": "Abacus is alleen bedoeld voor offline gebruik. De applicatie is verbonden met het internet, waardoor Abacus niet gebruikt kan worden. Zorg ervoor dat de applicatie niet verbonden is met het internet en probeer het opnieuw.",
+    "reload": "Probeer opnieuw"
+  },
   "api_error": {
     "AirgapViolation": "Abacus is niet beschikbaar omdat de applicatie verbonden is met het internet. Abacus is alleen bedoeld voor offline gebruik.",
     "AllListsExhausted": "Er zijn te weinig kandidaten om alle aan lijsten toegewezen zetels te vullen. Abacus kan daarom geen zetelverdeling berekenen. Neem contact op met de Kiesraad.",

--- a/frontend/src/testing/TestUserProvider.tsx
+++ b/frontend/src/testing/TestUserProvider.tsx
@@ -36,6 +36,7 @@ export function TestUserProvider({ userRole, children, overrideExpiration }: Tes
       return Promise.resolve({} as ApiResult<LoginResponse>);
     },
     loading: false,
+    airGapError: false,
     expiration,
     extendSession: function (): Promise<void> {
       expiration.setMinutes(expiration.getMinutes() + 30);


### PR DESCRIPTION
Fixes #1540

Handles 503 air gap violation errors in the frontend.

This PR mainly adds the mechanism to handle errors, the design of the dialog is part of another issue: #1558

Any API call could return a HTTP 503 response for air gap violation errors. Our API clients allows subscribing to errors. The `ApiProvider` (which is the parent element of our router element) subscribes to theses errors and keeps track of air gap violations.

The newly introduced error dialog `AirGapViolationDialog` will be shown if a violation occurs. The user has a button to reload the page.

To test, run the backend with airgap detection enabled:
```shell
RUST_LOG=abacus=trace cargo run -- --airgap-detection
```
Then run the frontend, which should show the dialog: 

![image](https://github.com/user-attachments/assets/014737f2-c74f-42ca-85c5-95402af8422c)

Try to disconnect from the internet and click the button. The application should be usable again.

