### PR TITLE
improve copy of airgap violation page

### DIFF
--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -15,7 +15,7 @@
   },
   "airgap_violation": {
     "title": "Abacus zit op slot",
-    "content": "<p>Abacus is geblokkeerd omdat de applicatie is verbonden met het internet.</p><ul><li>Wijzigingen zijn niet mogelijk</li><li>Alle werkplekken zijn vergrendeld</li></ul><h3>Wat te doen?</h3><ul><li>Verbreek de internetverbinding</li><li><reload>Herlaad de pagina</reload></li></ul><p>Pas daarna kan de steminvoer worden hervat.</p>",
+    "content": "<p>Abacus is geblokkeerd omdat de applicatie is verbonden met het internet.</p><ul><li>Wijzigingen zijn niet mogelijk</li><li>Alle werkplekken zijn vergrendeld</li></ul><h3>Wat te doen?</h3><ul><li>Verbreek de internetverbinding</li><li><reload>Herlaad de pagina</reload></li></ul><p>Pas daarna kan Abacus weer gebruikt worden.</p>",
     "reload": "Probeer opnieuw"
   },
   "api_error": {


### PR DESCRIPTION
### Scope

In the airgap violation page ("Abacus zit op slot") replace "Pas daarna kan de steminvoer worden hervat." with "Pas daarna kan Abacus weer gebruikt worden." This way the copy does not refer to a specific phase of Abacus usage.

#### old
<img width="1919" height="813" alt="image" src="https://github.com/user-attachments/assets/7862653f-cd6b-422e-bca8-03c364c8a4fa" />

#### new
<img width="1915" height="811" alt="20250715-152609" src="https://github.com/user-attachments/assets/7ba30610-dfd5-490f-9020-3a8b6625b3a4" />