### PR TITLE
NumberInput formatting using overlay

### DIFF
--- a/frontend/src/components/ui/InputGrid/InputGrid.module.css
+++ b/frontend/src/components/ui/InputGrid/InputGrid.module.css
@@ -42,19 +42,24 @@
         border-right: 1px solid var(--bg-gray-darkest);
         padding: 0;
         input {
-          text-align: right;
           width: 100%;
           height: 4.5rem;
           border: 2px solid transparent;
-          padding: 1rem 1.5rem;
-          font-size: var(--font-size-body);
-          font-style: normal;
           &:focus,
           &:focus-visible {
             outline: none;
             border-color: var(--border-color-focus);
           }
         }
+
+        input,
+        :global(.formatted-overlay) {
+          text-align: right;
+          padding: 1rem 1.5rem;
+          font-size: var(--font-size-body);
+          font-style: normal;
+        }
+
         &.readOnly span {
           display: block;
           height: 4.5rem;

--- a/frontend/src/components/ui/NumberInput/NumberInput.module.css
+++ b/frontend/src/components/ui/NumberInput/NumberInput.module.css
@@ -1,0 +1,23 @@
+.container {
+  position: relative;
+
+  /* Global to be able to give custom styling */
+  :global(.formatted-overlay) {
+    position: absolute;
+    background: white;
+    pointer-events: none;
+
+    /* Same as input border */
+    inset: 2px;
+
+    /* Same as reset.css input */
+    padding: 1px 2px;
+
+    display: flex;
+    > span {
+      /* Vertical center, horizontal grow to be able to align right */
+      align-self: center;
+      flex-grow: 1;
+    }
+  }
+}

--- a/frontend/src/components/ui/NumberInput/NumberInput.stories.tsx
+++ b/frontend/src/components/ui/NumberInput/NumberInput.stories.tsx
@@ -9,23 +9,26 @@ export const DefaultNumberInput: StoryObj = {
   },
   play: async ({ canvas, userEvent, step }) => {
     const input = canvas.getByRole("textbox");
+    const FORMATTED_OVERLAY = "test-formatted-overlay";
 
     await step("Test number formatting", async () => {
       // Test number formatting
       await expect(input).toBeVisible();
-      await expect(input).toHaveValue("12.300");
+      await expect(await canvas.findByTestId(FORMATTED_OVERLAY)).toHaveTextContent("12.300");
     });
 
     await step("Test focus removes formatting", async () => {
       // Test focus removes formatting
       await userEvent.click(input);
-      await expect(input).toHaveValue("12300");
+      await expect(input).toHaveFocus();
+      await expect(canvas.queryByTestId(FORMATTED_OVERLAY)).not.toBeInTheDocument();
     });
 
     await step("Test blur restores formatting", async () => {
       // Test blur restores formatting
       await userEvent.tab();
-      await expect(input).toHaveValue("12.300");
+      await expect(input).not.toHaveFocus();
+      await expect(await canvas.findByTestId(FORMATTED_OVERLAY)).toHaveTextContent("12.300");
     });
 
     await step("Test changing the value", async () => {
@@ -38,7 +41,8 @@ export const DefaultNumberInput: StoryObj = {
     await step("Test blur formats the new value", async () => {
       // Test blur formats the new value
       await userEvent.tab();
-      await expect(input).toHaveValue("9.999");
+      await expect(input).not.toHaveFocus();
+      await expect(await canvas.findByTestId(FORMATTED_OVERLAY)).toHaveTextContent("9.999");
     });
 
     await step("Test paste", async () => {
@@ -46,7 +50,8 @@ export const DefaultNumberInput: StoryObj = {
       await userEvent.dblClick(input);
       await userEvent.paste("12345");
       await userEvent.tab();
-      await expect(input).toHaveValue("12.345");
+      await expect(input).not.toHaveFocus();
+      await expect(await canvas.findByTestId(FORMATTED_OVERLAY)).toHaveTextContent("12.345");
     });
 
     await step("Test paste tooltip", async () => {

--- a/frontend/src/components/ui/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/ui/NumberInput/NumberInput.test.tsx
@@ -13,9 +13,8 @@ describe("UI Component: number input", () => {
 
   test("should format the number", () => {
     render(<NumberInput id="test" defaultValue={1200} />);
-    const input = screen.getByTestId("test");
-
-    expect(input).toHaveValue("1.200");
+    const formattedOverlay = screen.getByTestId("test-formatted-overlay");
+    expect(formattedOverlay).toHaveTextContent("1.200");
   });
 
   test("should deformat the number on focus", async () => {
@@ -23,7 +22,8 @@ describe("UI Component: number input", () => {
     const input = screen.getByTestId("test");
     const user = userEvent.setup();
     await user.click(input);
-    expect(input).toHaveValue("1200");
+    expect(input).toHaveFocus();
+    expect(screen.queryByTestId("test-formatted-overlay")).not.toBeInTheDocument();
   });
 
   test("should format the number on blur", async () => {
@@ -32,8 +32,13 @@ describe("UI Component: number input", () => {
     const user = userEvent.setup();
     await user.click(input);
     expect(input).toHaveValue("1200");
+    expect(input).toHaveFocus();
+    expect(screen.queryByTestId("test-formatted-overlay")).not.toBeInTheDocument();
+
     await user.tab();
-    expect(input).toHaveValue("1.200");
+    expect(input).not.toHaveFocus();
+    expect(input).toHaveValue("1200");
+    expect(await screen.findByTestId("test-formatted-overlay")).toHaveTextContent("1.200");
   });
 
   test("should only accept numbers", async () => {

--- a/frontend/src/features/data_entry/components/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/src/features/data_entry/components/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -109,7 +109,8 @@ describe("Test VotersAndVotesForm", () => {
       const proxyCertificates = screen.getByRole("textbox", { name: "B Volmachtbewijzen" });
       expect(proxyCertificates).toHaveFocus();
 
-      expect(pollCards).toHaveValue("12.345");
+      const pollCardsOverlay = await screen.findByTestId("data.voters_counts.poll_card_count-formatted-overlay");
+      expect(pollCardsOverlay).toHaveTextContent("12.345");
     });
 
     test("Form field entry and keybindings", async () => {

--- a/frontend/src/features/polling_stations/components/PollingStationForm.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationForm.tsx
@@ -33,7 +33,7 @@ const formFields: FormFields<PollingStationRequest> = {
   number: { required: true, type: "number", min: 1 },
   name: { required: true, type: "string" },
   polling_station_type: { type: "string", mapUndefined: true },
-  number_of_voters: { type: "number", isFormatted: true },
+  number_of_voters: { type: "number" },
   address: { type: "string" },
   postal_code: { type: "string" },
   locality: { type: "string" },

--- a/frontend/src/features/polling_stations/utils/form.test.ts
+++ b/frontend/src/features/polling_stations/utils/form.test.ts
@@ -44,17 +44,6 @@ describe("Form", () => {
     [{ type: "number", min: 1 }, "2", undefined, 2],
     [{ type: "number", max: 3 }, "4", "FORM_VALIDATION_RESULT_MAX", undefined],
     [{ type: "number", max: 5 }, "4", undefined, 4],
-
-    // Number isFormatted valid
-    [{ type: "number", isFormatted: true }, "5", undefined, 5],
-    [{ type: "number", isFormatted: true }, "-5", undefined, -5],
-    [{ type: "number", isFormatted: true }, "005", undefined, 5],
-    [{ type: "number", isFormatted: true }, "5.005", undefined, 5005],
-    [{ type: "number", isFormatted: true }, "x", "FORM_VALIDATION_RESULT_INVALID_NUMBER", undefined],
-
-    // Number isFormatted required
-    [{ type: "number", isFormatted: true, required: true }, "", "FORM_VALIDATION_RESULT_REQUIRED", undefined],
-    [{ type: "number", isFormatted: true, required: false }, "", undefined, undefined],
   ])("processForm for field type %j with input %j should return %j, %j", (field, inputValue, error, value) => {
     type RequestObject = { field: FieldValue<typeof field> };
     const formFields: FormFields<RequestObject> = { field };

--- a/frontend/src/features/polling_stations/utils/form.ts
+++ b/frontend/src/features/polling_stations/utils/form.ts
@@ -1,4 +1,3 @@
-import { deformatNumber } from "@/utils/format";
 import { parseIntUserInput } from "@/utils/strings";
 
 export type ValidationError =
@@ -31,7 +30,6 @@ export type FormFieldStringUndefined = FormFieldBase & {
 
 export type FormFieldNumber = FormFieldBase & {
   type: "number";
-  isFormatted?: boolean;
   min?: number;
   max?: number;
 };
@@ -74,9 +72,8 @@ export function processForm<RequestObject>(
           value = undefined;
           break;
         }
-        const parsedValue = field.isFormatted ? deformatNumber(value) : parseIntUserInput(value);
-        //parseInt is used in deformatNumber, the result is a number or NaN.
-        if (parsedValue === undefined || Number.isNaN(parsedValue)) {
+        const parsedValue = parseIntUserInput(value);
+        if (parsedValue === undefined) {
           validationResult[fieldName] = "FORM_VALIDATION_RESULT_INVALID_NUMBER";
           continue;
         } else {

--- a/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.test.tsx
@@ -15,16 +15,16 @@ function renderTable(rows: DifferencesRow[], action: ResolveDifferencesAction | 
 describe("DifferencesTable", () => {
   test("Render nothing when there are no differences", () => {
     renderTable([
-      { first: 10, second: 10 },
-      { first: 20, second: 20 },
+      { first: "10", second: "10" },
+      { first: "20", second: "20" },
     ]);
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
   test("Render rows that have differences", async () => {
     renderTable([
-      { code: "A", first: 10, second: 20, description: "Some value" },
-      { code: "B", first: 30, second: 30, description: "Another value" },
+      { code: "A", first: "10", second: "20", description: "Some value" },
+      { code: "B", first: "30", second: "30", description: "Another value" },
     ]);
     const table = await screen.findByRole("table");
     expect(table).toBeInTheDocument();
@@ -34,10 +34,10 @@ describe("DifferencesTable", () => {
   test("Falsy values are considered equal", async () => {
     renderTable([
       { code: "A", first: "A", second: undefined, description: "Truthy string" },
-      { code: "B", first: 1, second: undefined, description: "Truthy number" },
+      { code: "B", first: "1", second: undefined, description: "Truthy number" },
       { code: "A.1", first: "", second: undefined, description: "Falsy string" },
-      { code: "B.1", first: 0, second: undefined, description: "Falsy number" },
-      { code: "C", first: "", second: 0, description: "Falsy string and number" },
+      { code: "B.1", first: "0", second: undefined, description: "Falsy number" },
+      { code: "C", first: "", second: "0", description: "Falsy string and number" },
       { code: "D", first: undefined, second: undefined, description: "Undefined" },
     ]);
     const table = await screen.findByRole("table");
@@ -50,7 +50,7 @@ describe("DifferencesTable", () => {
   });
 
   test("Render an mdash as the zero value", async () => {
-    renderTable([{ code: "A", first: 10, second: 0, description: "Some value" }]);
+    renderTable([{ code: "A", first: "10", second: "0", description: "Some value" }]);
     const table = await screen.findByRole("table");
     expect(table).toBeInTheDocument();
     expect(table).toHaveTableContent([tableHeaders, ["A", "10", "\u2014", "Some value"]]);
@@ -64,7 +64,7 @@ describe("DifferencesTable", () => {
   });
 
   test("Render a big number with thousands separator", async () => {
-    renderTable([{ code: "A", first: 10_120_334, second: 9_344_042, description: "Some value" }]);
+    renderTable([{ code: "A", first: "10120334", second: "9344042", description: "Some value" }]);
     const table = await screen.findByRole("table");
     expect(table).toBeInTheDocument();
     expect(table).toHaveTableContent([tableHeaders, ["A", "10.120.334", "9.344.042", "Some value"]]);
@@ -72,15 +72,15 @@ describe("DifferencesTable", () => {
 
   test("Render gap rows between rows with differences", async () => {
     renderTable([
-      { code: "A", first: 10, second: 10, description: "Same" },
-      { code: "B", first: 20, second: 20, description: "Same" },
-      { code: "C", first: 30, second: 33, description: "But different" },
-      { code: "D", first: 40, second: 40, description: "Same" },
-      { code: "E", first: 50, second: 55, description: "Other" },
-      { code: "F", first: 60, second: 60, description: "Same" },
-      { code: "G", first: 70, second: 70, description: "Same" },
-      { code: "H", first: 80, second: 88, description: "Skip two" },
-      { code: "I", first: 90, second: 90, description: "Same" },
+      { code: "A", first: "10", second: "10", description: "Same" },
+      { code: "B", first: "20", second: "20", description: "Same" },
+      { code: "C", first: "30", second: "33", description: "But different" },
+      { code: "D", first: "40", second: "40", description: "Same" },
+      { code: "E", first: "50", second: "55", description: "Other" },
+      { code: "F", first: "60", second: "60", description: "Same" },
+      { code: "G", first: "70", second: "70", description: "Same" },
+      { code: "H", first: "80", second: "88", description: "Skip two" },
+      { code: "I", first: "90", second: "90", description: "Same" },
     ]);
     const table = await screen.findByRole("table");
     expect(table).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe("DifferencesTable", () => {
   });
 
   describe("show result of action in differences tables", () => {
-    const rows = [{ first: 10, second: 11 }];
+    const rows = [{ first: "10", second: "11" }];
 
     test("keep_first_entry", async () => {
       renderTable(rows, "keep_first_entry");

--- a/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
+++ b/frontend/src/features/resolve_differences/components/DifferencesTable.tsx
@@ -3,7 +3,7 @@ import { Fragment, ReactElement, useId } from "react";
 import { Table } from "@/components/ui/Table/Table";
 import { ResolveDifferencesAction } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
-import { formatNumber } from "@/utils/format";
+import { formatNumber, validateNumberString } from "@/utils/format";
 
 import cls from "./ResolveDifferences.module.css";
 
@@ -14,20 +14,20 @@ interface DifferencesTableProps {
   action?: ResolveDifferencesAction;
 }
 
-function formatValue(value: string | number | undefined): string | ReactElement {
+function formatValue(value: string | undefined): string | ReactElement {
   if (!value) {
     return <span className={cls.zeroDash}>&mdash;</span>;
-  } else if (typeof value === "string") {
-    return value;
-  } else {
+  } else if (validateNumberString(value)) {
     return formatNumber(value);
+  } else {
+    return value;
   }
 }
 
 export interface DifferencesRow {
   code?: number | string;
-  first?: number | string;
-  second?: number | string;
+  first?: string;
+  second?: string;
   description?: string;
 }
 

--- a/frontend/src/styles/reset.css
+++ b/frontend/src/styles/reset.css
@@ -68,3 +68,7 @@ textarea,
 select {
   font: inherit;
 }
+
+input {
+  padding: 1px 2px;
+}

--- a/frontend/src/utils/dataEntryMapping.test.ts
+++ b/frontend/src/utils/dataEntryMapping.test.ts
@@ -136,11 +136,11 @@ describe("mapSectionValues", () => {
     expect(result.voters_counts.poll_card_count).toBe(456); // InputGrid field gets deformatted to number
   });
 
-  test("should handle formatted numbers correctly when section info is provided", () => {
+  test("should handle numbers correctly when section info is provided", () => {
     const current = createBasePollingStationResults();
     const formValues = {
-      "voters_counts.poll_card_count": "1.234", // Formatted number for inputGrid
-      "voters_counts.proxy_certificate_count": "2.567", // Another formatted number for inputGrid
+      "voters_counts.poll_card_count": "1234", // Number for inputGrid
+      "voters_counts.proxy_certificate_count": "2567", // Another number for inputGrid
     };
 
     const testSection: DataEntrySection = {
@@ -161,15 +161,15 @@ describe("mapSectionValues", () => {
 
     const result = mapSectionValues(current, formValues, testSection);
 
-    expect(result.voters_counts.poll_card_count).toBe(1234); // Should be deformatted to number
-    expect(result.voters_counts.proxy_certificate_count).toBe(2567); // Should be deformatted to number
+    expect(result.voters_counts.poll_card_count).toBe(1234); // Should be converted to number
+    expect(result.voters_counts.proxy_certificate_count).toBe(2567); // Should be converted to number
   });
 
   test("should handle mixed field types when section is provided", () => {
     const current = createBasePollingStationResults();
     const formValues = {
       test: "true", // Boolean field - special case
-      "voters_counts.poll_card_count": "1.234", // Numeric value - should be deformatted
+      "voters_counts.poll_card_count": "1234", // Numeric value
       "differences_counts.more_ballots_count": "5", // Another numeric value
     };
 
@@ -384,18 +384,18 @@ describe("mapSectionValues", () => {
     expect(result.political_group_votes[2]?.total).toBe(12);
   });
 
-  test("should handle formatted numbers by deformatting them", () => {
+  test("should handle numbers", () => {
     const current = createBasePollingStationResults();
     const formValues = {
-      "voters_counts.poll_card_count": "1.234",
-      "votes_counts.votes_candidates_count": "2.567",
+      "voters_counts.poll_card_count": "1234",
+      "votes_counts.votes_candidates_count": "2567",
       "political_group_votes[0].candidate_votes[0].votes": "89",
     };
 
-    const formattedNumbersSection: DataEntrySection = {
+    const numbersSection: DataEntrySection = {
       id: "voters_votes_counts",
-      title: "Formatted Numbers Section",
-      short_title: "Formatted Numbers",
+      title: "Numbers Section",
+      short_title: "Numbers",
       subsections: [
         {
           type: "inputGrid",
@@ -409,7 +409,7 @@ describe("mapSectionValues", () => {
       ],
     };
 
-    const result = mapSectionValues(current, formValues, formattedNumbersSection);
+    const result = mapSectionValues(current, formValues, numbersSection);
 
     expect(result.voters_counts.poll_card_count).toBe(1234);
     expect(result.votes_counts.votes_candidates_count).toBe(2567);
@@ -536,39 +536,6 @@ describe("mapResultsToSectionValues", () => {
     const formValues = mapResultsToSectionValues(testSectionWithRadio, results);
 
     expect(formValues["test"]).toBe(expected);
-  });
-
-  test("should format only inputGrid values, not radio values", () => {
-    const results = createBasePollingStationResults();
-    results.voters_counts.poll_card_count = 1234; // Should be formatted
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = true; // Should stay as string when converted
-
-    const testSection: DataEntrySection = {
-      id: "voters_votes_counts",
-      title: "Test Section",
-      short_title: "Test",
-      subsections: [
-        {
-          type: "radio",
-          short_title: "test.short_title",
-          path: "test" as PollingStationResultsPath,
-          valueType: "boolean",
-          error: "test.error",
-          options: [],
-        },
-        {
-          type: "inputGrid",
-          headers: ["field", "counted_number", "description"],
-          rows: [{ code: "A", path: "voters_counts.poll_card_count", title: "Test Title" }],
-        },
-      ],
-    };
-
-    const formValues = mapResultsToSectionValues(testSection, results);
-
-    expect(formValues["test"]).toBe("true"); // Radio value stays as string
-    expect(formValues["voters_counts.poll_card_count"]).toBe("1.234"); // InputGrid value gets formatted
   });
 
   test("should extract voters_votes_counts section fields", () => {
@@ -724,17 +691,6 @@ describe("mapResultsToSectionValues", () => {
 
     expect(formValues["political_group_votes[2].candidate_votes[5].votes"]).toBe("12");
     expect(formValues["political_group_votes[2].total"]).toBe("12");
-  });
-
-  test("should format large numbers correctly", () => {
-    const results = createBasePollingStationResults();
-    results.voters_counts.poll_card_count = 1234;
-    results.votes_counts.votes_candidates_count = 5678;
-
-    const formValues = mapResultsToSectionValues(votersAndVotesSection, results);
-
-    expect(formValues["voters_counts.poll_card_count"]).toBe("1.234");
-    expect(formValues["votes_counts.votes_candidates_count"]).toBe("5.678");
   });
 
   test("should handle zero values", () => {

--- a/frontend/src/utils/strings.test.ts
+++ b/frontend/src/utils/strings.test.ts
@@ -18,6 +18,7 @@ describe("Strings util", () => {
     ["/123/456"],
     ["'123456'"],
     ["six"],
+    [""],
   ])("parseIntStrict %s", (input: string, expected: number | undefined = undefined) => {
     if (expected !== undefined) {
       expect(parseIntStrict(input)).toBe(expected);
@@ -58,6 +59,7 @@ describe("Strings util", () => {
     ["/123/456"],
     ["'123456'"],
     ["six"],
+    [""],
   ])("parseIntUserInput %s", (input: string, expected: number | undefined = undefined) => {
     if (expected !== undefined) {
       expect(parseIntUserInput(input)).toBe(expected);


### PR DESCRIPTION
### Context
At the moment, the NumberInput shows a formatted number when the input has no focus by changing the value to the formatted number, and changing it back to unformatted when receiving focus. 

This causes extra complexity for things like keeping the selection and using the value of this NumberInput (it has to be deformatted for each usage). It also causes timing issues in the tests (see e.g. [Bug: Formatted NumberInput does not clear in playwright tests](https://github.com/kiesraad/abacus/issues/1487)).

Also, I strongly feel that how the number is shown to the user is an implementation detail and that the rest of the code should be unaware of this formatting. This will also make changing it e.g. for [Experiment: replace '.' with thin space in numberinput](https://github.com/kiesraad/abacus/issues/360) much easier.

### Change
In this PR, the formatted number is shown with an overlay over the input when it does not have focus, and removes that overlay when it receives focus. With this way of showing the number, the value of the input does not have to be changed. Automated tests that do want to check if the formatting is shown, have to assert the overlay's text instead of the input value, and all application code should now be unaware of formatting and deformatting numbers.

### Testing
This NumberInput is part of the data entry and should be very thoroughly tested, on different browsers and with sorts of user interaction (keyboard, mouse, copy paste, ...?)

The NumberInput is also used in the polling station form, and will be used for number of voters when https://github.com/kiesraad/abacus/pull/1841 will be merged.
