### PR TITLE
Generate test election helper tool

### DIFF
--- a/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
+++ b/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
@@ -11,7 +11,7 @@
       {
         "name": "event: serde_json::Value",
         "ordinal": 1,
-        "type_info": "Text"
+        "type_info": "Null"
       }
     ],
     "parameters": {

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,10 @@ airgap-detection = []
 name = "gen-openapi"
 required-features = ["openapi"]
 
+[[bin]]
+name = "gen-test-election"
+required-features = ["dev-database"]
+
 # Note: if you add a dependency here, please update the README.md for the backend as well.
 
 [dependencies]

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -100,6 +100,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let ps_repo = PollingStations::new(pool.clone());
     generate_polling_stations(&mut rng, &election, &ps_repo, &args).await;
 
+    info!(
+        "Election generated with election id: {}, election name: '{}'",
+        election.id, election.name
+    );
+
     Ok(())
 }
 
@@ -107,7 +112,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
     // start by generation the political groups
     let mut political_groups = vec![];
-    for i in 1..rng.random_range(args.political_groups.clone()) {
+    let num_political_groups = rng.random_range(args.political_groups.clone());
+    info!("Generating {num_political_groups} political groups");
+
+    for i in 1..num_political_groups {
         political_groups.push(generate_political_party(rng, i, args));
     }
 
@@ -131,6 +139,8 @@ fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
     let name = format!("Gemeenteraad {locality} {year}");
     let cleaned_up_locality = locality.replace(" ", "_").replace("'", "");
     let election_id = format!("{cleaned_up_locality}_{year}");
+
+    info!("Election has name '{name}'");
 
     // and put it all in the struct (generating some additional fiels where needed)
     NewElection {
@@ -200,6 +210,7 @@ async fn generate_polling_stations(
     args: &Args,
 ) {
     let number_of_ps = rng.random_range(args.polling_stations.clone());
+    info!("Generating {number_of_ps} polling stations for election");
     let mut remaining_voters = election.number_of_voters;
     for i in 1..=number_of_ps {
         // compute a some somewhat distributed number of voters for each polling station

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -55,12 +55,10 @@ struct Args {
     voters: Range<u32>,
 }
 
-fn parse_range<T>(
-    range: &str,
-) -> Result<Range<T>, Box<dyn std::error::Error + 'static + Send + Sync>>
+fn parse_range<T>(range: &str) -> Result<Range<T>, Box<dyn Error + 'static + Send + Sync>>
 where
     T: FromStr + std::ops::Add<T, Output = T> + From<u8> + Copy,
-    <T as FromStr>::Err: std::error::Error + Send + Sync + 'static,
+    <T as FromStr>::Err: Error + Send + Sync + 'static,
 {
     let mut iter = range.split("..");
     let lower_bound = T::from_str(&iter.next().ok_or("Invalid range")?.replace("_", ""))?;
@@ -110,7 +108,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 /// Generate a random election using the limits from args.
 fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
-    // start by generation the political groups
+    // start by generating the political groups
     let mut political_groups = vec![];
     let num_political_groups = rng.random_range(args.political_groups.clone());
     info!("Generating {num_political_groups} political groups");
@@ -122,7 +120,7 @@ fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
     // generate the number of voters from the voters range
     let number_of_voters = rng.random_range(args.voters.clone());
 
-    // generate a nomination date, and an election date not too long afterwards
+    // generate a nomination date, and an election date not too long afterward
     let nomination_date = abacus::test_data_gen::date_between(
         rng,
         NaiveDate::from_ymd_opt(2020, 1, 1).expect("Invalid date"),
@@ -131,7 +129,7 @@ fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
     let election_date =
         abacus::test_data_gen::date_between(rng, nomination_date, nomination_date + Days::new(63));
 
-    // extract the year from the election date, generate the locality for which this election would be
+    // extract the year from the election date, generate the locality where this election would be
     let year = election_date.year();
     let locality = abacus::test_data_gen::locality(rng).to_owned();
 
@@ -142,7 +140,7 @@ fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
 
     info!("Election has name '{name}'");
 
-    // and put it all in the struct (generating some additional fiels where needed)
+    // and put it all in the struct (generating some additional fields where needed)
     NewElection {
         name,
         domain_id: abacus::test_data_gen::domain_id(rng),

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -1,0 +1,261 @@
+use std::{error::Error, ops::Range, str::FromStr};
+
+use abacus::{
+    election::{
+        CandidateGender, ElectionCategory, ElectionStatus, ElectionWithPoliticalGroups,
+        NewElection, PoliticalGroup, repository::Elections,
+    },
+    fixtures,
+    polling_station::{PollingStationRequest, PollingStationType, repository::PollingStations},
+};
+use chrono::{Datelike, Days, NaiveDate};
+use clap::Parser;
+use rand::seq::IndexedRandom;
+use sqlx::{SqlitePool, sqlite::SqliteConnectOptions};
+#[cfg(feature = "dev-database")]
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+/// Abacus API and asset server
+#[derive(Parser, Debug)]
+struct Args {
+    /// Server port, optional
+    #[arg(short, long, default_value_t = 8080)]
+    port: u16,
+
+    /// Location of the database file, will be created if it doesn't exist
+    #[arg(short, long, default_value = "db.sqlite")]
+    database: String,
+
+    /// Seed the database with initial data using the fixtures
+    #[cfg(feature = "dev-database")]
+    #[arg(short, long)]
+    seed_data: bool,
+
+    /// Reset the database
+    #[cfg(feature = "dev-database")]
+    #[arg(short, long)]
+    reset_database: bool,
+
+    /// Number of political groups to create
+    #[arg(long, default_value = "40..50", value_parser = parse_range::<u32>)]
+    political_groups: Range<u32>,
+
+    /// Number of candidates to create
+    #[arg(long, default_value = "30..80", value_parser = parse_range::<u32>)]
+    candidates_per_group: Range<u32>,
+
+    /// Number of polling stations to create
+    #[arg(long, default_value = "200..500", value_parser = parse_range::<u32>)]
+    polling_stations: Range<u32>,
+
+    /// Number of voters to create
+    #[arg(long, default_value = "500_000..800_000", value_parser = parse_range::<u32>)]
+    voters: Range<u32>,
+}
+
+fn parse_range<T>(
+    range: &str,
+) -> Result<Range<T>, Box<dyn std::error::Error + 'static + Send + Sync>>
+where
+    T: FromStr + std::ops::Add<T, Output = T> + From<u8> + Copy,
+    <T as FromStr>::Err: std::error::Error + Send + Sync + 'static,
+{
+    let mut iter = range.split("..");
+    let lower_bound = T::from_str(&iter.next().ok_or("Invalid range")?.replace("_", ""))?;
+    let upper_bound = if let Some(bound) = iter.next() {
+        T::from_str(&bound.replace("_", ""))?
+    } else {
+        lower_bound + T::from(1u8) // add one to the lower bound, this could fail if the lower bound is already a max
+    };
+    Ok(lower_bound..upper_bound)
+}
+
+/// Main entry point for the application. Sets up the database, and starts the
+/// API server and in-memory file router on port 8080.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // setup logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env()?,
+        )
+        .init();
+
+    // load arguments, setup database
+    let args = Args::parse();
+    let pool = create_sqlite_pool(&args).await?;
+    let mut rng = rand::rng();
+
+    // generate and store the election
+    let election = Elections::new(pool.clone())
+        .create(generate_election(&mut rng, &args))
+        .await
+        .expect("Failed to create election");
+
+    // generate the polling stations for the election
+    let ps_repo = PollingStations::new(pool.clone());
+    generate_polling_stations(&mut rng, &election, &ps_repo, &args).await;
+
+    Ok(())
+}
+
+/// Generate a random election using the limits from args.
+fn generate_election(rng: &mut impl rand::Rng, args: &Args) -> NewElection {
+    // start by generation the political groups
+    let mut political_groups = vec![];
+    for i in 1..rng.random_range(args.political_groups.clone()) {
+        political_groups.push(generate_political_party(rng, i, args));
+    }
+
+    // generate the number of voters from the voters range
+    let number_of_voters = rng.random_range(args.voters.clone());
+
+    // generate a nomination date, and an election date not too long afterwards
+    let nomination_date = abacus::test_data_gen::date_between(
+        rng,
+        NaiveDate::from_ymd_opt(2020, 1, 1).expect("Invalid date"),
+        NaiveDate::from_ymd_opt(2040, 1, 1).expect("Invalid date"),
+    );
+    let election_date =
+        abacus::test_data_gen::date_between(rng, nomination_date, nomination_date + Days::new(63));
+
+    // extract the year from the election date, generate the locality for which this election would be
+    let year = election_date.year();
+    let locality = abacus::test_data_gen::locality(rng).to_owned();
+
+    // use the previous data to generate some identifiers and names
+    let name = format!("Gemeenteraad {locality} {year}");
+    let cleaned_up_locality = locality.replace(" ", "_").replace("'", "");
+    let election_id = format!("{cleaned_up_locality}_{year}");
+
+    // and put it all in the struct (generating some additional fiels where needed)
+    NewElection {
+        name,
+        domain_id: abacus::test_data_gen::domain_id(rng),
+        election_id,
+        location: locality,
+        number_of_voters,
+        category: ElectionCategory::Municipal,
+        number_of_seats: rng.random_range(19..45),
+        election_date,
+        nomination_date,
+        status: ElectionStatus::DataEntryInProgress,
+        political_groups,
+    }
+}
+
+/// Generate a single political party using the limits from args
+fn generate_political_party(
+    rng: &mut impl rand::Rng,
+    pg_number: u32,
+    args: &Args,
+) -> PoliticalGroup {
+    let mut candidates = vec![];
+    let has_first_name = rng.random_ratio(1, 2);
+
+    for i in 1..rng.random_range(args.candidates_per_group.clone()) {
+        // sometimes first names are omitted
+        let first_name = if has_first_name {
+            Some(abacus::test_data_gen::first_name(rng).to_owned())
+        } else {
+            None
+        };
+
+        // initials are required, but if a first name is known, base initials on that
+        let initials = abacus::test_data_gen::initials(rng, first_name.as_deref());
+        let (prefix, last_name) = abacus::test_data_gen::last_name(rng);
+        candidates.push(abacus::election::Candidate {
+            number: i,
+            initials,
+            first_name,
+            last_name_prefix: prefix.map(ToOwned::to_owned),
+            last_name: last_name.to_owned(),
+            locality: abacus::test_data_gen::locality(rng).to_owned(),
+            country_code: None,
+            gender: [
+                CandidateGender::Male,
+                CandidateGender::Female,
+                CandidateGender::X,
+            ]
+            .choose(rng)
+            .cloned(),
+        })
+    }
+    PoliticalGroup {
+        number: pg_number,
+        name: abacus::test_data_gen::political_group_name(rng),
+        candidates,
+    }
+}
+
+/// Generate the polling stations for the given election using the limits from args
+async fn generate_polling_stations(
+    rng: &mut impl rand::Rng,
+    election: &ElectionWithPoliticalGroups,
+    ps_repo: &PollingStations,
+    args: &Args,
+) {
+    let number_of_ps = rng.random_range(args.polling_stations.clone());
+    let mut remaining_voters = election.number_of_voters;
+    for i in 1..=number_of_ps {
+        // compute a some somewhat distributed number of voters for each polling station
+        let remaining_ps = number_of_ps - i + 1;
+        let ps_num_voters = if remaining_ps == 1 {
+            remaining_voters
+        } else {
+            let sample_voters = remaining_voters / remaining_ps;
+            #[allow(clippy::cast_possible_truncation)]
+            let min_sample_voters = (sample_voters as f64 * 0.9) as u32;
+            #[allow(clippy::cast_possible_truncation)]
+            let max_sample_voters = (sample_voters as f64 * 1.1) as u32;
+            rng.random_range(min_sample_voters..=max_sample_voters)
+        };
+        remaining_voters -= ps_num_voters;
+
+        ps_repo
+            .create(
+                election.id,
+                PollingStationRequest {
+                    name: abacus::test_data_gen::polling_station_name(rng),
+                    number: i64::from(i),
+                    number_of_voters: Some(ps_num_voters.into()),
+                    polling_station_type: Some(PollingStationType::FixedLocation),
+                    address: abacus::test_data_gen::address(rng),
+                    postal_code: abacus::test_data_gen::postal_code(rng),
+                    locality: abacus::test_data_gen::locality(rng).to_owned(),
+                },
+            )
+            .await
+            .expect("Failed to create polling station");
+    }
+}
+
+/// Create a SQLite database if needed, then connect to it and run migrations.
+/// Return a connection pool.
+async fn create_sqlite_pool(
+    #[cfg_attr(not(feature = "dev-database"), allow(unused_variables))] args: &Args,
+) -> Result<SqlitePool, Box<dyn Error>> {
+    let db = format!("sqlite://{}", &args.database);
+    let opts = SqliteConnectOptions::from_str(&db)?.create_if_missing(true);
+
+    #[cfg(feature = "dev-database")]
+    if args.reset_database {
+        // remove the file, ignoring any errors that occurred (such as the file not existing)
+        let _ = tokio::fs::remove_file(opts.get_filename()).await;
+        info!("removed database file");
+    }
+
+    let pool = SqlitePool::connect_with(opts).await?;
+    sqlx::migrate!().run(&pool).await?;
+
+    #[cfg(feature = "dev-database")]
+    if args.seed_data {
+        fixtures::seed_fixture_data(&pool).await?;
+    }
+
+    Ok(pool)
+}

--- a/backend/src/election/mod.rs
+++ b/backend/src/election/mod.rs
@@ -1,5 +1,5 @@
 mod api;
-pub(crate) mod repository;
+pub mod repository;
 pub(crate) mod structs;
 
 pub use self::{api::*, structs::*};

--- a/backend/src/election/repository.rs
+++ b/backend/src/election/repository.rs
@@ -8,7 +8,6 @@ use crate::AppState;
 pub struct Elections(SqlitePool);
 
 impl Elections {
-    #[cfg(test)]
     pub fn new(pool: SqlitePool) -> Self {
         Self(pool)
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -36,6 +36,8 @@ pub mod pdf_gen;
 pub mod polling_station;
 pub mod report;
 pub mod summary;
+#[cfg(feature = "dev-database")]
+pub mod test_data_gen;
 
 pub use error::{APIError, ErrorResponse};
 

--- a/backend/src/polling_station/repository.rs
+++ b/backend/src/polling_station/repository.rs
@@ -7,7 +7,6 @@ use crate::AppState;
 pub struct PollingStations(SqlitePool);
 
 impl PollingStations {
-    #[cfg(test)]
     pub fn new(pool: SqlitePool) -> Self {
         Self(pool)
     }

--- a/backend/src/test_data_gen/mod.rs
+++ b/backend/src/test_data_gen/mod.rs
@@ -1,0 +1,347 @@
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
+
+use chrono::{Days, NaiveDate};
+use rand::seq::{IndexedRandom, SliceRandom};
+
+/// List of first names to select from
+const FIRST_NAMES: &[&str] = &[
+    "Jory",
+    "Rachid",
+    "Leontien",
+    "Royce",
+    "Sibel",
+    "Nicolaas",
+    "Sammie",
+    "Bart",
+    "Ruth",
+    "Florien",
+    "Edis",
+    "Kris",
+    "Nikky",
+    "Henk",
+    "Tiemen",
+    "Sijtze",
+    "Gijsbertje",
+    "Silvana",
+    "Eelko",
+    "Cornelus",
+    "Christina",
+    "Damian",
+    "Renso",
+    "Alek",
+    "Esra",
+    "Teun",
+    "Salomon",
+    "Jelisa",
+    "Dirk-Jan",
+    "Madelène",
+    "İlknur",
+];
+
+/// Generate a first name using the random number generator given
+pub fn first_name(rng: &mut impl rand::Rng) -> &'static str {
+    FIRST_NAMES.choose(rng).expect("Missing test data")
+}
+
+/// Helper function that generates some additional initials
+fn gen_initials_helper(rng: &mut impl rand::Rng, mut offset: u32) -> String {
+    let mut initials = String::new();
+
+    loop {
+        // That's enough initials!
+        if offset > 5 {
+            break;
+        }
+
+        if rng.random_ratio(1, offset + 1) {
+            initials.push_str(&format!("{}.", rng.random_range('A'..='Z')));
+            offset += 1;
+        } else {
+            break;
+        }
+    }
+
+    initials
+}
+
+/// Generate some initials, given some optional first name using the
+/// random number generator given. If the first name is provided most
+/// of the time the first letter of the first name will be used as the
+/// first initial.
+pub fn initials(rng: &mut impl rand::Rng, first_name: Option<&str>) -> String {
+    if let Some(first_name) = first_name {
+        if first_name.trim().is_empty() || rng.random_ratio(1, 8) {
+            // either we have no name, or we want some random initials
+            gen_initials_helper(rng, 0)
+        } else {
+            // use the first letter as the first initial
+            let first_letter = first_name.chars().next().expect("Missing test data");
+            let rest_initials = gen_initials_helper(rng, 1);
+            format!("{first_letter}.{rest_initials}")
+        }
+    } else {
+        // no first name, make something up
+        gen_initials_helper(rng, 0)
+    }
+}
+
+/// List of last names to select from
+const LAST_NAMES: &[(Option<&str>, &str)] = &[
+    (None, "Boermans"),
+    (Some("van de"), "Kerkhof"),
+    (None, "Prakken"),
+    (None, "Born"),
+    (None, "Brienen"),
+    (Some("van"), "Bekking"),
+    (Some("van de"), "Wal"),
+    (None, "Tax"),
+    (Some("van"), "Lent"),
+    (Some("van"), "Jaspers-Gezen"),
+    (None, "Meulenkolk"),
+    (None, "Katsma"),
+    (Some("den"), "Mateman"),
+    (None, "Cornelis"),
+    (Some("van der"), "Spek"),
+    (None, "Arets"),
+    (None, "Gopal"),
+    (None, "Wolfswinkel"),
+    (None, "Oorschot"),
+    (None, "Hoogstraten"),
+    (None, "Philippen"),
+    (None, "Goedhart"),
+    (Some("van der"), "Meulen"),
+    (None, "Wiertz"),
+    (Some("de"), "Vegt"),
+    (None, "Groenen"),
+    (None, "Aygün"),
+    (None, "Bruins-Van den Kerk"),
+    (None, "Titulaer"),
+];
+
+/// Generate a last name and an optional last name prefix using the random number generator given
+pub fn last_name(rng: &mut impl rand::Rng) -> (Option<&'static str>, &'static str) {
+    let (prefix, last_name) = LAST_NAMES.choose(rng).expect("Missing test data");
+    (*prefix, last_name)
+}
+
+const LOCALITIES: &[&str] = &[
+    "Heemdamseburg",
+    "Juinen",
+    "Middelgein",
+    "'s Gravenveen",
+    "Sluisdam",
+    "Hovenerwoud",
+    "Bloemstede",
+    "Eksterlo",
+    "Eemstricht",
+    "Hoek van Zoom",
+    "Lekkum",
+    "Huisden",
+];
+
+/// Generate a random locality, using the random number generator given
+pub fn locality(rng: &mut impl rand::Rng) -> &'static str {
+    LOCALITIES.choose(rng).expect("Missing test data")
+}
+
+const STREETNAMES: &[&str] = &[
+    "Dorpsstraat",
+    "Kerkstraat",
+    "Molenweg",
+    "Stationsweg",
+    "Schoolstraat",
+    "Molenstraat",
+    "Parallelweg",
+    "Sportlaan",
+    "Industrieweg",
+    "Grote Markt",
+    "Beukenlaan",
+    "Nieuwstraat",
+    "Kortestraat",
+    "Langestraat",
+    "Bredestraat",
+];
+
+/// Generate a random streetname and house number combination, using the random number generator given
+pub fn address(rng: &mut impl rand::Rng) -> String {
+    let street = STREETNAMES.choose(rng).expect("Missing test data");
+
+    let housenumber = rng.random_range(1..=120);
+    let ext = if rng.random_ratio(1, 5) {
+        ["a", "b", "c", "d"].choose(rng).expect("Missing test data")
+    } else {
+        ""
+    };
+
+    format!("{street} {housenumber}{ext}")
+}
+
+/// Generate a random postal code, using the random number generator given
+pub fn postal_code(rng: &mut impl rand::Rng) -> String {
+    let digits = rng.random_range(1000..10000).to_string();
+    let letter1 = rng.random_range('A'..='Z');
+    let letter2 = rng.random_range('A'..='Z');
+    format!("{digits}{letter1}{letter2}")
+}
+
+const POLITICAL_GROUP_NAMES: &[&str] = &[
+    "Partijdige Partij",
+    "Partij voor de Stemmer",
+    "Stemmmers 22",
+    "STEM",
+    "De Stemunie",
+    "Stemalliantie",
+    "Lijst De Partij",
+    "Het Stembiljet",
+    "Partij voor de Opkomst",
+    "Kiezers nu!",
+    "Verkiespartij",
+    "WET",
+    "Partij van de Wet",
+    "Stem van de partij",
+    "Kiesregelingsunie",
+    "De Lijst",
+    "Groep De Partij",
+    "Stemmersgroep",
+    "Algemene Partij",
+    "Stem voor de Partij",
+    "Partij van de Keuze",
+    "KEUS",
+    "Keuzepartij",
+    "Voorkeurskeuzepartij",
+    "De Kandidatenlijst",
+    "Lijst van de Kandidaten",
+    "Kandidaten eerst!",
+    "De Kandidaat",
+    "Politieke Groep de Partij",
+    "De partijdigen",
+    "Doorstemmers",
+    "Politieke Groep der Kandidaten",
+    "Groep van de Stemmers",
+    "Unie voor Stemmen",
+    "Alliantie van Partijen",
+    "Stem voor kandidaten",
+    "Kandidaten voor stemmen",
+    "Partij voor de Kiesregeling",
+    "De Kiezer",
+    "Stemmers eerst!",
+    "LIJST",
+    "Algemene Lijst",
+    "Lijst de stemmer",
+    "Partij van de groepen",
+    "Lijst van stemmers",
+    "Stemmers 101",
+    "Lijst voor de Partijdigheid",
+    "Unie van kandidaten",
+    "Stem nu!",
+];
+
+static PG_OFFSET: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a random political group name. This should not repeat political group names.
+/// This only uses the random number generator on the initial call to shuffle the list of
+/// political group names. If the list is exhausted, a simple "GROEP x" is returned.
+pub fn political_group_name(rng: &mut impl rand::Rng) -> String {
+    static RAND_POLITICAL_GROUP_NAMES: OnceLock<Vec<&str>> = OnceLock::new();
+
+    let offset = usize::try_from(PG_OFFSET.fetch_add(1, Ordering::Relaxed)).unwrap_or(usize::MAX);
+    if offset >= POLITICAL_GROUP_NAMES.len() {
+        let idx = offset - POLITICAL_GROUP_NAMES.len() + 1;
+        format!("GROEP {idx}")
+    } else {
+        let rpgs = RAND_POLITICAL_GROUP_NAMES.get_or_init(|| {
+            let mut v = Vec::from(POLITICAL_GROUP_NAMES);
+            v.shuffle(rng);
+            v
+        });
+        rpgs[offset].to_owned()
+    }
+}
+
+const POLLING_STATION_PREFIX: &[&str] = &[
+    "Buurthuis",
+    "Clubhuis",
+    "Openbare Basisschool",
+    "OBS",
+    "Hotel",
+    "Museum",
+    "Cultuurcentrum",
+    "Café",
+    "Sportzaal",
+    "Steunpunt",
+    "Wijkcentrum",
+    "Winkelcentrum",
+    "Sportcomplex",
+    "Studio",
+    "Theater",
+    "Filmhuis",
+    "Bioscoop",
+];
+
+const POLLING_STATION_SUFFIX: &[&str] = &[
+    "Het Stemmende Vogeltje",
+    "De Vliegende Stemmer",
+    "De Gang",
+    "Het Gebouw",
+    "De Deur",
+    "De Kiezende Olifant",
+    "Voor het Hek",
+    "Door de Kamer",
+    "De Tweede Kamer",
+    "Het Binnenhof",
+    "Voor het Veld",
+    "Het Pronkstuk",
+    "Den Echte Stemmer",
+    "Het Vriendelijke Bureau",
+    "Achter Het Huis",
+    "Van Den Stem",
+    "Het Gemeentehuis",
+    "De Genieter",
+    "De Doorstemmer",
+    "Het Kleurende Potlood",
+    "Het Potlood",
+    "De Sprankelende Stembus",
+    "Achter De Stembus",
+    "Via De Stemgang",
+];
+
+/// Generate a polling station name, using the random number generator given
+pub fn polling_station_name(rng: &mut impl rand::Rng) -> String {
+    let prefix = POLLING_STATION_PREFIX
+        .choose(rng)
+        .expect("Missing test data");
+    let suffix = POLLING_STATION_SUFFIX
+        .choose(rng)
+        .expect("Missing test data");
+    let add_quotes = rng.random_ratio(1, 10);
+    if add_quotes {
+        if rng.random_ratio(1, 2) {
+            format!("{prefix} '{suffix}'")
+        } else {
+            format!("{prefix} \"{suffix}\"")
+        }
+    } else {
+        format!("{prefix} {suffix}")
+    }
+}
+
+/// Generate a random election domain id using the given random number generator
+pub fn domain_id(rng: &mut impl rand::Rng) -> String {
+    let num = rng.random_range(100..1000);
+    format!("{num:04}")
+}
+
+/// Pick a date between the two given dates, using the given random number generator
+pub fn date_between(rng: &mut impl rand::Rng, start: NaiveDate, end: NaiveDate) -> NaiveDate {
+    assert!(end >= start, "Start date should be before end date");
+    let delta = end - start;
+    let days = delta.num_days();
+    if days <= 0 {
+        return start;
+    }
+    let rand = rng.random_range(0..days);
+    start + Days::new(rand as u64)
+}


### PR DESCRIPTION
A helper binary (run with `cargo run --bin gen-test-election`) that generates an election, the political groups and candidates in those groups, and a set of polling stations for the election. The size of the election can be specified with a couple of arguments to the binary. Intended for load testing and for generating testing data.

I've attempted to create some weird cases in the test data as well, including polling stations with quotes in their name, first and last names with special characters, including and excluding last name prefixes, sometimes omitting the first name entirely for some political groups. The same applies to names of localities etc. 

Names are all made up. Political groups and polling stations have names somewhat related to the election process. Locality names should all not exist. Street names are based on the most popular street names in the Netherlands. First and last names are based on some hand-picked entries from several Dutch name generators. Most of the rest is just random numbers. 