### PR TITLE
Retrieve user names on coordinator pages using getName from new useUsers hook

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { NotFoundPage } from "@/components/error/NotFoundPage";
 import { AdministratorLayout } from "@/components/layout/AdministratorLayout";
 import { ElectionLayout } from "@/components/layout/ElectionLayout";
+import { ElectionStatusLayout } from "@/components/layout/ElectionStatusLayout";
 import { accountRoutes } from "@/features/account/routes";
 import { apportionmentRoutes } from "@/features/apportionment/routes";
 import { dataEntryRoutes } from "@/features/data_entry/routes";
@@ -61,6 +62,7 @@ export const routes: RouteObject[] = [
               },
               {
                 path: "status",
+                Component: ElectionStatusLayout,
                 children: [
                   // index
                   ...electionStatusRoutes,

--- a/frontend/src/components/layout/ElectionStatusLayout.tsx
+++ b/frontend/src/components/layout/ElectionStatusLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router";
+
+import { UsersProvider } from "@/hooks/user/UsersProvider";
+
+export function ElectionStatusLayout() {
+  return (
+    <UsersProvider>
+      <Outlet />
+    </UsersProvider>
+  );
+}

--- a/frontend/src/features/election_status/components/ElectionStatus.stories.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.stories.tsx
@@ -2,7 +2,6 @@ import type { Story } from "@ladle/react";
 
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { extendedPollingStationMockData } from "@/testing/api-mocks/PollingStationMockData";
-import { userMockData } from "@/testing/api-mocks/UserMockData";
 
 import { ElectionStatus } from "./ElectionStatus";
 
@@ -73,20 +72,13 @@ export const DefaultElectionStatus: Story<StoryProps> = ({ navigate }) => {
       ]}
       election={electionMockData}
       pollingStations={extendedPollingStationMockData}
-      users={userMockData}
       navigate={navigate}
     />
   );
 };
 
 export const Empty: Story<StoryProps> = ({ navigate }) => (
-  <ElectionStatus
-    statuses={[]}
-    election={electionMockData}
-    pollingStations={[]}
-    users={userMockData}
-    navigate={navigate}
-  />
+  <ElectionStatus statuses={[]} election={electionMockData} pollingStations={[]} navigate={navigate} />
 );
 
 export default {

--- a/frontend/src/features/election_status/components/ElectionStatus.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.test.tsx
@@ -1,5 +1,8 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { UsersProvider } from "@/hooks/user/UsersProvider";
+import { UserListRequestHandler } from "@/testing/api-mocks/RequestHandlers";
+import { server } from "@/testing/server";
 import { render, screen, within } from "@/testing/test-utils";
 
 import { DefaultElectionStatus, Empty } from "./ElectionStatus.stories";
@@ -11,8 +14,16 @@ vi.mock(import("react-router"), async (importOriginal) => ({
 }));
 
 describe("ElectionStatus", () => {
+  beforeEach(() => {
+    server.use(UserListRequestHandler);
+  });
+
   test("Render status of polling station data entries correctly", async () => {
-    render(<DefaultElectionStatus navigate={navigate} />);
+    render(
+      <UsersProvider>
+        <DefaultElectionStatus navigate={navigate} />
+      </UsersProvider>,
+    );
 
     // Wait for the page to be loaded
     expect(await screen.findByRole("heading", { level: 2, name: "Statusoverzicht steminvoer" })).toBeVisible();
@@ -97,7 +108,11 @@ describe("ElectionStatus", () => {
   });
 
   test("Show no polling stations text instead of tables", async () => {
-    render(<Empty navigate={navigate} />);
+    render(
+      <UsersProvider>
+        <Empty navigate={navigate} />
+      </UsersProvider>,
+    );
 
     expect(await screen.findByText("Er zijn nog geen stembureaus toegevoegd voor deze verkiezing.")).toBeVisible();
   });

--- a/frontend/src/features/election_status/components/ElectionStatus.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.tsx
@@ -5,7 +5,7 @@ import { Progress } from "@/components/ui/ProgressBar/Progress";
 import { ProgressBar } from "@/components/ui/ProgressBar/ProgressBar";
 import { Table } from "@/components/ui/Table/Table";
 import { t } from "@/i18n/translate";
-import { Election, ElectionStatusResponseEntry, PollingStation, User } from "@/types/generated/openapi";
+import { Election, ElectionStatusResponseEntry, PollingStation } from "@/types/generated/openapi";
 
 import {
   categoryColorClass,
@@ -22,14 +22,12 @@ export interface ElectionStatusProps {
   election: Required<Election>;
   pollingStations: PollingStation[];
   navigate: (path: string) => void;
-  users: User[];
 }
 
-export function ElectionStatus({ statuses, election, pollingStations, navigate, users }: ElectionStatusProps) {
+export function ElectionStatus({ statuses, election, pollingStations, navigate }: ElectionStatusProps) {
   const { progressBarData, categoryCounts, pollingStationWithStatusAndTypist, tableCategories } = useElectionStatus(
     statuses,
     pollingStations,
-    users,
   );
 
   return (

--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -5,8 +5,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { ElectionLayout } from "@/components/layout/ElectionLayout";
-import { ElectionProvider } from "@/hooks/election/ElectionProvider";
-import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { ElectionStatusLayout } from "@/components/layout/ElectionStatusLayout";
 import { getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
   ElectionListRequestHandler,
@@ -16,19 +15,35 @@ import {
 } from "@/testing/api-mocks/RequestHandlers";
 import { Providers } from "@/testing/Providers";
 import { overrideOnce, server } from "@/testing/server";
-import { render, screen, setupTestRouter } from "@/testing/test-utils";
+import { screen, setupTestRouter } from "@/testing/test-utils";
 
 import { electionStatusRoutes } from "../routes";
-import { ElectionStatusPage } from "./ElectionStatusPage";
 
-const renderElectionStatusPage = () =>
-  render(
-    <ElectionProvider electionId={1}>
-      <ElectionStatusProvider electionId={1}>
-        <ElectionStatusPage />
-      </ElectionStatusProvider>
-    </ElectionProvider>,
-  );
+async function renderPage() {
+  // Set up router and navigate to the election data entry status page
+  const router = setupTestRouter([
+    {
+      path: "/elections/:electionId",
+      Component: ElectionLayout,
+      errorElement: <ErrorBoundary />,
+      children: [
+        {
+          path: "status",
+          Component: ElectionStatusLayout,
+          children: electionStatusRoutes,
+        },
+      ],
+    },
+  ]);
+
+  await router.navigate("/elections/1/status");
+  rtlRender(<Providers router={router} />);
+
+  // Wait for the page to be loaded
+  expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+
+  return router;
+}
 
 describe("ElectionStatusPage", () => {
   beforeEach(() => {
@@ -40,8 +55,8 @@ describe("ElectionStatusPage", () => {
     );
   });
 
-  test("Finish input not visible when data entry is in progress", () => {
-    renderElectionStatusPage();
+  test("Finish input not visible when data entry is in progress", async () => {
+    await renderPage();
 
     // Test that the data entry finished message doesn't exist
     expect(screen.queryByText("Alle stembureaus zijn twee keer ingevoerd")).not.toBeInTheDocument();
@@ -56,10 +71,7 @@ describe("ElectionStatusPage", () => {
       ],
     });
 
-    renderElectionStatusPage();
-
-    // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+    await renderPage();
 
     expect(await screen.findByText("Alle stembureaus zijn twee keer ingevoerd")).toBeVisible();
     expect(screen.getByRole("button", { name: "Invoerfase afronden" })).toBeVisible();
@@ -74,10 +86,7 @@ describe("ElectionStatusPage", () => {
       ],
     });
 
-    renderElectionStatusPage();
-
-    // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+    await renderPage();
 
     expect(screen.queryByText("Alle stembureaus zijn twee keer ingevoerd")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Invoerfase afronden" })).not.toBeInTheDocument();
@@ -85,22 +94,7 @@ describe("ElectionStatusPage", () => {
 
   test("Data entry kept alert works", async () => {
     const user = userEvent.setup();
-
-    // Set up router and navigate to the election data entry status page
-    const router = setupTestRouter([
-      {
-        path: "/elections/:electionId/status",
-        Component: ElectionLayout,
-        errorElement: <ErrorBoundary />,
-        children: electionStatusRoutes,
-      },
-    ]);
-
-    await router.navigate("/elections/1/status");
-    rtlRender(<Providers router={router} />);
-
-    // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+    const router = await renderPage();
 
     // Expect the alert to not be visible
     const alertHeading = "Verschil opgelost voor stembureau 33";
@@ -118,22 +112,7 @@ describe("ElectionStatusPage", () => {
 
   test("Both data entries discarded alert works", async () => {
     const user = userEvent.setup();
-
-    // Set up router and navigate to the election data entry status page
-    const router = setupTestRouter([
-      {
-        path: "/elections/:electionId/status",
-        Component: ElectionLayout,
-        errorElement: <ErrorBoundary />,
-        children: electionStatusRoutes,
-      },
-    ]);
-
-    await router.navigate("/elections/1/status");
-    rtlRender(<Providers router={router} />);
-
-    // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+    const router = await renderPage();
 
     // Expect the alert to not be visible
     const alertHeading = "Verschil opgelost voor stembureau 33";
@@ -151,22 +130,7 @@ describe("ElectionStatusPage", () => {
 
   test("First data entry resumed alert works", async () => {
     const user = userEvent.setup();
-
-    // Set up router and navigate to the election data entry status page
-    const router = setupTestRouter([
-      {
-        path: "/elections/:electionId/status",
-        Component: ElectionLayout,
-        errorElement: <ErrorBoundary />,
-        children: electionStatusRoutes,
-      },
-    ]);
-
-    await router.navigate("/elections/1/status");
-    rtlRender(<Providers router={router} />);
-
-    // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+    const router = await renderPage();
 
     // Expect the alert to not be visible
     const alertHeading = "Stembureau 36 teruggegeven aan Sanne Molenaar";
@@ -184,19 +148,7 @@ describe("ElectionStatusPage", () => {
 
   test("First data entry discarded alert works", async () => {
     const user = userEvent.setup();
-
-    // Set up router and navigate to the election data entry status page
-    const router = setupTestRouter([
-      {
-        path: "/elections/:electionId/status",
-        Component: ElectionLayout,
-        errorElement: <ErrorBoundary />,
-        children: electionStatusRoutes,
-      },
-    ]);
-
-    await router.navigate("/elections/1/status");
-    rtlRender(<Providers router={router} />);
+    const router = await renderPage();
 
     // Wait for the page to be loaded
     expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();

--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -1,6 +1,5 @@
 import { useLocation, useNavigate } from "react-router";
 
-import { useInitialApiGet } from "@/api/useInitialApiGet";
 import { HeaderCommitteeSessionStatusWithIcon } from "@/components/committee_session_status_with_icon/CommitteeSessionStatusWithIcon";
 import { Footer } from "@/components/footer/Footer";
 import { PageTitle } from "@/components/page_title/PageTitle";
@@ -8,8 +7,8 @@ import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { useElection } from "@/hooks/election/useElection";
 import { useElectionStatus } from "@/hooks/election/useElectionStatus";
+import { useUsers } from "@/hooks/user/useUsers";
 import { t } from "@/i18n/translate";
-import { USER_LIST_REQUEST_PATH, UserListResponse } from "@/types/generated/openapi";
 import { committeeSessionLabel } from "@/utils/committeeSession";
 
 import { ElectionStatus } from "./ElectionStatus";
@@ -19,9 +18,7 @@ export function ElectionStatusPage() {
   const location = useLocation();
   const { committeeSession, election, pollingStations } = useElection();
   const { statuses } = useElectionStatus();
-  const { requestState } = useInitialApiGet<UserListResponse>("/api/user" satisfies USER_LIST_REQUEST_PATH);
-
-  const users = requestState.status === "success" ? requestState.data.users : [];
+  const { getName } = useUsers();
 
   const showDataEntryKeptAlert = location.hash.startsWith("#data-entry-kept-") ? location.hash : null;
   const showDataEntriesDiscardedAlert = location.hash.startsWith("#data-entries-discarded-") ? location.hash : null;
@@ -40,7 +37,7 @@ export function ElectionStatusPage() {
     const id = parseInt(successAlert.substring(successAlert.lastIndexOf("-") + 1));
     pollingStationNumber = pollingStations.find((ps) => ps.id === id)?.number ?? 0;
     const typistId = statuses.find((status) => status.polling_station_id === id)?.first_entry_user_id;
-    typist = users.find((user) => user.id === typistId)?.fullname || "";
+    typist = getName(typistId);
   }
 
   function finishInput() {
@@ -101,7 +98,6 @@ export function ElectionStatusPage() {
           election={election}
           pollingStations={pollingStations}
           statuses={statuses}
-          users={users}
           navigate={(path) => void navigate(path)}
         />
       </main>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import cls from "@/features/resolve_differences/components/ResolveDifferences.module.css";
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { UsersProvider } from "@/hooks/user/UsersProvider";
 import {
   ElectionListRequestHandler,
   ElectionRequestHandler,
@@ -33,7 +34,9 @@ const renderPage = async () => {
     <TestUserProvider userRole="coordinator">
       <ElectionProvider electionId={1}>
         <ElectionStatusProvider electionId={1}>
-          <ResolveDifferencesPage />
+          <UsersProvider>
+            <ResolveDifferencesPage />
+          </UsersProvider>
         </ElectionStatusProvider>
       </ElectionProvider>
     </TestUserProvider>,

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Loader } from "@/components/ui/Loader/Loader";
 import { useNumericParam } from "@/hooks/useNumericParam";
+import { useUsers } from "@/hooks/user/useUsers";
 import { t } from "@/i18n/translate";
 import { ResolveDifferencesAction } from "@/types/generated/openapi";
 
@@ -42,10 +43,13 @@ export function ResolveDifferencesPage() {
     onSubmit,
     validationError,
   } = usePollingStationDataEntryDifferences(pollingStationId, afterSave);
+  const { getName } = useUsers();
 
   if (loading || status === null || dataEntryStructure === null) {
     return <Loader />;
   }
+
+  const { first_entry, first_entry_user_id, second_entry, second_entry_user_id } = status.state;
 
   return (
     <>
@@ -58,18 +62,14 @@ export function ResolveDifferencesPage() {
       </header>
       <main className={cls.resolveDifferences}>
         <aside>
-          <ResolveDifferencesOverview
-            first={status.state.first_entry}
-            second={status.state.second_entry}
-            structure={dataEntryStructure}
-          />
+          <ResolveDifferencesOverview first={first_entry} second={second_entry} structure={dataEntryStructure} />
         </aside>
         <article>
           <h2>{t("resolve_differences.title")}</h2>
           <p>{t("resolve_differences.page_content")}</p>
           <ResolveDifferencesTables
-            first={status.state.first_entry}
-            second={status.state.second_entry}
+            first={first_entry}
+            second={second_entry}
             structure={dataEntryStructure}
             action={action}
           />
@@ -85,7 +85,7 @@ export function ResolveDifferencesPage() {
               {validationError && <ChoiceList.Error id="resolve-differences-error">{validationError}</ChoiceList.Error>}
               <ChoiceList.Radio
                 id="keep_first_entry"
-                label={t("resolve_differences.options.keep_first_entry", { name: status.first_user })}
+                label={t("resolve_differences.options.keep_first_entry", { name: getName(first_entry_user_id) })}
                 checked={action === "keep_first_entry"}
                 onChange={() => {
                   setAction("keep_first_entry");
@@ -93,7 +93,7 @@ export function ResolveDifferencesPage() {
               />
               <ChoiceList.Radio
                 id="keep_second_entry"
-                label={t("resolve_differences.options.keep_second_entry", { name: status.second_user })}
+                label={t("resolve_differences.options.keep_second_entry", { name: getName(second_entry_user_id) })}
                 checked={action === "keep_second_entry"}
                 onChange={() => {
                   setAction("keep_second_entry");

--- a/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
+++ b/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 
 import { AnyApiError, isSuccess, NotFoundError } from "@/api/ApiResult";
 import { useApiClient } from "@/api/useApiClient";
-import { useInitialApiGet, useInitialApiGetWithErrors } from "@/api/useInitialApiGet";
+import { useInitialApiGet } from "@/api/useInitialApiGet";
 import { ElectionStatusProviderContext } from "@/hooks/election/ElectionStatusProviderContext";
 import { useElection } from "@/hooks/election/useElection";
 import { t } from "@/i18n/translate";
@@ -15,8 +15,6 @@ import {
   POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH,
   PollingStation,
   ResolveDifferencesAction,
-  USER_LIST_REQUEST_PATH,
-  UserListResponse,
 } from "@/types/generated/openapi";
 import { DataEntryStructure } from "@/types/types";
 import { getDataEntryStructureForDifferences } from "@/utils/dataEntryStructure";
@@ -24,8 +22,6 @@ import { getDataEntryStructureForDifferences } from "@/utils/dataEntryStructure"
 type EntriesDifferentStatus = {
   state: EntriesDifferent;
   status: "EntriesDifferent";
-  first_user: string;
-  second_user: string;
 };
 
 interface PollingStationDataEntryStatus {
@@ -56,10 +52,6 @@ export function usePollingStationDataEntryDifferences(
   const path: POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries`;
   const { requestState } = useInitialApiGet<DataEntryStatus>(path);
 
-  // fetch a list of users, to render the first entry and second entry user names
-  const usersPath: USER_LIST_REQUEST_PATH = "/api/user";
-  const { requestState: usersRequestState } = useInitialApiGetWithErrors<UserListResponse>(usersPath);
-
   // 404 error if polling station is not found
   if (!pollingStation) {
     throw new NotFoundError("error.polling_station_not_found");
@@ -75,11 +67,6 @@ export function usePollingStationDataEntryDifferences(
     throw requestState.error;
   }
 
-  // render generic error page when any error occurs
-  if (usersRequestState.status === "api-error") {
-    throw usersRequestState.error;
-  }
-
   // only allow polling stations with status "EntriesDifferent" to be resolved
   if (requestState.status === "success" && requestState.data.status !== "EntriesDifferent") {
     throw new NotFoundError("error.polling_station_not_found");
@@ -89,21 +76,8 @@ export function usePollingStationDataEntryDifferences(
   let dataEntryStructure: DataEntryStructure | null = null;
 
   // if the request was successful and the status is "EntriesDifferent", we can show the details
-  if (
-    requestState.status === "success" &&
-    usersRequestState.status === "success" &&
-    requestState.data.status === "EntriesDifferent"
-  ) {
-    const users = usersRequestState.data.users;
-    const state = requestState.data.state;
-    const firstUser = users.find((u) => u.id === state.first_entry_user_id);
-    const secondUser = users.find((u) => u.id === state.second_entry_user_id);
-
-    status = {
-      ...requestState.data,
-      first_user: firstUser?.fullname || firstUser?.username || "",
-      second_user: secondUser?.fullname || secondUser?.username || "",
-    };
+  if (requestState.status === "success" && requestState.data.status === "EntriesDifferent") {
+    status = requestState.data;
 
     dataEntryStructure = getDataEntryStructureForDifferences(
       election,
@@ -138,7 +112,7 @@ export function usePollingStationDataEntryDifferences(
     setAction,
     pollingStation,
     election,
-    loading: requestState.status === "loading" || usersRequestState.status === "loading",
+    loading: requestState.status === "loading",
     status,
     dataEntryStructure,
     onSubmit,

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsPage.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsPage.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { UsersProvider } from "@/hooks/user/UsersProvider";
 import {
   ElectionListRequestHandler,
   ElectionRequestHandler,
@@ -31,7 +32,9 @@ const renderPage = async () => {
     <TestUserProvider userRole="coordinator">
       <ElectionProvider electionId={1}>
         <ElectionStatusProvider electionId={1}>
-          <ResolveErrorsPage />
+          <UsersProvider>
+            <ResolveErrorsPage />
+          </UsersProvider>
         </ElectionStatusProvider>
       </ElectionProvider>
     </TestUserProvider>,

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsPage.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsPage.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Loader } from "@/components/ui/Loader/Loader";
 import { useNumericParam } from "@/hooks/useNumericParam";
+import { useUsers } from "@/hooks/user/useUsers";
 import { t, tx } from "@/i18n/translate";
 import { ResolveErrorsAction } from "@/types/generated/openapi";
 import { getDataEntryStructure } from "@/utils/dataEntryStructure";
@@ -30,8 +31,9 @@ export function ResolveErrorsPage() {
     void navigate(url);
   };
   const pollingStationId = useNumericParam("pollingStationId");
-  const { pollingStation, election, loading, dataEntry, userFullname, action, setAction, onSubmit, validationError } =
+  const { pollingStation, election, loading, dataEntry, action, setAction, onSubmit, validationError } =
     usePollingStationDataEntryErrors(pollingStationId, afterSave);
+  const { getName } = useUsers();
 
   if (loading || dataEntry === null) {
     return <Loader />;
@@ -81,7 +83,7 @@ export function ResolveErrorsPage() {
               <ChoiceList.Radio
                 id="keep_entry"
                 label={tx("resolve_errors.options.resume_first_entry", undefined, {
-                  name: userFullname ?? t("typist"),
+                  name: getName(dataEntry.first_entry_user_id, t("typist")),
                 })}
                 checked={action === "resume_first_entry"}
                 onChange={() => {

--- a/frontend/src/hooks/user/UsersProvider.tsx
+++ b/frontend/src/hooks/user/UsersProvider.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+import RequestStateHandler from "@/api/RequestStateHandler";
+import { useInitialApiGetWithErrors } from "@/api/useInitialApiGet";
+import { t } from "@/i18n/translate";
+import { USER_LIST_REQUEST_PATH, UserListResponse } from "@/types/generated/openapi";
+
+import { UsersProviderContext } from "./UsersProviderContext";
+
+export function UsersProvider({ children }: { children: React.ReactNode }) {
+  const path: USER_LIST_REQUEST_PATH = "/api/user";
+  const { requestState } = useInitialApiGetWithErrors<UserListResponse>(path);
+
+  return (
+    <RequestStateHandler
+      requestState={requestState}
+      notFoundMessage="error.not_found"
+      renderOnSuccess={({ users }) => {
+        function getName(userId?: number, fallback = t("user")) {
+          if (userId === undefined) {
+            return fallback;
+          }
+
+          const user = users.find(({ id }) => userId === id);
+          return user?.fullname ?? user?.username ?? fallback;
+        }
+
+        return <UsersProviderContext.Provider value={{ users, getName }}>{children}</UsersProviderContext.Provider>;
+      }}
+    />
+  );
+}

--- a/frontend/src/hooks/user/UsersProviderContext.ts
+++ b/frontend/src/hooks/user/UsersProviderContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+import { User } from "@/types/generated/openapi";
+
+export interface iUsersProviderContext {
+  users: User[];
+  getName: (userId?: number, fallback?: string) => string;
+}
+
+export const UsersProviderContext = createContext<iUsersProviderContext | undefined>(undefined);

--- a/frontend/src/hooks/user/useUsers.ts
+++ b/frontend/src/hooks/user/useUsers.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { UsersProviderContext } from "./UsersProviderContext";
+
+export function useUsers() {
+  const context = useContext(UsersProviderContext);
+
+  if (!context) {
+    throw new Error("useUsers must be used within an UsersProvider");
+  }
+
+  return context;
+}

--- a/frontend/src/i18n/locales/nl/generic.json
+++ b/frontend/src/i18n/locales/nl/generic.json
@@ -71,6 +71,7 @@
   "totals_list": "Totaal lijst {group_number}",
   "type": "Soort",
   "typist": "Invoerder",
+  "user": "Gebruiker",
   "version": "Versie",
   "vote_count": "Aantal stemmen",
   "yesterday": "gisteren",


### PR DESCRIPTION
- Add a new Provider and Layout to retrieve users once
- Expose users through a context, together with a `getName()` function to more easily get the user's name to display
- Hook to get the `getName()` function
- Use all of this on the coordinator status and resolve pages

To test:
Different pages (status page, resolve errors, resolve differences) should still show the user's name and the code is more clean, readable and therefore maintainable