### PR TITLE
Small improvement in frontend openapi generator

### DIFF
--- a/frontend/scripts/openapi/generator.ts
+++ b/frontend/scripts/openapi/generator.ts
@@ -176,12 +176,20 @@ function tsType(s: ReferenceObject | SchemaObject | undefined): string {
 
   if (Array.isArray(s.type)) {
     type = s.type
-      .map((t: NonArraySchemaObjectType | "null") => {
+      .map((t: NonArraySchemaObjectType | "null" | "array") => {
         if (t === "null") {
           return "null";
         }
 
-        return tsType({ type: t });
+        if (t === "array") {
+          if ("items" in s) {
+            return tsType({ type: t, items: s.items });
+          } else {
+            // Cannot determine type; type remains "unknown"
+          }
+        } else {
+          return tsType({ type: t });
+        }
       })
       .join(" | ");
   }


### PR DESCRIPTION
Fixed an issue in the openapi generator, where if the backend returns an Option<Vec<...>>, the typescript type becomes Unknown[].

In the openapi XML, the Option<Vec<...>> becomes type: ["array", "null"]:
![openapi1](https://github.com/user-attachments/assets/1a3ead11-a2a0-4dc9-b5b0-aa88e6f6c289)

The rest of the generated types remain unaffected:

![openapi3](https://github.com/user-attachments/assets/8d0c325e-ba3a-4baf-897a-264dbaeaf323)
