### PR TITLE
1377 frontend page to upload candidate list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .idea
+*swp

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -222,7 +222,7 @@
     },
     "/api/elections/import/validate-candidates": {
       "post": {
-        "description": "\n\n\n\n",
+        "summary": "Uploads candidate list, validates it and returns the associated candidate list and\na redacted hash, to be filled by the administrator.",
         "operationId": "election_import_candidates_validate",
         "requestBody": {
           "content": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2843,17 +2843,24 @@
       "CandidateDefinitionValidateRequest": {
         "type": "object",
         "required": [
-          "data",
-          "election"
+          "candidate_data",
+          "election_hash",
+          "election_data"
         ],
         "properties": {
-          "data": {
+          "candidate_data": {
             "type": "string"
           },
-          "election": {
-            "$ref": "#/components/schemas/NewElection"
+          "candidate_hash": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "hash": {
+          "election_data": {
+            "type": "string"
+          },
+          "election_hash": {
             "type": "array",
             "items": {
               "type": "string"
@@ -3372,25 +3379,25 @@
       "ElectionDefinitionImportRequest": {
         "type": "object",
         "required": [
-          "electionHash",
-          "electionData",
-          "candidateHash",
-          "candidateData"
+          "election_hash",
+          "election_data",
+          "candidate_hash",
+          "candidate_data"
         ],
         "properties": {
-          "candidateData": {
+          "candidate_data": {
             "type": "string"
           },
-          "candidateHash": {
+          "candidate_hash": {
             "type": "array",
             "items": {
               "type": "string"
             }
           },
-          "electionData": {
+          "election_data": {
             "type": "string"
           },
-          "electionHash": {
+          "election_hash": {
             "type": "array",
             "items": {
               "type": "string"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -220,6 +220,64 @@
         }
       }
     },
+    "/api/elections/import/validate-candidates": {
+      "post": {
+        "description": "\n\n\n\n",
+        "operationId": "election_import_candidates_validate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CandidateDefinitionValidateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Candidates validated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateDefinitionValidateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/elections/{election_id}": {
       "get": {
         "summary": "Get election details including the election's candidate list (political groups) and its polling stations",
@@ -2782,6 +2840,42 @@
           }
         }
       },
+      "CandidateDefinitionValidateRequest": {
+        "type": "object",
+        "required": [
+          "data",
+          "election"
+        ],
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "election": {
+            "$ref": "#/components/schemas/NewElection"
+          },
+          "hash": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CandidateDefinitionValidateResponse": {
+        "type": "object",
+        "required": [
+          "hash",
+          "list"
+        ],
+        "properties": {
+          "hash": {
+            "$ref": "#/components/schemas/RedactedEmlHash"
+          },
+          "list": {
+            "$ref": "#/components/schemas/NewCandidateList"
+          }
+        }
+      },
       "CandidateGender": {
         "type": "string",
         "description": "Candidate gender",
@@ -3278,14 +3372,25 @@
       "ElectionDefinitionImportRequest": {
         "type": "object",
         "required": [
-          "hash",
-          "data"
+          "electionHash",
+          "electionData",
+          "candidateHash",
+          "candidateData"
         ],
         "properties": {
-          "data": {
+          "candidateData": {
             "type": "string"
           },
-          "hash": {
+          "candidateHash": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "electionData": {
+            "type": "string"
+          },
+          "electionHash": {
             "type": "array",
             "items": {
               "type": "string"
@@ -3931,6 +4036,25 @@
           },
           "username": {
             "type": "string"
+          }
+        }
+      },
+      "NewCandidateList": {
+        "type": "object",
+        "description": "Candidate list request",
+        "required": [
+          "name",
+          "political_groups"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "political_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PoliticalGroup"
+            }
           }
         }
       },

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -156,8 +156,6 @@ pub async fn election_import_validate(
     _user: Admin,
     Json(edu): Json<ElectionDefinitionValidateRequest>,
 ) -> Result<Json<ElectionDefinitionValidateResponse>, APIError> {
-    println!("{:?}", EmlHash::from(edu.data.as_bytes()).chunks);
-
     if let Some(user_hash) = edu.hash {
         if user_hash != EmlHash::from(edu.data.as_bytes()).chunks {
             return Err(APIError::InvalidHashError);
@@ -196,9 +194,6 @@ pub async fn election_import_candidates_validate(
     _user: Admin,
     Json(edu): Json<CandidateDefinitionValidateRequest>,
 ) -> Result<Json<CandidateDefinitionValidateResponse>, APIError> {
-    // TODO: remove
-    println!("{:?}", EmlHash::from(edu.candidate_data.as_bytes()).chunks);
-
     if edu.election_hash != EmlHash::from(edu.election_data.as_bytes()).chunks {
         return Err(APIError::InvalidHashError);
     }

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -180,9 +180,8 @@ pub struct ElectionDefinitionImportRequest {
     candidate_data: String,
 }
 
-///
-///
-///
+/// Uploads candidate list, validates it and returns the associated candidate list and
+/// a redacted hash, to be filled by the administrator.
 #[utoipa::path(
     post,
     path = "/api/elections/import/validate-candidates",

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -1,5 +1,5 @@
 mod api;
 pub(crate) mod repository;
-mod structs;
+pub(crate) mod structs;
 
 pub use self::{api::*, structs::*};

--- a/backend/src/election/structs.rs
+++ b/backend/src/election/structs.rs
@@ -95,6 +95,13 @@ impl IntoResponse for ElectionWithPoliticalGroups {
     }
 }
 
+/// Candidate list request
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
+pub struct NewCandidateList {
+    pub name: String,
+    pub political_groups: Vec<PoliticalGroup>,
+}
+
 /// Election request
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct NewElection {

--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -207,38 +207,23 @@ impl TryFrom<Candidate> for structs::Candidate {
 
     fn try_from(parsed: Candidate) -> Result<Self, Self::Error> {
         Ok(structs::Candidate {
-            //pub number: CandidateNumber,
             number: parsed
                 .candidate_identifier
                 .id
                 .parse()
                 .or(Err(EMLImportError::InvalidCandidate))?,
-
-            //pub initials: String,
             initials: match parsed.candidate_full_name.person_name.name_line {
                 Some(line) => line.value,
                 None => return Err(EMLImportError::InvalidCandidate),
             },
-
-            //pub first_name: Option<String>,
             first_name: parsed.candidate_full_name.person_name.first_name,
-
-            //pub last_name_prefix: Option<String>,
             last_name_prefix: parsed.candidate_full_name.person_name.name_prefix,
-
-            //pub last_name: String,
             last_name: parsed.candidate_full_name.person_name.last_name,
-
-            //pub locality: String,
             locality: parsed.qualifying_address.locality_name().to_string(),
-
-            //pub country_code: Option<String>,
-            country_code: match parsed.qualifying_address.country_name_code() {
-                None => None,
-                Some(s) => Some(s.to_string()),
-            },
-
-            //pub gender: Option<CandidateGender>,
+            country_code: parsed
+                .qualifying_address
+                .country_name_code()
+                .map(|s| s.to_string()),
             gender: match parsed.gender {
                 None => None,
                 Some(gender) => match gender {

--- a/backend/src/eml/eml_230.rs
+++ b/backend/src/eml/eml_230.rs
@@ -38,19 +38,21 @@ impl EML230 {
 
     pub fn as_candidate_list(
         &self,
-        election: &NewElection,
+        _election: &NewElection,
     ) -> std::result::Result<NewCandidateList, EMLImportError> {
         // we need to be importing from a 230b file
         if self.base.id != "230b" {
             return Err(EMLImportError::Needs230b);
         }
 
+        // TODO: uncomment when we have new test files
+        //
         // make sure candidate list election matches election definition
         //if election.election_id != self.election().election_identifier.election_name {
         //    return Err(EMLImportError::MismatchElectionIdentifier);
         //}
 
-        // TODO: more checkes
+        // TODO: more validation see issue #1589
 
         // extract initial listing of political groups
         let political_groups = self

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -4,7 +4,7 @@ pub mod axum;
 mod base;
 mod common;
 mod eml_110;
-mod eml_230;
+pub mod eml_230;
 mod eml_510;
 mod eml_520;
 pub mod hash;

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -110,6 +110,32 @@ async fn test_election_validate_invalid_xml(pool: SqlitePool) {
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_candidates_validate_valid(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let admin_cookie = shared::admin_login(&addr).await;
+    let url = format!("http://{addr}/api/elections/import/validate-candidates");
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+          "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
+          "election_hash": [
+              "84c9", "caba", "ff33", "6c42",
+              "9825", "b20c", "2ba9", "1ceb",
+              "3c61", "9b99", "8af1", "a57e",
+              "cf00", "8930", "9bce", "0c33"
+          ],
+          "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
 async fn test_election_import_save(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
@@ -119,13 +145,20 @@ async fn test_election_import_save(pool: SqlitePool) {
         .post(&url)
         .header("cookie", admin_cookie)
         .json(&serde_json::json!({
-            "hash": [
+            "election_hash": [
                 "84c9", "caba", "ff33", "6c42",
                 "9825", "b20c", "2ba9", "1ceb",
                 "3c61", "9b99", "8af1", "a57e",
                 "cf00", "8930", "9bce", "0c33"
             ],
-            "data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "candidate_hash": [
+                "5566", "daaf", "7ecb", "adbf",
+                "8a7b", "2869", "3690", "2c23",
+                "5762", "40f2", "be24", "458a",
+                "0140", "2835", "3940", "e848"
+            ],
+            "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
         }))
         .send()
         .await
@@ -144,13 +177,20 @@ async fn test_election_import_save_empty_stubs(pool: SqlitePool) {
         .post(&url)
         .header("cookie", admin_cookie)
         .json(&serde_json::json!({
-            "hash": [
+            "election_hash": [
                 "84c9", "caba", "ff33", "6c42",
                 "", "b20c", "2ba9", "1ceb",
                 "3c61", "9b99", "", "a57e",
                 "cf00", "8930", "9bce", "0c33"
             ],
-            "data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "election_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
+            "candidate_hash": [
+                "5566", "daaf", "7ecb", "adbf",
+                "8a7b", "2869", "3690", "2c23",
+                "5762", "40f2", "be24", "458a",
+                "0140", "2835", "3940", "e848"
+            ],
+            "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
         }))
         .send()
         .await
@@ -169,13 +209,20 @@ async fn test_election_import_save_wrong_hash(pool: SqlitePool) {
         .post(&url)
         .header("cookie", admin_cookie)
         .json(&serde_json::json!({
-            "hash": [
+            "election_hash": [
                 "84c9", "caba", "ff33", "6c42",
                 "1234", "b20c", "2ba9", "1ceb",
                 "3c61", "9b99", "f0a6", "a57e",
                 "cf00", "8930", "9bce", "0c33"
             ],
-            "data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "candidate_hash": [
+                "5566", "daaf", "7ecb", "adbf",
+                "8a7b", "2869", "3690", "2c23",
+                "5762", "40f2", "be24", "458a",
+                "0140", "2835", "3940", "e848"
+            ],
+            "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
         }))
         .send()
         .await

--- a/frontend/e2e-tests/page-objects/election/create/CheckCandidateDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckCandidateDefinitionPgObj.ts
@@ -1,0 +1,19 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class CheckCandidateDefinitionPgObj {
+  readonly header: Locator;
+  readonly hash: Locator;
+  readonly hashInput1: Locator;
+  readonly hashInput2: Locator;
+  readonly next: Locator;
+  readonly error: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.header = page.getByRole("heading", { level: 2, name: "Controleer kandidatenlijst" });
+    this.hash = page.getByTestId("hash");
+    this.hashInput1 = page.getByLabel("Controle deel 1");
+    this.hashInput2 = page.getByLabel("Controle deel 2");
+    this.next = page.getByRole("button", { name: "Volgende" });
+    this.error = page.getByRole("heading", { level: 3, name: "Controle digitale vingerafdruk niet gelukt" });
+  }
+}

--- a/frontend/e2e-tests/page-objects/election/create/UploadCandidateDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/UploadCandidateDefinitionPgObj.ts
@@ -1,0 +1,20 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class UploadCandidateDefinitionPgObj {
+  readonly header: Locator;
+  readonly error: Locator;
+  readonly upload: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.header = page.getByRole("heading", { level: 2, name: "Importeer kandidatenlijst" });
+    this.error = page.getByRole("heading", { level: 3, name: "Ongeldige kandidatenlijst" });
+    this.upload = page.getByRole("button", { name: "Bestand kiezen" });
+  }
+
+  async uploadFile(page: Page, path: string) {
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.getByText("Bestand kiezen").click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(path);
+  }
+}

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -1,6 +1,8 @@
 import { expect } from "@playwright/test";
 import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckAndSavePgObj";
+import { CheckCandidateDefinitionPgObj } from "e2e-tests/page-objects/election/create/CheckCandidateDefinitionPgObj";
 import { CheckDefinitionPgObj } from "e2e-tests/page-objects/election/create/CheckDefinitionPgObj";
+import { UploadCandidateDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadCandidateDefinitionPgObj";
 import { UploadDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadDefinitionPgObj";
 import { OverviewPgObj } from "e2e-tests/page-objects/election/OverviewPgObj";
 
@@ -11,12 +13,11 @@ test.use({
 });
 
 test.describe("Election creation", () => {
-  test("it uploads a file", async ({ page }) => {
+  test("it uploads an election file and candidate list", async ({ page }) => {
     await page.goto("/elections");
     const overviewPage = new OverviewPgObj(page);
     const initialElectionCount = await overviewPage.electionCount();
     const initialReadyStateCount = await page.getByText("Klaar voor invoer").count();
-
     await overviewPage.create.click();
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
@@ -35,6 +36,22 @@ test.describe("Election creation", () => {
     await checkDefinitionPage.hashInput2.fill("8af1");
     await checkDefinitionPage.next.click();
 
+    // Candidate page
+    const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
+    await expect(uploadCandidateDefinitionPage.header).toBeVisible();
+    await uploadCandidateDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml230b_test.eml.xml");
+
+    // Candidate check page
+    const checkCandidateDefinitionPage = new CheckCandidateDefinitionPgObj(page);
+    await expect(checkCandidateDefinitionPage.header).toBeVisible();
+    await expect(page.getByText("eml230b_test.eml.xml")).toBeVisible();
+    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(checkCandidateDefinitionPage.hashInput1).toBeFocused();
+    await checkCandidateDefinitionPage.hashInput1.fill("8a7b");
+    await checkCandidateDefinitionPage.hashInput2.fill("458a");
+    await checkCandidateDefinitionPage.next.click();
+
+    // Now we should be at the check and save page
     const checkAndSavePage = new CheckAndSavePgObj(page);
     await expect(checkAndSavePage.header).toBeVisible();
     await checkAndSavePage.save.click();
@@ -75,5 +92,66 @@ test.describe("Election creation", () => {
     await expect(uploadDefinitionPage.header).toBeVisible();
     await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110b_test.eml.xml");
     await expect(uploadDefinitionPage.error).toBeVisible();
+  });
+
+  test("it fails on incorrect hash for candidate list", async ({ page }) => {
+    await page.goto("/elections");
+    const overviewPage = new OverviewPgObj(page);
+    await overviewPage.create.click();
+
+    const uploadDefinitionPage = new UploadDefinitionPgObj(page);
+    await expect(uploadDefinitionPage.header).toBeVisible();
+    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+
+    const checkDefinitionPage = new CheckDefinitionPgObj(page);
+    await expect(checkDefinitionPage.header).toBeVisible();
+    await expect(page.getByText("eml110a_test.eml.xml")).toBeVisible();
+    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(checkDefinitionPage.hashInput1).toBeFocused();
+    await checkDefinitionPage.hashInput1.fill("9825");
+    await checkDefinitionPage.hashInput2.fill("8af1");
+    await checkDefinitionPage.next.click();
+
+    // Candidate page
+    const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
+    await expect(uploadCandidateDefinitionPage.header).toBeVisible();
+    await uploadCandidateDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml230b_test.eml.xml");
+
+    // Candidate check page
+    const checkCandidateDefinitionPage = new CheckCandidateDefinitionPgObj(page);
+    await expect(checkCandidateDefinitionPage.header).toBeVisible();
+    await expect(page.getByText("eml230b_test.eml.xml")).toBeVisible();
+    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(checkCandidateDefinitionPage.hashInput1).toBeFocused();
+    await checkCandidateDefinitionPage.hashInput1.fill("1234");
+    await checkCandidateDefinitionPage.hashInput2.fill("1234");
+    await checkCandidateDefinitionPage.next.click();
+
+    await expect(checkCandidateDefinitionPage.error).toBeVisible();
+  });
+
+  test("it fails on valid, but incorrect file for candidate list", async ({ page }) => {
+    await page.goto("/elections");
+    const overviewPage = new OverviewPgObj(page);
+    await overviewPage.create.click();
+
+    const uploadDefinitionPage = new UploadDefinitionPgObj(page);
+    await expect(uploadDefinitionPage.header).toBeVisible();
+    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+
+    const checkDefinitionPage = new CheckDefinitionPgObj(page);
+    await expect(checkDefinitionPage.header).toBeVisible();
+    await expect(page.getByText("eml110a_test.eml.xml")).toBeVisible();
+    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(checkDefinitionPage.hashInput1).toBeFocused();
+    await checkDefinitionPage.hashInput1.fill("9825");
+    await checkDefinitionPage.hashInput2.fill("8af1");
+    await checkDefinitionPage.next.click();
+
+    // Candidate page
+    const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
+    await expect(uploadCandidateDefinitionPage.header).toBeVisible();
+    await uploadCandidateDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110b_test.eml.xml");
+    await expect(uploadCandidateDefinitionPage.error).toBeVisible();
   });
 });

--- a/frontend/src/features/election_create/components/CheckAndSave.tsx
+++ b/frontend/src/features/election_create/components/CheckAndSave.tsx
@@ -45,7 +45,7 @@ export function CheckAndSave() {
           <strong>{t("election.singular")}:</strong> {state.election.name}
         </li>
         <li>
-          <strong>{t("election.candidate_list")}:</strong> {state.candidateList.name}
+          <strong>{t("election.candidate_list")}:</strong> {state.candidateList?.name}
         </li>
         <li>
           <strong>{t("area_designation")}:</strong> {state.election.location}

--- a/frontend/src/features/election_create/components/CheckAndSave.tsx
+++ b/frontend/src/features/election_create/components/CheckAndSave.tsx
@@ -22,10 +22,10 @@ export function CheckAndSave() {
 
   async function handleSubmit() {
     const response = await create({
-      electionData: state.electionDefinitionData,
-      electionHash: state.electionDefinitionHash,
-      candidateData: state.candidateDefinitionData,
-      candidateHash: state.candidateDefinitionHash,
+      election_data: state.electionDefinitionData,
+      election_hash: state.electionDefinitionHash,
+      candidate_data: state.candidateDefinitionData,
+      candidate_hash: state.candidateDefinitionHash,
     });
 
     if (isSuccess(response)) {

--- a/frontend/src/features/election_create/components/CheckAndSave.tsx
+++ b/frontend/src/features/election_create/components/CheckAndSave.tsx
@@ -22,8 +22,10 @@ export function CheckAndSave() {
 
   async function handleSubmit() {
     const response = await create({
-      data: state.electionDefinitionData,
-      hash: state.electionDefinitionHash,
+      electionData: state.electionDefinitionData,
+      electionHash: state.electionDefinitionHash,
+      candidateData: state.candidateDefinitionData,
+      candidateHash: state.candidateDefinitionHash,
     });
 
     if (isSuccess(response)) {
@@ -41,6 +43,9 @@ export function CheckAndSave() {
       <ul>
         <li>
           <strong>{t("election.singular")}:</strong> {state.election.name}
+        </li>
+        <li>
+          <strong>{t("election.candidate_list")}:</strong> {state.candidateList.name}
         </li>
         <li>
           <strong>{t("area_designation")}:</strong> {state.election.location}

--- a/frontend/src/features/election_create/components/CheckHash.tsx
+++ b/frontend/src/features/election_create/components/CheckHash.tsx
@@ -4,7 +4,7 @@ import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { Form } from "@/components/ui/Form/Form";
 import { InputField } from "@/components/ui/InputField/InputField";
-import { t, tx } from "@/i18n/translate";
+import { t } from "@/i18n/translate";
 import { RedactedEmlHash } from "@/types/generated/openapi";
 import { formatDateFull } from "@/utils/format";
 
@@ -14,7 +14,7 @@ interface CheckHashProps {
   date: string;
   title: string;
   header: string;
-  description: string;
+  description: ReactNode;
   redactedHash: RedactedEmlHash;
   error: ReactNode | undefined;
   onSubmit: (chunks: string[]) => void;

--- a/frontend/src/features/election_create/components/CheckHash.tsx
+++ b/frontend/src/features/election_create/components/CheckHash.tsx
@@ -13,13 +13,14 @@ import { RedactedHash, Stub } from "./RedactedHash";
 interface CheckHashProps {
   date: string;
   title: string;
-  fileName: string;
+  header: string;
+  description: string;
   redactedHash: RedactedEmlHash;
   error: ReactNode | undefined;
   onSubmit: (chunks: string[]) => void;
 }
 
-export function CheckHash({ date, title, fileName, redactedHash, error, onSubmit }: CheckHashProps) {
+export function CheckHash({ date, title, header, description, redactedHash, error, onSubmit }: CheckHashProps) {
   const [stubs, setStubs] = useState<Stub[]>(
     redactedHash.redacted_indexes.map((redacted_index: number) => ({
       selected: false,
@@ -65,19 +66,13 @@ export function CheckHash({ date, title, fileName, redactedHash, error, onSubmit
 
   return (
     <section className="md">
-      <h2>{t("election.check_eml.title")}</h2>
+      <h2>{header}</h2>
       {(stubs.some((stub) => stub.error.length > 0) || error) && (
         <Alert type="error" title={t("election.check_eml.error.title")} inline>
           <p> {t("election.check_eml.error.description")} </p>
         </Alert>
       )}
-      <p className="mt-lg">
-        {tx("election.check_eml.description", {
-          file: () => {
-            return <strong>{fileName}</strong>;
-          },
-        })}
-      </p>
+      <p className="mt-lg">{description}</p>
       <Alert type="notify" variant="no-icon" margin="mb-md" small>
         <p>
           <strong>{title}</strong>

--- a/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
@@ -14,14 +14,28 @@ export type ElectionCreateAction =
   | {
       type: "SET_ELECTION_DEFINITION_HASH";
       electionDefinitionHash: string[];
+    }
+  | {
+      type: "SELECT_CANDIDATES_DEFINITION";
+      response: ElectionDefinitionValidateResponse;
+      candidateDefinitionData: string;
+      candidateDefinitionFileName: string;
+    }
+  | {
+      type: "SET_CANDIDATES_DEFINITION_HASH";
+      candidateDefinitionHash: string[];
     };
 
 export interface ElectionCreateState {
   electionDefinitionRedactedHash?: RedactedEmlHash;
   election?: NewElection;
+  candidateList?: NewCandidateList;
   electionDefinitionHash?: string[];
   electionDefinitionData?: string;
   electionDefinitionFileName?: string;
+  candidateDefinitionHash?: string[];
+  candidateDefinitionData?: string;
+  candidateDefinitionFileName?: string;
 }
 
 function reducer(state: ElectionCreateState, action: ElectionCreateAction): ElectionCreateState {
@@ -38,6 +52,19 @@ function reducer(state: ElectionCreateState, action: ElectionCreateAction): Elec
       return {
         ...state,
         electionDefinitionHash: action.electionDefinitionHash,
+      };
+    case "SELECT_CANDIDATES_DEFINITION":
+      return {
+        ...state,
+        candidateList: action.response.list,
+        candidateDefinitionRedactedHash: action.response.hash,
+        candidateDefinitionData: action.candidateDefinitionData,
+        candidateDefinitionFileName: action.candidateDefinitionFileName,
+      };
+    case "SET_CANDIDATES_DEFINITION_HASH":
+      return {
+        ...state,
+        candidateDefinitionHash: action.candidateDefinitionHash,
       };
   }
 }

--- a/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
@@ -1,6 +1,12 @@
 import { useReducer } from "react";
 
-import { ElectionDefinitionValidateResponse, NewElection, RedactedEmlHash } from "@/types/generated/openapi";
+import {
+  CandidateDefinitionValidateResponse,
+  ElectionDefinitionValidateResponse,
+  NewCandidateList,
+  NewElection,
+  RedactedEmlHash,
+} from "@/types/generated/openapi";
 
 import { ElectionCreateContext, IElectionCreateContext } from "../hooks/ElectionCreateContext";
 
@@ -17,7 +23,7 @@ export type ElectionCreateAction =
     }
   | {
       type: "SELECT_CANDIDATES_DEFINITION";
-      response: ElectionDefinitionValidateResponse;
+      response: CandidateDefinitionValidateResponse;
       candidateDefinitionData: string;
       candidateDefinitionFileName: string;
     }
@@ -27,15 +33,16 @@ export type ElectionCreateAction =
     };
 
 export interface ElectionCreateState {
-  electionDefinitionRedactedHash?: RedactedEmlHash;
   election?: NewElection;
   candidateList?: NewCandidateList;
   electionDefinitionHash?: string[];
   electionDefinitionData?: string;
   electionDefinitionFileName?: string;
+  electionDefinitionRedactedHash?: RedactedEmlHash;
   candidateDefinitionHash?: string[];
   candidateDefinitionData?: string;
   candidateDefinitionFileName?: string;
+  candidateDefinitionRedactedHash?: RedactedEmlHash;
 }
 
 function reducer(state: ElectionCreateState, action: ElectionCreateAction): ElectionCreateState {

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -11,10 +11,11 @@ import { ELECTION_IMPORT_VALIDATE_REQUEST_PATH, ElectionDefinitionValidateRespon
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 import { CheckHash } from "./CheckHash";
 
-export function UploadElectionDefinition() {
+export function UploadCandidatesDefinition() {
   const { state, dispatch } = useElectionCreateContext();
   const navigate = useNavigate();
-  const path: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate`;
+
+  const path: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate-candidates`;
   const [error, setError] = useState<ReactNode | undefined>();
   const { create } = useCrud<ElectionDefinitionValidateResponse>({ create: path });
 
@@ -22,14 +23,14 @@ export function UploadElectionDefinition() {
     const currentFile = e.target.files ? e.target.files[0] : undefined;
     if (currentFile !== undefined) {
       const data = await currentFile.text();
-      const response = await create({ data });
+      const response = await create({ data, election: state.election });
 
       if (isSuccess(response)) {
         dispatch({
-          type: "SELECT_ELECTION_DEFINITION",
+          type: "SELECT_CANDIDATES_DEFINITION",
           response: response.data,
-          electionDefinitionData: data,
-          electionDefinitionFileName: currentFile.name,
+          candidateDefinitionData: data,
+          candidateDefinitionFileName: currentFile.name,
         });
         setError(undefined);
       } else if (isError(response)) {
@@ -37,7 +38,7 @@ export function UploadElectionDefinition() {
         if (response instanceof ApiError && response.code === 413) {
           setError(
             tx(
-              "election.invalid_election_definition.file_too_large",
+              "election.invalid_candidates_definition.file_too_large",
               {
                 file: () => <strong>{currentFile.name}</strong>,
               },
@@ -48,7 +49,7 @@ export function UploadElectionDefinition() {
           );
         } else {
           setError(
-            tx("election.invalid_election_definition.description", {
+            tx("election.invalid_candidates_definition.description", {
               file: () => <strong>{currentFile.name}</strong>,
             }),
           );
@@ -59,18 +60,18 @@ export function UploadElectionDefinition() {
 
   if (
     state.election &&
-    state.electionDefinitionFileName &&
-    state.electionDefinitionRedactedHash &&
-    state.electionDefinitionData
+    state.candidateDefinitionFileName &&
+    state.candidateDefinitionRedactedHash &&
+    state.candidateDefinitionData
   ) {
     async function onSubmit(chunks: string[]) {
-      const response = await create({ data: state.electionDefinitionData, hash: chunks });
+      const response = await create({ data: state.candidateDefinitionData, election: state.election, hash: chunks });
       if (isSuccess(response)) {
         dispatch({
-          type: "SET_ELECTION_DEFINITION_HASH",
-          electionDefinitionHash: chunks,
+          type: "SET_CANDIDATES_DEFINITION_HASH",
+          candidateDefinitionHash: chunks,
         });
-        await navigate("/elections/create/list-of-candidates");
+        await navigate("/elections/create/check-and-save");
       } else if (isError(response) && response instanceof ApiError && response.reference === "InvalidHash") {
         setError(response.message);
       }
@@ -79,14 +80,14 @@ export function UploadElectionDefinition() {
     return (
       <CheckHash
         date={state.election.election_date}
-        title={state.election.name}
-        header={t("election.check_eml.election_title")}
-        description={tx("election.check_eml.election_description", {
+        title={state.candidateList.name}
+        header={t("election.check_eml.candidates_title")}
+        description={tx("election.check_eml.candidates_description", {
           file: () => {
-            return <strong>{state.electionDefinitionFileName}</strong>;
+            return <strong>{state.candidateDefinitionFileName}</strong>;
           },
         })}
-        redactedHash={state.electionDefinitionRedactedHash}
+        redactedHash={state.candidateDefinitionRedactedHash}
         error={error}
         onSubmit={(chunks) => void onSubmit(chunks)}
       />
@@ -95,15 +96,15 @@ export function UploadElectionDefinition() {
 
   return (
     <section className="md">
-      <h2>{t("election.import_eml")}</h2>
+      <h2>{t("election.import_candidates_eml")}</h2>
       <div className="mt-lg mb-lg">
         {error && (
-          <Alert type="error" title={t("election.invalid_election_definition.title")} inline>
+          <Alert type="error" title={t("election.invalid_candidates_definition.title")} inline>
             <p>{error}</p>
           </Alert>
         )}
       </div>
-      <p className="mb-lg">{t("election.use_instructions_to_import_eml")}</p>
+      <p className="mb-lg">{t("election.use_instructions_to_import_candidates_eml")}</p>
       <FileInput id="upload-eml" onChange={(e) => void onFileChange(e)}>
         {t("select_file")}
       </FileInput>

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -26,7 +26,11 @@ export function UploadCandidatesDefinition() {
     const currentFile = e.target.files ? e.target.files[0] : undefined;
     if (currentFile !== undefined) {
       const data = await currentFile.text();
-      const response = await create({ data, election: state.election });
+      const response = await create({
+        candidate_data: data,
+        election_hash: state.electionDefinitionHash,
+        election_data: state.electionDefinitionData,
+      });
 
       if (isSuccess(response)) {
         dispatch({
@@ -69,7 +73,12 @@ export function UploadCandidatesDefinition() {
     state.candidateDefinitionData
   ) {
     async function onSubmit(chunks: string[]) {
-      const response = await create({ data: state.candidateDefinitionData, election: state.election, hash: chunks });
+      const response = await create({
+        candidate_data: state.candidateDefinitionData,
+        election_hash: state.electionDefinitionHash,
+        election_data: state.electionDefinitionData,
+        candidate_hash: chunks,
+      });
       if (isSuccess(response)) {
         dispatch({
           type: "SET_CANDIDATES_DEFINITION_HASH",

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -6,7 +6,10 @@ import { useCrud } from "@/api/useCrud";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { FileInput } from "@/components/ui/FileInput/FileInput";
 import { t, tx } from "@/i18n/translate";
-import { ELECTION_IMPORT_VALIDATE_REQUEST_PATH, ElectionDefinitionValidateResponse } from "@/types/generated/openapi";
+import {
+  CandidateDefinitionValidateResponse,
+  ELECTION_IMPORT_CANDIDATES_VALIDATE_REQUEST_PATH,
+} from "@/types/generated/openapi";
 
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 import { CheckHash } from "./CheckHash";
@@ -15,9 +18,9 @@ export function UploadCandidatesDefinition() {
   const { state, dispatch } = useElectionCreateContext();
   const navigate = useNavigate();
 
-  const path: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate-candidates`;
+  const path: ELECTION_IMPORT_CANDIDATES_VALIDATE_REQUEST_PATH = `/api/elections/import/validate-candidates`;
   const [error, setError] = useState<ReactNode | undefined>();
-  const { create } = useCrud<ElectionDefinitionValidateResponse>({ create: path });
+  const { create } = useCrud<CandidateDefinitionValidateResponse>({ create: path });
 
   async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const currentFile = e.target.files ? e.target.files[0] : undefined;
@@ -60,6 +63,7 @@ export function UploadCandidatesDefinition() {
 
   if (
     state.election &&
+    state.candidateList &&
     state.candidateDefinitionFileName &&
     state.candidateDefinitionRedactedHash &&
     state.candidateDefinitionData

--- a/frontend/src/features/election_create/routes.tsx
+++ b/frontend/src/features/election_create/routes.tsx
@@ -2,6 +2,7 @@ import { RouteObject } from "react-router";
 
 import { CheckAndSave } from "./components/CheckAndSave";
 import { ElectionCreateLayout } from "./components/ElectionCreateLayout";
+import { UploadCandidatesDefinition } from "./components/UploadCandidatesDefinition";
 import { UploadElectionDefinition } from "./components/UploadElectionDefinition";
 
 export const electionCreateRoutes: RouteObject[] = [
@@ -9,6 +10,7 @@ export const electionCreateRoutes: RouteObject[] = [
     Component: ElectionCreateLayout,
     children: [
       { index: true, Component: UploadElectionDefinition },
+      { path: "list-of-candidates", Component: UploadCandidatesDefinition },
       { path: "check-and-save", Component: CheckAndSave },
     ],
   },

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -5,8 +5,10 @@
     "description": "Je gaat de volgende verkiezing toevoegen:"
   },
   "check_eml": {
-    "title": "Controleer verkiezingsdefinitie",
-    "description": "Het bestand <file>filename</file> is geïmporteerd en bevat de instellingen voor de volgende verkiezing:",
+    "election_title": "Controleer verkiezingsdefinitie",
+    "candidates_title": "Controleer kandidatenlijst",
+    "election_description": "Het bestand <file>filename</file> is geïmporteerd en bevat de instellingen voor de volgende verkiezing:",
+    "candidates_description": "Het bestand <file>filename</file> is geïmporteerd en bevat de instellingen voor de volgende kandidaten:",
     "check_hash": {
       "description": "Vul ter controle de hierboven afgeschermde delen van de digitale vingerafdruk in. De volledige code heb je van de Kiesraad ontvangen.",
       "label": "Controle deel {stub}",
@@ -30,6 +32,7 @@
   "not_ready_for_use": "Abacus is nog niet klaar voor gebruik",
   "please_wait_for_coordinator": "Je kan als invoerder nog niks doen. Wacht tot de coördinator het systeem openstelt voor het invoeren van telresultaten.",
   "singular": "verkiezing",
+  "candidate_list": "kandidatenlijst",
   "start_when_count_list_received": "Zodra je een tellijst van een stembureau hebt gekregen kan je beginnen met invoeren.",
   "status": "Status",
   "title": {
@@ -39,5 +42,12 @@
     "plural": "Verkiezingen",
     "singular": "Verkiezing"
   },
-  "use_instructions_to_import_eml": "Je hebt van de Kiesraad instructies gekregen waarmee je de verkiezingsdefinitie kunt downloaden. Zet het bestand op deze computer en importeer het."
+  "use_instructions_to_import_eml": "Je hebt van de Kiesraad instructies gekregen waarmee je de verkiezingsdefinitie kunt downloaden. Zet het bestand op deze computer en importeer het.",
+  "import_candidates_eml": "Importeer kandidatenlijst",
+  "use_instructions_to_import_candidates_eml": "Je hebt van de Kiesraad instructies gekregen waarmee je de kandidatenlijst kunt downloaden. Zet het bestand op deze computer en importeer het.",
+  "invalid_candidates_definition": {
+    "title": "Ongeldige kandidatenlijst",
+    "description": "Het bestand <file>filename</file> bevat geen geldige kandidatenlijst. Kies een bestand met een geldige definitie.",
+    "file_too_large": "Het bestand <file>filename</file> is te groot. Kies een bestand van maximaal {max_size} Megabyte."
+  }
 }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -283,9 +283,10 @@ export interface Candidate {
 }
 
 export interface CandidateDefinitionValidateRequest {
-  data: string;
-  election: NewElection;
-  hash?: string[];
+  candidate_data: string;
+  candidate_hash?: string[];
+  election_data: string;
+  election_hash: string[];
 }
 
 export interface CandidateDefinitionValidateResponse {
@@ -440,10 +441,10 @@ export interface ElectionApportionmentResponse {
 export type ElectionCategory = "Municipal";
 
 export interface ElectionDefinitionImportRequest {
-  candidateData: string;
-  candidateHash: string[];
-  electionData: string;
-  electionHash: string[];
+  candidate_data: string;
+  candidate_hash: string[];
+  election_data: string;
+  election_hash: string[];
 }
 
 export interface ElectionDefinitionValidateRequest {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -19,6 +19,11 @@ export type ELECTION_IMPORT_VALIDATE_REQUEST_PARAMS = Record<string, never>;
 export type ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate`;
 export type ELECTION_IMPORT_VALIDATE_REQUEST_BODY = ElectionDefinitionValidateRequest;
 
+// /api/elections/import/validate-candidates
+export type ELECTION_IMPORT_CANDIDATES_VALIDATE_REQUEST_PARAMS = Record<string, never>;
+export type ELECTION_IMPORT_CANDIDATES_VALIDATE_REQUEST_PATH = `/api/elections/import/validate-candidates`;
+export type ELECTION_IMPORT_CANDIDATES_VALIDATE_REQUEST_BODY = CandidateDefinitionValidateRequest;
+
 // /api/elections/{election_id}
 export interface ELECTION_DETAILS_REQUEST_PARAMS {
   election_id: number;
@@ -277,6 +282,17 @@ export interface Candidate {
   number: number;
 }
 
+export interface CandidateDefinitionValidateRequest {
+  data: string;
+  election: NewElection;
+  hash?: string[];
+}
+
+export interface CandidateDefinitionValidateResponse {
+  hash: RedactedEmlHash;
+  list: NewCandidateList;
+}
+
 /**
  * Candidate gender
  */
@@ -424,8 +440,10 @@ export interface ElectionApportionmentResponse {
 export type ElectionCategory = "Municipal";
 
 export interface ElectionDefinitionImportRequest {
-  data: string;
-  hash: string[];
+  candidateData: string;
+  candidateHash: string[];
+  electionData: string;
+  electionHash: string[];
 }
 
 export interface ElectionDefinitionValidateRequest {
@@ -676,6 +694,14 @@ export interface LoginResponse {
   role: Role;
   user_id: number;
   username: string;
+}
+
+/**
+ * Candidate list request
+ */
+export interface NewCandidateList {
+  name: string;
+  political_groups: PoliticalGroup[];
 }
 
 /**


### PR DESCRIPTION
Implements [#1376](https://github.com/kiesraad/abacus/issues/1376) and [#1377](https://github.com/kiesraad/abacus/issues/1377)

After uploading an election definition, the user can upload a candidate list, must then enter a valid hash and if successful is sent to the check and save page where the election is created.

Note: Validation for the candidate list in the backend will be added in  [#1589](url)
