### PR TITLE
Add tooltip for invalid paste content to number input

### DIFF
--- a/frontend/src/components/ui/Tooltip/Tooltip.module.css
+++ b/frontend/src/components/ui/Tooltip/Tooltip.module.css
@@ -1,0 +1,49 @@
+.container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  /* Positioning */
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 10px;
+  z-index: 10;
+
+  /* Appearance */
+  background: var(--base-white);
+  border: 1px solid var(--border-color-default);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 8px;
+
+  /* Typography */
+  font-size: 14px;
+  line-height: 1.2rem;
+  color: var(--text-color-body);
+  white-space: nowrap;
+
+  /* Behavior */
+  pointer-events: none;
+
+  /* Arrow pointing up */
+  &::before {
+    content: "";
+    position: absolute;
+    top: -5px;
+    left: 16px;
+    width: 10px;
+    height: 10px;
+    background: var(--base-white);
+    border: 1px solid var(--border-color-default);
+    border-right: none;
+    border-bottom: none;
+    transform: rotate(45deg);
+  }
+
+  :global(.tooltip-content) {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+}

--- a/frontend/src/components/ui/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/ui/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,23 @@
+import type { Story } from "@ladle/react";
+
+import { IconWarningSquare } from "@/components/generated/icons";
+import { tx } from "@/i18n/translate";
+
+import { Icon } from "../Icon/Icon";
+import { Tooltip } from "./Tooltip";
+
+export const PermanentTooltip: Story = () => {
+  return (
+    <Tooltip
+      content={
+        <div className="tooltip-content">
+          <Icon color="warning" icon={<IconWarningSquare />} />
+          <span>{tx("invalid_paste_content", undefined, { value: "abc123" })}</span>
+        </div>
+      }
+      onClose={() => {}}
+    >
+      <input id="demo-input" type="text" placeholder="" />
+    </Tooltip>
+  );
+};

--- a/frontend/src/components/ui/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip/Tooltip.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import cls from "./Tooltip.module.css";
+
+export interface TooltipProps {
+  children: React.ReactNode;
+  content?: React.ReactNode;
+  onClose: () => void;
+}
+
+export function Tooltip({ children, content, onClose }: TooltipProps): React.ReactNode {
+  React.useEffect(() => {
+    document.addEventListener("mousedown", onClose);
+    document.addEventListener("keydown", onClose);
+    return () => {
+      document.removeEventListener("mousedown", onClose);
+      document.removeEventListener("keydown", onClose);
+    };
+  }, [onClose]);
+
+  return (
+    <div className={cls.container}>
+      {children}
+      {content && (
+        <div className={cls.tooltip} role="dialog">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/nl/generic.json
+++ b/frontend/src/i18n/locales/nl/generic.json
@@ -31,6 +31,7 @@
   "general_details": "Algemene gegevens",
   "hashcode": "hashcode",
   "history_back": "Terug naar de vorige pagina",
+  "invalid_paste_content": "Je probeert <strong>{value}</strong> te plakken. Je kunt hier alleen cijfers invullen.",
   "list": "Lijst",
   "list_name": "Lijstnaam",
   "loading": "Laden...",


### PR DESCRIPTION
Reimplement tooltip, closes #299 

Ladle stories:
- [Permanent tooltip](https://299-reimplement-tooltip.kiesraad-abacus.pages.dev/ladle/?story=tooltip--permanent-tooltip)
- [NumberInput with tooltip](https://299-reimplement-tooltip.kiesraad-abacus.pages.dev/ladle/?story=number-input--default-number-input) (try pasting)

@jorisleker I noticed that the tooltip is no longer in the design, but some variants are still in the '🗑️  Archief' section in Figma.