### PR TITLE
Add zebra striping to political group data entry

### DIFF
--- a/frontend/src/features/data_entry/components/subsections/InputGridSubsection.tsx
+++ b/frontend/src/features/data_entry/components/subsections/InputGridSubsection.tsx
@@ -25,7 +25,7 @@ export function InputGridSubsectionComponent({
   missingTotalError,
 }: InputGridSubsectionProps) {
   return (
-    <InputGrid>
+    <InputGrid zebra={subsection.zebra}>
       <InputGrid.Header>
         <th>{t(subsection.headers[0])}</th>
         <th>{t(subsection.headers[1])}</th>

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -136,6 +136,7 @@ export function createPoliticalGroupSections(election: ElectionWithPoliticalGrou
         {
           type: "inputGrid",
           headers: ["number", "vote_count", "candidate.title"],
+          zebra: true,
           rows,
         },
       ],


### PR DESCRIPTION
Add back zebra striping to the political group data entry forms, which was accidentally removed in #1547.