### PR TITLE
Fix Clippy uninlined_format_args warnings

### DIFF
--- a/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
+++ b/backend/.sqlx/query-4660bfcdf0bdee50df05c66848f10b73d40829367369694cc0a563f476ec3a38.json
@@ -11,7 +11,7 @@
       {
         "name": "event: serde_json::Value",
         "ordinal": 1,
-        "type_info": "Text"
+        "type_info": "Null"
       }
     ],
     "parameters": {

--- a/backend/src/apportionment/fraction.rs
+++ b/backend/src/apportionment/fraction.rs
@@ -148,7 +148,7 @@ impl Display for Fraction {
             if remainder > 0 {
                 write!(f, "{} {}/{}", integer, remainder, self.denominator)
             } else {
-                write!(f, "{}", integer)
+                write!(f, "{integer}")
             }
         } else {
             write!(f, "{}/{}", self.numerator, self.denominator)
@@ -158,7 +158,7 @@ impl Display for Fraction {
 
 impl Debug for Fraction {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -658,7 +658,7 @@ impl Display for DataEntryTransitionError {
             }
             DataEntryTransitionError::Invalid => write!(f, "Invalid state transition"),
             DataEntryTransitionError::ValidatorError(data_error) => {
-                write!(f, "Validator error: {}", data_error)
+                write!(f, "Validator error: {data_error}")
             }
             DataEntryTransitionError::ValidationError(_) => write!(f, "Validation errors"),
         }
@@ -932,8 +932,7 @@ mod tests {
             .expect("should be Ok");
         assert!(
             matches!(next, DataEntryStatus::FirstEntryHasErrors(_)),
-            "actual: {:?}",
-            next
+            "actual: {next:?}"
         );
     }
 
@@ -1314,7 +1313,7 @@ mod tests {
         if let DataEntryStatus::SecondEntryNotStarted(kept_entry) = next {
             assert_eq!(kept_entry.finalised_first_entry, second_entry);
         } else {
-            panic!("{:?}", next)
+            panic!("{next:?}")
         };
     }
 
@@ -1340,7 +1339,7 @@ mod tests {
         if let DataEntryStatus::FirstEntryHasErrors(kept_entry) = next {
             assert_eq!(kept_entry.finalised_first_entry, second_entry);
         } else {
-            panic!("{:?}", next)
+            panic!("{next:?}")
         };
     }
 

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -105,7 +105,7 @@ impl FieldPath {
         path.components
             .last_mut()
             .expect("FieldPath constructed with no components")
-            .push_str(&format!("[{}]", index));
+            .push_str(&format!("[{index}]"));
         path
     }
 
@@ -122,7 +122,7 @@ impl fmt::Display for FieldPath {
             if i > 0 {
                 write!(f, ".")?;
             }
-            write!(f, "{}", component)?;
+            write!(f, "{component}")?;
         }
 
         Ok(())

--- a/backend/src/eml/hash.rs
+++ b/backend/src/eml/hash.rs
@@ -22,8 +22,8 @@ impl From<&[u8]> for EmlHash {
 
         while let (Some(b1), Some(b2)) = (iter.next(), iter.next()) {
             let mut chunk = String::new();
-            write!(&mut chunk, "{:02x}", b1).expect("Writing to a string cannot fail");
-            write!(&mut chunk, "{:02x}", b2).expect("Writing to a string cannot fail");
+            write!(&mut chunk, "{b1:02x}").expect("Writing to a string cannot fail");
+            write!(&mut chunk, "{b2:02x}").expect("Writing to a string cannot fail");
             chunks[chunk_counter] = chunk;
             chunk_counter += 1;
         }


### PR DESCRIPTION
Fix uninlined_format_args lints as reported by Clippy since Rust 1.88.
