### PR TITLE
Add section number badge to data entry form sections

### DIFF
--- a/frontend/src/features/data_entry/components/DataEntrySection.module.css
+++ b/frontend/src/features/data_entry/components/DataEntrySection.module.css
@@ -1,0 +1,29 @@
+.titleContainer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  font-family: var(--font-header-body);
+  font-size: 1.25rem;
+  font-weight: bold;
+  line-height: 1.875rem;
+  color: var(--text-color-header);
+}
+
+.title {
+  margin: 0;
+}
+
+.badge {
+  font-family: var(--font-text);
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.875rem;
+  padding: 0 0.5rem;
+  border-radius: 0.25rem;
+  background: var(--blue-300);
+  color: var(--base-black);
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}

--- a/frontend/src/features/data_entry/components/DataEntrySection.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.test.tsx
@@ -1,0 +1,81 @@
+import { useParams } from "react-router";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useUser } from "@/hooks/user/useUser";
+import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import {
+  PollingStationDataEntryClaimHandler,
+  PollingStationDataEntrySaveHandler,
+} from "@/testing/api-mocks/RequestHandlers";
+import { server } from "@/testing/server";
+import { render, screen } from "@/testing/test-utils";
+import { getDataEntryStructure } from "@/utils/dataEntryStructure";
+
+import { getTypistUser } from "../testing/mock-data";
+import { DataEntryProvider } from "./DataEntryProvider";
+import { DataEntrySection } from "./DataEntrySection";
+
+vi.mock("@/hooks/user/useUser");
+vi.mock("react-router");
+
+function renderComponent(sectionId: string) {
+  vi.mocked(useParams).mockReturnValue({ sectionId });
+
+  return render(
+    <DataEntryProvider election={electionMockData} pollingStationId={1} entryNumber={1}>
+      <DataEntrySection />
+    </DataEntryProvider>,
+  );
+}
+
+describe("DataEntrySection", () => {
+  beforeEach(() => {
+    vi.mocked(useUser).mockReturnValue(getTypistUser());
+    server.use(PollingStationDataEntryClaimHandler, PollingStationDataEntrySaveHandler);
+  });
+
+  describe("Section Badge Display", () => {
+    test("displays badge for voters_votes_counts section", async () => {
+      renderComponent("voters_votes_counts");
+
+      const title = await screen.findByText("Toegelaten kiezers en uitgebrachte stemmen");
+      expect(title).toBeInTheDocument();
+
+      const badge = screen.getByText("B1-3.1 en 3.2");
+      expect(badge).toBeInTheDocument();
+    });
+
+    test("displays badge for differences_counts section", async () => {
+      renderComponent("differences_counts");
+
+      const title = await screen.findByText("Verschillen tussen toegelaten kiezers en uitgebrachte stemmen");
+      expect(title).toBeInTheDocument();
+
+      const badge = screen.getByText("B1-3.3");
+      expect(badge).toBeInTheDocument();
+    });
+
+    test.each([
+      {
+        sectionId: "recounted",
+        expectedTitle: "Is het selectievakje op de eerste pagina aangevinkt?",
+      },
+      {
+        sectionId: "political_group_votes_1",
+        expectedTitle: "Lijst 1 - Vurige Vleugels Partij",
+      },
+    ])("does not display badge for $sectionId", async ({ sectionId, expectedTitle }) => {
+      renderComponent(sectionId);
+
+      const title = await screen.findByText(expectedTitle);
+      expect(title).toBeInTheDocument();
+
+      const dataEntryStructure = getDataEntryStructure(electionMockData);
+      const section = dataEntryStructure.find((s) => s.id === sectionId);
+      expect(section?.sectionNumber).toBeUndefined();
+
+      expect(screen.queryByText(/B1-.*/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -16,6 +16,7 @@ import { KeyboardKey } from "@/types/ui";
 
 import { useDataEntryFormSection } from "../hooks/useDataEntryFormSection";
 import { DataEntryNavigation } from "./DataEntryNavigation";
+import cls from "./DataEntrySection.module.css";
 
 export function DataEntrySection() {
   const user = useUser();
@@ -66,7 +67,11 @@ export function DataEntrySection() {
   };
 
   return (
-    <Form onSubmit={handleSubmit} ref={formRef} id={formId} title={section.title}>
+    <Form onSubmit={handleSubmit} ref={formRef} id={formId}>
+      <legend className={cls.titleContainer}>
+        <span className={cls.title}>{section.title}</span>
+        {section.sectionNumber && <span className={cls.badge}>{section.sectionNumber}</span>}
+      </legend>
       <DataEntryNavigation onSubmit={onSubmit} currentValues={currentValues} />
       {error instanceof ApiError && <ErrorModal error={error} />}
       {formSection.isSaved && memoizedErrorCodes.length > 0 && (

--- a/frontend/src/features/data_entry/components/differences/DifferenceForm.test.tsx
+++ b/frontend/src/features/data_entry/components/differences/DifferenceForm.test.tsx
@@ -121,7 +121,7 @@ describe("Test DifferencesForm", () => {
 
       const moreBallotsCount = await screen.findByRole("textbox", { name: "I Stembiljetten méér geteld" });
       expect(moreBallotsCount.closest("fieldset")).toHaveAccessibleName(
-        "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen",
+        "Verschillen tussen toegelaten kiezers en uitgebrachte stemmen B1-3.3",
       );
       expect(moreBallotsCount).toHaveAccessibleName("I Stembiljetten méér geteld");
       expect(moreBallotsCount).toHaveFocus();

--- a/frontend/src/features/data_entry/components/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/src/features/data_entry/components/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -136,7 +136,9 @@ describe("Test VotersAndVotesForm", () => {
       renderForm();
 
       const pollCards = await screen.findByRole("textbox", { name: "A Stempassen" });
-      expect(pollCards.closest("fieldset")).toHaveAccessibleName("Toegelaten kiezers en uitgebrachte stemmen");
+      expect(pollCards.closest("fieldset")).toHaveAccessibleName(
+        "Toegelaten kiezers en uitgebrachte stemmen B1-3.1 en 3.2",
+      );
       expect(pollCards).toHaveAccessibleName("A Stempassen");
       expect(pollCards).toHaveFocus();
 
@@ -1036,7 +1038,7 @@ describe("Test VotersAndVotesForm", () => {
       renderForm();
 
       // wait for form to render
-      await screen.findByRole("group", { name: "Toegelaten kiezers en uitgebrachte stemmen" });
+      await screen.findByRole("group", { name: "Toegelaten kiezers en uitgebrachte stemmen B1-3.1 en 3.2" });
 
       // make sure recounted subsection is not shown
       expect(
@@ -1058,7 +1060,7 @@ describe("Test VotersAndVotesForm", () => {
       renderForm();
 
       // wait for form to render
-      await screen.findByRole("group", { name: "Toegelaten kiezers en uitgebrachte stemmen" });
+      await screen.findByRole("group", { name: "Toegelaten kiezers en uitgebrachte stemmen B1-3.1 en 3.2" });
 
       // make sure recounted subsection is shown
       expect(

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -79,6 +79,7 @@ export interface DataEntrySection {
   id: FormSectionId;
   title: string;
   short_title: string;
+  sectionNumber?: string;
   subsections: DataEntrySubsection[];
 }
 

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -61,6 +61,7 @@ export const createVotersAndVotesSection = (recounted: boolean): DataEntrySectio
     id: "voters_votes_counts",
     title: t("voters_votes_counts.form_title"),
     short_title: t("voters_votes_counts.short_title"),
+    sectionNumber: "B1-3.1 en 3.2",
     subsections: [
       {
         type: "inputGrid",
@@ -85,6 +86,7 @@ export const differencesSection: DataEntrySection = {
   id: "differences_counts",
   title: t("differences_counts.form_title"),
   short_title: t("differences_counts.short_title"),
+  sectionNumber: "B1-3.3",
   subsections: [
     {
       type: "inputGrid",


### PR DESCRIPTION
Add section number badge to data entry form sections, resolves #1738.

Can be tested by using the data entry: the "Aantal kiezers en stemmen" and "Verschillen" sections now show the badge.