### PR TITLE
Fix data entry session timeout error

### DIFF
--- a/frontend/src/api/ApiClient.ts
+++ b/frontend/src/api/ApiClient.ts
@@ -1,4 +1,3 @@
-import { TranslationPath } from "@/i18n/i18n.types";
 import { ErrorResponse } from "@/types/generated/openapi";
 
 import { ApiErrorEvent, SessionExpirationEvent } from "./ApiEvents";
@@ -88,11 +87,10 @@ export class ApiClient extends EventTarget {
       const isError = isErrorResponse(body);
 
       // NOTE: the reference field references the error we should show to the user,
-      // We prefix it by `error.` to namespace the translation message.
+      // We prefix it by `error.api_error.` to get the translation key.
 
       if (response.status === 404 && isError) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        return new NotFoundError(`error.${body.reference}` as TranslationPath);
+        return new NotFoundError(`error.api_error.${body.reference}`);
       }
 
       if (response.status >= 400 && response.status <= 499 && isError) {

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -26,27 +26,16 @@ export function DataEntrySection() {
     onSubmit,
     currentValues,
     setValues,
-    dataEntryStructure,
     formSection,
     status,
     setAcceptErrorsAndWarnings,
     defaultProps,
     showAcceptErrorsAndWarnings,
-    sectionId,
+    section,
   } = useDataEntryFormSection();
   const acceptCheckboxRef = React.useRef<HTMLInputElement>(null);
 
-  const section = dataEntryStructure.find((s) => s.id === sectionId);
-
-  if (!section) {
-    throw new Error(`Section with id ${sectionId} not found`);
-  }
-
-  if (!user) {
-    throw new Error("No user found");
-  }
-
-  const formId = sectionId + "_form";
+  const formId = section.id + "_form";
 
   const bottomBarType = section.subsections.some((subsection) => subsection.type === "inputGrid")
     ? "inputGrid"
@@ -77,6 +66,10 @@ export function DataEntrySection() {
     e.preventDefault();
     void onSubmit();
   };
+
+  if (!user) {
+    return null;
+  }
 
   return (
     <Form onSubmit={handleSubmit} ref={formRef} id={formId}>

--- a/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
+++ b/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
@@ -103,6 +103,6 @@ export function useDataEntryFormSection() {
     showAcceptErrorsAndWarnings,
     isSaving: status === "saving",
     election,
-    sectionId,
+    section,
   };
 }


### PR DESCRIPTION
- Fix `Abacus is stuk - No user found` error that was shown when the user session timed out during data entry.
  - Throwing an error when there was no user interfered with redirecting to the login screen
- Cleanup handling of other error that could never occur, for an unknown section (already handled by hook).
- Can be tested by being very patient on the data entry screen (30 minutes), or changing the following constants and running Abacus locally: `SESSION_LIFE_TIME` (20), `SESSION_MIN_LIFE_TIME` (10) and `EXPIRATION_DIALOG_SECONDS` (5)

Extra:
- Fix title translation for not found backend errors in `ApiClient`. 
- This can be tested by e.g. updating a polling station and changing the url to an unknown polling station id.