### PR TITLE
Fix e2e url await flake

### DIFF
--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -450,7 +450,9 @@ test.describe("second data entry", () => {
     await expect(dataEntryHomePage.pollingStationFeedback).toContainText(pollingStation.name);
     await dataEntryHomePage.clickStart();
 
-    await expect(page).toHaveURL(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2`);
+    await expect(page).toHaveURL(
+      `/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2/voters_votes_counts`,
+    );
 
     await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntry);
 
@@ -548,7 +550,9 @@ test.describe("second data entry", () => {
     await expect(dataEntryHomePage.pollingStationFeedback).toContainText(pollingStation.name);
     await dataEntryHomePage.clickStart();
 
-    await expect(typistPage).toHaveURL(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2`);
+    await expect(typistPage).toHaveURL(
+      `/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2/voters_votes_counts`,
+    );
 
     // fill form with data that is different from first data entry
     const votersAndVotesPage = new VotersAndVotesPage(typistPage);


### PR DESCRIPTION
Sometimes the router has already redirected from `/elections/1/data-entry/42/2` to `/elections/1/data-entry/42/2/voters_votes_counts` so it is better to await that.

