### PR TITLE
Update validation result mapping

### DIFF
--- a/frontend/src/features/data_entry/testing/mock-data.ts
+++ b/frontend/src/features/data_entry/testing/mock-data.ts
@@ -8,7 +8,7 @@ import {
 } from "@/types/generated/openapi";
 import { FormSectionId } from "@/types/types";
 
-import { DataEntryState, DataEntryStateAndActionsLoaded, FormSection } from "../types/types";
+import { DataEntryState, DataEntryStateAndActionsLoaded, DataEntryStructure, FormSection } from "../types/types";
 import { getDataEntryStructure } from "../utils/structure";
 import { ValidationResultSet } from "../utils/ValidationResults";
 
@@ -57,6 +57,18 @@ export function getDefaultFormSection(id: FormSectionId, index: number): FormSec
     errors: new ValidationResultSet(),
     warnings: new ValidationResultSet(),
   };
+}
+
+export function getDefaultDataEntryStructure(): DataEntryStructure {
+  return getDataEntryStructure(electionMockData);
+}
+
+export function getRecountedDataEntryStructure(): DataEntryStructure {
+  const results: PollingStationResults = {
+    ...getInitialValues(),
+    recounted: true,
+  };
+  return getDataEntryStructure(electionMockData, results);
 }
 
 export function getDefaultDataEntryState(): DataEntryState {
@@ -172,7 +184,7 @@ export const errorWarningMocks: ErrorWarningsMap<ValidationResultCode> = {
   F401: { fields: ["data.political_group_votes[0]"], code: "F401" },
   W001: { fields: ["data.recounted"], code: "W001" },
   W201: { fields: ["data.votes_counts.blank_votes_count"], code: "W201" },
-  W202: { fields: ["data.voters_counts.invalid_votes_count"], code: "W202" },
+  W202: { fields: ["data.votes_counts.invalid_votes_count"], code: "W202" },
   W203: {
     fields: ["data.votes_counts.total_votes_cast_count", "data.voters_counts.total_admitted_voters_count"],
     code: "W203",

--- a/frontend/src/features/data_entry/utils/ValidationResults.ts
+++ b/frontend/src/features/data_entry/utils/ValidationResults.ts
@@ -1,7 +1,7 @@
 import { ValidationResult, ValidationResultCode } from "@/types/generated/openapi";
 import { FormSectionId } from "@/types/types";
 
-import { FormState } from "../types/types";
+import { DataEntryStructure, FormState } from "../types/types";
 
 /*
  * A set of validation results.
@@ -57,35 +57,56 @@ export function isGlobalValidationResult(validationResult: ValidationResult): bo
 /*
  * Maps a field name as used in a ValidationResult to a form section as used in the data entry state.
  */
-export function mapFieldNameToFormSection(fieldName: string): FormSectionId {
-  const parts = fieldName.split(".");
-  if (parts[1] === undefined) {
-    throw new Error(`Field "${fieldName}" could not be mapped to a form section (no second part).`);
-  }
-  const section = parts[1].split("[")[0];
-  switch (section) {
-    case "recounted":
-      return "recounted";
-    case "votes_counts":
-    case "voters_counts":
-    case "voters_recounts":
-      return "voters_votes_counts";
-    case "differences_counts":
-      return "differences_counts";
-    case "political_group_votes": {
-      const index = parseInt(parts[1].substring(parts[1].indexOf("[") + 1, parts[1].indexOf("]"))) + 1;
-      return `political_group_votes_${index}`;
+export function mapFieldNameToFormSection(fieldName: string, dataEntryStructure: DataEntryStructure): FormSectionId {
+  // Remove "data." prefix if present
+  const normalizedFieldName = fieldName.startsWith("data.") ? fieldName.substring(5) : fieldName;
+
+  // First, try to find exact match in the data entry structure
+  for (const section of dataEntryStructure) {
+    for (const subsection of section.subsections) {
+      if (subsection.type === "radio" && subsection.path === normalizedFieldName) {
+        return section.id;
+      }
+
+      if (subsection.type === "inputGrid") {
+        for (const row of subsection.rows) {
+          if (row.path === normalizedFieldName) {
+            return section.id;
+          }
+        }
+      }
     }
-    default:
-      throw new Error(`Field "${fieldName}" could not be mapped to a form section (unknown second part).`);
   }
+
+  // Fallback: handle parent object paths
+  // For cases like "data.political_group_votes[0]" or "data.voters_counts"
+  for (const section of dataEntryStructure) {
+    for (const subsection of section.subsections) {
+      if (subsection.type === "radio" && subsection.path.startsWith(normalizedFieldName + ".")) {
+        return section.id;
+      }
+
+      if (subsection.type === "inputGrid") {
+        for (const row of subsection.rows) {
+          if (row.path.startsWith(normalizedFieldName + ".") || row.path.startsWith(normalizedFieldName + "[")) {
+            return section.id;
+          }
+        }
+      }
+    }
+  }
+
+  throw new Error(`Field "${fieldName}" could not be mapped to any form section in the data entry structure.`);
 }
 
 /*
  * Returns the set of form sections for a given validation result.
  */
-export function getFormSectionsForValidationResult(validationResult: ValidationResult): Set<FormSectionId> {
-  return new Set(validationResult.fields.map(mapFieldNameToFormSection));
+export function getFormSectionsForValidationResult(
+  validationResult: ValidationResult,
+  dataEntryStructure: DataEntryStructure,
+): Set<FormSectionId> {
+  return new Set(validationResult.fields.map((field) => mapFieldNameToFormSection(field, dataEntryStructure)));
 }
 
 /*
@@ -94,10 +115,11 @@ export function getFormSectionsForValidationResult(validationResult: ValidationR
 export function addValidationResultsToFormState(
   validationResults: ValidationResult[],
   formState: FormState,
+  dataEntryStructure: DataEntryStructure,
   errorsOrWarnings: "errors" | "warnings",
 ) {
   for (const validationResult of validationResults) {
-    const formSections = getFormSectionsForValidationResult(validationResult);
+    const formSections = getFormSectionsForValidationResult(validationResult, dataEntryStructure);
     for (const formSection of formSections) {
       if (formState.sections[formSection] && formState.sections[formSection].isSaved) {
         formState.sections[formSection][errorsOrWarnings].add(validationResult);

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -219,7 +219,7 @@ export function buildFormState(
     (sectionID: FormSectionId) => sectionID === newFormState.current,
   );
 
-  updateFormStateAfterSubmit(newFormState, validationResults, acceptErrorsAndWarnings);
+  updateFormStateAfterSubmit(dataEntryStructure, newFormState, validationResults, acceptErrorsAndWarnings);
 
   let targetFormSectionId: FormSectionId;
   if (clientState.continue) {
@@ -232,6 +232,7 @@ export function buildFormState(
 }
 
 export function updateFormStateAfterSubmit(
+  dataEntryStructure: DataEntryStructure,
   formState: FormState,
   validationResults: ValidationResults,
   continueToNextSection: boolean = false,
@@ -250,8 +251,8 @@ export function updateFormStateAfterSubmit(
   }
 
   //distribute errors and warnings to sections
-  addValidationResultsToFormState(validationResults.errors, formState, "errors");
-  addValidationResultsToFormState(validationResults.warnings, formState, "warnings");
+  addValidationResultsToFormState(validationResults.errors, formState, dataEntryStructure, "errors");
+  addValidationResultsToFormState(validationResults.warnings, formState, dataEntryStructure, "warnings");
 
   //determine the new furthest section, if applicable
   if (continueToNextSection && currentFormSection && formState.furthest === currentFormSection.id) {

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -98,7 +98,10 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         error: action.error,
       };
     case "FORM_SAVED": {
+      const dataEntryStructure = getDataEntryStructure(state.election, action.data);
+
       const formState = updateFormStateAfterSubmit(
+        dataEntryStructure,
         state.formState,
         action.validationResults,
         action.continueToNextSection,
@@ -109,7 +112,7 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         status: "idle",
         error: null,
         pollingStationResults: action.data,
-        dataEntryStructure: getDataEntryStructure(state.election, action.data),
+        dataEntryStructure,
         formState,
         targetFormSectionId: action.continueToNextSection ? getNextSectionID(formState) : state.targetFormSectionId,
       };


### PR DESCRIPTION
Use data entry structure (#1588) instead of hardcoded sections to map validation results to form sections. UI/UX should be the same compared to `main`.