### PR TITLE
Delete frontend/.babelrc

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env", ["@babel/preset-react", { "runtime": "automatic" }]]
-}


### PR DESCRIPTION
The `.babelrc` is not used by Vite.

_Draft to check if CI passes_