### PR TITLE
Go to resolve errors after resolve differences when keeping second data entry with errors

### DIFF
--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -14,17 +14,14 @@ import {
 } from "@/types/generated/openapi";
 
 import { DataEntryApiClient } from "./helpers-utils/api-clients";
-import {
-  completePollingStationDataEntries,
-  completePollingStationDataEntriesWithDifferences,
-  loginAs,
-} from "./helpers-utils/e2e-test-api-helpers";
+import { completePollingStationDataEntries, loginAs } from "./helpers-utils/e2e-test-api-helpers";
 import { createRandomUsername } from "./helpers-utils/e2e-test-utils";
 import {
+  dataEntryRequest,
+  dataEntryWithDifferencesRequest,
+  dataEntryWithErrorRequest,
   electionRequest,
-  noRecountNoDifferencesRequest,
   pollingStationRequests,
-  requestWithError,
 } from "./test-data/request-response-templates";
 
 export const FIXTURE_TYPIST_TEMP_PASSWORD: string = "temp_password_9876";
@@ -53,6 +50,8 @@ type Fixtures = {
   pollingStationDefinitive: PollingStation;
   // First polling station of the election with differences between the first and second data entry
   pollingStationEntriesDifferent: PollingStation;
+  // First polling station of the election with second data entry that has errors and is therefore different
+  pollingStationEntriesDifferentWithErrors: PollingStation;
   // Election with polling stations and two completed data entries for each
   completedElection: Election;
   // Newly created User
@@ -129,7 +128,7 @@ export const test = base.extend<Fixtures>({
 
     const firstDataEntry = new DataEntryApiClient(request, pollingStation.id, 1);
     await firstDataEntry.claim();
-    await firstDataEntry.save(noRecountNoDifferencesRequest);
+    await firstDataEntry.save(dataEntryRequest);
     await firstDataEntry.finalise();
 
     await use(pollingStation);
@@ -139,7 +138,7 @@ export const test = base.extend<Fixtures>({
 
     const firstDataEntry = new DataEntryApiClient(request, pollingStation.id, 1);
     await firstDataEntry.claim();
-    await firstDataEntry.save(requestWithError);
+    await firstDataEntry.save(dataEntryWithErrorRequest);
     await firstDataEntry.finalise();
 
     await use(pollingStation);
@@ -150,7 +149,18 @@ export const test = base.extend<Fixtures>({
     await use(pollingStation);
   },
   pollingStationEntriesDifferent: async ({ request, pollingStation }, use) => {
-    await completePollingStationDataEntriesWithDifferences(request, pollingStation.id);
+    await completePollingStationDataEntries(
+      request,
+      pollingStation.id,
+      dataEntryRequest,
+      dataEntryWithDifferencesRequest,
+    );
+
+    await use(pollingStation);
+  },
+  pollingStationEntriesDifferentWithErrors: async ({ request, pollingStation }, use) => {
+    await completePollingStationDataEntries(request, pollingStation.id, dataEntryRequest, dataEntryWithErrorRequest);
+
     await use(pollingStation);
   },
   completedElection: async ({ request, election }, use) => {

--- a/frontend/e2e-tests/helpers-utils/e2e-test-api-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-api-helpers.ts
@@ -1,8 +1,6 @@
 import { APIRequestContext } from "@playwright/test";
-import { noRecountNoDifferencesRequest } from "e2e-tests/test-data/request-response-templates";
 
-import { DataEntry } from "@/types/generated/openapi";
-
+import { dataEntryRequest } from "../test-data/request-response-templates";
 import { DataEntryApiClient } from "./api-clients";
 
 export async function loginAs(request: APIRequestContext, username: string) {
@@ -15,37 +13,22 @@ export async function loginAs(request: APIRequestContext, username: string) {
     },
   });
 }
-export async function completePollingStationDataEntries(request: APIRequestContext, pollingStationId: number) {
-  for (const entryNumber of [1, 2]) {
-    if (entryNumber === 1) {
-      await loginAs(request, "typist1");
-    } else if (entryNumber === 2) {
-      await loginAs(request, "typist2");
-    }
 
-    const dataEntry = new DataEntryApiClient(request, pollingStationId, entryNumber);
-    await dataEntry.claim();
-    await dataEntry.save(noRecountNoDifferencesRequest);
-    await dataEntry.finalise();
-  }
-}
-
-export async function completePollingStationDataEntriesWithDifferences(
+export async function completePollingStationDataEntries(
   request: APIRequestContext,
   pollingStationId: number,
+  firstRequest = dataEntryRequest,
+  secondRequest = dataEntryRequest,
 ) {
   await loginAs(request, "typist1");
   const firstDataEntry = new DataEntryApiClient(request, pollingStationId, 1);
   await firstDataEntry.claim();
-  await firstDataEntry.save(noRecountNoDifferencesRequest);
+  await firstDataEntry.save(firstRequest);
   await firstDataEntry.finalise();
 
   await loginAs(request, "typist2");
   const secondDataEntry = new DataEntryApiClient(request, pollingStationId, 2);
   await secondDataEntry.claim();
-  const cloneDataEntry = JSON.parse(JSON.stringify(noRecountNoDifferencesRequest)) as DataEntry;
-  cloneDataEntry.data.political_group_votes[0]!.candidate_votes[0]!.votes -= 10;
-  cloneDataEntry.data.political_group_votes[0]!.candidate_votes[1]!.votes += 10;
-  await secondDataEntry.save(cloneDataEntry);
+  await secondDataEntry.save(secondRequest);
   await secondDataEntry.finalise();
 }

--- a/frontend/e2e-tests/page-objects/election/ResolveDifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/ResolveDifferencesPgObj.ts
@@ -1,6 +1,7 @@
 import { type Locator, type Page } from "@playwright/test";
 
 export class ResolveDifferencesPgObj {
+  readonly title: Locator;
   readonly firstValue: Locator;
   readonly secondValue: Locator;
   readonly validationError: Locator;
@@ -10,6 +11,7 @@ export class ResolveDifferencesPgObj {
   readonly save: Locator;
 
   constructor(protected readonly page: Page) {
+    this.title = this.page.getByRole("heading", { name: "Verschil tussen eerste en tweede invoer" });
     this.firstValue = this.page.getByRole("cell").nth(0);
     this.secondValue = this.page.getByRole("cell").nth(1);
     this.validationError = page.getByText(/Dit is een verplichte vraag/);

--- a/frontend/e2e-tests/page-objects/election/ResolveErrorsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/ResolveErrorsPgObj.ts
@@ -1,12 +1,14 @@
 import { type Locator, type Page } from "@playwright/test";
 
 export class ResolveErrorsPgObj {
+  readonly title: Locator;
   readonly validationError: Locator;
   readonly resumeFirstEntry: Locator;
   readonly discardFirstEntry: Locator;
   readonly save: Locator;
 
   constructor(protected readonly page: Page) {
+    this.title = this.page.getByRole("heading", { name: "Alle fouten en waarschuwingen" });
     this.validationError = page.getByText(/Dit is een verplichte vraag/);
     this.resumeFirstEntry = page.getByLabel(/Invoer bewaren/);
     this.discardFirstEntry = page.getByLabel(/Stembureau opnieuw laten invoeren/);

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -195,7 +195,7 @@ export const noRecountNoDifferencesDataEntry: PollingStationResults = {
   ],
 };
 
-export const noRecountNoDifferencesRequest: DataEntry = {
+export const dataEntryRequest: DataEntry = {
   progress: 83,
   data: noRecountNoDifferencesDataEntry,
   client_state: {
@@ -206,7 +206,7 @@ export const noRecountNoDifferencesRequest: DataEntry = {
   },
 };
 
-export const requestWithError: DataEntry = {
+export const dataEntryWithErrorRequest: DataEntry = {
   progress: 83,
   data: {
     ...noRecountNoDifferencesDataEntry,
@@ -221,6 +221,24 @@ export const requestWithError: DataEntry = {
     furthest: "political_group_votes_2",
     current: "political_group_votes_2",
     acceptedErrorsAndWarnings: ["voters_votes_counts", "differences_counts"],
+    continue: true,
+  },
+};
+
+export const dataEntryWithDifferencesRequest: DataEntry = {
+  progress: 83,
+  data: {
+    ...noRecountNoDifferencesDataEntry,
+    voters_counts: {
+      ...noRecountNoDifferencesDataEntry.voters_counts,
+      poll_card_count: noRecountNoDifferencesDataEntry.voters_counts.poll_card_count - 20,
+      proxy_certificate_count: noRecountNoDifferencesDataEntry.voters_counts.proxy_certificate_count + 20,
+    },
+  },
+  client_state: {
+    furthest: "political_group_votes_2",
+    current: "political_group_votes_2",
+    acceptedErrorsAndWarnings: [],
     continue: true,
   },
 };

--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -18,9 +18,9 @@ import { RecountedPage } from "e2e-tests/page-objects/data_entry/RecountedPgObj"
 import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
 import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
 import {
+  dataEntryRequest,
   noErrorsWarningsResponse,
   noRecountNoDifferencesDataEntry,
-  noRecountNoDifferencesRequest,
 } from "e2e-tests/test-data/request-response-templates";
 
 import { VotersCounts, VotesCounts } from "@/types/generated/openapi";
@@ -85,7 +85,7 @@ test.describe("full data entry flow", () => {
 
     const response = await responsePromise;
     expect(response.status()).toBe(200);
-    expect(response.request().postDataJSON()).toStrictEqual(noRecountNoDifferencesRequest);
+    expect(response.request().postDataJSON()).toStrictEqual(dataEntryRequest);
     expect(await response.json()).toStrictEqual(noErrorsWarningsResponse);
 
     const checkAndSavePage = new CheckAndSavePage(page);

--- a/frontend/e2e-tests/tests/data-entry/resolve-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resolve-differences.e2e.ts
@@ -94,9 +94,6 @@ test.describe("resolve differences then errors", () => {
     await resolveDifferencesPage.keepSecondEntry.click();
     await resolveDifferencesPage.save.click();
 
-    // TODO skip overview page
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
-
     const resolveErrorsPage = new ResolveErrorsPgObj(page);
     await expect(resolveErrorsPage.title).toBeVisible();
     await resolveErrorsPage.resumeFirstEntry.click();

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -15,9 +15,10 @@ import {
   PollingStationDataEntryResolveDifferencesHandler,
   UserListRequestHandler,
 } from "@/testing/api-mocks/RequestHandlers";
-import { server } from "@/testing/server";
+import { overrideOnce, server } from "@/testing/server";
 import { screen, spyOnHandler } from "@/testing/test-utils";
 import { TestUserProvider } from "@/testing/TestUserProvider";
+import { DataEntryStatusName } from "@/types/generated/openapi";
 
 import { ResolveDifferencesPage } from "./ResolveDifferencesPage";
 
@@ -43,6 +44,10 @@ const renderPage = async () => {
   );
   expect(await screen.findByRole("table")).toBeInTheDocument();
 };
+
+function overrideResponseStatus(status: DataEntryStatusName) {
+  overrideOnce("post", "/api/polling_stations/3/data_entries/resolve_differences", 200, { status });
+}
 
 describe("ResolveDifferencesPage", () => {
   beforeEach(() => {
@@ -112,6 +117,7 @@ describe("ResolveDifferencesPage", () => {
     await user.click(submit);
     expect(resolve).not.toHaveBeenCalled();
 
+    overrideResponseStatus("second_entry_not_started");
     await user.click(await screen.findByLabelText(/De eerste invoer/));
     await user.click(submit);
     expect(resolve).toHaveBeenCalledWith("keep_first_entry");
@@ -125,6 +131,7 @@ describe("ResolveDifferencesPage", () => {
     await renderPage();
     expect(getElectionStatus).toHaveBeenCalledTimes(1);
 
+    overrideResponseStatus("second_entry_not_started");
     await user.click(await screen.findByLabelText(/De tweede invoer/));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
@@ -137,9 +144,22 @@ describe("ResolveDifferencesPage", () => {
 
     await renderPage();
 
+    overrideResponseStatus("first_entry_not_started");
     await user.click(await screen.findByLabelText(/Geen van beide/));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(navigate).toHaveBeenCalledWith("/elections/1/status#data-entries-discarded-3");
+  });
+
+  test("should navigate to resolve errors page after keeping second entry which has errors", async () => {
+    const user = userEvent.setup();
+
+    await renderPage();
+
+    overrideResponseStatus("first_entry_has_errors");
+    await user.click(await screen.findByLabelText(/De tweede invoer/));
+    await user.click(await screen.findByRole("button", { name: "Opslaan" }));
+
+    expect(navigate).toHaveBeenCalledWith("/elections/1/status/3/resolve-errors");
   });
 });

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -9,7 +9,7 @@ import { Loader } from "@/components/ui/Loader/Loader";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { useUsers } from "@/hooks/user/useUsers";
 import { t } from "@/i18n/translate";
-import { ResolveDifferencesAction } from "@/types/generated/openapi";
+import { DataEntryStatusName } from "@/types/generated/openapi";
 
 import { usePollingStationDataEntryDifferences } from "../hooks/usePollingStationDataEntryDifferences";
 import cls from "./ResolveDifferences.module.css";
@@ -18,19 +18,27 @@ import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
 
 export function ResolveDifferencesPage() {
   const navigate = useNavigate();
-  const afterSave = (action: ResolveDifferencesAction) => {
-    let url = `/elections/${election.id}/status`;
-    switch (action) {
-      case "keep_first_entry":
-      case "keep_second_entry":
-        url += `#data-entry-kept-${pollingStation.id}`;
+  const afterSave = (status: DataEntryStatusName) => {
+    let nextPage = `/elections/${election.id}/status`;
+    let message = "";
+
+    switch (status) {
+      case "first_entry_has_errors":
+        nextPage = `/elections/${election.id}/status/${pollingStationId}/resolve-errors`;
         break;
-      case "discard_both_entries":
-        url += `#data-entries-discarded-${pollingStation.id}`;
+      case "second_entry_not_started":
+        message = `#data-entry-kept-${pollingStation.id}`;
+        break;
+      case "first_entry_not_started":
+        message = `#data-entries-discarded-${pollingStation.id}`;
+        break;
+      default:
         break;
     }
-    void navigate(url);
+
+    void navigate(nextPage + message);
   };
+
   const pollingStationId = useNumericParam("pollingStationId");
   const {
     pollingStation,

--- a/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
+++ b/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
@@ -8,6 +8,8 @@ import { useElection } from "@/hooks/election/useElection";
 import { t } from "@/i18n/translate";
 import {
   DataEntryGetDifferencesResponse,
+  DataEntryStatusName,
+  DataEntryStatusResponse,
   ElectionWithPoliticalGroups,
   POLLING_STATION_DATA_ENTRY_GET_DIFFERENCES_REQUEST_PATH,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY,
@@ -32,7 +34,7 @@ interface PollingStationDataEntryStatus {
 
 export function usePollingStationDataEntryDifferences(
   pollingStationId: number,
-  afterSave: (action: ResolveDifferencesAction) => void,
+  afterSave: (status: DataEntryStatusName) => void,
 ): PollingStationDataEntryStatus {
   const client = useApiClient();
   const { election, pollingStations } = useElection();
@@ -75,12 +77,12 @@ export function usePollingStationDataEntryDifferences(
 
     const path: POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/resolve_differences`;
     const body: POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY = action;
-    const response = await client.postRequest(path, body);
+    const response = await client.postRequest<DataEntryStatusResponse>(path, body);
 
     if (isSuccess(response)) {
-      // reload the election status and navigate to the overview page
+      // reload the election status data then navigate according to new status
       await electionContext?.refetch();
-      afterSave(action);
+      afterSave(response.data.status);
     } else {
       setError(response);
     }

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -199,7 +199,7 @@ export const PollingStationDataEntryResolveDifferencesHandler = http.post<
   DataEntryStatusResponse,
   POLLING_STATION_DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PATH
 >("/api/polling_stations/3/data_entries/resolve_differences", () =>
-  HttpResponse.json({ status: "definitive" }, { status: 200 }),
+  HttpResponse.json({ status: "first_entry_not_started" }, { status: 200 }),
 );
 
 export const PollingStationDataEntryResolveErrorsHandler = http.post<
@@ -208,7 +208,7 @@ export const PollingStationDataEntryResolveErrorsHandler = http.post<
   DataEntryStatusResponse,
   POLLING_STATION_DATA_ENTRY_RESOLVE_ERRORS_REQUEST_PATH
 >("/api/polling_stations/5/data_entries/resolve_errors", () =>
-  HttpResponse.json({ status: "definitive" }, { status: 200 }),
+  HttpResponse.json({ status: "first_entry_not_started" }, { status: 200 }),
 );
 
 // get polling stations


### PR DESCRIPTION
- Closes https://github.com/kiesraad/abacus/issues/1515
- Add e2e scenario, fixture and do some refactoring
- Use new state returned by the backend to decide where to go after resolve differences

Question: Is this refactor better? are these data entry response templates names better?

To test: 
- do a first data entry and then a second data entry that has an error and therefore is different from the first
- resolve the differences as a coordinator by keeping the second data entry
- see that the resolve errors page is now shown instead of the coordinator status page