### PR TITLE
Add overview to resolve errors feature

### DIFF
--- a/frontend/src/components/ui/Feedback/Feedback.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.tsx
@@ -5,6 +5,7 @@ import { t, tx } from "@/i18n/translate";
 import { Role } from "@/types/generated/openapi";
 import { AlertType, FeedbackId } from "@/types/ui";
 import { cn } from "@/utils/classnames";
+import { dottedCode } from "@/utils/ValidationResults";
 
 import { AlertIcon } from "../Icon/AlertIcon";
 import cls from "./Feedback.module.css";
@@ -27,7 +28,7 @@ export function Feedback({ id, type, data, userRole, shouldFocus = true }: Feedb
     data?.map(
       (code: ClientValidationResultCode): FeedbackItem => ({
         title: t(`feedback.${code}.${role}.title`),
-        code: `${code[0]}.${code.slice(1)}`,
+        code: dottedCode(code),
         content: tx(`feedback.${code}.${role}.content`, { link }),
         action: role === "typist" && code === "F101" ? tx(`feedback.F101.${role}.action`, {}) : undefined,
       }),

--- a/frontend/src/components/ui/StatusList/StatusList.module.css
+++ b/frontend/src/components/ui/StatusList/StatusList.module.css
@@ -5,7 +5,7 @@
 
   li {
     display: flex;
-    align-items: center;
+    align-items: start;
     margin-bottom: 1rem;
     gap: 0.5rem;
 

--- a/frontend/src/components/ui/StatusList/StatusList.tsx
+++ b/frontend/src/components/ui/StatusList/StatusList.tsx
@@ -35,6 +35,10 @@ StatusList.Item = function StatusListItem({ status, children, emphasis, padding,
   );
 };
 
-StatusList.Title = function StatusListTitle({ children }: { children: React.ReactNode }) {
-  return <div className={cls.title}>{children}</div>;
+StatusList.Title = function StatusListTitle({ id, children }: { id?: string; children: React.ReactNode }) {
+  return (
+    <div id={id} className={cls.title}>
+      {children}
+    </div>
+  );
 };

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -14,6 +14,7 @@ import { useElection } from "@/hooks/election/useElection";
 import { t, tx } from "@/i18n/translate";
 import { FormSectionId } from "@/types/types";
 import { KeyboardKey, MenuStatus } from "@/types/ui";
+import { dottedCode } from "@/utils/ValidationResults";
 
 import { useDataEntryContext } from "../../hooks/useDataEntryContext";
 import { useFormKeyboardNavigation } from "../../hooks/useFormKeyboardNavigation";
@@ -143,9 +144,7 @@ export function CheckAndSaveForm() {
                   {section.errors.getCodes().map((code) => {
                     return (
                       <StatusList.Item key={code} status="error" id={`section-error-${section.id}-${code}`}>
-                        <strong>
-                          {code[0]}.{code.slice(1)}
-                        </strong>
+                        <strong>{dottedCode(code)}</strong>
                         &nbsp;
                         {tx(`feedback.${code}.typist.title`)}
                       </StatusList.Item>
@@ -154,9 +153,7 @@ export function CheckAndSaveForm() {
                   {section.warnings.getCodes().map((code) => {
                     return (
                       <StatusList.Item key={code} status="warning" id={`section-error-${section.id}-${code}`}>
-                        <strong>
-                          {code[0]}.{code.slice(1)}
-                        </strong>
+                        <strong>{dottedCode(code)}</strong>
                         &nbsp;
                         {tx(`feedback.${code}.typist.title`)}
                       </StatusList.Item>

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsOverview.stories.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsOverview.stories.tsx
@@ -1,0 +1,23 @@
+import type { Story } from "@ladle/react";
+
+import { ResolveErrorsOverview } from "@/features/resolve_errors/components/ResolveErrorsOverview";
+import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
+import { ValidationResults } from "@/types/generated/openapi";
+import { getDataEntryStructure } from "@/utils/dataEntryStructure";
+
+export default {
+  title: "App / Resolve Errors",
+};
+
+const structure = getDataEntryStructure(electionMockData);
+const results: ValidationResults = {
+  errors: [validationResultMockData.F201, validationResultMockData.F401],
+  warnings: [validationResultMockData.W201, validationResultMockData.W001],
+};
+
+export const ResolveErrorsOverviewStory: Story = () => (
+  <ResolveErrorsOverview structure={structure} results={results} />
+);
+
+ResolveErrorsOverviewStory.storyName = "ResolveErrorsOverview";

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsOverview.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsOverview.test.tsx
@@ -1,0 +1,57 @@
+import { screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { ResolveErrorsOverview } from "@/features/resolve_errors/components/ResolveErrorsOverview";
+import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
+import { render } from "@/testing/test-utils";
+import { ValidationResults } from "@/types/generated/openapi";
+import { getDataEntryStructure } from "@/utils/dataEntryStructure";
+
+function getValidationResults(section: HTMLElement | null) {
+  return (
+    within(section!)
+      .getAllByRole("listitem")
+      // Assume that each list item starts with the validation result code with a dot
+      .map((item) => item.textContent!.split(" ")[0])
+  );
+}
+
+describe("ResolveErrorsOverview", () => {
+  const structure = getDataEntryStructure(electionMockData);
+
+  test("render sections with errors and warnings", () => {
+    const results: ValidationResults = {
+      errors: [
+        validationResultMockData.F201, // voters_counts
+        validationResultMockData.F401, // political_group_votes[0]
+      ],
+      warnings: [
+        validationResultMockData.W001, // recounted
+        validationResultMockData.W201, // votes_counts
+      ],
+    };
+
+    render(<ResolveErrorsOverview structure={structure} results={results} />);
+
+    const recounted = screen.queryByRole("region", { name: "Is het selectievakje op de eerste pagina aangevinkt?" });
+    expect(recounted).toBeInTheDocument();
+    expect(getValidationResults(recounted)).toEqual(["W.001"]);
+
+    const voters_votes_counts = screen.queryByRole("region", { name: "Toegelaten kiezers en uitgebrachte stemmen" });
+    expect(voters_votes_counts).toBeInTheDocument();
+    expect(getValidationResults(voters_votes_counts)).toEqual(["F.201", "W.201"]);
+
+    const differences_counts = screen.queryByRole("region", {
+      name: "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen",
+    });
+    expect(differences_counts).not.toBeInTheDocument();
+
+    const political_group_votes_1 = screen.queryByRole("region", { name: "Lijst 1 - Vurige Vleugels Partij" });
+    expect(political_group_votes_1).toBeInTheDocument();
+    expect(getValidationResults(political_group_votes_1)).toEqual(["F.401"]);
+
+    const political_group_votes_2 = screen.queryByRole("region", { name: "Lijst 2 - Wijzen van Water en Wind" });
+    expect(political_group_votes_2).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsOverview.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsOverview.tsx
@@ -1,0 +1,55 @@
+import { Link } from "react-router";
+
+import { StatusList } from "@/components/ui/StatusList/StatusList";
+import { t } from "@/i18n/translate";
+import { ValidationResultCode, ValidationResults } from "@/types/generated/openapi";
+import { DataEntrySection } from "@/types/types";
+import { dottedCode, getValidationResultSetForSection } from "@/utils/ValidationResults";
+
+interface ResolveErrorsOverviewProps {
+  structure: DataEntrySection[];
+  results: ValidationResults;
+}
+
+export function ResolveErrorsOverview({ structure, results }: ResolveErrorsOverviewProps) {
+  const sections = structure
+    .map((section) => {
+      const errors = getValidationResultSetForSection(results.errors, section);
+      const warnings = getValidationResultSetForSection(results.warnings, section);
+      return { section, errors, warnings };
+    })
+    .filter(({ errors, warnings }) => !errors.isEmpty() || !warnings.isEmpty());
+
+  return (
+    <>
+      {sections.map(({ section, errors, warnings }) => (
+        <section key={section.id} aria-labelledby={`${section.id}_title`}>
+          <StatusList.Title id={`${section.id}_title`}>
+            <Link to={`./${section.id}`}>{section.title}</Link>
+          </StatusList.Title>
+          <StatusList id={`overview-${section.id}`}>
+            {errors.getCodes().map((code) => (
+              <OverviewItem key={code} code={code} status={"error"} />
+            ))}
+            {warnings.getCodes().map((code) => (
+              <OverviewItem key={code} code={code} status={"warning"} />
+            ))}
+          </StatusList>
+        </section>
+      ))}
+    </>
+  );
+}
+
+function OverviewItem({ code, status }: { code: ValidationResultCode; status: "error" | "warning" }) {
+  return (
+    <StatusList.Item status={status}>
+      <div className="font-bold">
+        {dottedCode(code)} {t(`feedback.${code}.coordinator.title`)}
+      </div>
+      <div>
+        <strong>→</strong> <span className="font-italic">{t(`feedback.${code}.coordinator.title`)}</span>
+      </div>
+    </StatusList.Item>
+  );
+}

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsPage.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsPage.test.tsx
@@ -1,4 +1,3 @@
-import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -14,14 +13,15 @@ import {
   UserListRequestHandler,
 } from "@/testing/api-mocks/RequestHandlers";
 import { server } from "@/testing/server";
-import { screen, spyOnHandler } from "@/testing/test-utils";
+import { render, screen, spyOnHandler } from "@/testing/test-utils";
 import { TestUserProvider } from "@/testing/TestUserProvider";
 
 import { ResolveErrorsPage } from "./ResolveErrorsPage";
 
 const navigate = vi.fn();
 
-vi.mock("react-router", () => ({
+vi.mock("react-router", async (importOriginal) => ({
+  ...(await importOriginal()),
   useNavigate: () => navigate,
   useParams: () => ({ pollingStationId: "5" }),
   useLocation: () => ({ pathname: "/" }),

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsPage.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsPage.tsx
@@ -15,6 +15,7 @@ import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 import { usePollingStationDataEntryErrors } from "../hooks/usePollingStationDataEntryErrors";
 import { ReadOnlyDataEntrySection } from "./ReadOnlyDataEntrySection";
 import cls from "./ResolveErrors.module.css";
+import { ResolveErrorsOverview } from "./ResolveErrorsOverview";
 
 export function ResolveErrorsPage() {
   const navigate = useNavigate();
@@ -57,7 +58,7 @@ export function ResolveErrorsPage() {
           <h2>{t("resolve_errors.title")}</h2>
           <p>{t("resolve_errors.page_content")}</p>
 
-          <pre>{JSON.stringify(dataEntry.validation_results, null, 2)}</pre>
+          <ResolveErrorsOverview structure={structure} results={dataEntry.validation_results} />
 
           {structure.map((section) => (
             <section key={section.id}>

--- a/frontend/src/styles/util.css
+++ b/frontend/src/styles/util.css
@@ -44,6 +44,14 @@
   background-color: var(--yellow-200);
 }
 
+.font-bold {
+  font-weight: bold;
+}
+
+.font-italic {
+  font-style: italic;
+}
+
 .text-muted {
   color: var(--gray-400);
 }

--- a/frontend/src/utils/ValidationResults.test.ts
+++ b/frontend/src/utils/ValidationResults.test.ts
@@ -8,6 +8,7 @@ import { PollingStationResults } from "@/types/generated/openapi";
 import { getDataEntryStructure } from "./dataEntryStructure";
 import {
   doesValidationResultApplyToSection,
+  dottedCode,
   getValidationResultSetForSection,
   isGlobalValidationResult,
   mapValidationResultSetsToFields,
@@ -154,5 +155,12 @@ describe("getValidationResultSetForSection", () => {
     expect(resultSet.includes("F401")).toBe(true);
     expect(resultSet.includes("F204")).toBe(true);
     expect(resultSet.includes("F301")).toBe(false);
+  });
+});
+
+describe("dottedCode", () => {
+  test("should insert a dot in between validation result code letter and number", () => {
+    expect(dottedCode("F301")).toBe("F.301");
+    expect(dottedCode("W204")).toBe("W.204");
   });
 });

--- a/frontend/src/utils/ValidationResults.ts
+++ b/frontend/src/utils/ValidationResults.ts
@@ -136,3 +136,7 @@ export function getValidationResultSetForSection(
   );
   return new ValidationResultSet(filteredResults);
 }
+
+export function dottedCode(code: ValidationResultCode): string {
+  return `${code[0]}.${code.slice(1)}`;
+}


### PR DESCRIPTION
- Closes #1654 
- Add `ResolveErrorsOverview` component and use on the `ResolveErrorsPage`
- Add ladle story and test
- Add and use util function `dottedCode()` to add a dot to a validation result code, e.g. `W.203`
- Add css utils `font-bold` and `font-italic`

