### PR TITLE
Fix typst date format

### DIFF
--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -101,13 +101,13 @@
   let date = datetime(year: int(dp.at(0)), month: int(dp.at(1)), day: int(dp.at(2)))
 
   let weekdays = (
-    "zondag",
     "maandag",
     "dinsdag",
     "woensdag",
     "donderdag",
     "vrijdag",
     "zaterdag",
+    "zondag",
   )
 
   let months = (
@@ -125,7 +125,7 @@
     "december",
   )
 
-  weekdays.at(date.weekday())
+  weekdays.at(date.weekday() - 1)
   date.display(" [day padding:none] ")
   months.at(date.month() - 1)
   date.display(" [year]")


### PR DESCRIPTION
Fixes a bug in main.

Typst date type outputs a 7 for Sunday instead of a 0....

https://typst.app/docs/reference/foundations/datetime#definitions-weekday

Unfortunately we cannot easily write unit tests for typsts functions.

This bug caused a test to fail only on Sunday 😆 