### PR TITLE
Allow exporting of a generated test election to EML files

### DIFF
--- a/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
+++ b/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
@@ -11,7 +11,7 @@
       {
         "name": "event: serde_json::Value",
         "ordinal": 1,
-        "type_info": "Text"
+        "type_info": "Null"
       }
     ],
     "parameters": {

--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -74,7 +74,7 @@ impl From<crate::election::ElectionCategory> for ElectionCategory {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ElectionSubcategory {
     /// Provinciale staten (provinicial council), single electoral district
     PS1,
@@ -141,6 +141,36 @@ pub struct ElectionIdentifier {
     pub nomination_date: Option<String>,
 }
 
+impl ElectionIdentifier {
+    pub fn from_election(
+        election: &crate::election::structs::ElectionWithPoliticalGroups,
+        include_nomination_date: bool,
+    ) -> Self {
+        let subcategory = if election.number_of_seats >= 19 {
+            ElectionSubcategory::GR2
+        } else {
+            ElectionSubcategory::GR1
+        };
+
+        Self {
+            id: election.election_id.clone(),
+            election_name: election.name.clone(),
+            election_category: ElectionCategory::GR,
+            election_subcategory: Some(subcategory),
+            election_domain: Some(ElectionDomain {
+                id: election.domain_id.clone(),
+                name: election.location.clone(),
+            }),
+            election_date: election.election_date.format("%Y-%m-%d").to_string(),
+            nomination_date: if include_nomination_date {
+                Some(election.nomination_date.format("%Y-%m-%d").to_string())
+            } else {
+                None
+            },
+        }
+    }
+}
+
 /// Election domain part of election identifier
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -185,11 +215,15 @@ pub struct ContestIdentifier {
 }
 
 impl ContestIdentifier {
-    pub fn new(id: impl Into<String>, contest_name: Option<String>) -> ContestIdentifier {
+    pub fn new(id: impl Into<String>, contest_name: Option<String>) -> Self {
         ContestIdentifier {
             id: id.into(),
             contest_name,
         }
+    }
+
+    pub fn geen() -> Self {
+        Self::new("geen", None)
     }
 }
 

--- a/backend/src/eml/eml_110.rs
+++ b/backend/src/eml/eml_110.rs
@@ -1,7 +1,10 @@
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
-use crate::election::PoliticalGroup;
+use crate::{
+    election::PoliticalGroup,
+    eml::common::{AuthorityAddress, AuthorityIdentifier},
+};
 
 use super::{
     EMLBase,
@@ -90,8 +93,7 @@ impl EML110 {
         }
 
         // election subcategory is required
-        let Some(election_subcategory) = self.election_identifier().election_subcategory.clone()
-        else {
+        let Some(election_subcategory) = self.election_identifier().election_subcategory else {
             return Err(EMLImportError::MissingSubcategory);
         };
 
@@ -177,6 +179,137 @@ impl EML110 {
         };
 
         Ok(election)
+    }
+
+    pub fn definition_from_abacus_election(
+        election: &crate::election::ElectionWithPoliticalGroups,
+        transaction_id: &str,
+    ) -> Self {
+        let now = chrono::Utc::now();
+        let subcategory = if election.number_of_seats >= 19 {
+            ElectionSubcategory::GR2
+        } else {
+            ElectionSubcategory::GR1
+        };
+
+        Self {
+            base: EMLBase::new("110a"),
+            transaction_id: transaction_id.to_owned(),
+            creation_date_time: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            issue_date: Some(now.format("%Y-%m-%d").to_string()),
+            managing_authority: None,
+            election_event: ElectionEvent {
+                event_identifier: EventIdentifier {},
+                election: Election {
+                    election_identifier: ElectionIdentifier::from_election(election, true),
+                    contest: Contest {
+                        contest_identifier: Some(ContestIdentifier::geen()),
+                        voting_method: VotingMethod::SinglePreferenceVote,
+                        max_votes: Some("".to_string()),
+                        polling_places: vec![],
+                    },
+                    number_of_seats: Some(election.number_of_seats),
+                    preference_threshold: Some(if subcategory == ElectionSubcategory::GR2 {
+                        25
+                    } else {
+                        50
+                    }),
+                    // TODO: we currently don't have all the information in the election tree datastructure
+                    election_tree: Some(ElectionTree {
+                        regions: vec![Region {
+                            region_name: election.location.clone(),
+                            region_number: Some(election.domain_id.clone()),
+                            region_category: RegionCategory::Municipality,
+                            roman_numerals: false,
+                            frysian_export_allowed: false,
+                            superior_region_number: None,
+                            superior_region_category: None,
+                            committees: vec![
+                                Committee {
+                                    category: CommitteeCategory::CSB,
+                                    name: None,
+                                    accept_central_submissions: false,
+                                },
+                                Committee {
+                                    category: CommitteeCategory::HSB,
+                                    name: None,
+                                    accept_central_submissions: false,
+                                },
+                            ],
+                        }],
+                    }),
+                    registered_parties: election
+                        .political_groups
+                        .iter()
+                        .map(|group| RegisteredParty {
+                            registered_appellation: group.name.clone(),
+                        })
+                        .collect(),
+                },
+            },
+        }
+    }
+
+    pub fn polling_stations_from_election(
+        election: &crate::election::ElectionWithPoliticalGroups,
+        polling_stations: &[crate::polling_station::PollingStation],
+        transaction_id: &str,
+    ) -> Self {
+        let now = chrono::Utc::now();
+
+        Self {
+            base: EMLBase::new("110b"),
+            transaction_id: transaction_id.to_string(),
+            creation_date_time: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            issue_date: None,
+            managing_authority: Some(ManagingAuthority {
+                authority_identifier: AuthorityIdentifier {
+                    id: election.domain_id.clone(),
+                    name: election.location.clone(),
+                    created_by_authority: None,
+                },
+                authority_address: AuthorityAddress {},
+            }),
+            election_event: ElectionEvent {
+                event_identifier: EventIdentifier {},
+                election: Election {
+                    election_identifier: ElectionIdentifier::from_election(election, false),
+                    contest: Contest {
+                        contest_identifier: Some(ContestIdentifier::geen()),
+                        voting_method: VotingMethod::Unknown,
+                        max_votes: Some(election.number_of_voters.to_string()),
+                        polling_places: polling_stations
+                            .iter()
+                            .map(|ps| PollingPlace {
+                                physical_location: PhysicalLocation {
+                                    address: Address {
+                                        locality: Locality {
+                                            locality_name: LocalityName {
+                                                name: ps.name.clone(),
+                                                locality_type: None,
+                                                code: None,
+                                            },
+                                            postal_code: Some(PostalCode {
+                                                postal_code_number: ps.postal_code.clone(),
+                                            }),
+                                        },
+                                    },
+                                    polling_station: PollingStation {
+                                        token: ps.number.to_string(),
+                                        id: ps.id.to_string(),
+                                    },
+                                },
+                                channel: VotingChannelType::Polling,
+                            })
+                            .collect(),
+                    },
+                    number_of_seats: None,
+                    preference_threshold: None,
+                    election_tree: None,
+                    registered_parties: vec![],
+                },
+            },
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1661 

- Added some logic that allows converting an abacus election back to the EML files that it consists of
- Added some CLI parameters to configure the behavior of the export (only if a path is specified an export should be made)
- Added a way to configure the number of seats in the election
- Updated some defaults to generate a little smaller elections by default
- Can be tested by running `cargo run --bin gen-test-election -- --export-definition path/to/somewhere` (also check the other options by running `cargo run --bin gen-test-election -- --help`)