### PR TITLE
Fix button styling and added icon

### DIFF
--- a/frontend/src/app/AuthorizationDialog.tsx
+++ b/frontend/src/app/AuthorizationDialog.tsx
@@ -76,7 +76,7 @@ export function AuthorizationDialog() {
         <nav>
           <Button
             variant="primary"
-            size="lg"
+            size="xl"
             onClick={() => {
               void extendSession();
               setHideDialog(true);

--- a/frontend/src/components/ui/Button/Button.module.css
+++ b/frontend/src/components/ui/Button/Button.module.css
@@ -143,6 +143,9 @@ label.button {
   }
 
   &.lg {
+  }
+
+  &.xl {
     min-width: 13rem;
   }
 }

--- a/frontend/src/components/ui/Modal/Modal.stories.tsx
+++ b/frontend/src/components/ui/Modal/Modal.stories.tsx
@@ -32,8 +32,8 @@ export const DefaultModal: StoryObj = {
             </p>
             <p>Twijfel je? Overleg dan met de coördinator.</p>
             <nav>
-              <Button size="lg">Invoer bewaren</Button>
-              <Button size="lg" variant="secondary">
+              <Button size="xl">Invoer bewaren</Button>
+              <Button size="xl" variant="secondary">
                 Niet bewaren
               </Button>
             </nav>

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -161,7 +161,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
       {tx("data_entry.abort.description")}
       <nav>
         <Button
-          size="lg"
+          size="xl"
           onClick={() => {
             void onAbortModalSave();
           }}
@@ -171,7 +171,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           {t("data_entry.abort.save_input")}
         </Button>
         <Button
-          size="lg"
+          size="xl"
           variant="secondary"
           onClick={() => {
             void onAbortModalDelete();

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -61,7 +61,7 @@ export function AbortModal() {
       {tx("election.abort.description")}
       <nav>
         <Button
-          size="lg"
+          size="xl"
           variant="primary-destructive"
           onClick={() => {
             onAbortModalDelete();

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -78,7 +78,7 @@ export function AbortModal() {
           }}
           type="button"
         >
-          {t("election.abort.save_input")}
+          {t("election.abort.keep_input")}
         </Button>
       </nav>
     </Modal>

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -71,6 +71,7 @@ export function AbortModal() {
           {t("election.abort.discard_input")}
         </Button>
         <Button
+          size="lg"
           variant="secondary"
           onClick={() => {
             onAbortModalCancel();

--- a/frontend/src/features/polling_stations/components/PollingStationDeleteModal.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationDeleteModal.tsx
@@ -1,5 +1,6 @@
 import { isSuccess } from "@/api/ApiResult";
 import { useCrud } from "@/api/useCrud";
+import { IconTrash } from "@/components/generated/icons";
 import { Button } from "@/components/ui/Button/Button";
 import { Modal } from "@/components/ui/Modal/Modal";
 import { t } from "@/i18n/translate";
@@ -38,10 +39,16 @@ export function PollingStationDeleteModal({
     <Modal title={t("polling_station.delete")} onClose={onCancel}>
       <p>{t("polling_station.delete_are_you_sure")}</p>
       <nav>
-        <Button variant="primary-destructive" size="lg" onClick={handleDelete} disabled={deleting}>
+        <Button
+          leftIcon={<IconTrash />}
+          variant="primary-destructive"
+          size="xl"
+          onClick={handleDelete}
+          disabled={deleting}
+        >
           {t("delete")}
         </Button>
-        <Button variant="secondary" size="lg" onClick={onCancel} disabled={deleting}>
+        <Button variant="secondary" size="xl" onClick={onCancel} disabled={deleting}>
           {t("cancel")}
         </Button>
       </nav>

--- a/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
@@ -82,11 +82,11 @@ describe("PollingStationUpdatePage", () => {
         </ElectionProvider>,
       );
 
-      const deleteButton = await screen.findByRole("button", { name: "Stembureau verwijderen" });
+      const deleteButton = await screen.findByRole("button", { name: "Stembureau verwijderen?" });
       await user.click(deleteButton);
 
       const modal = await screen.findByTestId("modal-dialog");
-      expect(modal).toHaveTextContent("Stembureau verwijderen");
+      expect(modal).toHaveTextContent("Stembureau verwijderen?");
 
       const deletePollingStation = spyOnHandler(PollingStationDeleteHandler);
 
@@ -115,11 +115,11 @@ describe("PollingStationUpdatePage", () => {
         </ElectionProvider>,
       );
 
-      const deleteButton = await screen.findByRole("button", { name: "Stembureau verwijderen" });
+      const deleteButton = await screen.findByRole("button", { name: "Stembureau verwijderen?" });
       await user.click(deleteButton);
 
       const modal = await screen.findByTestId("modal-dialog");
-      expect(modal).toHaveTextContent("Stembureau verwijderen");
+      expect(modal).toHaveTextContent("Stembureau verwijderen?");
 
       const confirmButton = await within(modal).findByRole("button", { name: "Verwijderen" });
       await user.click(confirmButton);

--- a/frontend/src/features/users/components/update/UserDelete.tsx
+++ b/frontend/src/features/users/components/update/UserDelete.tsx
@@ -44,10 +44,16 @@ export function UserDelete({ user, onDeleted, onError }: UserDeleteProps) {
         <Modal title={t("users.delete")} onClose={toggleModal}>
           <p>{t("users.delete_are_you_sure")}</p>
           <nav>
-            <Button variant="primary-destructive" size="lg" onClick={handleDelete} disabled={deleting}>
+            <Button
+              leftIcon={<IconTrash />}
+              variant="primary-destructive"
+              size="xl"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
               {t("delete")}
             </Button>
-            <Button variant="secondary" size="lg" onClick={toggleModal} disabled={deleting}>
+            <Button variant="secondary" size="xl" onClick={toggleModal} disabled={deleting}>
               {t("cancel")}
             </Button>
           </nav>

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -5,7 +5,7 @@
     "action": "Afbreken",
     "description": "<p>De verkiezing wordt pas opgeslagen als je alle stappen doorlopen hebt. Weet je zeker dat je het aanmaken van de verkiezing wilt afbreken?</p>",
     "discard_input": "Ja, verwijder verkiezing",
-    "save_input": "Annuleren",
+    "keep_input": "Annuleren",
     "title": "Niet opgeslagen wijzigingen"
   },
   "check_and_save": {

--- a/frontend/src/i18n/locales/nl/polling_station.json
+++ b/frontend/src/i18n/locales/nl/polling_station.json
@@ -3,8 +3,8 @@
   "address": "Straatnaam en huisnummer",
   "create": "Stembureau toevoegen",
   "current_form": "het huidige formulier",
-  "delete": "Stembureau verwijderen",
-  "delete_are_you_sure": "Weet je zeker dat je dit stembureau wilt verwijderen? Deze actie kan niet worden teruggedraaid.",
+  "delete": "Stembureau verwijderen?",
+  "delete_are_you_sure": "Je kan dit niet ongedaan maken. Weet je zeker dat je dit stembureau wilt verwijderen?",
   "empty": "Er zijn nog geen stembureaus ingevoerd voor deze verkiezing. Kies hoe je stembureaus gaat toevoegen.",
   "form": {
     "create": "Stembureau toevoegen",


### PR DESCRIPTION
The .lg button class was given a min-width of 13rem. 


As a result many buttons are wider than the design, such as the login page.

On main:

<img height="350" alt="Screenshot_2025-07-21_13-45-31" src="https://github.com/user-attachments/assets/91f15e03-8389-4317-b02b-bb28226003be" />

Design:

<img height="350" alt="Screenshot_2025-07-21_13-51-28" src="https://github.com/user-attachments/assets/8a1d5c6c-f5b4-4e20-8ead-3dce08bc0caa" />

The same goes for most buttons for data entry.

On main:

<img height="350" alt="Screenshot_2025-07-21_13-45-46" src="https://github.com/user-attachments/assets/651174cc-68ed-4d69-b257-11f568ff410b" />

Design:

<img height="350" alt="Screenshot_2025-07-21_13-37-48" src="https://github.com/user-attachments/assets/245edadb-6d46-4001-a558-ad64a04bfbf3" />

This commit fixes the width of these buttons.

Only the modal buttons should have min-width, so I added a class .xl (should maybe be renamed to extra-wide or something more descriptive?) used only on the modal buttons.

I also added a missing icon for two modal buttons:

<img height="350" alt="Screenshot_2025-07-21_13-43-08" src="https://github.com/user-attachments/assets/83fa3a3e-9783-4176-991e-542d732ec2cd" />


Fixes #1756