### PR TITLE
Dedicated get resolve differences endpoint and only return status name

### DIFF
--- a/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
+++ b/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
@@ -11,7 +11,7 @@
       {
         "name": "event: serde_json::Value",
         "ordinal": 1,
-        "type_info": "Null"
+        "type_info": "Text"
       }
     ],
     "parameters": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1387,7 +1387,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PollingStationDataEntry"
+                  "$ref": "#/components/schemas/DataEntryStatusResponse"
                 }
               }
             }
@@ -1537,7 +1537,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PollingStationDataEntry"
+                  "$ref": "#/components/schemas/DataEntryStatusResponse"
                 }
               }
             }
@@ -1876,7 +1876,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataEntryStatus"
+                  "$ref": "#/components/schemas/DataEntryStatusResponse"
                 }
               }
             }
@@ -3462,132 +3462,6 @@
           }
         }
       },
-      "DataEntryStatus": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "status"
-            ],
-            "properties": {
-              "status": {
-                "type": "string",
-                "enum": [
-                  "FirstEntryNotStarted"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "state",
-              "status"
-            ],
-            "properties": {
-              "state": {
-                "$ref": "#/components/schemas/FirstEntryInProgress"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "FirstEntryInProgress"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "state",
-              "status"
-            ],
-            "properties": {
-              "state": {
-                "$ref": "#/components/schemas/FirstEntryHasErrors"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "FirstEntryHasErrors"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "state",
-              "status"
-            ],
-            "properties": {
-              "state": {
-                "$ref": "#/components/schemas/SecondEntryNotStarted"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "SecondEntryNotStarted"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "state",
-              "status"
-            ],
-            "properties": {
-              "state": {
-                "$ref": "#/components/schemas/SecondEntryInProgress"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "SecondEntryInProgress"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "state",
-              "status"
-            ],
-            "properties": {
-              "state": {
-                "$ref": "#/components/schemas/EntriesDifferent"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "EntriesDifferent"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "state",
-              "status"
-            ],
-            "properties": {
-              "state": {
-                "$ref": "#/components/schemas/Definitive"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "Definitive"
-                ]
-              }
-            }
-          }
-        ]
-      },
       "DataEntryStatusName": {
         "type": "string",
         "enum": [
@@ -3600,29 +3474,14 @@
           "definitive"
         ]
       },
-      "Definitive": {
+      "DataEntryStatusResponse": {
         "type": "object",
         "required": [
-          "first_entry_user_id",
-          "second_entry_user_id",
-          "finished_at"
+          "status"
         ],
         "properties": {
-          "finished_at": {
-            "type": "string",
-            "description": "When both data entries were finalised"
-          },
-          "first_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the first data entry",
-            "minimum": 0
-          },
-          "second_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the second data entry",
-            "minimum": 0
+          "status": {
+            "$ref": "#/components/schemas/DataEntryStatusName"
           }
         }
       },
@@ -4098,47 +3957,6 @@
           }
         }
       },
-      "EntriesDifferent": {
-        "type": "object",
-        "required": [
-          "first_entry_user_id",
-          "second_entry_user_id",
-          "first_entry",
-          "second_entry",
-          "first_entry_finished_at",
-          "second_entry_finished_at"
-        ],
-        "properties": {
-          "first_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "First data entry for a polling station"
-          },
-          "first_entry_finished_at": {
-            "type": "string",
-            "description": "When the first data entry was finalised"
-          },
-          "first_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the first data entry",
-            "minimum": 0
-          },
-          "second_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "Second data entry for a polling station"
-          },
-          "second_entry_finished_at": {
-            "type": "string",
-            "description": "When the second data entry was finalised"
-          },
-          "second_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the second data entry",
-            "minimum": 0
-          }
-        }
-      },
       "ErrorDetails": {
         "type": "object",
         "required": [
@@ -4212,62 +4030,6 @@
           },
           "reference": {
             "$ref": "#/components/schemas/ErrorReference"
-          }
-        }
-      },
-      "FirstEntryHasErrors": {
-        "type": "object",
-        "required": [
-          "first_entry_user_id",
-          "finalised_first_entry",
-          "first_entry_finished_at"
-        ],
-        "properties": {
-          "finalised_first_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "First data entry for a polling station"
-          },
-          "first_entry_finished_at": {
-            "type": "string",
-            "description": "When the first data entry was finalised"
-          },
-          "first_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the first data entry",
-            "minimum": 0
-          }
-        }
-      },
-      "FirstEntryInProgress": {
-        "type": "object",
-        "required": [
-          "progress",
-          "first_entry_user_id",
-          "first_entry",
-          "client_state"
-        ],
-        "properties": {
-          "client_state": {
-            "type": "object",
-            "description": "Client state for the data entry (arbitrary JSON)"
-          },
-          "first_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "First data entry for a polling station"
-          },
-          "first_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who is doing the first data entry",
-            "minimum": 0
-          },
-          "progress": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Data entry progress between 0 and 100",
-            "maximum": 100,
-            "minimum": 0
           }
         }
       },
@@ -4746,27 +4508,6 @@
           }
         }
       },
-      "PollingStationDataEntry": {
-        "type": "object",
-        "required": [
-          "polling_station_id",
-          "state",
-          "updated_at"
-        ],
-        "properties": {
-          "polling_station_id": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          "state": {
-            "$ref": "#/components/schemas/DataEntryStatus"
-          },
-          "updated_at": {
-            "type": "string"
-          }
-        }
-      },
       "PollingStationDetails": {
         "type": "object",
         "required": [
@@ -5169,79 +4910,6 @@
             "items": {
               "$ref": "#/components/schemas/PoliticalGroupStanding"
             }
-          }
-        }
-      },
-      "SecondEntryInProgress": {
-        "type": "object",
-        "required": [
-          "first_entry_user_id",
-          "finalised_first_entry",
-          "first_entry_finished_at",
-          "progress",
-          "second_entry_user_id",
-          "second_entry",
-          "client_state"
-        ],
-        "properties": {
-          "client_state": {
-            "type": "object",
-            "description": "Client state for the data entry (arbitrary JSON)"
-          },
-          "finalised_first_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "First data entry for a polling station"
-          },
-          "first_entry_finished_at": {
-            "type": "string",
-            "description": "When the first data entry was finalised"
-          },
-          "first_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the first data entry",
-            "minimum": 0
-          },
-          "progress": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Data entry progress between 0 and 100",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "second_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "Second data entry for a polling station"
-          },
-          "second_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who is doing the second data entry",
-            "minimum": 0
-          }
-        }
-      },
-      "SecondEntryNotStarted": {
-        "type": "object",
-        "required": [
-          "first_entry_user_id",
-          "finalised_first_entry",
-          "first_entry_finished_at"
-        ],
-        "properties": {
-          "finalised_first_entry": {
-            "$ref": "#/components/schemas/PollingStationResults",
-            "description": "First data entry for a polling station"
-          },
-          "first_entry_finished_at": {
-            "type": "string",
-            "description": "When the first data entry was finalised"
-          },
-          "first_entry_user_id": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User who did the first data entry",
-            "minimum": 0
           }
         }
       },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1295,13 +1295,15 @@
         }
       }
     },
-    "/api/polling_stations/{polling_station_id}/data_entries": {
+    "/api/polling_stations/{polling_station_id}/data_entries/resolve_differences": {
       "get": {
-        "operationId": "polling_station_data_entry_status",
+        "summary": "Get data entry differences to be resolved",
+        "operationId": "polling_station_data_entry_get_differences",
         "parameters": [
           {
             "name": "polling_station_id",
             "in": "path",
+            "description": "Polling station database id",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1312,17 +1314,27 @@
         ],
         "responses": {
           "200": {
-            "description": "Get data entries for polling station",
+            "description": "Data entry differences to be resolved",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataEntryStatus"
+                  "$ref": "#/components/schemas/DataEntryGetDifferencesResponse"
                 }
               }
             }
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No data entry with differences found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1342,9 +1354,7 @@
             }
           }
         }
-      }
-    },
-    "/api/polling_stations/{polling_station_id}/data_entries/resolve_differences": {
+      },
       "post": {
         "summary": "Resolve data entry differences by providing a `ResolveDifferencesAction`",
         "operationId": "polling_station_data_entry_resolve_differences",
@@ -3395,6 +3405,33 @@
               "integer",
               "null"
             ],
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "DataEntryGetDifferencesResponse": {
+        "type": "object",
+        "required": [
+          "first_entry_user_id",
+          "first_entry",
+          "second_entry_user_id",
+          "second_entry"
+        ],
+        "properties": {
+          "first_entry": {
+            "$ref": "#/components/schemas/PollingStationResults"
+          },
+          "first_entry_user_id": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "second_entry": {
+            "$ref": "#/components/schemas/PollingStationResults"
+          },
+          "second_entry_user_id": {
+            "type": "integer",
             "format": "int32",
             "minimum": 0
           }

--- a/backend/src/data_entry/structs.rs
+++ b/backend/src/data_entry/structs.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, types::Json};
 use utoipa::ToSchema;
 
-use super::status::DataEntryStatus;
+use super::status::{DataEntryStatus, DataEntryStatusName};
 use crate::{
     APIError,
     audit_log::DataEntryDetails,
@@ -313,5 +313,18 @@ mod tests {
         assert_eq!(curr_votes.proxy_certificate_count, 5);
         assert_eq!(curr_votes.voter_card_count, 7);
         assert_eq!(curr_votes.total_admitted_voters_count, 14);
+    }
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Debug)]
+pub struct DataEntryStatusResponse {
+    status: DataEntryStatusName,
+}
+
+impl From<PollingStationDataEntry> for DataEntryStatusResponse {
+    fn from(data_entry: PollingStationDataEntry) -> Self {
+        DataEntryStatusResponse {
+            status: data_entry.state.0.status_name(),
+        }
     }
 }

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -2,7 +2,7 @@ import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, test } from "vitest";
 
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
-import { dataEntryStatusDifferences, firstEntryHasErrorsStatus } from "@/testing/api-mocks/DataEntryMockData";
+import { entriesDifferentStatus, firstEntryHasErrorsStatus } from "@/testing/api-mocks/DataEntryMockData";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
   ElectionRequestHandler,
@@ -73,7 +73,7 @@ describe("Test CheckAndSaveForm", () => {
 
     // set up a listener to check if the finalisation request is made
     const finalise = spyOnHandler(PollingStationDataEntryFinaliseHandler);
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, dataEntryStatusDifferences);
+    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, entriesDifferentStatus);
 
     // click the save button
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -2,7 +2,6 @@ import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, test } from "vitest";
 
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
-import { entriesDifferentStatus, firstEntryHasErrorsStatus } from "@/testing/api-mocks/DataEntryMockData";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
   ElectionRequestHandler,
@@ -13,6 +12,7 @@ import {
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
 import { overrideOnce, server } from "@/testing/server";
 import { renderReturningRouter, screen, spyOnHandler, within } from "@/testing/test-utils";
+import { DataEntryStatusResponse } from "@/types/generated/openapi";
 import { ValidationResultSet } from "@/utils/ValidationResults";
 
 import { getDefaultDataEntryState, getEmptyDataEntryRequest, getInitialValues } from "../../testing/mock-data";
@@ -73,7 +73,9 @@ describe("Test CheckAndSaveForm", () => {
 
     // set up a listener to check if the finalisation request is made
     const finalise = spyOnHandler(PollingStationDataEntryFinaliseHandler);
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, entriesDifferentStatus);
+
+    const response: DataEntryStatusResponse = { status: "entries_different" };
+    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, response);
 
     // click the save button
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
@@ -92,7 +94,9 @@ describe("Test CheckAndSaveForm", () => {
 
     // set up a listener to check if the finalisation request is made
     const finalise = spyOnHandler(PollingStationDataEntryFinaliseHandler);
-    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, firstEntryHasErrorsStatus);
+
+    const response: DataEntryStatusResponse = { status: "first_entry_has_errors" };
+    overrideOnce("post", "/api/polling_stations/1/data_entries/1/finalise", 200, response);
 
     // click the save button
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -94,9 +94,9 @@ export function CheckAndSaveForm() {
 
     const dataEntryStatus = await onFinaliseDataEntry();
     if (dataEntryStatus !== undefined) {
-      if (dataEntryStatus.status === "EntriesDifferent") {
+      if (dataEntryStatus.status === "entries_different") {
         await navigate(`/elections/${election.id}/data-entry#data-entry-different`);
-      } else if (dataEntryStatus.status === "FirstEntryHasErrors") {
+      } else if (dataEntryStatus.status === "first_entry_has_errors") {
         await navigate(`/elections/${election.id}/data-entry#data-entry-errors`);
       } else {
         await navigate(`/elections/${election.id}/data-entry#data-entry-${entryNumber}-saved`);

--- a/frontend/src/features/data_entry/types/types.ts
+++ b/frontend/src/features/data_entry/types/types.ts
@@ -3,14 +3,13 @@ import { Dispatch } from "react";
 import { AnyApiError } from "@/api/ApiResult";
 import {
   ClaimDataEntryResponse,
-  DataEntryStatus,
+  DataEntryStatusResponse,
   ElectionWithPoliticalGroups,
   PollingStationResults,
   ValidationResults,
 } from "@/types/generated/openapi";
 import { DataEntryStructure, FormSectionId, SectionValues } from "@/types/types";
-
-import { ValidationResultSet } from "../../../utils/ValidationResults";
+import { ValidationResultSet } from "@/utils/ValidationResults";
 
 export interface DataEntryState {
   // state from providers
@@ -37,7 +36,7 @@ export interface DataEntryStateAndActions extends DataEntryState {
   dispatch: DataEntryDispatch;
   onSubmitForm: (currentValues: SectionValues, options?: SubmitCurrentFormOptions) => Promise<boolean>;
   onDeleteDataEntry: () => Promise<boolean>;
-  onFinaliseDataEntry: () => Promise<DataEntryStatus | undefined>;
+  onFinaliseDataEntry: () => Promise<DataEntryStatusResponse | undefined>;
   register: (formSectionId: FormSectionId) => void;
   setCache: (cache: TemporaryCache) => void;
   updateFormSection: (partialFormSection: Partial<FormSection>) => void;

--- a/frontend/src/features/data_entry/utils/actions.ts
+++ b/frontend/src/features/data_entry/utils/actions.ts
@@ -1,6 +1,6 @@
 import { ApiClient } from "@/api/ApiClient";
 import { ApiResult, isSuccess } from "@/api/ApiResult";
-import { DataEntry, DataEntryStatus, SaveDataEntryResponse } from "@/types/generated/openapi";
+import { DataEntry, DataEntryStatusResponse, SaveDataEntryResponse } from "@/types/generated/openapi";
 import { FormSectionId, SectionValues } from "@/types/types";
 import { mapSectionValues } from "@/utils/dataEntryMapping";
 
@@ -138,10 +138,10 @@ export function onDeleteDataEntry(client: ApiClient, requestPath: string, dispat
 }
 
 export function onFinaliseDataEntry(client: ApiClient, requestPath: string, dispatch: DataEntryDispatch) {
-  return async (): Promise<DataEntryStatus | undefined> => {
+  return async (): Promise<DataEntryStatusResponse | undefined> => {
     dispatch({ type: "SET_STATUS", status: "finalising" });
 
-    const response = await client.postRequest<DataEntryStatus>(requestPath);
+    const response = await client.postRequest<DataEntryStatusResponse>(requestPath);
 
     if (!isSuccess(response)) {
       dispatch({ type: "SET_STATUS", status: "idle" });

--- a/frontend/src/features/data_entry/utils/reducer.test.ts
+++ b/frontend/src/features/data_entry/utils/reducer.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test, vi } from "vitest";
 
 import { ApiClient } from "@/api/ApiClient";
 import { ApiResponseStatus } from "@/api/ApiResult";
-import { secondEntryNotStartedStatus } from "@/testing/api-mocks/DataEntryMockData";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
   PollingStationDataEntryDeleteHandler,
@@ -365,6 +364,6 @@ describe("onFinaliseDataEntry", () => {
       { type: "SET_STATUS", status: "finalised" } satisfies DataEntryAction,
     ]);
 
-    expect(result).toStrictEqual(secondEntryNotStartedStatus);
+    expect(result?.status).toBe("second_entry_not_started");
   });
 });

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -11,8 +11,8 @@ import {
   ElectionListRequestHandler,
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
+  PollingStationDataEntryGetDifferencesHandler,
   PollingStationDataEntryResolveDifferencesHandler,
-  PollingStationDataEntryStatusEntriesDifferentHandler,
   UserListRequestHandler,
 } from "@/testing/api-mocks/RequestHandlers";
 import { server } from "@/testing/server";
@@ -50,8 +50,8 @@ describe("ResolveDifferencesPage", () => {
       ElectionRequestHandler,
       ElectionStatusRequestHandler,
       ElectionListRequestHandler,
+      PollingStationDataEntryGetDifferencesHandler,
       PollingStationDataEntryResolveDifferencesHandler,
-      PollingStationDataEntryStatusEntriesDifferentHandler,
       UserListRequestHandler,
     );
   });

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -36,7 +36,7 @@ export function ResolveDifferencesPage() {
     pollingStation,
     election,
     loading,
-    status,
+    differences,
     dataEntryStructure,
     action,
     setAction,
@@ -45,11 +45,11 @@ export function ResolveDifferencesPage() {
   } = usePollingStationDataEntryDifferences(pollingStationId, afterSave);
   const { getName } = useUsers();
 
-  if (loading || status === null || dataEntryStructure === null) {
+  if (loading || differences === null || dataEntryStructure === null) {
     return <Loader />;
   }
 
-  const { first_entry, first_entry_user_id, second_entry, second_entry_user_id } = status.state;
+  const { first_entry, first_entry_user_id, second_entry, second_entry_user_id } = differences;
 
   return (
     <>

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -3,8 +3,6 @@ import {
   ClaimDataEntryResponse,
   DataEntryGetDifferencesResponse,
   DataEntryGetErrorsResponse,
-  DataEntryStatus,
-  PollingStationDataEntry,
   PollingStationResults,
   SaveDataEntryResponse,
   ValidationResults,
@@ -161,56 +159,12 @@ export const dataEntryStatusDifferences: DataEntryGetDifferencesResponse = {
   },
 };
 
-export const entriesDifferentStatus: DataEntryStatus = {
-  state: {
-    ...dataEntryStatusDifferences,
-    first_entry_finished_at: "",
-    second_entry_finished_at: "",
-  },
-  status: "EntriesDifferent",
-};
-
-export const firstEntryHasErrorsStatus: DataEntryStatus = {
-  state: {
-    finalised_first_entry: getEmptyDataEntryRequest().data,
-    first_entry_finished_at: "",
-    first_entry_user_id: 1,
-  },
-  status: "FirstEntryHasErrors",
-};
-
-export const secondEntryNotStartedStatus: DataEntryStatus = {
-  state: {
-    finalised_first_entry: getEmptyDataEntryRequest().data,
-    first_entry_finished_at: "",
-    first_entry_user_id: 1,
-  },
-  status: "SecondEntryNotStarted",
-};
-
-export const dataEntryResolveDifferencesMockResponse: PollingStationDataEntry = {
-  polling_station_id: 3,
-  updated_at: "2025-04-14T17:19:42.133270353Z",
-  state: {
-    state: {
-      finished_at: "2025-04-14T17:19:42.133270353Z",
-      first_entry_user_id: 2,
-      second_entry_user_id: 1,
-    },
-    status: "Definitive",
-  },
-};
-
 export const dataEntryGetErrorsMockResponse: DataEntryGetErrorsResponse = {
-  ...firstEntryHasErrorsStatus.state,
+  finalised_first_entry: getEmptyDataEntryRequest().data,
+  first_entry_finished_at: "",
+  first_entry_user_id: 1,
   validation_results: {
     errors: [validationResultMockData.F101],
     warnings: [validationResultMockData.W201, validationResultMockData.W301],
   },
-};
-
-export const dataEntryResolveErrorsMockResponse: PollingStationDataEntry = {
-  polling_station_id: 3,
-  updated_at: "2025-04-14T17:19:42.133270353Z",
-  state: secondEntryNotStartedStatus,
 };

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -1,6 +1,7 @@
 import { getEmptyDataEntryRequest } from "@/features/data_entry/testing/mock-data";
 import {
   ClaimDataEntryResponse,
+  DataEntryGetDifferencesResponse,
   DataEntryGetErrorsResponse,
   DataEntryStatus,
   PollingStationDataEntry,
@@ -59,110 +60,114 @@ export const saveDataEntryResponse: SaveDataEntryResponse = {
   validation_results: emptyValidationResults,
 };
 
-export const dataEntryStatusDifferences: DataEntryStatus = {
-  status: "EntriesDifferent",
-  state: {
-    first_entry_user_id: 3,
-    second_entry_user_id: 4,
-    first_entry: {
-      recounted: false,
-      voters_counts: {
-        poll_card_count: 2,
-        proxy_certificate_count: 0,
-        voter_card_count: 0,
-        total_admitted_voters_count: 2,
-      },
-      votes_counts: {
-        votes_candidates_count: 2,
-        blank_votes_count: 0,
-        invalid_votes_count: 0,
-        total_votes_cast_count: 2,
-      },
-      differences_counts: {
-        more_ballots_count: 0,
-        fewer_ballots_count: 0,
-        unreturned_ballots_count: 0,
-        too_few_ballots_handed_out_count: 0,
-        too_many_ballots_handed_out_count: 0,
-        other_explanation_count: 0,
-        no_explanation_count: 0,
-      },
-      political_group_votes: [
-        {
-          number: 1,
-          total: 0,
-          candidate_votes: politicalGroupMockData.candidates.map((c) => ({
-            number: c.number,
-            votes: 0,
-          })),
-        },
-        {
-          number: 2,
-          total: 2,
-          candidate_votes: [
-            {
-              number: 1,
-              votes: 2,
-            },
-            {
-              number: 2,
-              votes: 0,
-            },
-          ],
-        },
-      ],
+export const dataEntryStatusDifferences: DataEntryGetDifferencesResponse = {
+  first_entry_user_id: 3,
+  second_entry_user_id: 4,
+  first_entry: {
+    recounted: false,
+    voters_counts: {
+      poll_card_count: 2,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 2,
     },
-    second_entry: {
-      recounted: false,
-      voters_counts: {
-        poll_card_count: 2,
-        proxy_certificate_count: 0,
-        voter_card_count: 0,
-        total_admitted_voters_count: 2,
-      },
-      votes_counts: {
-        votes_candidates_count: 2,
-        blank_votes_count: 0,
-        invalid_votes_count: 0,
-        total_votes_cast_count: 2,
-      },
-      differences_counts: {
-        more_ballots_count: 0,
-        fewer_ballots_count: 0,
-        unreturned_ballots_count: 0,
-        too_few_ballots_handed_out_count: 0,
-        too_many_ballots_handed_out_count: 0,
-        other_explanation_count: 0,
-        no_explanation_count: 0,
-      },
-      political_group_votes: [
-        {
-          number: 1,
-          total: 0,
-          candidate_votes: politicalGroupMockData.candidates.map((c) => ({
-            number: c.number,
-            votes: 0,
-          })),
-        },
-        {
-          number: 2,
-          total: 2,
-          candidate_votes: [
-            {
-              number: 1,
-              votes: 0,
-            },
-            {
-              number: 2,
-              votes: 2,
-            },
-          ],
-        },
-      ],
+    votes_counts: {
+      votes_candidates_count: 2,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 2,
     },
-    first_entry_finished_at: "2025-04-14T17:17:27.536338155Z",
-    second_entry_finished_at: "2025-04-14T17:18:45.433270353Z",
+    differences_counts: {
+      more_ballots_count: 0,
+      fewer_ballots_count: 0,
+      unreturned_ballots_count: 0,
+      too_few_ballots_handed_out_count: 0,
+      too_many_ballots_handed_out_count: 0,
+      other_explanation_count: 0,
+      no_explanation_count: 0,
+    },
+    political_group_votes: [
+      {
+        number: 1,
+        total: 0,
+        candidate_votes: politicalGroupMockData.candidates.map((c) => ({
+          number: c.number,
+          votes: 0,
+        })),
+      },
+      {
+        number: 2,
+        total: 2,
+        candidate_votes: [
+          {
+            number: 1,
+            votes: 2,
+          },
+          {
+            number: 2,
+            votes: 0,
+          },
+        ],
+      },
+    ],
   },
+  second_entry: {
+    recounted: false,
+    voters_counts: {
+      poll_card_count: 2,
+      proxy_certificate_count: 0,
+      voter_card_count: 0,
+      total_admitted_voters_count: 2,
+    },
+    votes_counts: {
+      votes_candidates_count: 2,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 2,
+    },
+    differences_counts: {
+      more_ballots_count: 0,
+      fewer_ballots_count: 0,
+      unreturned_ballots_count: 0,
+      too_few_ballots_handed_out_count: 0,
+      too_many_ballots_handed_out_count: 0,
+      other_explanation_count: 0,
+      no_explanation_count: 0,
+    },
+    political_group_votes: [
+      {
+        number: 1,
+        total: 0,
+        candidate_votes: politicalGroupMockData.candidates.map((c) => ({
+          number: c.number,
+          votes: 0,
+        })),
+      },
+      {
+        number: 2,
+        total: 2,
+        candidate_votes: [
+          {
+            number: 1,
+            votes: 0,
+          },
+          {
+            number: 2,
+            votes: 2,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const entriesDifferentStatus: DataEntryStatus = {
+  state: {
+    ...dataEntryStatusDifferences,
+    first_entry_finished_at: "",
+    second_entry_finished_at: "",
+  },
+  status: "EntriesDifferent",
 };
 
 export const firstEntryHasErrorsStatus: DataEntryStatus = {

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -13,7 +13,7 @@ import {
   CommitteeSessionListResponse,
   DataEntryGetDifferencesResponse,
   DataEntryGetErrorsResponse,
-  DataEntryStatus,
+  DataEntryStatusResponse,
   ELECTION_COMMITTEE_SESSION_LIST_REQUEST_PARAMS,
   ELECTION_COMMITTEE_SESSION_LIST_REQUEST_PATH,
   ELECTION_DETAILS_REQUEST_PARAMS,
@@ -61,7 +61,6 @@ import {
   POLLING_STATION_UPDATE_REQUEST_PARAMS,
   POLLING_STATION_UPDATE_REQUEST_PATH,
   PollingStation,
-  PollingStationDataEntry,
   PollingStationListResponse,
   SaveDataEntryResponse,
   User,
@@ -86,11 +85,8 @@ import { committeeSessionListMockResponse } from "./CommitteeSessionMockData";
 import {
   claimDataEntryResponse,
   dataEntryGetErrorsMockResponse,
-  dataEntryResolveDifferencesMockResponse,
-  dataEntryResolveErrorsMockResponse,
   dataEntryStatusDifferences,
   saveDataEntryResponse,
-  secondEntryNotStartedStatus,
 } from "./DataEntryMockData";
 import { electionDetailsMockResponse, electionListMockResponse } from "./ElectionMockData";
 import { statusResponseMock } from "./ElectionStatusMockData";
@@ -200,19 +196,19 @@ export const PollingStationDataEntryGetErrorsHandler = http.get<
 export const PollingStationDataEntryResolveDifferencesHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PARAMS>,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY,
-  PollingStationDataEntry,
+  DataEntryStatusResponse,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PATH
 >("/api/polling_stations/3/data_entries/resolve_differences", () =>
-  HttpResponse.json(dataEntryResolveDifferencesMockResponse, { status: 200 }),
+  HttpResponse.json({ status: "definitive" }, { status: 200 }),
 );
 
 export const PollingStationDataEntryResolveErrorsHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_RESOLVE_ERRORS_REQUEST_PARAMS>,
   POLLING_STATION_DATA_ENTRY_RESOLVE_ERRORS_REQUEST_BODY,
-  PollingStationDataEntry,
+  DataEntryStatusResponse,
   POLLING_STATION_DATA_ENTRY_RESOLVE_ERRORS_REQUEST_PATH
 >("/api/polling_stations/5/data_entries/resolve_errors", () =>
-  HttpResponse.json(dataEntryResolveErrorsMockResponse, { status: 200 }),
+  HttpResponse.json({ status: "definitive" }, { status: 200 }),
 );
 
 // get polling stations
@@ -254,10 +250,10 @@ export const PollingStationDataEntryDeleteHandler = http.delete<
 export const PollingStationDataEntryFinaliseHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PARAMS>,
   null,
-  DataEntryStatus | ErrorResponse,
+  DataEntryStatusResponse | ErrorResponse,
   POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PATH
 >("/api/polling_stations/1/data_entries/1/finalise", () =>
-  HttpResponse.json(secondEntryNotStartedStatus, { status: 200 }),
+  HttpResponse.json({ status: "second_entry_not_started" }, { status: 200 }),
 );
 
 export const PollingStationCreateHandler = http.post<

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -11,6 +11,7 @@ import {
   AuditLogListResponse,
   ClaimDataEntryResponse,
   CommitteeSessionListResponse,
+  DataEntryGetDifferencesResponse,
   DataEntryGetErrorsResponse,
   DataEntryStatus,
   ELECTION_COMMITTEE_SESSION_LIST_REQUEST_PARAMS,
@@ -37,6 +38,8 @@ import {
   POLLING_STATION_DATA_ENTRY_DELETE_REQUEST_PATH,
   POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PARAMS,
   POLLING_STATION_DATA_ENTRY_FINALISE_REQUEST_PATH,
+  POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PARAMS,
+  POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PATH,
   POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PARAMS,
   POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PATH,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY,
@@ -48,8 +51,6 @@ import {
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_BODY,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PARAMS,
   POLLING_STATION_DATA_ENTRY_SAVE_REQUEST_PATH,
-  POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PARAMS,
-  POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH,
   POLLING_STATION_DELETE_REQUEST_PARAMS,
   POLLING_STATION_DELETE_REQUEST_PATH,
   POLLING_STATION_GET_REQUEST_PARAMS,
@@ -178,6 +179,15 @@ export const LoginHandler = http.post<LOGIN_REQUEST_PARAMS, LOGIN_REQUEST_BODY, 
   () => HttpResponse.json(loginResponseMockData, { status: 200 }),
 );
 
+export const PollingStationDataEntryGetDifferencesHandler = http.get<
+  ParamsToString<POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PARAMS>,
+  null,
+  DataEntryGetDifferencesResponse,
+  POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PATH
+>("/api/polling_stations/3/data_entries/resolve_differences", () =>
+  HttpResponse.json(dataEntryStatusDifferences, { status: 200 }),
+);
+
 export const PollingStationDataEntryGetErrorsHandler = http.get<
   ParamsToString<POLLING_STATION_DATA_ENTRY_GET_ERRORS_REQUEST_PARAMS>,
   null,
@@ -186,13 +196,6 @@ export const PollingStationDataEntryGetErrorsHandler = http.get<
 >("/api/polling_stations/5/data_entries/resolve_errors", () =>
   HttpResponse.json(dataEntryGetErrorsMockResponse, { status: 200 }),
 );
-
-export const PollingStationDataEntryStatusEntriesDifferentHandler = http.get<
-  ParamsToString<POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PARAMS>,
-  null,
-  DataEntryStatus,
-  POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH
->("/api/polling_stations/3/data_entries", () => HttpResponse.json(dataEntryStatusDifferences, { status: 200 }));
 
 export const PollingStationDataEntryResolveDifferencesHandler = http.post<
   ParamsToString<POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PARAMS>,
@@ -343,8 +346,8 @@ export const handlers: HttpHandler[] = [
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
   LoginHandler,
+  PollingStationDataEntryGetDifferencesHandler,
   PollingStationDataEntryGetErrorsHandler,
-  PollingStationDataEntryStatusEntriesDifferentHandler,
   PollingStationDataEntryResolveDifferencesHandler,
   PollingStationDataEntryResolveErrorsHandler,
   PollingStationListRequestHandler,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -117,13 +117,12 @@ export type AUDIT_LOG_LIST_REQUEST_PATH = `/api/log`;
 export type AUDIT_LOG_LIST_USERS_REQUEST_PARAMS = Record<string, never>;
 export type AUDIT_LOG_LIST_USERS_REQUEST_PATH = `/api/log-users`;
 
-// /api/polling_stations/{polling_station_id}/data_entries
-export interface POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PARAMS {
+// /api/polling_stations/{polling_station_id}/data_entries/resolve_differences
+export interface POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PARAMS {
   polling_station_id: number;
 }
-export type POLLING_STATION_DATA_ENTRY_STATUS_REQUEST_PATH = `/api/polling_stations/${number}/data_entries`;
-
-// /api/polling_stations/{polling_station_id}/data_entries/resolve_differences
+export type POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PATH =
+  `/api/polling_stations/${number}/data_entries/resolve_differences`;
 export interface POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PARAMS {
   polling_station_id: number;
 }
@@ -425,6 +424,13 @@ export interface DataEntryDetails {
   firstEntryUserId?: number | null;
   pollingStationId: number;
   secondEntryUserId?: number | null;
+}
+
+export interface DataEntryGetDifferencesResponse {
+  first_entry: PollingStationResults;
+  first_entry_user_id: number;
+  second_entry: PollingStationResults;
+  second_entry_user_id: number;
 }
 
 export interface DataEntryGetErrorsResponse {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -440,15 +440,6 @@ export interface DataEntryGetErrorsResponse {
   validation_results: ValidationResults;
 }
 
-export type DataEntryStatus =
-  | { status: "FirstEntryNotStarted" }
-  | { state: FirstEntryInProgress; status: "FirstEntryInProgress" }
-  | { state: FirstEntryHasErrors; status: "FirstEntryHasErrors" }
-  | { state: SecondEntryNotStarted; status: "SecondEntryNotStarted" }
-  | { state: SecondEntryInProgress; status: "SecondEntryInProgress" }
-  | { state: EntriesDifferent; status: "EntriesDifferent" }
-  | { state: Definitive; status: "Definitive" };
-
 export type DataEntryStatusName =
   | "first_entry_not_started"
   | "first_entry_in_progress"
@@ -458,13 +449,8 @@ export type DataEntryStatusName =
   | "entries_different"
   | "definitive";
 
-export interface Definitive {
-  /** When both data entries were finalised */
-  finished_at: string;
-  /** User who did the first data entry */
-  first_entry_user_id: number;
-  /** User who did the second data entry */
-  second_entry_user_id: number;
+export interface DataEntryStatusResponse {
+  status: DataEntryStatusName;
 }
 
 /**
@@ -628,21 +614,6 @@ export interface ElectionWithPoliticalGroups {
   political_groups: PoliticalGroup[];
 }
 
-export interface EntriesDifferent {
-  /** First data entry for a polling station */
-  first_entry: PollingStationResults;
-  /** When the first data entry was finalised */
-  first_entry_finished_at: string;
-  /** User who did the first data entry */
-  first_entry_user_id: number;
-  /** Second data entry for a polling station */
-  second_entry: PollingStationResults;
-  /** When the second data entry was finalised */
-  second_entry_finished_at: string;
-  /** User who did the second data entry */
-  second_entry_user_id: number;
-}
-
 export interface ErrorDetails {
   level: AuditEventLevel;
   path: string;
@@ -692,26 +663,6 @@ export interface ErrorResponse {
   error: string;
   fatal: boolean;
   reference: ErrorReference;
-}
-
-export interface FirstEntryHasErrors {
-  /** First data entry for a polling station */
-  finalised_first_entry: PollingStationResults;
-  /** When the first data entry was finalised */
-  first_entry_finished_at: string;
-  /** User who did the first data entry */
-  first_entry_user_id: number;
-}
-
-export interface FirstEntryInProgress {
-  /** Client state for the data entry (arbitrary JSON) */
-  client_state: unknown;
-  /** First data entry for a polling station */
-  first_entry: PollingStationResults;
-  /** User who is doing the first data entry */
-  first_entry_user_id: number;
-  /** Data entry progress between 0 and 100 */
-  progress: number;
 }
 
 /**
@@ -877,12 +828,6 @@ export interface PollingStation {
   postal_code: string;
 }
 
-export interface PollingStationDataEntry {
-  polling_station_id: number;
-  state: DataEntryStatus;
-  updated_at: string;
-}
-
 export interface PollingStationDetails {
   pollingStationAddress: string;
   pollingStationElectionId: number;
@@ -1005,32 +950,6 @@ export interface SeatChangeStep {
   change: SeatChange;
   residual_seat_number?: number;
   standings: PoliticalGroupStanding[];
-}
-
-export interface SecondEntryInProgress {
-  /** Client state for the data entry (arbitrary JSON) */
-  client_state: unknown;
-  /** First data entry for a polling station */
-  finalised_first_entry: PollingStationResults;
-  /** When the first data entry was finalised */
-  first_entry_finished_at: string;
-  /** User who did the first data entry */
-  first_entry_user_id: number;
-  /** Data entry progress between 0 and 100 */
-  progress: number;
-  /** Second data entry for a polling station */
-  second_entry: PollingStationResults;
-  /** User who is doing the second data entry */
-  second_entry_user_id: number;
-}
-
-export interface SecondEntryNotStarted {
-  /** First data entry for a polling station */
-  finalised_first_entry: PollingStationResults;
-  /** When the first data entry was finalised */
-  first_entry_finished_at: string;
-  /** User who did the first data entry */
-  first_entry_user_id: number;
 }
 
 /**


### PR DESCRIPTION
First commit:
- Add dedicated endpoint to get the differences for resolve differences
- Use endpoint for resolve differences
- Remove now unused get data entries / data entry status endpoint

Second commit:
- Change response for data entry finalise and resolve differences & errors endpoint to only return status name, so that the data entry status object is not exposed in the API anymore and has to be mocked etc

