### PR TITLE
fix typo in EMLImportError: Needs101a -> Needs110a

### DIFF
--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -199,7 +199,7 @@ pub enum EMLImportError {
     MissingSubcategory,
     MissingElectionTree,
     MissingElectionDomain,
-    Needs101a,
+    Needs110a,
     Needs230b,
     NumberOfSeatsNotInRange,
     OnlyMunicipalSupported,

--- a/backend/src/eml/eml_110.rs
+++ b/backend/src/eml/eml_110.rs
@@ -58,7 +58,7 @@ impl EML110 {
     pub fn as_abacus_election(&self) -> Result<crate::election::NewElection, EMLImportError> {
         // we need to be importing from a 110a file
         if self.base.id != "110a" {
-            return Err(EMLImportError::Needs101a);
+            return Err(EMLImportError::Needs110a);
         }
 
         // check that the election tree is specified
@@ -682,7 +682,7 @@ mod tests {
         let data = include_str!("./tests/eml110b_test.eml.xml");
         let doc = EML110::from_str(data).unwrap();
         let res = doc.as_abacus_election().unwrap_err();
-        assert!(matches!(res, EMLImportError::Needs101a));
+        assert!(matches!(res, EMLImportError::Needs110a));
     }
 
     #[test]


### PR DESCRIPTION
### Scope
The `EMLImportError` Enum in `src/eml/common.rs` contained the entry `Needs101a`. I changed it to `Needs110a`.

### What did I test
- ran `cargo test`
- `2025-07-03T12:08:26.403004Z ERROR request{method=POST uri=/api/elections/import/validate version=HTTP/1.1}: abacus::error: Error importing EML file: Needs110a`
