### PR TITLE
fix abort and save on check-and-save page of data entry

### DIFF
--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -81,7 +81,7 @@ test.describe("full data entry flow", () => {
 
     await candidatesListPage_2.fillCandidatesAndTotal([3, 1], 4);
     const responsePromise = page.waitForResponse(new RegExp("/api/polling_stations/(\\d+)/data_entries/([12])"));
-    await candidatesListPage_1.next.click();
+    await candidatesListPage_2.next.click();
 
     const response = await responsePromise;
     expect(response.status()).toBe(200);

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -47,26 +47,26 @@ test.describe("resume data entry flow", () => {
     return new AbortInputModal(page);
   };
 
-  test.describe("abort data entry", () => {
-    test("Closing abort modal with X only closes the modal", async ({ page, pollingStation }) => {
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1/recounted`);
-      const recountedPage = new RecountedPage(page);
-      await recountedPage.no.click();
-      await recountedPage.abortInput.click();
+  test("Closing abort modal with X only closes the modal", async ({ page, pollingStation }) => {
+    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1/recounted`);
+    const recountedPage = new RecountedPage(page);
+    await recountedPage.no.click();
+    await recountedPage.abortInput.click();
 
-      const abortInputModal = new AbortInputModal(page);
+    const abortInputModal = new AbortInputModal(page);
+    await expect(abortInputModal.heading).toBeVisible();
 
-      let requestMade = false;
-      page.on("request", (request) => {
-        if (request.url().includes("/api/polling_stations")) {
-          requestMade = true;
-        }
-      });
-      await abortInputModal.close.click();
-      expect(requestMade).toBe(false);
-
-      await expect(recountedPage.no).toBeChecked();
+    let requestMade = false;
+    page.on("request", (request) => {
+      if (request.url().includes("/api/polling_stations")) {
+        requestMade = true;
+      }
     });
+    await abortInputModal.close.click();
+    await expect(abortInputModal.heading).toBeHidden();
+    expect(requestMade).toBe(false);
+
+    await expect(recountedPage.no).toBeChecked();
   });
 
   test.describe("resume after saving", () => {

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -359,7 +359,9 @@ test.describe("resume data entry flow", () => {
       await expect(recountedPage.no).not.toBeChecked();
     });
 
-    test("discard input from voters and votes page with error", async ({ page, request, pollingStation }) => {
+    test("discard input from voters and votes page with error", async ({ typistOne, pollingStation }) => {
+      const { page, request } = typistOne;
+
       await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1/recounted`);
 
       const recountedPage = new RecountedPage(page);
@@ -382,13 +384,14 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await loginAs(request, "typist1");
       const claimResponse = await request.post(`/api/polling_stations/${pollingStation.id}/data_entries/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject(emptyDataEntryResponse);
     });
 
-    test("discard input from voters and votes page with warning", async ({ page, request, pollingStation }) => {
+    test("discard input from voters and votes page with warning", async ({ typistOne, pollingStation }) => {
+      const { page, request } = typistOne;
+
       await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1/recounted`);
 
       const recountedPage = new RecountedPage(page);
@@ -424,7 +427,6 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await loginAs(request, "typist1");
       const claimResponse = await request.post(`/api/polling_stations/${pollingStation.id}/data_entries/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject(emptyDataEntryResponse);

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -394,7 +394,7 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      expect(requestMade).toBe(false); // assumes a particular fix to the issue
+      expect(requestMade).toBe(false);
     });
   });
 

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.test.tsx
@@ -235,6 +235,34 @@ describe("DataEntryNavigation", () => {
       });
     });
 
+    test("Abort modal save, sectionId save", async () => {
+      const state: DataEntryStateAndActionsLoaded = {
+        ...getDefaultDataEntryStateAndActionsLoaded(),
+        status: "idle",
+      };
+
+      const onSubmit = vi.fn(async () => {
+        return Promise.resolve(true);
+      });
+
+      vi.mocked(useParams).mockReturnValue({ sectionId: "save" });
+      vi.mocked(useDataEntryContext).mockReturnValue(state);
+      vi.mocked(useUser).mockReturnValue(getTypistUser());
+      const router = renderComponent(onSubmit);
+      await router.navigate("/test");
+
+      const modal = await screen.findByRole("dialog");
+
+      const saveButton = within(modal).getByRole("button", { name: "Invoer bewaren" });
+      expect(saveButton).toBeVisible();
+      saveButton.click();
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe("/test");
+      });
+    });
+
     test("Abort modal save, onSubmit false", async () => {
       const state: DataEntryStateAndActionsLoaded = {
         ...getDefaultDataEntryStateAndActionsLoaded(),

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -81,9 +81,12 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
       blocker.reset();
     }
   };
+
   // when save is chosen in the abort dialog
   const onAbortModalSave = async () => {
-    if (await onSubmit({ aborting: true, continueToNextSection: false, showAcceptErrorsAndWarnings: false })) {
+    if (sectionId === "save") {
+      blocker.proceed();
+    } else if (await onSubmit({ aborting: true, continueToNextSection: false, showAcceptErrorsAndWarnings: false })) {
       blocker.proceed();
     } else {
       if (status === "aborted") {


### PR DESCRIPTION
fixes #1695 

### Scope
- fix issue that on the check-and-save page, aborting data entry and clicking "Invoer opslaan" did nothing
- add unit test and e2e tests for fix
- small improvements to existing e2e tests

### About the fix
I decided to fix this by skipping the POST when clicking "Invoer opslaan" on the check-and-save page, because there is no unsaved data to be saved. The only input field on that page is the checkbox to confirm you talked to the coordinator about accepted errors. That's not something we want to or are able to save in the backend.

An alternative fix (also see "Analysis" section of the issue) would be to make changes to `actions.ts` and `dataEntryMapping.ts` to account for the fact that `"save"` is not in `state.dataEntryStructure`. That fix, however, would be more complicated and also more hidden.