### PR TITLE
1660 refactor election create e2e test

### DIFF
--- a/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
@@ -7,23 +7,15 @@ export class OverviewPgObj {
   readonly header: Locator;
   readonly alert: Locator;
   readonly create: Locator;
-  readonly importedElections: Locator;
-  readonly readyStates: Locator;
+  readonly elections: Locator;
+  readonly electionsInReadyState: Locator;
 
   constructor(protected readonly page: Page) {
     this.navBar = new NavBar(page);
     this.header = page.getByRole("heading", { name: "Beheer verkiezingen" });
     this.alert = page.getByRole("heading", { name: "Je account is ingesteld" });
     this.create = page.getByRole("link", { name: "Verkiezing toevoegen" });
-    this.importedElections = page.getByText("Gemeenteraad Amsterdam 2022");
-    this.readyStates = page.getByText("Klaar voor invoer");
-  }
-
-  async electionCount(): Promise<number> {
-    return await this.importedElections.count();
-  }
-
-  async readyStateCount(): Promise<number> {
-    return await this.readyStates.count();
+    this.elections = page.getByTestId("overview").locator("tbody").getByRole("row");
+    this.electionsInReadyState = this.elections.filter({ hasText: "Klaar voor invoer" });
   }
 }

--- a/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
@@ -4,6 +4,7 @@ import { NavBar } from "../NavBarPgObj";
 
 export class OverviewPgObj {
   readonly navBar: NavBar;
+  readonly main: Locator;
   readonly header: Locator;
   readonly alert: Locator;
   readonly create: Locator;
@@ -12,6 +13,7 @@ export class OverviewPgObj {
 
   constructor(protected readonly page: Page) {
     this.navBar = new NavBar(page);
+    this.main = page.getByRole("main");
     this.header = page.getByRole("heading", { name: "Beheer verkiezingen" });
     this.alert = page.getByRole("heading", { name: "Je account is ingesteld" });
     this.create = page.getByRole("link", { name: "Verkiezing toevoegen" });

--- a/frontend/e2e-tests/page-objects/election/create/CheckCandidateDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckCandidateDefinitionPgObj.ts
@@ -2,7 +2,6 @@ import { type Locator, type Page } from "@playwright/test";
 
 export class CheckCandidateDefinitionPgObj {
   readonly header: Locator;
-  readonly hash: Locator;
   readonly hashInput1: Locator;
   readonly hashInput2: Locator;
   readonly next: Locator;
@@ -10,7 +9,6 @@ export class CheckCandidateDefinitionPgObj {
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Controleer kandidatenlijst" });
-    this.hash = page.getByTestId("hash");
     this.hashInput1 = page.getByLabel("Controle deel 1");
     this.hashInput2 = page.getByLabel("Controle deel 2");
     this.next = page.getByRole("button", { name: "Volgende" });

--- a/frontend/e2e-tests/page-objects/election/create/CheckDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckDefinitionPgObj.ts
@@ -2,7 +2,6 @@ import { type Locator, type Page } from "@playwright/test";
 
 export class CheckDefinitionPgObj {
   readonly header: Locator;
-  readonly hash: Locator;
   readonly hashInput1: Locator;
   readonly hashInput2: Locator;
   readonly next: Locator;
@@ -10,7 +9,6 @@ export class CheckDefinitionPgObj {
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Controleer verkiezingsdefinitie" });
-    this.hash = page.getByTestId("hash");
     this.hashInput1 = page.getByLabel("Controle deel 1");
     this.hashInput2 = page.getByLabel("Controle deel 2");
     this.next = page.getByRole("button", { name: "Volgende" });

--- a/frontend/e2e-tests/test-data/eml-files.ts
+++ b/frontend/e2e-tests/test-data/eml-files.ts
@@ -1,0 +1,20 @@
+export const eml110a = {
+  filename: "eml110a_test.eml.xml",
+  path: "../backend/src/eml/tests/eml110a_test.eml.xml",
+  electionDate: "Woensdag 16 maart 2022",
+  hashInput1: "9825",
+  hashInput2: "8af1",
+};
+
+export const eml110b = {
+  filename: "eml110b_test.eml.xml",
+  path: "../backend/src/eml/tests/eml110b_test.eml.xml",
+};
+
+export const eml230b = {
+  filename: "eml230b_test.eml.xml",
+  path: "../backend/src/eml/tests/eml230b_test.eml.xml",
+  electionDate: "Woensdag 16 maart 2022",
+  hashInput1: "8a7b",
+  hashInput2: "458a",
+};

--- a/frontend/e2e-tests/test-data/eml-files.ts
+++ b/frontend/e2e-tests/test-data/eml-files.ts
@@ -1,7 +1,7 @@
 export const eml110a = {
   filename: "eml110a_test.eml.xml",
   path: "../backend/src/eml/tests/eml110a_test.eml.xml",
-  electionDate: "Woensdag 16 maart 2022",
+  electionDate: "woensdag 16 maart 2022",
   hashInput1: "9825",
   hashInput2: "8af1",
 };
@@ -14,7 +14,7 @@ export const eml110b = {
 export const eml230b = {
   filename: "eml230b_test.eml.xml",
   path: "../backend/src/eml/tests/eml230b_test.eml.xml",
-  electionDate: "Woensdag 16 maart 2022",
+  electionDate: "woensdag 16 maart 2022",
   hashInput1: "8a7b",
   hashInput2: "458a",
 };

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -17,7 +17,7 @@ test.describe("Election creation", () => {
   test("it uploads an election file and candidate list", async ({ page }) => {
     await page.goto("/elections");
     const overviewPage = new OverviewPgObj(page);
-    const initialElectionCount = await overviewPage.electionCount();
+    const initialElectionCount = await overviewPage.elections.count();
     const initialReadyStateCount = await page.getByText("Klaar voor invoer").count();
     await overviewPage.create.click();
 
@@ -57,13 +57,11 @@ test.describe("Election creation", () => {
     await expect(checkAndSavePage.header).toBeVisible();
     await checkAndSavePage.save.click();
 
-    // Redefine the Overview page, so we can locate the newly
-    // added objects
     await expect(overviewPage.header).toBeVisible();
     // Check if the amount of elections by this title is greater than before the import
-    expect(await overviewPage.electionCount()).toBeGreaterThan(initialElectionCount);
+    expect(await overviewPage.elections.count()).toBeGreaterThan(initialElectionCount);
     // Check if the amount of "Klaar voor invoer states" is greater than before the import
-    expect(await overviewPage.readyStateCount()).toBeGreaterThan(initialReadyStateCount);
+    expect(await overviewPage.electionsInReadyState.count()).toBeGreaterThan(initialReadyStateCount);
   });
 
   test("it fails on incorrect hash", async ({ page }) => {

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -7,6 +7,7 @@ import { UploadDefinitionPgObj } from "e2e-tests/page-objects/election/create/Up
 import { OverviewPgObj } from "e2e-tests/page-objects/election/OverviewPgObj";
 
 import { test } from "../fixtures";
+import { eml110a, eml110b, eml230b } from "../test-data/eml-files";
 
 test.use({
   storageState: "e2e-tests/state/admin.json",
@@ -22,33 +23,33 @@ test.describe("Election creation", () => {
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
     await expect(uploadDefinitionPage.header).toBeVisible();
-    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+    await uploadDefinitionPage.uploadFile(page, eml110a.path);
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
     // Check that the uploaded file name is present somewhere on the page
-    await expect(page.getByText("eml110a_test.eml.xml")).toBeVisible();
+    await expect(page.getByText(eml110a.filename)).toBeVisible();
     // Election date
-    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(page.getByText(eml110a.electionDate)).toBeVisible();
 
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
-    await checkDefinitionPage.hashInput1.fill("9825");
-    await checkDefinitionPage.hashInput2.fill("8af1");
+    await checkDefinitionPage.hashInput1.fill(eml110a.hashInput1);
+    await checkDefinitionPage.hashInput2.fill(eml110a.hashInput2);
     await checkDefinitionPage.next.click();
 
     // Candidate page
     const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
     await expect(uploadCandidateDefinitionPage.header).toBeVisible();
-    await uploadCandidateDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml230b_test.eml.xml");
+    await uploadCandidateDefinitionPage.uploadFile(page, eml230b.path);
 
     // Candidate check page
     const checkCandidateDefinitionPage = new CheckCandidateDefinitionPgObj(page);
     await expect(checkCandidateDefinitionPage.header).toBeVisible();
-    await expect(page.getByText("eml230b_test.eml.xml")).toBeVisible();
-    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(page.getByText(eml230b.filename)).toBeVisible();
+    await expect(page.getByText(eml230b.electionDate)).toBeVisible();
     await expect(checkCandidateDefinitionPage.hashInput1).toBeFocused();
-    await checkCandidateDefinitionPage.hashInput1.fill("8a7b");
-    await checkCandidateDefinitionPage.hashInput2.fill("458a");
+    await checkCandidateDefinitionPage.hashInput1.fill(eml230b.hashInput1);
+    await checkCandidateDefinitionPage.hashInput2.fill(eml230b.hashInput2);
     await checkCandidateDefinitionPage.next.click();
 
     // Now we should be at the check and save page
@@ -72,7 +73,7 @@ test.describe("Election creation", () => {
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
     await expect(uploadDefinitionPage.header).toBeVisible();
-    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+    await uploadDefinitionPage.uploadFile(page, eml110a.path);
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
@@ -90,7 +91,7 @@ test.describe("Election creation", () => {
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
     await expect(uploadDefinitionPage.header).toBeVisible();
-    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110b_test.eml.xml");
+    await uploadDefinitionPage.uploadFile(page, eml110b.path);
     await expect(uploadDefinitionPage.error).toBeVisible();
   });
 
@@ -101,27 +102,27 @@ test.describe("Election creation", () => {
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
     await expect(uploadDefinitionPage.header).toBeVisible();
-    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+    await uploadDefinitionPage.uploadFile(page, eml110a.path);
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
-    await expect(page.getByText("eml110a_test.eml.xml")).toBeVisible();
-    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(page.getByText(eml110a.filename)).toBeVisible();
+    await expect(page.getByText(eml110a.electionDate)).toBeVisible();
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
-    await checkDefinitionPage.hashInput1.fill("9825");
-    await checkDefinitionPage.hashInput2.fill("8af1");
+    await checkDefinitionPage.hashInput1.fill(eml110a.hashInput1);
+    await checkDefinitionPage.hashInput2.fill(eml110a.hashInput2);
     await checkDefinitionPage.next.click();
 
     // Candidate page
     const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
     await expect(uploadCandidateDefinitionPage.header).toBeVisible();
-    await uploadCandidateDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml230b_test.eml.xml");
+    await uploadCandidateDefinitionPage.uploadFile(page, eml230b.path);
 
     // Candidate check page
     const checkCandidateDefinitionPage = new CheckCandidateDefinitionPgObj(page);
     await expect(checkCandidateDefinitionPage.header).toBeVisible();
-    await expect(page.getByText("eml230b_test.eml.xml")).toBeVisible();
-    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(page.getByText(eml230b.filename)).toBeVisible();
+    await expect(page.getByText(eml230b.electionDate)).toBeVisible();
     await expect(checkCandidateDefinitionPage.hashInput1).toBeFocused();
     await checkCandidateDefinitionPage.hashInput1.fill("1234");
     await checkCandidateDefinitionPage.hashInput2.fill("1234");
@@ -137,21 +138,21 @@ test.describe("Election creation", () => {
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
     await expect(uploadDefinitionPage.header).toBeVisible();
-    await uploadDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110a_test.eml.xml");
+    await uploadDefinitionPage.uploadFile(page, eml110a.path);
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
-    await expect(page.getByText("eml110a_test.eml.xml")).toBeVisible();
-    await expect(page.getByText("Woensdag 16 maart 2022")).toBeVisible();
+    await expect(page.getByText(eml110a.filename)).toBeVisible();
+    await expect(page.getByText(eml110a.electionDate)).toBeVisible();
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
-    await checkDefinitionPage.hashInput1.fill("9825");
-    await checkDefinitionPage.hashInput2.fill("8af1");
+    await checkDefinitionPage.hashInput1.fill(eml110a.hashInput1);
+    await checkDefinitionPage.hashInput2.fill(eml110a.hashInput2);
     await checkDefinitionPage.next.click();
 
     // Candidate page
     const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
     await expect(uploadCandidateDefinitionPage.header).toBeVisible();
-    await uploadCandidateDefinitionPage.uploadFile(page, "../backend/src/eml/tests/eml110b_test.eml.xml");
+    await uploadCandidateDefinitionPage.uploadFile(page, eml110b.path);
     await expect(uploadCandidateDefinitionPage.error).toBeVisible();
   });
 });

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -18,7 +18,7 @@ test.describe("Election creation", () => {
     await page.goto("/elections");
     const overviewPage = new OverviewPgObj(page);
     const initialElectionCount = await overviewPage.elections.count();
-    const initialReadyStateCount = await page.getByText("Klaar voor invoer").count();
+    const initialReadyStateCount = await overviewPage.electionsInReadyState.count();
     await overviewPage.create.click();
 
     const uploadDefinitionPage = new UploadDefinitionPgObj(page);
@@ -27,10 +27,8 @@ test.describe("Election creation", () => {
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
-    // Check that the uploaded file name is present somewhere on the page
-    await expect(page.getByText(eml110a.filename)).toBeVisible();
-    // Election date
-    await expect(page.getByText(eml110a.electionDate)).toBeVisible();
+    await expect(overviewPage.main).toContainText(eml110a.filename);
+    await expect(overviewPage.main).toContainText(eml110a.electionDate);
 
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
     await checkDefinitionPage.hashInput1.fill(eml110a.hashInput1);
@@ -45,8 +43,8 @@ test.describe("Election creation", () => {
     // Candidate check page
     const checkCandidateDefinitionPage = new CheckCandidateDefinitionPgObj(page);
     await expect(checkCandidateDefinitionPage.header).toBeVisible();
-    await expect(page.getByText(eml230b.filename)).toBeVisible();
-    await expect(page.getByText(eml230b.electionDate)).toBeVisible();
+    await expect(overviewPage.main).toContainText(eml230b.filename);
+    await expect(overviewPage.main).toContainText(eml230b.electionDate);
     await expect(checkCandidateDefinitionPage.hashInput1).toBeFocused();
     await checkCandidateDefinitionPage.hashInput1.fill(eml230b.hashInput1);
     await checkCandidateDefinitionPage.hashInput2.fill(eml230b.hashInput2);
@@ -104,8 +102,8 @@ test.describe("Election creation", () => {
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
-    await expect(page.getByText(eml110a.filename)).toBeVisible();
-    await expect(page.getByText(eml110a.electionDate)).toBeVisible();
+    await expect(overviewPage.main).toContainText(eml110a.filename);
+    await expect(overviewPage.main).toContainText(eml110a.electionDate);
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
     await checkDefinitionPage.hashInput1.fill(eml110a.hashInput1);
     await checkDefinitionPage.hashInput2.fill(eml110a.hashInput2);
@@ -119,8 +117,8 @@ test.describe("Election creation", () => {
     // Candidate check page
     const checkCandidateDefinitionPage = new CheckCandidateDefinitionPgObj(page);
     await expect(checkCandidateDefinitionPage.header).toBeVisible();
-    await expect(page.getByText(eml230b.filename)).toBeVisible();
-    await expect(page.getByText(eml230b.electionDate)).toBeVisible();
+    await expect(overviewPage.main).toContainText(eml230b.filename);
+    await expect(overviewPage.main).toContainText(eml230b.electionDate);
     await expect(checkCandidateDefinitionPage.hashInput1).toBeFocused();
     await checkCandidateDefinitionPage.hashInput1.fill("1234");
     await checkCandidateDefinitionPage.hashInput2.fill("1234");
@@ -140,8 +138,8 @@ test.describe("Election creation", () => {
 
     const checkDefinitionPage = new CheckDefinitionPgObj(page);
     await expect(checkDefinitionPage.header).toBeVisible();
-    await expect(page.getByText(eml110a.filename)).toBeVisible();
-    await expect(page.getByText(eml110a.electionDate)).toBeVisible();
+    await expect(overviewPage.main).toContainText(eml110a.filename);
+    await expect(overviewPage.main).toContainText(eml110a.electionDate);
     await expect(checkDefinitionPage.hashInput1).toBeFocused();
     await checkDefinitionPage.hashInput1.fill(eml110a.hashInput1);
     await checkDefinitionPage.hashInput2.fill(eml110a.hashInput2);


### PR DESCRIPTION
### In scope
- put all strings related to an eml file in a single re-usable object and put those in a file in the test-data folder
- refactor `OverviewPgObj.ts`: `this.importedElections = page.getByText("Gemeenteraad Amsterdam 2022");`
- refactor all locators in the test itself
- remove two single-line methods and unused `hash` locators

### Not in scope
**check on the overview page if the specific election has been added, taking into account parallel test execution**
Reason: only solution I can think of is copying the election definition eml and changing the election name to something unique for each test. This would also require recalculating the hash. That seems more trouble than it's worth.

A different and lesser option is to check if the final POST of election creation returns a 201. I don't think we need to do this. I'm fine with relying on the check that we return to the overview page and rely on our error handling in the frontend that returing to the overview page implies the 201 response.

### Comments
I have mixed feelings about changing `await expect(page.getByText(eml110a.filename)).toBeVisible();`
to `await expect(overviewPage.main).toContainText(eml110a.filename);`. I'm in favor of the change because it refactors the locator out of the test and as a result I could make the `expect` express the intention of the test a tiny bit better. But I wish I had been able to find a better locator than `overviewPage.main`.

