### PR TITLE
Use watch channel instead of a mpsc channel for airgap detection updates

### DIFF
--- a/backend/src/airgap/detect.rs
+++ b/backend/src/airgap/detect.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, RwLock, atomic::AtomicBool},
     time::{Duration, Instant},
 };
-use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::watch::{self, Sender};
 use tracing::{error, info, trace, warn};
 
 use crate::audit_log::{AuditEvent, AuditLog};
@@ -59,7 +59,7 @@ impl AirgapDetection {
     /// Starts the airgap detection in a background task.
     /// It will periodically check for airgap violations by attempting to connect to a known server.
     pub async fn start(pool: SqlitePool) -> AirgapDetection {
-        let (tx, mut rx) = mpsc::channel::<AirGapStatusChange>(1);
+        let (tx, mut rx) = watch::channel(AirGapStatusChange::AirGapViolationResolved);
 
         let airgap_detection = AirgapDetection {
             enabled: true,
@@ -72,18 +72,24 @@ impl AirgapDetection {
 
         tokio::task::spawn(async move {
             loop {
-                if let Some(status) = rx.recv().await {
-                    let event = match status {
-                        AirGapStatusChange::AirGapViolationDetected => {
-                            AuditEvent::AirGapViolationDetected
-                        }
-                        AirGapStatusChange::AirGapViolationResolved => {
-                            AuditEvent::AirGapViolationResolved
-                        }
-                    };
+                match rx.changed().await {
+                    Ok(_) => {
+                        let event = match *rx.borrow() {
+                            AirGapStatusChange::AirGapViolationDetected => {
+                                AuditEvent::AirGapViolationDetected
+                            }
+                            AirGapStatusChange::AirGapViolationResolved => {
+                                AuditEvent::AirGapViolationResolved
+                            }
+                        };
 
-                    if let Err(e) = audit_log.create(&event, None, None, None).await {
-                        error!("Failed to log air gap status change: {e:#?}");
+                        if let Err(e) = audit_log.create(&event, None, None, None).await {
+                            error!("Failed to log air gap status change: {e:#?}");
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to receive air gap status change: {e:#?}");
+                        break;
                     }
                 }
             }
@@ -112,7 +118,7 @@ impl AirgapDetection {
                 AirGapStatusChange::AirGapViolationResolved
             };
 
-            if let Err(e) = sender.blocking_send(status) {
+            if let Err(e) = sender.send(status) {
                 error!("Failed to send airgap status update: {e}");
             }
         }

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -49,7 +49,7 @@ pub async fn serve_api_with_airgap_detection(pool: SqlitePool) -> SocketAddr {
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
     }
 
-    assert_eq!(violation_detected, true, "Airgap detection did not run");
+    assert!(violation_detected, "Airgap detection did not run");
 
     serve_api_inner(pool, airgap_detection).await
 }

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -34,23 +34,22 @@ pub async fn serve_api(pool: SqlitePool) -> SocketAddr {
 
 pub async fn serve_api_with_airgap_detection(pool: SqlitePool) -> SocketAddr {
     let airgap_detection = AirgapDetection::start(pool.clone()).await;
+    let mut violation_detected = false;
 
-    for i in 0..=100 {
-        if i == 100 {
-            panic!("Airgap detection failed to detect violation after 5 seconds");
+    for i in 0..=200 {
+        if i == 200 {
+            panic!("Airgap detection failed to detect violation after 10 seconds");
         }
 
         if airgap_detection.violation_detected() {
+            violation_detected = true;
             break;
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
     }
 
-    assert!(
-        airgap_detection.get_last_check().is_some(),
-        "Airgap detection did not run"
-    );
+    assert_eq!(violation_detected, true, "Airgap detection did not run");
 
     serve_api_inner(pool, airgap_detection).await
 }


### PR DESCRIPTION
Possible fix for a flaky test: https://github.com/kiesraad/abacus/actions/runs/16420154869/job/46396218293?pr=1799

Replace the mpsc channel for a watch channel, which should be more reliable when communicating from an sync to an async context.