### PR TITLE
handle all non available states in PollingStationChoiceForm

### DIFF
--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -104,8 +104,6 @@ describe("Test PollingStationChoiceForm", () => {
 
     test.each([
       // TODO add tests for:
-      // "first_entry_in_progress" by other user => invalid, PollingStationUserStatus.InProgressOtherUser
-      // "first_entry_has_errors" => not handled on submit, PollingStationUserStatus.HasErrors
       // "second_entry_not_started" 1st entry by same user => not handled on submit, PollingStationUserStatus.SecondEntryNotAllowed
       {
         testDescription: "invalid",
@@ -137,7 +135,12 @@ describe("Test PollingStationChoiceForm", () => {
         selectorFeedback: "Een andere invoerder is bezig met stembureau 36",
         submitFeedback: "Een andere invoerder is bezig met stembureau 36 (Testbuurthuis)",
       },
-      // polling station 37: "first_entry_has_errors"
+      {
+        testDescription: "second entry in progress",
+        pollingStationInput: "37", // status: "first_entry_has_errors"
+        selectorFeedback: "Stembureau 37 ligt ter beoordeling bij de coördinator",
+        submitFeedback: "Stembureau 37 ligt ter beoordeling bij de coördinator",
+      },
       {
         testDescription: "first entry in progress",
         pollingStationInput: "38", // status: "first_entry_in_progress"

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -105,8 +105,8 @@ describe("Test PollingStationChoiceForm", () => {
     test.each([
       // TODO add tests for:
       // "first_entry_in_progress" by other user => invalid, PollingStationUserStatus.InProgressOtherUser
-      // "first_entry_has_errors" => invalid, PollingStationUserStatus.HasErrors
-      // "second_entry_not_started" 1st entry by same user => invalid, PollingStationUserStatus.SecondEntryNotAllowed
+      // "first_entry_has_errors" => not handled on submit, PollingStationUserStatus.HasErrors
+      // "second_entry_not_started" 1st entry by same user => not handled on submit, PollingStationUserStatus.SecondEntryNotAllowed
       {
         testDescription: "invalid",
         pollingStationInput: "abc",
@@ -136,6 +136,13 @@ describe("Test PollingStationChoiceForm", () => {
         pollingStationInput: "36", // status: "second_entry_in_progress"
         selectorFeedback: "Een andere invoerder is bezig met stembureau 36",
         submitFeedback: "Een andere invoerder is bezig met stembureau 36 (Testbuurthuis)",
+      },
+      // polling station 37: "first_entry_has_errors"
+      {
+        testDescription: "first entry in progress",
+        pollingStationInput: "38", // status: "first_entry_in_progress"
+        selectorFeedback: "Een andere invoerder is bezig met stembureau 38",
+        submitFeedback: "Een andere invoerder is bezig met stembureau 38 (Testmuseum)",
       },
     ])(
       "Entering a $testDescription polling station shows feedback and alert",

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -147,6 +147,12 @@ describe("Test PollingStationChoiceForm", () => {
         selectorFeedback: "Een andere invoerder is bezig met stembureau 38",
         submitFeedback: "Een andere invoerder is bezig met stembureau 38 (Testmuseum)",
       },
+      {
+        testDescription: "second entry not started",
+        pollingStationInput: "39", // status: "second_entry_not_started"
+        selectorFeedback: "Je mag stembureau 39 niet nog een keer invoeren",
+        submitFeedback: "Je mag stembureau 39 niet nog een keer invoeren",
+      },
     ])(
       "Entering a $testDescription polling station shows feedback and alert",
       async ({ pollingStationInput, selectorFeedback, submitFeedback }) => {

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -102,6 +102,56 @@ describe("Test PollingStationChoiceForm", () => {
       expect(await within(pollingStationFeedback).findByText(/Testplek/)).toBeVisible();
     });
 
+    test.each([
+      {
+        testDescription: "invalid",
+        pollingStationInput: "abc",
+        selectorFeedback: "Geen stembureau gevonden met nummer abc",
+        submitFeedback: "Voer een geldig nummer van een stembureau in om te beginnen",
+      },
+      {
+        testDescription: "non-existing",
+        pollingStationInput: "987654",
+        selectorFeedback: "Geen stembureau gevonden met nummer 987654",
+        submitFeedback: "Voer een geldig nummer van een stembureau in om te beginnen",
+      },
+      {
+        testDescription: "finalized",
+        pollingStationInput: "34",
+        selectorFeedback: "Stembureau 34 (Testplek) is al twee keer ingevoerd",
+        submitFeedback: "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
+      },
+      {
+        testDescription: "different entries",
+        pollingStationInput: "35",
+        selectorFeedback: "Stembureau 35 (Testschool) is al twee keer ingevoerd",
+        submitFeedback: "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
+      },
+    ])(
+      "Entering a $testDescription polling station shows feedback and alert",
+      async ({ pollingStationInput, selectorFeedback, submitFeedback }) => {
+        overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
+        overrideOnce("get", "/api/elections/1/status", 200, statusResponseMock);
+
+        const user = userEvent.setup();
+        await renderPollingStationChoiceForm();
+
+        const pollingStation = await screen.findByTestId("pollingStation");
+        await user.type(pollingStation, pollingStationInput);
+
+        const pollingStationSelectFeedback = await screen.findByTestId("pollingStationSelectorFeedback");
+        await waitFor(() => {
+          expect(pollingStationSelectFeedback).toHaveTextContent(selectorFeedback);
+        });
+
+        const submitButton = screen.getByRole("button", { name: "Beginnen" });
+        await user.click(submitButton);
+
+        const pollingStationSubmitFeedback = await screen.findByTestId("pollingStationSubmitFeedback");
+        expect(pollingStationSubmitFeedback).toHaveTextContent(submitFeedback);
+      },
+    );
+
     test("Selecting a non-existing polling station", async () => {
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
@@ -123,6 +173,7 @@ describe("Test PollingStationChoiceForm", () => {
     });
 
     test("Submitting an empty or invalid polling station shows alert", async () => {
+      // TODO: split test in (1) submitting empty and (2) resetting alerts when typing
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
       await renderPollingStationChoiceForm();
@@ -150,76 +201,6 @@ describe("Test PollingStationChoiceForm", () => {
       expect(
         within(screen.getByTestId("pollingStationSubmitFeedback")).getByText(
           "Voer een geldig nummer van een stembureau in om te beginnen",
-        ),
-      ).toBeVisible();
-    });
-
-    test("Selecting a valid, but finalised polling station shows alert", async () => {
-      overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
-      overrideOnce("get", "/api/elections/1/status", 200, statusResponseMock);
-      const user = userEvent.setup();
-      render(
-        <ElectionProvider electionId={1}>
-          <ElectionStatusProvider electionId={1}>
-            <PollingStationChoiceForm anotherEntry />
-          </ElectionStatusProvider>
-        </ElectionProvider>,
-      );
-
-      const submitButton = await screen.findByRole("button", { name: "Beginnen" });
-      const pollingStation = screen.getByTestId("pollingStation");
-
-      // Test if the polling station name is shown
-      await user.type(pollingStation, "34");
-
-      // Click submit and see that the alert appears
-      await user.click(submitButton);
-
-      // Test if the warning message is shown correctly
-      await waitFor(() => {
-        expect(screen.getByTestId("pollingStationSelectorFeedback").textContent).toBe(
-          "Stembureau 34 (Testplek) is al twee keer ingevoerd",
-        );
-      });
-
-      expect(
-        within(screen.getByTestId("pollingStationSubmitFeedback")).getByText(
-          "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
-        ),
-      ).toBeVisible();
-    });
-
-    test("Selecting a valid, but with different entries polling station shows alert", async () => {
-      overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
-      overrideOnce("get", "/api/elections/1/status", 200, statusResponseMock);
-      const user = userEvent.setup();
-      render(
-        <ElectionProvider electionId={1}>
-          <ElectionStatusProvider electionId={1}>
-            <PollingStationChoiceForm anotherEntry />
-          </ElectionStatusProvider>
-        </ElectionProvider>,
-      );
-
-      const submitButton = await screen.findByRole("button", { name: "Beginnen" });
-      const pollingStation = screen.getByTestId("pollingStation");
-
-      // Test if the polling station name is shown
-      await user.type(pollingStation, "35");
-
-      // Click submit and see that the alert appears
-      await user.click(submitButton);
-
-      // Test if the warning message is shown correctly
-      await waitFor(() => {
-        expect(screen.getByTestId("pollingStationSelectorFeedback").textContent).toBe(
-          "Stembureau 35 (Testschool) is al twee keer ingevoerd",
-        );
-      });
-
-      expect(
-        within(screen.getByTestId("pollingStationSubmitFeedback")).getByText(
-          "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
         ),
       ).toBeVisible();
     });

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -103,8 +103,6 @@ describe("Test PollingStationChoiceForm", () => {
     });
 
     test.each([
-      // TODO add tests for:
-      // "second_entry_not_started" 1st entry by same user => not handled on submit, PollingStationUserStatus.SecondEntryNotAllowed
       {
         testDescription: "invalid",
         pollingStationInput: "abc",
@@ -199,7 +197,6 @@ describe("Test PollingStationChoiceForm", () => {
     });
 
     test("Submitting an empty or invalid polling station shows alert", async () => {
-      // TODO: split test in (1) submitting empty and (2) resetting alerts when typing
       overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
       const user = userEvent.setup();
       await renderPollingStationChoiceForm();

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -103,6 +103,10 @@ describe("Test PollingStationChoiceForm", () => {
     });
 
     test.each([
+      // TODO add tests for:
+      // "first_entry_in_progress" by other user => invalid, PollingStationUserStatus.InProgressOtherUser
+      // "first_entry_has_errors" => invalid, PollingStationUserStatus.HasErrors
+      // "second_entry_not_started" 1st entry by same user => invalid, PollingStationUserStatus.SecondEntryNotAllowed
       {
         testDescription: "invalid",
         pollingStationInput: "abc",
@@ -117,15 +121,21 @@ describe("Test PollingStationChoiceForm", () => {
       },
       {
         testDescription: "finalized",
-        pollingStationInput: "34",
+        pollingStationInput: "34", // status: "definitive"
         selectorFeedback: "Stembureau 34 (Testplek) is al twee keer ingevoerd",
         submitFeedback: "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
       },
       {
         testDescription: "different entries",
-        pollingStationInput: "35",
+        pollingStationInput: "35", // status: "entries_different"
         selectorFeedback: "Stembureau 35 (Testschool) is al twee keer ingevoerd",
         submitFeedback: "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
+      },
+      {
+        testDescription: "second entry in progress",
+        pollingStationInput: "36", // status: "second_entry_in_progress"
+        selectorFeedback: "Een andere invoerder is bezig met stembureau 36",
+        submitFeedback: "Een andere invoerder is bezig met stembureau 36 (Testbuurthuis)",
       },
     ])(
       "Entering a $testDescription polling station shows feedback and alert",

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -117,42 +117,42 @@ describe("Test PollingStationChoiceForm", () => {
       },
       {
         testDescription: "finalized",
-        pollingStationInput: "34", // status: "definitive"
+        pollingStationInput: "34",
         selectorFeedback: "Stembureau 34 (Testplek) is al twee keer ingevoerd",
         submitFeedback: "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
       },
       {
-        testDescription: "different entries",
-        pollingStationInput: "35", // status: "entries_different"
+        testDescription: "entries different",
+        pollingStationInput: "35",
         selectorFeedback: "Stembureau 35 (Testschool) is al twee keer ingevoerd",
         submitFeedback: "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
       },
       {
-        testDescription: "second entry in progress",
-        pollingStationInput: "36", // status: "second_entry_in_progress"
+        testDescription: "second entry in progress by other",
+        pollingStationInput: "36",
         selectorFeedback: "Een andere invoerder is bezig met stembureau 36",
         submitFeedback: "Een andere invoerder is bezig met stembureau 36 (Testbuurthuis)",
       },
       {
-        testDescription: "second entry in progress",
-        pollingStationInput: "37", // status: "first_entry_has_errors"
+        testDescription: "first entry has errors",
+        pollingStationInput: "37",
         selectorFeedback: "Stembureau 37 ligt ter beoordeling bij de coördinator",
         submitFeedback: "Stembureau 37 ligt ter beoordeling bij de coördinator",
       },
       {
-        testDescription: "first entry in progress",
-        pollingStationInput: "38", // status: "first_entry_in_progress"
+        testDescription: "first entry in progress by other",
+        pollingStationInput: "38",
         selectorFeedback: "Een andere invoerder is bezig met stembureau 38",
         submitFeedback: "Een andere invoerder is bezig met stembureau 38 (Testmuseum)",
       },
       {
-        testDescription: "second entry not started",
-        pollingStationInput: "39", // status: "second_entry_not_started"
+        testDescription: "first entry done by same user",
+        pollingStationInput: "39",
         selectorFeedback: "Je mag stembureau 39 niet nog een keer invoeren",
         submitFeedback: "Je mag stembureau 39 niet nog een keer invoeren",
       },
     ])(
-      "Entering a $testDescription polling station shows feedback and alert",
+      "Inputting and submitting an invalid polling station shows feedback and alert: $testDescription",
       async ({ pollingStationInput, selectorFeedback, submitFeedback }) => {
         overrideOnce("get", "/api/elections/1", 200, electionDetailsMockResponse);
         overrideOnce("get", "/api/elections/1/status", 200, statusResponseMock);

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -114,6 +114,16 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
       return;
     }
 
+    if (pollingStation.userStatus === PollingStationUserStatus.SecondEntryNotAllowed) {
+      setAlert(
+        t("polling_station_choice.second_entry_not_allowed", {
+          nr: pollingStation.number,
+        }),
+      );
+      setLoading(false);
+      return;
+    }
+
     void navigate(getUrlForDataEntry(election.id, pollingStation.id, pollingStation.statusEntry.status));
   };
 

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -104,6 +104,16 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
       return;
     }
 
+    if (pollingStation.userStatus === PollingStationUserStatus.HasErrors) {
+      setAlert(
+        t("polling_station_choice.has_errors", {
+          nr: pollingStation.number,
+        }),
+      );
+      setLoading(false);
+      return;
+    }
+
     void navigate(getUrlForDataEntry(election.id, pollingStation.id, pollingStation.statusEntry.status));
   };
 

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -52,7 +52,7 @@ describe("ElectionHomePage", () => {
       ["Lijsten en kandidaten", "2 lijsten en 31 kandidaten"],
       ["Aantal kiesgerechtigden", "100"],
       ["Invoer doen voor", ""],
-      ["Stembureaus", "7 stembureaus"],
+      ["Stembureaus", "8 stembureaus"],
       ["Type stemopneming", "Centrale stemopneming"],
     ]);
   });

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -52,7 +52,7 @@ describe("ElectionHomePage", () => {
       ["Lijsten en kandidaten", "2 lijsten en 31 kandidaten"],
       ["Aantal kiesgerechtigden", "100"],
       ["Invoer doen voor", ""],
-      ["Stembureaus", "6 stembureaus"],
+      ["Stembureaus", "7 stembureaus"],
       ["Type stemopneming", "Centrale stemopneming"],
     ]);
   });

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -52,7 +52,7 @@ describe("ElectionHomePage", () => {
       ["Lijsten en kandidaten", "2 lijsten en 31 kandidaten"],
       ["Aantal kiesgerechtigden", "100"],
       ["Invoer doen voor", ""],
-      ["Stembureaus", "5 stembureaus"],
+      ["Stembureaus", "6 stembureaus"],
       ["Type stemopneming", "Centrale stemopneming"],
     ]);
   });

--- a/frontend/src/features/election_status/components/ElectionStatus.stories.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
-import { extendedPollingStationMockData } from "@/testing/api-mocks/PollingStationMockData";
+import { pollingStationMockData } from "@/testing/api-mocks/PollingStationMockData";
 
 import { ElectionStatus } from "./ElectionStatus";
 
@@ -73,7 +73,7 @@ export const DefaultElectionStatus: StoryObj<StoryProps> = {
           },
         ]}
         election={electionMockData}
-        pollingStations={extendedPollingStationMockData}
+        pollingStations={pollingStationMockData}
         navigate={navigate}
       />
     );

--- a/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
@@ -35,6 +35,7 @@ describe("PollingStationListPage", () => {
       ["37", "Dansschool Oeps nou deed ik het weer", "Bijzonder"],
       ["38", "Testmuseum", "Bijzonder"],
       ["39", "Test gemeentehuis", "Vaste locatie"],
+      ["40", "Test kerk", "Vaste locatie"],
     ]);
   });
 

--- a/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
@@ -34,6 +34,7 @@ describe("PollingStationListPage", () => {
       ["36", "Testbuurthuis", "Vaste locatie"],
       ["37", "Dansschool Oeps nou deed ik het weer", "Bijzonder"],
       ["38", "Testmuseum", "Bijzonder"],
+      ["39", "Test gemeentehuis", "Vaste locatie"],
     ]);
   });
 

--- a/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
@@ -33,6 +33,7 @@ describe("PollingStationListPage", () => {
       ["35", "Testschool", "Vaste locatie"],
       ["36", "Testbuurthuis", "Vaste locatie"],
       ["37", "Dansschool Oeps nou deed ik het weer", "Bijzonder"],
+      ["38", "Testmuseum", "Bijzonder"],
     ]);
   });
 

--- a/frontend/src/i18n/locales/nl/polling_station_choice.json
+++ b/frontend/src/i18n/locales/nl/polling_station_choice.json
@@ -11,7 +11,7 @@
   "no_polling_station_found_with_number": "Geen stembureau gevonden met nummer {nr}",
   "no_polling_stations_found": "Geen stembureaus gevonden",
   "polling_station_entry_not_possible": "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
-  "polling_station_in_progress_different_user": "Een andere invoerder is bezig met stembureau {nr} ({name})",
+  "polling_station_in_progress_different_user": "Een andere invoerder is bezig met stembureau {nr} <strong>({name})</strong>",
   "searching": "aan het zoeken",
   "second_entry_not_allowed": "Je mag stembureau {nr} niet nog een keer invoeren",
   "there_are_no_polling_stations_left_to_fill_in": "Er zijn voor jou geen stembureaus meer om in te voeren",

--- a/frontend/src/i18n/locales/nl/polling_station_choice.json
+++ b/frontend/src/i18n/locales/nl/polling_station_choice.json
@@ -11,7 +11,7 @@
   "no_polling_station_found_with_number": "Geen stembureau gevonden met nummer {nr}",
   "no_polling_stations_found": "Geen stembureaus gevonden",
   "polling_station_entry_not_possible": "Het stembureau dat je geselecteerd hebt kan niet meer ingevoerd worden",
-  "polling_station_in_progress_different_user": "Een andere invoerder is bezig met stembureau {nr} <strong>({name})</strong>",
+  "polling_station_in_progress_different_user": "Een andere invoerder is bezig met stembureau {nr} ({name})",
   "searching": "aan het zoeken",
   "second_entry_not_allowed": "Je mag stembureau {nr} niet nog een keer invoeren",
   "there_are_no_polling_stations_left_to_fill_in": "Er zijn voor jou geen stembureaus meer om in te voeren",

--- a/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
@@ -35,11 +35,16 @@ export const statusResponseMock: ElectionStatusResponse = {
       first_entry_progress: 100,
     },
     {
-      // TODO: will this break other tests?
       polling_station_id: 6,
       status: "first_entry_in_progress",
       first_entry_user_id: 2,
       first_entry_progress: 50,
+    },
+    {
+      polling_station_id: 7,
+      status: "second_entry_not_started",
+      first_entry_user_id: 1,
+      first_entry_progress: 100,
     },
   ],
 };

--- a/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
@@ -46,5 +46,6 @@ export const statusResponseMock: ElectionStatusResponse = {
       first_entry_user_id: 1,
       first_entry_progress: 100,
     },
+    { polling_station_id: 8, status: "first_entry_not_started" },
   ],
 };

--- a/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionStatusMockData.ts
@@ -34,5 +34,12 @@ export const statusResponseMock: ElectionStatusResponse = {
       first_entry_user_id: 1,
       first_entry_progress: 100,
     },
+    {
+      // TODO: will this break other tests?
+      polling_station_id: 6,
+      status: "first_entry_in_progress",
+      first_entry_user_id: 2,
+      first_entry_progress: 50,
+    },
   ],
 };

--- a/frontend/src/testing/api-mocks/PollingStationMockData.ts
+++ b/frontend/src/testing/api-mocks/PollingStationMockData.ts
@@ -78,10 +78,6 @@ export const pollingStationMockData: PollingStation[] = [
     postal_code: "1234 AB",
     locality: "Teststad",
   },
-];
-
-export const extendedPollingStationMockData: PollingStation[] = [
-  ...pollingStationMockData,
   {
     id: 8,
     election_id: 1,

--- a/frontend/src/testing/api-mocks/PollingStationMockData.ts
+++ b/frontend/src/testing/api-mocks/PollingStationMockData.ts
@@ -67,10 +67,6 @@ export const pollingStationMockData: PollingStation[] = [
     postal_code: "1234 QY",
     locality: "Testdorp",
   },
-];
-
-export const extendedPollingStationMockData: PollingStation[] = [
-  ...pollingStationMockData,
   {
     id: 7,
     election_id: 1,
@@ -82,6 +78,10 @@ export const extendedPollingStationMockData: PollingStation[] = [
     postal_code: "1234 AB",
     locality: "Teststad",
   },
+];
+
+export const extendedPollingStationMockData: PollingStation[] = [
+  ...pollingStationMockData,
   {
     id: 8,
     election_id: 1,

--- a/frontend/src/testing/api-mocks/PollingStationMockData.ts
+++ b/frontend/src/testing/api-mocks/PollingStationMockData.ts
@@ -56,10 +56,6 @@ export const pollingStationMockData: PollingStation[] = [
     postal_code: "4444 JP",
     locality: "Twaalfsteden",
   },
-];
-
-export const extendedPollingStationMockData: PollingStation[] = [
-  ...pollingStationMockData,
   {
     id: 6,
     election_id: 1,
@@ -71,6 +67,10 @@ export const extendedPollingStationMockData: PollingStation[] = [
     postal_code: "1234 QY",
     locality: "Testdorp",
   },
+];
+
+export const extendedPollingStationMockData: PollingStation[] = [
+  ...pollingStationMockData,
   {
     id: 7,
     election_id: 1,


### PR DESCRIPTION
closes #1707

### Scope

- Make PollingStationChoiceForm handle all error scenarios when a user clicks "Beginnen" after inputting the number of a polling station they are not allowed to do data entry for.
- Parametrize the tests of these error scenarios
- Get rid of `extendedPollingStationMockData` (PollingStationMockData.ts), because only one polling station left in it

### Question
There are some inconsistencies in the messages we show to the user, see `frontend/src/i18n/locales/nl/polling_station_choice.json`:
1. After submitting a polling station number (so clicking "Beginnen"), we sometimes put the polling station name in the alert and sometimes we don't.
2. In the PollingStationChoice Selector the polling station name is in a `<strong>`, in the PollingStationChoiceForm it is not. (Requires a bigger change than just adding the `<strong>`.)

Should we address this this week in a separate PR, or is this good enough as-is? cc @jorisleker 