### PR TITLE
Enable tabular figures for number cells in Table

### DIFF
--- a/frontend/src/components/ui/Table/Table.module.css
+++ b/frontend/src/components/ui/Table/Table.module.css
@@ -98,4 +98,6 @@
 :where(.numberCell) {
   font-weight: bold;
   font-size: var(--font-size-body);
+  /* Enable 'Tabular Figures' font feature for fixed-width numbers */
+  font-feature-settings: "tnum" on;
 }


### PR DESCRIPTION
Before
<img width="600" alt="Screenshot 2025-06-17 at 12 49 17" src="https://github.com/user-attachments/assets/1e434f6c-0884-4399-bce9-3345621ea6e4" />

After:
<img width="600" alt="Screenshot 2025-06-17 at 12 53 25" src="https://github.com/user-attachments/assets/93f1a037-0b5a-4103-8eaa-39c8d222aa97" />
