### PR TITLE
Fix import of candidate list without addresses

### DIFF
--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -237,7 +237,8 @@ pub struct Candidate {
     pub candidate_full_name: CandidateFullName,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub gender: Option<Gender>,
-    pub qualifying_address: QualifyingAddress,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub qualifying_address: Option<QualifyingAddress>,
 }
 
 impl TryFrom<Candidate> for structs::Candidate {
@@ -257,11 +258,16 @@ impl TryFrom<Candidate> for structs::Candidate {
             first_name: parsed.candidate_full_name.person_name.first_name,
             last_name_prefix: parsed.candidate_full_name.person_name.name_prefix,
             last_name: parsed.candidate_full_name.person_name.last_name,
-            locality: parsed.qualifying_address.locality_name().to_string(),
+            locality: parsed
+                .qualifying_address
+                .as_ref()
+                .map(|qa| qa.locality_name().to_string())
+                .unwrap_or_default(),
             country_code: parsed
                 .qualifying_address
-                .country_name_code()
-                .map(|s| s.to_string()),
+                .as_ref()
+                .map(|qa| qa.country_name_code())
+                .and_then(|code| code.map(|s| s.to_string())),
             gender: match parsed.gender {
                 None => None,
                 Some(gender) => match gender {

--- a/backend/src/eml/tests/eml230b_test_without_addresses.eml.xml
+++ b/backend/src/eml/tests/eml230b_test_without_addresses.eml.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0"?>
+<EML xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:kr="http://www.kiesraad.nl/extensions" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" Id="230b" SchemaVersion="5">
+  <TransactionId>1</TransactionId>
+  <ManagingAuthority>
+    <AuthorityIdentifier Id="0363">Amsterdam</AuthorityIdentifier>
+    <AuthorityAddress/>
+  </ManagingAuthority>
+  <IssueDate>2022-02-04</IssueDate>
+  <kr:CreationDateTime>2022-02-04T11:16:26.827</kr:CreationDateTime>
+  <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"/>
+  <CandidateList>
+    <Election>
+      <ElectionIdentifier Id="GR2022_Amsterdam">
+        <ElectionName>Gemeenteraad Amsterdam 2022</ElectionName>
+        <ElectionCategory>GR</ElectionCategory>
+        <kr:ElectionSubcategory>GR2</kr:ElectionSubcategory>
+        <kr:ElectionDomain Id="0363">Amsterdam</kr:ElectionDomain>
+        <kr:ElectionDate>2022-03-16</kr:ElectionDate>
+         <kr:NominationDate>2022-01-31</kr:NominationDate>
+      </ElectionIdentifier>
+      <Contest>
+        <ContestIdentifier Id="geen"/>
+        <Affiliation>
+          <AffiliationIdentifier Id="1">
+            <RegisteredName>GROENLINKS</RegisteredName>
+          </AffiliationIdentifier>
+          <Type>op zichzelf staande lijst</Type>
+          <kr:ListData PublicationLanguage="nl" PublishGender="true"/>
+          <Candidate>
+            <CandidateIdentifier Id="1"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">A.B.C.</xnl:NameLine>
+                <xnl:FirstName>Annemieke</xnl:FirstName>
+                <xnl:LastName>Oorschot</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="2"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">K.</xnl:NameLine>
+                <xnl:FirstName>Krisje</xnl:FirstName>
+                <xnl:NamePrefix>de</xnl:NamePrefix>
+                <xnl:LastName>Blikkert</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="3"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">G.H.O.</xnl:NameLine>
+                <xnl:FirstName>George</xnl:FirstName>
+                <xnl:NamePrefix>van</xnl:NamePrefix>
+                <xnl:LastName>Jaspers-Gezen</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="4"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">T.M.</xnl:NameLine>
+                <xnl:FirstName>Teun</xnl:FirstName>
+                <xnl:LastName>Meulenkolk</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="5"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">L.</xnl:NameLine>
+                <xnl:FirstName>Luc</xnl:FirstName>
+                <xnl:LastName>Katsma</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="6"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">M.</xnl:NameLine>
+                <xnl:FirstName>Christine</xnl:FirstName>
+                <xnl:LastName>Blankenvoorde</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="7"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">S</xnl:NameLine>
+                <xnl:FirstName>Salomon</xnl:FirstName>
+                <xnl:NamePrefix>den</xnl:NamePrefix>
+                <xnl:LastName>Mateman</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="8"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">F.G.P.</xnl:NameLine>
+                <xnl:FirstName>Fabio</xnl:FirstName>
+                <xnl:LastName>Oudenalder</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="9"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">I.</xnl:NameLine>
+                <xnl:FirstName>Ishana</xnl:FirstName>
+                <xnl:NamePrefix>den</xnl:NamePrefix>
+                <xnl:LastName>Wolbert</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="10"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">P.A.</xnl:NameLine>
+                <xnl:FirstName>Patrik</xnl:FirstName>
+                <xnl:LastName>Hoven</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="11"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">J.M.H.</xnl:NameLine>
+                <xnl:FirstName>Jorian</xnl:FirstName>
+                <xnl:LastName>Vredeveld</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="12"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">A.</xnl:NameLine>
+                <xnl:FirstName>Arendina</xnl:FirstName>
+                <xnl:LastName>Cornelis</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+        </Affiliation>
+        <Affiliation>
+          <AffiliationIdentifier Id="2">
+            <RegisteredName>Lokaal Belang Heemdamseburg</RegisteredName>
+          </AffiliationIdentifier>
+          <Type>op zichzelf staande lijst</Type>
+          <kr:ListData PublicationLanguage="nl" PublishGender="true"/>
+          <Candidate>
+            <CandidateIdentifier Id="1"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">C.P.M.</xnl:NameLine>
+                <xnl:FirstName>Charèl</xnl:FirstName>
+                <xnl:NamePrefix>van der</xnl:NamePrefix>
+                <xnl:LastName>Spek</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="2"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">W.P.</xnl:NameLine>
+                <xnl:FirstName>Tjeu</xnl:FirstName>
+                <xnl:LastName>Arets</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="3"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">X.T.</xnl:NameLine>
+                <xnl:FirstName>Xuan</xnl:FirstName>
+                <xnl:NamePrefix>van den</xnl:NamePrefix>
+                <xnl:LastName>Arets</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="4"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">F.M.</xnl:NameLine>
+                <xnl:FirstName>Fr&#xE9;d&#xE9;rique</xnl:FirstName>
+                <xnl:NamePrefix>van den</xnl:NamePrefix>
+                <xnl:LastName>Eijnden</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+        </Affiliation>
+
+        <Affiliation>
+          <AffiliationIdentifier Id="3">
+            <RegisteredName>D66</RegisteredName>
+          </AffiliationIdentifier>
+          <Type>op zichzelf staande lijst</Type>
+          <kr:ListData PublicationLanguage="nl" PublishGender="true"/>
+          <Candidate>
+            <CandidateIdentifier Id="1"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">M.O.</xnl:NameLine>
+                <xnl:FirstName>Marcela</xnl:FirstName>
+                <xnl:LastName>Gopal</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>female</Gender>
+          </Candidate>
+          <Candidate>
+            <CandidateIdentifier Id="2"/>
+            <CandidateFullName>
+              <xnl:PersonName>
+                <xnl:NameLine NameType="Initials">G.W.</xnl:NameLine>
+                <xnl:FirstName>Giovani</xnl:FirstName>
+                <xnl:LastName>Wolfswinkel</xnl:LastName>
+              </xnl:PersonName>
+            </CandidateFullName>
+            <Gender>male</Gender>
+          </Candidate>
+        </Affiliation>
+      </Contest>
+    </Election>
+  </CandidateList>
+</EML>


### PR DESCRIPTION
Fixes #1749. I accidentally misinterpreted the QualifyingAddress as being required, I've updated the code to make sure it is now optional and added a test to test against this.