### PR TITLE
Always use SQLite in WAL mode

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,7 +10,10 @@ use axum::{
     serve::ListenerExt,
 };
 use hyper::http::{HeaderName, HeaderValue, header};
-use sqlx::{SqlitePool, sqlite::SqliteConnectOptions};
+use sqlx::{
+    SqlitePool,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode},
+};
 use tokio::{net::TcpListener, signal};
 use tower_http::{
     set_header::SetResponseHeaderLayer,
@@ -260,7 +263,9 @@ pub async fn create_sqlite_pool(
     #[cfg(feature = "dev-database")] seed_data: bool,
 ) -> Result<SqlitePool, Box<dyn Error>> {
     let db = format!("sqlite://{database}");
-    let opts = SqliteConnectOptions::from_str(&db)?.create_if_missing(true);
+    let opts = SqliteConnectOptions::from_str(&db)?
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal);
 
     #[cfg(feature = "dev-database")]
     if reset_database {


### PR DESCRIPTION
Always use SQLite in [WAL mode](https://sqlite.org/wal.html): "WAL is significantly faster in most scenarios."

SQLx doesn't use WAL mode by default, but the [`journal_mode` function](https://docs.rs/sqlx/0.8.6/sqlx/sqlite/struct.SqliteConnectOptions.html#method.journal_mode) can be used to enable it. Interestingly, the SQLx documentation mentions that "any commands in `sqlx-cli` which create a SQLite database will create it in WAL mode.", so only if the database was created using the SQLx CLI, Abacus would already use WAL mode.

A k6 load test with 1000 parallel users[^1] shows a huge performance boost when using WAL mode: p99 http request duration decreases from 1s to 5ms. This is also clearly noticeable when browsing the election status page during the load test.

Without WAL:
<img width="694" height="294" alt="no-wal" src="https://github.com/user-attachments/assets/40862487-03af-4ad2-9229-09d7479c4f01" />

With WAL:
<img width="693" height="304" alt="wal" src="https://github.com/user-attachments/assets/e646b407-3723-4b1b-8291-2fe5b43464d7" />

[^1]: on my laptop on battery 🔋 