### PR TITLE
move button to create polling station to the left

### DIFF
--- a/frontend/src/components/ui/Toolbar/Toolbar.stories.tsx
+++ b/frontend/src/components/ui/Toolbar/Toolbar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite";
 import { IconPlus } from "@/components/generated/icons";
 
 import { Button } from "../Button/Button";
-import { Toolbar, ToolbarSection } from "./Toolbar";
+import { Toolbar } from "./Toolbar";
 
 type Props = {
   pos: "start" | "center" | "end";
@@ -28,11 +28,11 @@ export const BasicToolbar: StoryObj<Props> = {
 
 export const ExampleToolbar: StoryFn = () => (
   <Toolbar id="example-toolbar">
-    <ToolbarSection pos="start">
+    <Toolbar.Section pos="start">
       <Button variant="secondary" size="sm">
         Toolbar button
       </Button>
-    </ToolbarSection>
+    </Toolbar.Section>
     <Toolbar.Section pos="end">
       <Button leftIcon={<IconPlus />} variant="secondary" size="sm">
         Lijst exporteren

--- a/frontend/src/components/ui/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/ui/Toolbar/Toolbar.tsx
@@ -19,7 +19,7 @@ export interface ToolbarSectionProps extends React.HTMLAttributes<HTMLElement> {
   pos?: "start" | "center" | "end";
   children: React.ReactNode;
 }
-export function ToolbarSection({ children, pos = "start", ...htmlProps }: ToolbarSectionProps) {
+function ToolbarSection({ children, pos = "start", ...htmlProps }: ToolbarSectionProps) {
   return (
     <section className={cn(cls.toolbarSection, cls[pos])} {...htmlProps}>
       {children}

--- a/frontend/src/features/logs/components/LogsHomePage.tsx
+++ b/frontend/src/features/logs/components/LogsHomePage.tsx
@@ -6,7 +6,7 @@ import { PageTitle } from "@/components/page_title/PageTitle";
 import { Button } from "@/components/ui/Button/Button";
 import { Loader } from "@/components/ui/Loader/Loader";
 import { Pagination } from "@/components/ui/Pagination/Pagination";
-import { Toolbar, ToolbarSection } from "@/components/ui/Toolbar/Toolbar";
+import { Toolbar } from "@/components/ui/Toolbar/Toolbar";
 import { t } from "@/i18n/translate";
 import { AuditLogEvent } from "@/types/generated/openapi";
 
@@ -59,7 +59,7 @@ export function LogsHomePage() {
         <article>
           <Toolbar>
             {!showFilter && (
-              <ToolbarSection>
+              <Toolbar.Section>
                 <Button
                   variant="secondary"
                   size="sm"
@@ -69,12 +69,12 @@ export function LogsHomePage() {
                 >
                   <IconFilter /> {t("log.action.filter")}
                 </Button>
-              </ToolbarSection>
+              </Toolbar.Section>
             )}
             {pagination && pagination.totalPages > 1 && (
-              <ToolbarSection pos="end">
+              <Toolbar.Section pos="end">
                 <Pagination page={pagination.page} totalPages={pagination.totalPages} onPageChange={onPageChange} />
-              </ToolbarSection>
+              </Toolbar.Section>
             )}
           </Toolbar>
           <LogsTable events={events} setDetails={setDetails} />

--- a/frontend/src/features/polling_stations/components/PollingStationListPage.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.tsx
@@ -48,21 +48,17 @@ export function PollingStationListPage() {
             <p className="mb-lg">{t("polling_station.message.no_polling_stations")}</p>
 
             <Toolbar>
-              <Toolbar.Section pos="start">
-                <Button.Link variant="secondary" size="sm" to="./create">
-                  <IconPlus /> {t("manual_input")}
-                </Button.Link>
-              </Toolbar.Section>
+              <Button.Link variant="secondary" size="sm" to="./create">
+                <IconPlus /> {t("manual_input")}
+              </Button.Link>
             </Toolbar>
           </article>
         ) : (
           <article>
             <Toolbar>
-              <Toolbar.Section pos="end">
-                <Button.Link variant="secondary" size="sm" to="./create">
-                  <IconPlus /> {t("polling_station.form.create")}
-                </Button.Link>
-              </Toolbar.Section>
+              <Button.Link variant="secondary" size="sm" to="./create">
+                <IconPlus /> {t("polling_station.form.create")}
+              </Button.Link>
             </Toolbar>
 
             <Table id="polling_stations">


### PR DESCRIPTION
### Scope
This makes the position of the button consistent with the elections and user management pages.

This was [discussed with Joris](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp?node-id=1121-9960#1325271076), who has updated the design: https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=5442-50666&t=anpcKMQSFRViMZH4-0

### Question
The PollingStationListPage used `Toolbar.Section`. The LogsHomePage used `ToolbarSection`. They are the same thing because Toolbar does `Toolbar.Section = ToolbarSection;`. Which of these is the prefered way?

Because either `Toolbar.Section = ToolbarSection;` needs to be removed, or the LogsHomePage needs to use `Toolbar.Section`.

### Pictures
<img width="1910" height="465" alt="image" src="https://github.com/user-attachments/assets/dc0bb85f-d254-4598-b1dd-dec494a2101c" />

<img width="1917" height="495" alt="image" src="https://github.com/user-attachments/assets/0e31b1bd-6e49-43aa-9854-065800ac330e" />

<img width="1913" height="488" alt="image" src="https://github.com/user-attachments/assets/fc9561be-1fcb-4360-bc72-890fd76e6035" />
