### PR TITLE
Resolve errors and resolve differences messages using useMessages

### DIFF
--- a/frontend/e2e-tests/page-objects/election/ResolveErrorsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/ResolveErrorsPgObj.ts
@@ -1,6 +1,7 @@
 import { type Locator, type Page } from "@playwright/test";
 
 export class ResolveErrorsPgObj {
+  readonly alertDifferencesResolved: Locator;
   readonly title: Locator;
   readonly validationError: Locator;
   readonly resumeFirstEntry: Locator;
@@ -8,6 +9,7 @@ export class ResolveErrorsPgObj {
   readonly save: Locator;
 
   constructor(protected readonly page: Page) {
+    this.alertDifferencesResolved = page.getByRole("alert").filter({ hasText: /Verschil opgelost/ });
     this.title = this.page.getByRole("heading", { name: "Alle fouten en waarschuwingen" });
     this.validationError = page.getByText(/Dit is een verplichte vraag/);
     this.resumeFirstEntry = page.getByLabel(/Invoer bewaren/);

--- a/frontend/e2e-tests/tests/data-entry/resolve-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resolve-differences.e2e.ts
@@ -96,6 +96,7 @@ test.describe("resolve differences then errors", () => {
 
     const resolveErrorsPage = new ResolveErrorsPgObj(page);
     await expect(resolveErrorsPage.title).toBeVisible();
+    await expect(resolveErrorsPage.alertDifferencesResolved).toBeVisible();
     await resolveErrorsPage.resumeFirstEntry.click();
     await resolveErrorsPage.save.click();
 

--- a/frontend/src/components/layout/ElectionStatusLayout.tsx
+++ b/frontend/src/components/layout/ElectionStatusLayout.tsx
@@ -1,11 +1,14 @@
 import { Outlet } from "react-router";
 
+import { MessagesProvider } from "@/hooks/messages/MessagesProvider";
 import { UsersProvider } from "@/hooks/user/UsersProvider";
 
 export function ElectionStatusLayout() {
   return (
     <UsersProvider>
-      <Outlet />
+      <MessagesProvider>
+        <Outlet />
+      </MessagesProvider>
     </UsersProvider>
   );
 }

--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -92,24 +92,6 @@ describe("ElectionStatusPage", () => {
     expect(screen.queryByRole("button", { name: "Invoerfase afronden" })).not.toBeInTheDocument();
   });
 
-  test("Both data entries discarded alert works", async () => {
-    const user = userEvent.setup();
-    const router = await renderPage();
-
-    // Expect the alert to not be visible
-    const alertHeading = "Verschil opgelost voor stembureau 33";
-    expect(screen.queryByText(alertHeading)).not.toBeInTheDocument();
-
-    // Set the hash to show the alert and expect it to be visible
-    await router.navigate({ hash: "data-entries-discarded-1" });
-    expect(await screen.findByRole("heading", { level: 2, name: alertHeading })).toBeVisible();
-
-    // Close the alert and expect it to be hidden
-    const alertClosed = waitForElementToBeRemoved(screen.getByRole("heading", { level: 2, name: alertHeading }));
-    await user.click(screen.getByRole("button", { name: "Melding sluiten" }));
-    await alertClosed;
-  });
-
   test("First data entry resumed alert works", async () => {
     const user = userEvent.setup();
     const router = await renderPage();

--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -92,24 +92,6 @@ describe("ElectionStatusPage", () => {
     expect(screen.queryByRole("button", { name: "Invoerfase afronden" })).not.toBeInTheDocument();
   });
 
-  test("Data entry kept alert works", async () => {
-    const user = userEvent.setup();
-    const router = await renderPage();
-
-    // Expect the alert to not be visible
-    const alertHeading = "Verschil opgelost voor stembureau 33";
-    expect(screen.queryByText(alertHeading)).not.toBeInTheDocument();
-
-    // Set the hash to show the alert and expect it to be visible
-    await router.navigate({ hash: "data-entry-kept-1" });
-    expect(await screen.findByRole("heading", { level: 2, name: alertHeading })).toBeVisible();
-
-    // Close the alert and expect it to be hidden
-    const alertClosed = waitForElementToBeRemoved(screen.getByRole("heading", { level: 2, name: alertHeading }));
-    await user.click(screen.getByRole("button", { name: "Melding sluiten" }));
-    await alertClosed;
-  });
-
   test("Both data entries discarded alert works", async () => {
     const user = userEvent.setup();
     const router = await renderPage();

--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -1,6 +1,4 @@
-import { waitForElementToBeRemoved } from "@testing-library/dom";
 import { render as rtlRender } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, test } from "vitest";
 
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
@@ -90,44 +88,5 @@ describe("ElectionStatusPage", () => {
 
     expect(screen.queryByText("Alle stembureaus zijn twee keer ingevoerd")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Invoerfase afronden" })).not.toBeInTheDocument();
-  });
-
-  test("First data entry resumed alert works", async () => {
-    const user = userEvent.setup();
-    const router = await renderPage();
-
-    // Expect the alert to not be visible
-    const alertHeading = "Stembureau 36 teruggegeven aan Sanne Molenaar";
-    expect(screen.queryByText(alertHeading)).not.toBeInTheDocument();
-
-    // Set the hash to show the alert and expect it to be visible
-    await router.navigate({ hash: "data-entry-resumed-4" });
-    expect(await screen.findByRole("heading", { level: 2, name: alertHeading })).toBeVisible();
-
-    // Close the alert and expect it to be hidden
-    const alertClosed = waitForElementToBeRemoved(screen.getByRole("heading", { level: 2, name: alertHeading }));
-    await user.click(screen.getByRole("button", { name: "Melding sluiten" }));
-    await alertClosed;
-  });
-
-  test("First data entry discarded alert works", async () => {
-    const user = userEvent.setup();
-    const router = await renderPage();
-
-    // Wait for the page to be loaded
-    expect(await screen.findByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
-
-    // Expect the alert to not be visible
-    const alertHeading = "Invoer stembureau 36 verwijderd";
-    expect(screen.queryByText(alertHeading)).not.toBeInTheDocument();
-
-    // Set the hash to show the alert and expect it to be visible
-    await router.navigate({ hash: "data-entry-discarded-4" });
-    expect(await screen.findByRole("heading", { level: 2, name: alertHeading })).toBeVisible();
-
-    // Close the alert and expect it to be hidden
-    const alertClosed = waitForElementToBeRemoved(screen.getByRole("heading", { level: 2, name: alertHeading }));
-    await user.click(screen.getByRole("button", { name: "Melding sluiten" }));
-    await alertClosed;
   });
 });

--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -21,11 +21,9 @@ export function ElectionStatusPage() {
   const { statuses } = useElectionStatus();
   const { getName } = useUsers();
 
-  const showDataEntriesDiscardedAlert = location.hash.startsWith("#data-entries-discarded-") ? location.hash : null;
   const showFirstEntryResumedAlert = location.hash.startsWith("#data-entry-resumed-") ? location.hash : null;
   const showFirstEntryDiscardedAlert = location.hash.startsWith("#data-entry-discarded-") ? location.hash : null;
-  const successAlert =
-    showDataEntriesDiscardedAlert || showFirstEntryResumedAlert || showFirstEntryDiscardedAlert || undefined;
+  const successAlert = showFirstEntryResumedAlert || showFirstEntryDiscardedAlert || undefined;
 
   let pollingStationNumber = 0;
   let typist = "";
@@ -65,14 +63,14 @@ export function ElectionStatusPage() {
               ? t("election_status.success.data_entry_discarded", { nr: pollingStationNumber })
               : showFirstEntryResumedAlert
                 ? t("election_status.success.data_entry_resumed", { nr: pollingStationNumber, typist: typist })
-                : t("election_status.success.differences_resolved", { nr: pollingStationNumber })}
+                : null}
           </h2>
           <p>
             {showFirstEntryDiscardedAlert
               ? t("election_status.success.polling_station_can_be_filled_again")
               : showFirstEntryResumedAlert
                 ? t("election_status.success.typist_can_continue_data_entry")
-                : t("election_status.success.data_entries_discarded", { nr: pollingStationNumber })}
+                : null}
           </p>
         </Alert>
       )}

--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
 import { HeaderCommitteeSessionStatusWithIcon } from "@/components/committee_session/CommitteeSessionStatus";
 import { Footer } from "@/components/footer/Footer";
@@ -8,7 +8,6 @@ import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { useElection } from "@/hooks/election/useElection";
 import { useElectionStatus } from "@/hooks/election/useElectionStatus";
-import { useUsers } from "@/hooks/user/useUsers";
 import { t } from "@/i18n/translate";
 import { committeeSessionLabel } from "@/utils/committeeSession";
 
@@ -16,31 +15,12 @@ import { ElectionStatus } from "./ElectionStatus";
 
 export function ElectionStatusPage() {
   const navigate = useNavigate();
-  const location = useLocation();
   const { committeeSession, election, pollingStations } = useElection();
   const { statuses } = useElectionStatus();
-  const { getName } = useUsers();
-
-  const showFirstEntryResumedAlert = location.hash.startsWith("#data-entry-resumed-") ? location.hash : null;
-  const showFirstEntryDiscardedAlert = location.hash.startsWith("#data-entry-discarded-") ? location.hash : null;
-  const successAlert = showFirstEntryResumedAlert || showFirstEntryDiscardedAlert || undefined;
-
-  let pollingStationNumber = 0;
-  let typist = "";
-  if (successAlert) {
-    const id = parseInt(successAlert.substring(successAlert.lastIndexOf("-") + 1));
-    pollingStationNumber = pollingStations.find((ps) => ps.id === id)?.number ?? 0;
-    const typistId = statuses.find((status) => status.polling_station_id === id)?.first_entry_user_id;
-    typist = getName(typistId);
-  }
 
   function finishInput() {
     // TODO: Add call to endpoint that changes status of committee session to "data_entry_finished" in issue #1650
     void navigate("../report");
-  }
-
-  function closeSuccessAlert() {
-    void navigate(location.pathname);
   }
 
   return (
@@ -56,25 +36,9 @@ export function ElectionStatusPage() {
           </div>
         </section>
       </header>
-      {successAlert && (
-        <Alert type="success" onClose={closeSuccessAlert}>
-          <h2>
-            {showFirstEntryDiscardedAlert
-              ? t("election_status.success.data_entry_discarded", { nr: pollingStationNumber })
-              : showFirstEntryResumedAlert
-                ? t("election_status.success.data_entry_resumed", { nr: pollingStationNumber, typist: typist })
-                : null}
-          </h2>
-          <p>
-            {showFirstEntryDiscardedAlert
-              ? t("election_status.success.polling_station_can_be_filled_again")
-              : showFirstEntryResumedAlert
-                ? t("election_status.success.typist_can_continue_data_entry")
-                : null}
-          </p>
-        </Alert>
-      )}
+
       <Messages />
+
       {committeeSession.status !== "data_entry_finished" &&
         statuses.length > 0 &&
         statuses.every((s) => s.status === "definitive") && (
@@ -86,6 +50,7 @@ export function ElectionStatusPage() {
             </Button>
           </Alert>
         )}
+
       <main>
         <ElectionStatus
           election={election}

--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate } from "react-router";
 
 import { HeaderCommitteeSessionStatusWithIcon } from "@/components/committee_session/CommitteeSessionStatus";
 import { Footer } from "@/components/footer/Footer";
+import { Messages } from "@/components/messages/Messages";
 import { PageTitle } from "@/components/page_title/PageTitle";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
@@ -20,16 +21,11 @@ export function ElectionStatusPage() {
   const { statuses } = useElectionStatus();
   const { getName } = useUsers();
 
-  const showDataEntryKeptAlert = location.hash.startsWith("#data-entry-kept-") ? location.hash : null;
   const showDataEntriesDiscardedAlert = location.hash.startsWith("#data-entries-discarded-") ? location.hash : null;
   const showFirstEntryResumedAlert = location.hash.startsWith("#data-entry-resumed-") ? location.hash : null;
   const showFirstEntryDiscardedAlert = location.hash.startsWith("#data-entry-discarded-") ? location.hash : null;
   const successAlert =
-    showDataEntryKeptAlert ||
-    showDataEntriesDiscardedAlert ||
-    showFirstEntryResumedAlert ||
-    showFirstEntryDiscardedAlert ||
-    undefined;
+    showDataEntriesDiscardedAlert || showFirstEntryResumedAlert || showFirstEntryDiscardedAlert || undefined;
 
   let pollingStationNumber = 0;
   let typist = "";
@@ -76,12 +72,11 @@ export function ElectionStatusPage() {
               ? t("election_status.success.polling_station_can_be_filled_again")
               : showFirstEntryResumedAlert
                 ? t("election_status.success.typist_can_continue_data_entry")
-                : showDataEntryKeptAlert
-                  ? t("election_status.success.data_entry_kept", { typist: typist })
-                  : t("election_status.success.data_entries_discarded", { nr: pollingStationNumber })}
+                : t("election_status.success.data_entries_discarded", { nr: pollingStationNumber })}
           </p>
         </Alert>
       )}
+      <Messages />
       {committeeSession.status !== "data_entry_finished" &&
         statuses.length > 0 &&
         statuses.every((s) => s.status === "definitive") && (

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -179,7 +179,7 @@ describe("ResolveDifferencesPage", () => {
     });
   });
 
-  test("should navigate to election status page after submit with correct hash", async () => {
+  test("should navigate to election status page after submit and push message", async () => {
     const user = userEvent.setup();
 
     await renderPage();
@@ -188,7 +188,11 @@ describe("ResolveDifferencesPage", () => {
     await user.click(await screen.findByLabelText(/Geen van beide/));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
-    expect(navigate).toHaveBeenCalledWith("/elections/1/status#data-entries-discarded-3");
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Verschil opgelost voor stembureau 35",
+      text: "Omdat beide invoeren zijn verwijderd, moet stembureau 35 twee keer opnieuw ingevoerd worden.",
+    });
+    expect(navigate).toHaveBeenCalledWith("/elections/1/status");
   });
 
   test("should navigate to resolve errors page after keeping second entry which has errors", async () => {

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import cls from "@/features/resolve_differences/components/ResolveDifferences.module.css";
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { useMessages } from "@/hooks/messages/useMessages";
 import { UsersProvider } from "@/hooks/user/UsersProvider";
 import {
   ElectionListRequestHandler,
@@ -30,6 +31,8 @@ vi.mock("react-router", () => ({
   useLocation: () => ({ pathname: "/" }),
 }));
 
+vi.mock("@/hooks/messages/useMessages");
+
 const renderPage = async () => {
   render(
     <TestUserProvider userRole="coordinator">
@@ -50,7 +53,11 @@ function overrideResponseStatus(status: DataEntryStatusName) {
 }
 
 describe("ResolveDifferencesPage", () => {
+  const pushMessage = vi.fn();
+
   beforeEach(() => {
+    vi.mocked(useMessages).mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+
     server.use(
       ElectionRequestHandler,
       ElectionStatusRequestHandler,
@@ -159,6 +166,10 @@ describe("ResolveDifferencesPage", () => {
     await user.click(await screen.findByLabelText(/De tweede invoer/));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Verschil opgelost voor stembureau 35",
+      text: "Let op: het proces-verbaal bevat fouten die moeten worden opgelost",
+    });
     expect(navigate).toHaveBeenCalledWith("/elections/1/status/3/resolve-errors");
   });
 });

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -127,7 +127,7 @@ describe("ResolveDifferencesPage", () => {
     await user.click(await screen.findByLabelText(/De eerste invoer/));
     await user.click(submit);
     expect(resolve).toHaveBeenCalledWith("keep_first_entry");
-    expect(navigate).toHaveBeenCalledWith("/elections/1/status#data-entry-kept-3");
+    expect(navigate).toHaveBeenCalledWith("/elections/1/status");
   });
 
   test("should refresh election status and navigate to election status page after submit", async () => {
@@ -142,7 +142,41 @@ describe("ResolveDifferencesPage", () => {
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(getElectionStatus).toHaveBeenCalledTimes(2);
-    expect(navigate).toHaveBeenCalledWith("/elections/1/status#data-entry-kept-3");
+    expect(navigate).toHaveBeenCalledWith("/elections/1/status");
+  });
+
+  test("should show the first data entry user in the message after keeping the first entry", async () => {
+    const user = userEvent.setup();
+
+    await renderPage();
+    overrideResponseStatus("second_entry_not_started");
+    await user.click(await screen.findByLabelText("De eerste invoer (Gebruiker01)"));
+    await user.click(await screen.findByRole("button", { name: "Opslaan" }));
+
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Verschil opgelost voor stembureau 35",
+      text: [
+        "Omdat er nog maar één invoer over is, moet er een nieuwe tweede invoer gedaan worden.",
+        "Kies hiervoor een andere invoerder dan Gebruiker01.",
+      ].join(" "),
+    });
+  });
+
+  test("should show the second data entry user in the message after keeping the second entry", async () => {
+    const user = userEvent.setup();
+
+    await renderPage();
+    overrideResponseStatus("second_entry_not_started");
+    await user.click(await screen.findByLabelText("De tweede invoer (Gebruiker02)"));
+    await user.click(await screen.findByRole("button", { name: "Opslaan" }));
+
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Verschil opgelost voor stembureau 35",
+      text: [
+        "Omdat er nog maar één invoer over is, moet er een nieuwe tweede invoer gedaan worden.",
+        "Kies hiervoor een andere invoerder dan Gebruiker02.",
+      ].join(" "),
+    });
   });
 
   test("should navigate to election status page after submit with correct hash", async () => {

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -22,7 +22,6 @@ export function ResolveDifferencesPage() {
   const navigate = useNavigate();
   const afterSave = (status: DataEntryStatusName, firstEntryUserId: number | undefined) => {
     let nextPage = `/elections/${election.id}/status`;
-    let message = "";
 
     switch (status) {
       case "first_entry_has_errors":
@@ -39,13 +38,16 @@ export function ResolveDifferencesPage() {
         });
         break;
       case "first_entry_not_started":
-        message = `#data-entries-discarded-${pollingStation.id}`;
+        pushMessage({
+          title: t("election_status.success.differences_resolved", { nr: pollingStation.number }),
+          text: t("election_status.success.data_entries_discarded", { nr: pollingStation.number }),
+        });
         break;
       default:
         break;
     }
 
-    void navigate(nextPage + message);
+    void navigate(nextPage);
   };
 
   const pollingStationId = useNumericParam("pollingStationId");

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -6,6 +6,7 @@ import { BottomBar } from "@/components/ui/BottomBar/BottomBar";
 import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Loader } from "@/components/ui/Loader/Loader";
+import { useMessages } from "@/hooks/messages/useMessages";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { useUsers } from "@/hooks/user/useUsers";
 import { t } from "@/i18n/translate";
@@ -17,6 +18,7 @@ import { ResolveDifferencesOverview } from "./ResolveDifferencesOverview";
 import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
 
 export function ResolveDifferencesPage() {
+  const { pushMessage } = useMessages();
   const navigate = useNavigate();
   const afterSave = (status: DataEntryStatusName) => {
     let nextPage = `/elections/${election.id}/status`;
@@ -24,6 +26,10 @@ export function ResolveDifferencesPage() {
 
     switch (status) {
       case "first_entry_has_errors":
+        pushMessage({
+          title: t("resolve_errors.differences_resolved", { number: pollingStation.number }),
+          text: t("resolve_errors.alert_contains_errors"),
+        });
         nextPage = `/elections/${election.id}/status/${pollingStationId}/resolve-errors`;
         break;
       case "second_entry_not_started":

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -21,33 +21,29 @@ export function ResolveDifferencesPage() {
   const { pushMessage } = useMessages();
   const navigate = useNavigate();
   const afterSave = (status: DataEntryStatusName, firstEntryUserId: number | undefined) => {
-    let nextPage = `/elections/${election.id}/status`;
-
     switch (status) {
       case "first_entry_has_errors":
         pushMessage({
           title: t("resolve_errors.differences_resolved", { number: pollingStation.number }),
           text: t("resolve_errors.alert_contains_errors"),
         });
-        nextPage = `/elections/${election.id}/status/${pollingStationId}/resolve-errors`;
+        void navigate(`/elections/${election.id}/status/${pollingStationId}/resolve-errors`);
         break;
       case "second_entry_not_started":
         pushMessage({
           title: t("election_status.success.differences_resolved", { nr: pollingStation.number }),
           text: t("election_status.success.data_entry_kept", { typist: getName(firstEntryUserId) }),
         });
+        void navigate(`/elections/${election.id}/status`);
         break;
       case "first_entry_not_started":
         pushMessage({
           title: t("election_status.success.differences_resolved", { nr: pollingStation.number }),
           text: t("election_status.success.data_entries_discarded", { nr: pollingStation.number }),
         });
-        break;
-      default:
+        void navigate(`/elections/${election.id}/status`);
         break;
     }
-
-    void navigate(nextPage);
   };
 
   const pollingStationId = useNumericParam("pollingStationId");

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -20,7 +20,7 @@ import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
 export function ResolveDifferencesPage() {
   const { pushMessage } = useMessages();
   const navigate = useNavigate();
-  const afterSave = (status: DataEntryStatusName) => {
+  const afterSave = (status: DataEntryStatusName, firstEntryUserId: number | undefined) => {
     let nextPage = `/elections/${election.id}/status`;
     let message = "";
 
@@ -33,7 +33,10 @@ export function ResolveDifferencesPage() {
         nextPage = `/elections/${election.id}/status/${pollingStationId}/resolve-errors`;
         break;
       case "second_entry_not_started":
-        message = `#data-entry-kept-${pollingStation.id}`;
+        pushMessage({
+          title: t("election_status.success.differences_resolved", { nr: pollingStation.number }),
+          text: t("election_status.success.data_entry_kept", { typist: getName(firstEntryUserId) }),
+        });
         break;
       case "first_entry_not_started":
         message = `#data-entries-discarded-${pollingStation.id}`;

--- a/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
+++ b/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
@@ -34,7 +34,7 @@ interface PollingStationDataEntryStatus {
 
 export function usePollingStationDataEntryDifferences(
   pollingStationId: number,
-  afterSave: (status: DataEntryStatusName) => void,
+  afterSave: (status: DataEntryStatusName, firstEntryUserId: number | undefined) => void,
 ): PollingStationDataEntryStatus {
   const client = useApiClient();
   const { election, pollingStations } = useElection();
@@ -82,7 +82,13 @@ export function usePollingStationDataEntryDifferences(
     if (isSuccess(response)) {
       // reload the election status data then navigate according to new status
       await electionContext?.refetch();
-      afterSave(response.data.status);
+      let firstEntryUserId = undefined;
+      if (differences && action === "keep_first_entry") {
+        firstEntryUserId = differences.first_entry_user_id;
+      } else if (differences && action === "keep_second_entry") {
+        firstEntryUserId = differences.second_entry_user_id;
+      }
+      afterSave(response.data.status, firstEntryUserId);
     } else {
       setError(response);
     }

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { useMessages } from "@/hooks/messages/useMessages";
 import { UsersProvider } from "@/hooks/user/UsersProvider";
 import {
   ElectionListRequestHandler,
@@ -27,6 +28,8 @@ vi.mock("react-router", async (importOriginal) => ({
   useLocation: () => ({ pathname: "/" }),
 }));
 
+vi.mock("@/hooks/messages/useMessages");
+
 const renderPage = async () => {
   render(
     <TestUserProvider userRole="coordinator">
@@ -43,7 +46,10 @@ const renderPage = async () => {
 };
 
 describe("ResolveErrorsPage", () => {
+  const pushMessage = vi.fn();
+
   beforeEach(() => {
+    vi.mocked(useMessages).mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
     server.use(
       ElectionRequestHandler,
       ElectionStatusRequestHandler,
@@ -62,9 +68,7 @@ describe("ResolveErrorsPage", () => {
     expect(
       await screen.findByRole("heading", { level: 3, name: "Wat wil je doen met de invoer in Abacus?" }),
     ).toBeVisible();
-    expect(
-      await screen.findByLabelText(/Invoer bewaren en correcties laten invoeren door Sanne Molenaar/),
-    ).toBeVisible();
+    expect(await screen.findByLabelText(/Invoer bewaren en correcties laten invoeren door Gebruiker01/)).toBeVisible();
     expect(await screen.findByLabelText(/Stembureau opnieuw laten invoeren/)).toBeVisible();
   });
 
@@ -82,7 +86,12 @@ describe("ResolveErrorsPage", () => {
     await user.click(submit);
 
     expect(resolve).toHaveBeenCalledWith("resume_first_entry");
-    expect(navigate).toHaveBeenCalledWith("/elections/1/status#data-entry-resumed-5");
+
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Stembureau 37 teruggegeven aan Gebruiker01",
+      text: "De invoerder kan verder met invoeren",
+    });
+    expect(navigate).toHaveBeenCalledWith("/elections/1/status");
   });
 
   test("should refresh election status and navigate to election status page after submit", async () => {
@@ -96,6 +105,11 @@ describe("ResolveErrorsPage", () => {
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(getElectionStatus).toHaveBeenCalledTimes(2);
-    expect(navigate).toHaveBeenCalledWith("/elections/1/status#data-entry-discarded-5");
+
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Invoer stembureau 37 verwijderd",
+      text: "Het stembureau kan opnieuw ingevoerd worden",
+    });
+    expect(navigate).toHaveBeenCalledWith("/elections/1/status");
   });
 });

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Loader } from "@/components/ui/Loader/Loader";
+import { useMessages } from "@/hooks/messages/useMessages";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { useUsers } from "@/hooks/user/useUsers";
 import { t, tx } from "@/i18n/translate";
@@ -14,23 +15,33 @@ import cls from "./ResolveErrors.module.css";
 import { ResolveErrorsOverview } from "./ResolveErrorsOverview";
 
 export function ResolveErrorsIndexPage() {
+  const { pushMessage } = useMessages();
   const navigate = useNavigate();
   const pollingStationId = useNumericParam("pollingStationId");
   const { pollingStation, election, loading, dataEntry, action, setAction, onSubmit, validationError } =
     usePollingStationDataEntryErrors(pollingStationId);
 
   const afterSave = (action: ResolveErrorsAction) => {
-    let url = `/elections/${election.id}/status`;
     switch (action) {
       case "resume_first_entry":
-        url += `#data-entry-resumed-${pollingStation.id}`;
+        pushMessage({
+          title: t("election_status.success.data_entry_resumed", {
+            nr: pollingStation.number,
+            typist: getName(dataEntry?.first_entry_user_id),
+          }),
+          text: t("election_status.success.typist_can_continue_data_entry"),
+        });
         break;
       case "discard_first_entry":
-        url += `#data-entry-discarded-${pollingStation.id}`;
+        pushMessage({
+          title: t("election_status.success.data_entry_discarded", { nr: pollingStation.number }),
+          text: t("election_status.success.polling_station_can_be_filled_again"),
+        });
         break;
     }
-    void navigate(url);
+    void navigate(`/elections/${election.id}/status`);
   };
+
   const { getName } = useUsers();
 
   if (loading || dataEntry === null) {

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsLayout.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsLayout.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { MessagesProvider } from "@/hooks/messages/MessagesProvider";
 import {
   ElectionListRequestHandler,
   ElectionRequestHandler,
@@ -27,7 +28,9 @@ const renderLayout = () => {
     <TestUserProvider userRole="coordinator">
       <ElectionProvider electionId={1}>
         <ElectionStatusProvider electionId={1}>
-          <ResolveErrorsLayout />
+          <MessagesProvider>
+            <ResolveErrorsLayout />
+          </MessagesProvider>
         </ElectionStatusProvider>
       </ElectionProvider>
     </TestUserProvider>,

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsLayout.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router";
 
 import { NotFoundError } from "@/api/ApiResult";
+import { Messages } from "@/components/messages/Messages";
 import { PageTitle } from "@/components/page_title/PageTitle";
 import { StickyNav } from "@/components/ui/AppLayout/StickyNav";
 import { Badge } from "@/components/ui/Badge/Badge";
@@ -39,6 +40,7 @@ export function ResolveErrorsLayout() {
           <Badge type="first_entry_has_errors" />
         </section>
       </header>
+      <Messages />
       <main className={cls.resolveErrors}>
         <StickyNav>
           <ResolveErrorsNavigation structure={structure} validationResults={dataEntry.validation_results} />

--- a/frontend/src/i18n/locales/nl/resolve_errors.json
+++ b/frontend/src/i18n/locales/nl/resolve_errors.json
@@ -1,4 +1,6 @@
 {
+  "alert_contains_errors": "Let op: het proces-verbaal bevat fouten die moeten worden opgelost",
+  "differences_resolved": "Verschil opgelost voor stembureau {number}",
   "form_content": "In de invoer zijn fouten gevonden die wijzen op fouten in het papieren proces-verbaal. Als het om kleine verschrijvingen of optelfouten gaat, mag een lid van het Gemeentelijk Stembureau het proces-verbaal corrigeren. Je kan de invoer dan teruggeven aan de oorspronkelijke invoerder zodat die de fout ook in Abacus kan herstellen.",
   "form_question": "Wat wil je doen met de invoer in Abacus?",
   "options": {

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -157,7 +157,7 @@ export const dataEntryStatusDifferences: DataEntryGetDifferencesResponse = {
 export const dataEntryGetErrorsMockResponse: DataEntryGetErrorsResponse = {
   finalised_first_entry: getEmptyDataEntryRequest().data,
   first_entry_finished_at: "",
-  first_entry_user_id: 1,
+  first_entry_user_id: 3,
   validation_results: {
     errors: [validationResultMockData.F201],
     warnings: [validationResultMockData.W001, validationResultMockData.W201, validationResultMockData.W301],


### PR DESCRIPTION
- Implements https://github.com/kiesraad/abacus/issues/1705
- Fixes https://github.com/kiesraad/abacus/issues/1731

Changes:
- Show message (alert) coming from resolve differences, on resolve errors page
- Show messages from resolve differences and resolve errors on election status page using `pushMessage()` and `<Messages>`
  - Fix showing correct typist name corresponding to data entry that was selected in resolve differences
- Update vitest tests
- Add new message to Playwright test, rest is still working!

To test:
- Create two data entries with differences, see as a coordinator that after resolving differences, the message on the status page corresponds to the choice made
- Create two data entries with differences and an error in the second data entry. Choose the second data entry as coordinator on the resolve differences and see that the message is shown on the resolve errors page that comes afterwards.
- Try to reproduce https://github.com/kiesraad/abacus/issues/1731

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->