### PR TITLE
Remove `eslint-config-prettier` from `package.json`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,6 @@
         "@xstate/graph": "^3.0.4",
         "cross-env": "^7.0.3",
         "eslint": "^9.31.0",
-        "eslint-config-prettier": "^10.1.5",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -4947,22 +4946,6 @@
         "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-config-prettier": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
-      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-config-prettier"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-context": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,6 @@
     "@xstate/graph": "^3.0.4",
     "cross-env": "^7.0.3",
     "eslint": "^9.31.0",
-    "eslint-config-prettier": "^10.1.5",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",


### PR DESCRIPTION

We removed `eslint-config-prettier` from the ESLint configuration in #1526, but did not remove it from `package.json`. This PR fixes that.