### PR TITLE
Add and use get data entry errors endpoint

### DIFF
--- a/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
+++ b/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
@@ -11,7 +11,7 @@
       {
         "name": "event: serde_json::Value",
         "ordinal": 1,
-        "type_info": "Null"
+        "type_info": "Text"
       }
     ],
     "parameters": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1253,6 +1253,65 @@
       }
     },
     "/api/polling_stations/{polling_station_id}/data_entries/resolve_errors": {
+      "get": {
+        "summary": "Get accepted data entry errors to be resolved",
+        "operationId": "polling_station_data_entry_get_errors",
+        "parameters": [
+          {
+            "name": "polling_station_id",
+            "in": "path",
+            "description": "Polling station database id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Data entry with errors and warnings to be resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataEntryGetErrorsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No data entry with accepted errors found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Resolve accepted data entry errors by providing a `ResolveErrorsAction`",
         "operationId": "polling_station_data_entry_resolve_errors",
@@ -2964,6 +3023,31 @@
             ],
             "format": "int32",
             "minimum": 0
+          }
+        }
+      },
+      "DataEntryGetErrorsResponse": {
+        "type": "object",
+        "required": [
+          "first_entry_user_id",
+          "finalised_first_entry",
+          "first_entry_finished_at",
+          "validation_results"
+        ],
+        "properties": {
+          "finalised_first_entry": {
+            "$ref": "#/components/schemas/PollingStationResults"
+          },
+          "first_entry_finished_at": {
+            "type": "string"
+          },
+          "first_entry_user_id": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "validation_results": {
+            "$ref": "#/components/schemas/ValidationResults"
           }
         }
       },

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -5,9 +5,14 @@ use utoipa::ToSchema;
 
 use super::{
     CandidateVotes, Count, DifferencesCounts, PoliticalGroupVotes, PollingStationResults,
-    VotersCounts, VotesCounts, comparison::Compare, status::DataEntryStatus,
+    VotersCounts, VotesCounts,
+    comparison::Compare,
+    status::{DataEntryStatus, FirstEntryInProgress},
 };
-use crate::{election::ElectionWithPoliticalGroups, polling_station::PollingStation};
+use crate::{
+    data_entry::status::FirstEntryHasErrors, election::ElectionWithPoliticalGroups,
+    polling_station::PollingStation,
+};
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Default, PartialEq, Eq)]
 pub struct ValidationResults {
@@ -194,8 +199,15 @@ impl Validate for DataEntryStatus {
         path: &FieldPath,
     ) -> Result<(), DataError> {
         match self {
-            DataEntryStatus::FirstEntryInProgress(state) => {
-                state.first_entry.validate(
+            DataEntryStatus::FirstEntryInProgress(FirstEntryInProgress {
+                first_entry: entry,
+                ..
+            })
+            | DataEntryStatus::FirstEntryHasErrors(FirstEntryHasErrors {
+                finalised_first_entry: entry,
+                ..
+            }) => {
+                entry.validate(
                     election,
                     polling_station,
                     validation_results,

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsPage.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsPage.test.tsx
@@ -8,8 +8,8 @@ import {
   ElectionListRequestHandler,
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
+  PollingStationDataEntryGetErrorsHandler,
   PollingStationDataEntryResolveErrorsHandler,
-  PollingStationDataEntryStatusFirstEntryHasErrorsHandler,
   UserListRequestHandler,
 } from "@/testing/api-mocks/RequestHandlers";
 import { server } from "@/testing/server";
@@ -45,8 +45,8 @@ describe("ResolveErrorsPage", () => {
       ElectionRequestHandler,
       ElectionStatusRequestHandler,
       ElectionListRequestHandler,
+      PollingStationDataEntryGetErrorsHandler,
       PollingStationDataEntryResolveErrorsHandler,
-      PollingStationDataEntryStatusFirstEntryHasErrorsHandler,
       UserListRequestHandler,
     );
   });

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsPage.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsPage.tsx
@@ -28,10 +28,10 @@ export function ResolveErrorsPage() {
     void navigate(url);
   };
   const pollingStationId = useNumericParam("pollingStationId");
-  const { pollingStation, election, loading, status, action, setAction, onSubmit, validationError } =
+  const { pollingStation, election, loading, dataEntry, userFullname, action, setAction, onSubmit, validationError } =
     usePollingStationDataEntryErrors(pollingStationId, afterSave);
 
-  if (loading || status === null) {
+  if (loading || dataEntry === null) {
     return <Loader />;
   }
 
@@ -50,6 +50,9 @@ export function ResolveErrorsPage() {
         <article>
           <h2>{t("resolve_errors.title")}</h2>
           <p>{t("resolve_errors.page_content")}</p>
+
+          <pre>{JSON.stringify(dataEntry.validation_results, null, 2)}</pre>
+
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -62,7 +65,9 @@ export function ResolveErrorsPage() {
               {validationError && <ChoiceList.Error id="resolve-errors-error">{validationError}</ChoiceList.Error>}
               <ChoiceList.Radio
                 id="keep_entry"
-                label={tx("resolve_errors.options.resume_first_entry", undefined, { name: status.first_user })}
+                label={tx("resolve_errors.options.resume_first_entry", undefined, {
+                  name: userFullname ?? t("typist"),
+                })}
                 checked={action === "resume_first_entry"}
                 onChange={() => {
                   setAction("resume_first_entry");

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -1,6 +1,7 @@
-import { getEmptyDataEntryRequest } from "@/features/data_entry/testing/mock-data";
+import { errorWarningMocks, getEmptyDataEntryRequest } from "@/features/data_entry/testing/mock-data";
 import {
   ClaimDataEntryResponse,
+  DataEntryGetErrorsResponse,
   DataEntryStatus,
   PollingStationDataEntry,
   PollingStationResults,
@@ -191,6 +192,14 @@ export const dataEntryResolveDifferencesMockResponse: PollingStationDataEntry = 
       second_entry_user_id: 1,
     },
     status: "Definitive",
+  },
+};
+
+export const dataEntryGetErrorsMockResponse: DataEntryGetErrorsResponse = {
+  ...firstEntryHasErrorsStatus.state,
+  validation_results: {
+    errors: [errorWarningMocks.F101],
+    warnings: [errorWarningMocks.W201, errorWarningMocks.W301],
   },
 };
 

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -10,6 +10,7 @@ import {
   AUDIT_LOG_LIST_USERS_REQUEST_PATH,
   AuditLogListResponse,
   ClaimDataEntryResponse,
+  DataEntryGetErrorsResponse,
   DataEntryStatus,
   ELECTION_DETAILS_REQUEST_PARAMS,
   ELECTION_DETAILS_REQUEST_PATH,
@@ -33,6 +34,8 @@ import {
   POLLING_STATION_DATA_ENTRY_DELETE_REQUEST_PATH,
   POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PARAMS,
   POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PATH,
+  POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PARAMS,
+  POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PATH,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PARAMS,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PATH,
@@ -77,10 +80,10 @@ import {
 
 import {
   claimDataEntryResponse,
+  dataEntryGetErrorsMockResponse,
   dataEntryResolveDifferencesMockResponse,
   dataEntryResolveErrorsMockResponse,
   dataEntryStatusDifferences,
-  firstEntryHasErrorsStatus,
   saveDataEntryResponse,
   secondEntryNotStartedStatus,
 } from "./DataEntryMockData";
@@ -163,19 +166,21 @@ export const LoginHandler = http.post<LOGIN_REQUEST_PARAMS, LOGIN_REQUEST_BODY, 
   () => HttpResponse.json(loginResponseMockData, { status: 200 }),
 );
 
+export const PollingStationDataEntryGetErrorsHandler = http.get<
+  ParamsToString<POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PARAMS>,
+  null,
+  DataEntryGetErrorsResponse,
+  POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PATH
+>("/api/polling_stations/5/data_entries/resolve_errors", () =>
+  HttpResponse.json(dataEntryGetErrorsMockResponse, { status: 200 }),
+);
+
 export const PollingStationDataEntryStatusEntriesDifferentHandler = http.get<
   ParamsToString<POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PARAMS>,
   null,
   DataEntryStatus,
   POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH
 >("/api/polling_stations/3/data_entries", () => HttpResponse.json(dataEntryStatusDifferences, { status: 200 }));
-
-export const PollingStationDataEntryStatusFirstEntryHasErrorsHandler = http.get<
-  ParamsToString<POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PARAMS>,
-  null,
-  DataEntryStatus,
-  POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH
->("/api/polling_stations/5/data_entries", () => HttpResponse.json(firstEntryHasErrorsStatus, { status: 200 }));
 
 export const PollingStationDataEntryResolveDifferencesHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PARAMS>,
@@ -326,8 +331,8 @@ export const handlers: HttpHandler[] = [
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
   LoginHandler,
+  PollingStationDataEntryGetErrorsHandler,
   PollingStationDataEntryStatusEntriesDifferentHandler,
-  PollingStationDataEntryStatusFirstEntryHasErrorsHandler,
   PollingStationDataEntryResolveDifferencesHandler,
   PollingStationDataEntryResolveErrorsHandler,
   PollingStationListRequestHandler,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -114,6 +114,11 @@ export type POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PATH =
 export type POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY = ResolveDifferencesAction;
 
 // /api/polling_stations/{polling_station_id}/data_entries/resolve_errors
+export interface POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PARAMS {
+  polling_station_id: number;
+}
+export type POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PATH =
+  `/api/polling_stations/${number}/data_entries/resolve_errors`;
 export interface POLLING_STATION_DATA_ENTRY_RESOLVE_ERRORS_REQUEST_PARAMS {
   polling_station_id: number;
 }
@@ -343,6 +348,13 @@ export interface DataEntryDetails {
   firstEntryUserId?: number | null;
   pollingStationId: number;
   secondEntryUserId?: number | null;
+}
+
+export interface DataEntryGetErrorsResponse {
+  finalised_first_entry: PollingStationResults;
+  first_entry_finished_at: string;
+  first_entry_user_id: number;
+  validation_results: ValidationResults;
 }
 
 export type DataEntryStatus =


### PR DESCRIPTION
- resolves https://github.com/kiesraad/abacus/issues/1641
- added endpoint and tests to get data entry with errors and warnings, for a first data entry with accepted errors
- update `usePollingStationDataEntryErrors` hook to call the endpoint
- update page to show errors and warnings in JSON
- backend integration tests, openapi, MSW hook
- can be fully tested once the typist can succesfully finish a first entry with errors

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->