### PR TITLE
Fix display of unnamed political groups

### DIFF
--- a/frontend/e2e-tests/page-objects/data_entry/ProgressListPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/ProgressListPgObj.ts
@@ -32,7 +32,7 @@ export class ProgressList {
   }
 
   list(listNumber: number) {
-    return this.navElement.getByRole("listitem").filter({ hasText: `Lijst ${listNumber} - ` });
+    return this.navElement.getByRole("listitem").filter({ hasText: `Lijst ${listNumber}` });
   }
 
   listIcon(listNumber: number) {

--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -76,7 +76,7 @@ test.describe("full data entry flow", () => {
     await candidatesListPage_1.fillCandidatesAndTotal([737, 153], 890);
     await candidatesListPage_1.next.click();
 
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await expect(candidatesListPage_2.getCandidate(0)).toBeFocused();
 
     await candidatesListPage_2.fillCandidatesAndTotal([3, 1], 4);
@@ -172,7 +172,7 @@ test.describe("full data entry flow", () => {
     await candidatesListPage_1.fillCandidatesAndTotal([837, 253], 1090);
     await candidatesListPage_1.next.click();
 
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await expect(candidatesListPage_2.fieldset).toBeVisible();
     await candidatesListPage_2.fillCandidatesAndTotal([0, 0], 0);
     await candidatesListPage_2.next.click();
@@ -241,7 +241,7 @@ test.describe("full data entry flow", () => {
     await candidatesListPage_1.fillCandidatesAndTotal([902, 233], 1135);
     await candidatesListPage_1.next.click();
 
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await expect(candidatesListPage_2.fieldset).toBeVisible();
     await candidatesListPage_2.fillCandidatesAndTotal([0, 0], 0);
     await candidatesListPage_2.next.click();
@@ -321,7 +321,7 @@ test.describe("full data entry flow", () => {
     await candidatesListPage_1.fillCandidatesAndTotal([837, 253], 1090);
     await candidatesListPage_1.next.click();
 
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await expect(candidatesListPage_2.fieldset).toBeVisible();
     await candidatesListPage_2.fillCandidatesAndTotal([0, 0], 0);
     await candidatesListPage_2.next.click();
@@ -377,7 +377,7 @@ test.describe("full data entry flow", () => {
     await candidatesListPage_1.fillCandidatesAndTotal([99, 1], 100);
     await candidatesListPage_1.next.click();
 
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await expect(candidatesListPage_2.fieldset).toBeVisible();
     await candidatesListPage_2.fillCandidatesAndTotal([0, 0], 0);
     await candidatesListPage_2.next.click();
@@ -453,7 +453,7 @@ test.describe("full data entry flow", () => {
     await candidatesListPage_1.checkAcceptErrorsAndWarnings();
     await candidatesListPage_1.next.click();
 
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await candidatesListPage_2.fillCandidatesAndTotal([0, 0], 0);
     await candidatesListPage_2.next.click();
     await expect(candidatesListPage_2.error).toContainText("F.204");
@@ -763,7 +763,7 @@ test.describe("errors and warnings", () => {
     await candidatesListPage_1.next.click();
 
     // fill counts of List 2 with 0 so correcting the error is easier
-    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+    const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
     await candidatesListPage_2.fillCandidatesAndTotal([0, 0], 0);
     await candidatesListPage_2.next.click();
 
@@ -1134,7 +1134,7 @@ test.describe("navigation", () => {
       await candidatesListPage_1.fillCandidatesAndTotal([50, 50], 100);
       await candidatesListPage_1.next.click();
 
-      const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2 -");
+      const candidatesListPage_2 = new CandidatesListPage(page, 2, "Lijst 2");
       await expect(candidatesListPage_2.fieldset).toBeVisible();
       await expect(candidatesListPage_2.progressList.listIcon(2)).toHaveAccessibleName("je bent hier");
       await expect(candidatesListPage_2.progressList.listIcon(1)).toHaveAccessibleName("opgeslagen");

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.tsx
@@ -3,6 +3,7 @@ import { useElection } from "@/hooks/election/useElection";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { t, tx } from "@/i18n/translate";
 import { cn } from "@/utils/classnames";
+import { formatPoliticalGroupName } from "@/utils/politicalGroup";
 
 import { useApportionmentContext } from "../../hooks/useApportionmentContext";
 import { render_title_and_header } from "../../utils/utils";
@@ -22,7 +23,7 @@ export function ApportionmentListDetailsPage() {
     throw new NotFoundError("error.not_found");
   }
 
-  const pgName = `${t("list")} ${pg.number} - ${pg.name}`;
+  const pgName = formatPoliticalGroupName(pg);
 
   if (error) {
     return (

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -8,6 +8,7 @@ import {
   InputGridSubsectionRow,
 } from "@/types/types";
 import { getCandidateFullName } from "@/utils/candidate";
+import { formatPoliticalGroupName } from "@/utils/politicalGroup";
 
 export const recountedSection: DataEntrySection = {
   id: "recounted",
@@ -127,7 +128,7 @@ export function createPoliticalGroupSections(election: ElectionWithPoliticalGrou
       isListTotal: true,
     });
 
-    const title = `${t("list")} ${politicalGroup.number} - ${politicalGroup.name}`;
+    const title = formatPoliticalGroupName(politicalGroup);
     return {
       id: `political_group_votes_${politicalGroup.number}` as FormSectionId,
       title: title,

--- a/frontend/src/utils/politicalGroup.test.ts
+++ b/frontend/src/utils/politicalGroup.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import type { PoliticalGroup } from "@/types/generated/openapi";
+
+import { formatPoliticalGroupName } from "./politicalGroup";
+
+describe("formatPoliticalGroupName", () => {
+  it("formats named political groups correctly", () => {
+    const politicalGroup1: PoliticalGroup = { name: "Group Name", number: 10, candidates: [] };
+    const politicalGroup2: PoliticalGroup = { name: "Test Group", number: 15, candidates: [] };
+
+    expect(formatPoliticalGroupName(politicalGroup1)).toBe("Lijst 10 - Group Name");
+    expect(formatPoliticalGroupName(politicalGroup2)).toBe("Lijst 15 - Test Group");
+  });
+
+  it("formats unnamed political groups correctly", () => {
+    const politicalGroup1: PoliticalGroup = { name: "", number: 2, candidates: [] };
+    const politicalGroup2: PoliticalGroup = { name: "", number: 123, candidates: [] };
+
+    expect(formatPoliticalGroupName(politicalGroup1)).toBe("Lijst 2");
+    expect(formatPoliticalGroupName(politicalGroup2)).toBe("Lijst 123");
+  });
+});

--- a/frontend/src/utils/politicalGroup.ts
+++ b/frontend/src/utils/politicalGroup.ts
@@ -1,0 +1,17 @@
+import { t } from "@/i18n/translate";
+import type { PoliticalGroup } from "@/types/generated/openapi";
+
+/**
+ * Formats a political group name for display.
+ * For named groups: "Lijst {number} - {name}"
+ * For unnamed groups: "Lijst {number}"
+ */
+export function formatPoliticalGroupName(politicalGroup: PoliticalGroup): string {
+  const listPrefix = `${t("list")} ${politicalGroup.number}`;
+
+  if (politicalGroup.name === "") {
+    return listPrefix;
+  } else {
+    return `${listPrefix} - ${politicalGroup.name}`;
+  }
+}


### PR DESCRIPTION
Fix display of unnamed lists: unnamed lists are now shown as e.g. "List 1" instead of "List 1 - ".

Can be tested by locally editing the political group name in `backend/fixtures/election_1.sql`:
<img width="1077" alt="Screenshot 2025-07-01 at 16 00 09" src="https://github.com/user-attachments/assets/e87f1ff9-6dfc-4457-b34b-13f6a928a1ac" />

Resolves #1685.