### PR TITLE
Corrected to state highest instead of largest

### DIFF
--- a/backend/src/apportionment/seat_assignment.rs
+++ b/backend/src/apportionment/seat_assignment.rs
@@ -953,7 +953,7 @@ fn step_assign_remainder_using_largest_remainder(
         } else {
             // We've now even exhausted unique highest average seats: every group that qualified
             // got a largest remainder seat, and every group also had at least a single residual seat
-            // assigned to them. We now allow any residual seats to be assigned using the largest
+            // assigned to them. We now allow any residual seats to be assigned using the highest
             // averages procedure
             debug!("Assign residual seat using highest averages method");
             step_assign_remainder_using_highest_averages(


### PR DESCRIPTION
A bit of nitpicking :grin: But because largest is used in combination with remainder and highest in combination with averages it seems fair to do change the wording here.

Interestingly the condition/method call made here this comment applies to seems to be not supported by law. In P8 3 it only mentions that only 1 seat should be assigned. No mention what to do in case all parties have 1 seat and there would still be seats left. While here in the code it just implements to use the 'normal' way to assign. So unless there is jurisdictional evidence this has been done in the past, I think the correct way to implement here is to throw an error and that the kiesraad should decide what to do. (I also think, in practice, this  case will never occur, so it's a bit of a theoretical case. But it should be handled supported by law).

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->