### PR TITLE
Remove MSW addon from Ladle

### DIFF
--- a/frontend/.ladle/config.mjs
+++ b/frontend/.ladle/config.mjs
@@ -3,9 +3,4 @@ export default {
   outDir: "dist/ladle",
   base: "/ladle/",
   viteConfig: "./.ladle/vite.config.ts",
-  addons: {
-    msw: {
-      enabled: true,
-    },
-  },
 };


### PR DESCRIPTION
This config was added in #1216 and we were not sure why it was needed (https://github.com/kiesraad/abacus/pull/1216/files#r2006161058), but it looks like it isn't. Ladle seems to work fine without it.

Fixes #1566.