### PR TITLE
Improve data entry testability

### DIFF
--- a/frontend/src/components/data_entry/subsections/RadioSubsection.stories.tsx
+++ b/frontend/src/components/data_entry/subsections/RadioSubsection.stories.tsx
@@ -8,18 +8,18 @@ import { RadioSubsectionComponent } from "./RadioSubsection";
 
 const radioSubsection: RadioSubsection = {
   type: "radio",
-  short_title: "voters_votes_counts.short_title",
-  error: "form_errors.FORM_VALIDATION_RESULT_REQUIRED",
-  path: "voters_counts.poll_card_count",
+  short_title: "radio",
+  error: "error",
+  path: "test.radio",
   options: [
     {
-      value: "yes",
+      value: "true",
       label: "yes",
       short_label: "yes",
       autoFocusInput: true,
     },
     {
-      value: "no",
+      value: "false",
       label: "no",
       short_label: "no",
     },

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.test.tsx
@@ -86,7 +86,7 @@ describe("DataEntryNavigation", () => {
             sections: {
               ...getDefaultDataEntryState().formState.sections,
               voters_votes_counts: {
-                ...getDefaultDataEntryState().formState.sections.voters_votes_counts,
+                ...getDefaultDataEntryState().formState.sections.voters_votes_counts!,
                 hasChanges: true,
               },
             },
@@ -150,7 +150,7 @@ describe("DataEntryNavigation", () => {
           sections: {
             ...getDefaultDataEntryState().formState.sections,
             voters_votes_counts: {
-              ...getDefaultDataEntryState().formState.sections.voters_votes_counts,
+              ...getDefaultDataEntryState().formState.sections.voters_votes_counts!,
               hasChanges: true,
             },
           },
@@ -325,7 +325,7 @@ describe("DataEntryNavigation", () => {
           sections: {
             ...getDefaultDataEntryState().formState.sections,
             voters_votes_counts: {
-              ...getDefaultDataEntryState().formState.sections.voters_votes_counts,
+              ...getDefaultDataEntryState().formState.sections.voters_votes_counts!,
               hasChanges: true,
             },
           },
@@ -367,7 +367,7 @@ describe("DataEntryNavigation", () => {
           sections: {
             ...getDefaultDataEntryState().formState.sections,
             voters_votes_counts: {
-              ...getDefaultDataEntryState().formState.sections.voters_votes_counts,
+              ...getDefaultDataEntryState().formState.sections.voters_votes_counts!,
               hasChanges: true,
             },
           },
@@ -405,7 +405,7 @@ describe("DataEntryNavigation", () => {
           sections: {
             ...getDefaultDataEntryState().formState.sections,
             voters_votes_counts: {
-              ...getDefaultDataEntryState().formState.sections.voters_votes_counts,
+              ...getDefaultDataEntryState().formState.sections.voters_votes_counts!,
               hasChanges: true,
             },
           },

--- a/frontend/src/features/data_entry/components/DataEntryProgress.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.test.tsx
@@ -55,7 +55,7 @@ const pollingStationResults = {
     {
       number: 1,
       total: 0,
-      candidate_votes: [{ number: 1, votes: 0 }],
+      candidate_votes: Array.from({ length: 29 }, (_, i) => ({ number: i, votes: 0 })),
     },
     {
       number: 2,
@@ -65,7 +65,7 @@ const pollingStationResults = {
   ],
 };
 
-describe("Test DataEntryProgress", () => {
+describe("DataEntryProgress", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, PollingStationDataEntryClaimHandler);
     vi.mocked(useParams).mockReturnValue({ pollingStationId: "1", sectionId: "differences_counts" });

--- a/frontend/src/features/data_entry/components/DataEntryProgress.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.test.tsx
@@ -76,8 +76,8 @@ describe("Test DataEntryProgress", () => {
     const formState = getDefaultFormState();
 
     formState.furthest = "political_group_votes_2";
-    formState.sections.voters_votes_counts.acceptErrorsAndWarnings = false;
-    formState.sections.differences_counts.acceptErrorsAndWarnings = true;
+    formState.sections.voters_votes_counts!.acceptErrorsAndWarnings = false;
+    formState.sections.differences_counts!.acceptErrorsAndWarnings = true;
 
     overrideServerClaimDataEntryResponse({
       formState: formState,
@@ -131,8 +131,8 @@ describe("Test DataEntryProgress", () => {
 
     formState.furthest = "political_group_votes_2";
 
-    formState.sections.voters_votes_counts.errors = new ValidationResultSet([validationResultMockData.F201]);
-    formState.sections.voters_votes_counts.warnings = new ValidationResultSet([validationResultMockData.W201]);
+    formState.sections.voters_votes_counts!.errors = new ValidationResultSet([validationResultMockData.F201]);
+    formState.sections.voters_votes_counts!.warnings = new ValidationResultSet([validationResultMockData.W201]);
 
     overrideServerClaimDataEntryResponse({
       formState: formState,

--- a/frontend/src/features/data_entry/components/DataEntryProgress.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.tsx
@@ -37,7 +37,7 @@ export function DataEntryProgress() {
       if (furthestSection) {
         //check if section has been left empty
         if (formSection.index < furthestSection.index) {
-          if (isFormSectionEmpty(formSection, pollingStationResults)) {
+          if (isFormSectionEmpty(dataEntryStructure, formSection, pollingStationResults)) {
             return "empty";
           }
         }
@@ -49,7 +49,7 @@ export function DataEntryProgress() {
 
       return "idle";
     },
-    [formState, pollingStationResults],
+    [formState, pollingStationResults, dataEntryStructure],
   );
 
   const currentIndex = formState.sections[formState.furthest]?.index || 0;

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -160,7 +160,7 @@ describe("Test CheckAndSaveForm", () => {
 
   test("Data entry shows finalise button with accepted warnings", async () => {
     const formState = customFormState();
-    formState.sections.voters_votes_counts.acceptErrorsAndWarnings = true;
+    formState.sections.voters_votes_counts!.acceptErrorsAndWarnings = true;
 
     overrideServerClaimDataEntryResponse({
       formState: formState,
@@ -180,7 +180,7 @@ describe("Test CheckAndSaveForm", () => {
       sections: {
         ...defaultState.sections,
         voters_votes_counts: {
-          ...defaultState.sections.voters_votes_counts,
+          ...defaultState.sections.voters_votes_counts!,
           errors: new ValidationResultSet([validationResultMockData.F201]),
           warnings: new ValidationResultSet([validationResultMockData.W203]),
           acceptErrorsAndWarnings: true,
@@ -213,7 +213,7 @@ describe("Test CheckAndSaveForm", () => {
       sections: {
         ...defaultState.sections,
         voters_votes_counts: {
-          ...defaultState.sections.voters_votes_counts,
+          ...defaultState.sections.voters_votes_counts!,
           errors: new ValidationResultSet([validationResultMockData.F201]),
           warnings: new ValidationResultSet([validationResultMockData.W203]),
           acceptErrorsAndWarnings: true,
@@ -284,7 +284,7 @@ describe("Test CheckAndSaveForm summary", () => {
 
   test("Accepted with warnings", async () => {
     const formState = customFormState();
-    formState.sections.differences_counts.acceptErrorsAndWarnings = true;
+    formState.sections.differences_counts!.acceptErrorsAndWarnings = true;
     overrideServerClaimDataEntryResponse({
       formState: formState,
       pollingStationResults: getInitialValues(),

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -2,26 +2,22 @@ import { describe, expect, test } from "vitest";
 
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
 import { ValidationResult } from "@/types/generated/openapi";
+import { DataEntrySection } from "@/types/types";
 import { ValidationResultSet } from "@/utils/ValidationResults";
 
-import { getDefaultDataEntryState, getDefaultFormSection, getInitialValues } from "../testing/mock-data";
+import {
+  getDefaultDataEntryState,
+  getDefaultDataEntryStructure,
+  getDefaultFormSection,
+  getInitialValues,
+} from "../testing/mock-data";
 import {
   addValidationResultsToFormState,
   formSectionComplete,
   getNextSectionID,
   isFormSectionEmpty,
-  objectHasOnlyEmptyValues,
   resetFormSectionState,
 } from "./dataEntryUtils";
-
-describe("objectHasOnlyEmptyValues", () => {
-  test("objectHasOnlyEmptyValues", () => {
-    expect(objectHasOnlyEmptyValues({ foo: "" })).equals(true);
-    expect(objectHasOnlyEmptyValues({ foo: 0 })).equals(true);
-    expect(objectHasOnlyEmptyValues({ foo: 1 })).equals(false);
-    expect(objectHasOnlyEmptyValues({ foo: 1, bar: "", baz: "" })).equals(false);
-  });
-});
 
 describe("formSectionComplete", () => {
   test("formSectionComplete", () => {
@@ -77,11 +73,13 @@ describe("getNextSectionID", () => {
 });
 
 describe("isFormSectionEmpty", () => {
+  const dataEntryStructure = getDefaultDataEntryStructure();
+
   test("political group form is empty", () => {
     const section = getDefaultFormSection("political_group_votes_1", 0);
     const values = getInitialValues();
 
-    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeTruthy();
   });
 
   test("political group form: total is not empty", () => {
@@ -89,22 +87,22 @@ describe("isFormSectionEmpty", () => {
     const values = getInitialValues();
     values.political_group_votes[0]!.total = 100;
 
-    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeFalsy();
   });
 
-  test("political group formL: candidate votes is not empty", () => {
+  test("political group form: candidate votes is not empty", () => {
     const section = getDefaultFormSection("political_group_votes_1", 0);
     const values = getInitialValues();
     values.political_group_votes[0]!.candidate_votes[0]!.votes = 100;
 
-    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeFalsy();
   });
 
   test("voters and votes form is empty", () => {
-    const section = getDefaultFormSection("political_group_votes_1", 0);
+    const section = getDefaultFormSection("voters_votes_counts", 0);
     const values = getInitialValues();
 
-    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeTruthy();
   });
 
   test("voters and votes form: votes is not empty", () => {
@@ -112,7 +110,7 @@ describe("isFormSectionEmpty", () => {
     const values = getInitialValues();
     values.votes_counts.invalid_votes_count = 3;
 
-    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeFalsy();
   });
 
   test("voters and votes form: voters is not empty", () => {
@@ -120,14 +118,14 @@ describe("isFormSectionEmpty", () => {
     const values = getInitialValues();
     values.voters_counts.total_admitted_voters_count = 6;
 
-    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeFalsy();
   });
 
   test("differences form is empty", () => {
     const section = getDefaultFormSection("differences_counts", 0);
     const values = getInitialValues();
 
-    expect(isFormSectionEmpty(section, values)).toBeTruthy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeTruthy();
   });
 
   test("differences form is not empty", () => {
@@ -135,7 +133,65 @@ describe("isFormSectionEmpty", () => {
     const values = getInitialValues();
     values.differences_counts.more_ballots_count = 5;
 
-    expect(isFormSectionEmpty(section, values)).toBeFalsy();
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeFalsy();
+  });
+
+  test("section not in data entry structure is considered empty", () => {
+    const section = getDefaultFormSection("unknown_section", 0);
+    const values = getInitialValues();
+
+    expect(isFormSectionEmpty(dataEntryStructure, section, values)).toBeTruthy();
+  });
+
+  test("boolean fields with value false are considered empty", () => {
+    const booleanSection: DataEntrySection = {
+      id: "boolean_test",
+      title: "Boolean Test Section",
+      short_title: "Boolean Test",
+      subsections: [
+        {
+          type: "radio",
+          short_title: "Radio Test",
+          error: "Radio error",
+          path: "test.radio_field",
+          options: [
+            { value: "true", label: "Yes", short_label: "Yes" },
+            { value: "false", label: "No", short_label: "No" },
+          ],
+        },
+        {
+          type: "checkboxes",
+          short_title: "Checkbox Test",
+          error_path: "test.checkbox_error",
+          error_message: "Checkbox error",
+          options: [{ path: "test.checkbox_field", label: "Checkbox", short_label: "Checkbox" }],
+        },
+      ],
+    };
+
+    const section = getDefaultFormSection("boolean_test", 0);
+
+    // Test with false values - should be considered empty
+    const valuesWithFalse = {
+      ...getInitialValues(),
+      test: {
+        radio_field: false,
+        checkbox_field: false,
+      },
+    };
+
+    expect(isFormSectionEmpty([booleanSection], section, valuesWithFalse)).toBeTruthy();
+
+    // Test with a true value - should be considered non-empty
+    const valuesWithTrue = {
+      ...getInitialValues(),
+      test: {
+        radio_field: true,
+        checkbox_field: false,
+      },
+    };
+
+    expect(isFormSectionEmpty([booleanSection], section, valuesWithTrue)).toBeFalsy();
   });
 });
 

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -56,19 +56,19 @@ describe("formSectionComplete", () => {
 describe("resetFormSectionState", () => {
   test("should reset form section state", () => {
     const formState = getDefaultDataEntryState().formState;
-    formState.sections.voters_votes_counts.errors = new ValidationResultSet([validationResultMockData.W201]);
+    formState.sections.voters_votes_counts!.errors = new ValidationResultSet([validationResultMockData.W201]);
 
     resetFormSectionState(formState);
 
-    expect(formState.sections.voters_votes_counts.errors.size()).toBe(0);
+    expect(formState.sections.voters_votes_counts!.errors.size()).toBe(0);
   });
 });
 
 describe("getNextSectionID", () => {
   test("should get next section ID", () => {
     const formState = getDefaultDataEntryState().formState;
-    formState.sections.voters_votes_counts.isSaved = true;
-    formState.sections.voters_votes_counts.isSubmitted = true;
+    formState.sections.voters_votes_counts!.isSaved = true;
+    formState.sections.voters_votes_counts!.isSubmitted = true;
 
     const nextSection = getNextSectionID(formState, "voters_votes_counts");
 
@@ -144,12 +144,12 @@ describe("addValidationResultToFormState", () => {
     const defaultState = getDefaultDataEntryState();
     const formState = defaultState.formState;
     const dataEntryStructure = defaultState.dataEntryStructure;
-    formState.sections.differences_counts.isSaved = true;
+    formState.sections.differences_counts!.isSaved = true;
     const validationResults: ValidationResult[] = [validationResultMockData.F303];
 
     addValidationResultsToFormState(validationResults, formState, dataEntryStructure, "errors");
 
-    expect(formState.sections.differences_counts.errors.size()).toBe(1);
+    expect(formState.sections.differences_counts!.errors.size()).toBe(1);
   });
 
   test("addValidationResultToFormState adds result to multiple sections", () => {
@@ -157,14 +157,14 @@ describe("addValidationResultToFormState", () => {
     const formState = defaultState.formState;
     const dataEntryStructure = defaultState.dataEntryStructure;
 
-    formState.sections.voters_votes_counts.isSaved = true;
+    formState.sections.voters_votes_counts!.isSaved = true;
     if (formState.sections.political_group_votes_1) formState.sections.political_group_votes_1.isSaved = true;
 
     const validationResults: ValidationResult[] = [validationResultMockData.F204];
 
     addValidationResultsToFormState(validationResults, formState, dataEntryStructure, "errors");
 
-    expect(formState.sections.voters_votes_counts.errors.size()).toBe(1);
+    expect(formState.sections.voters_votes_counts!.errors.size()).toBe(1);
     const pg1 = formState.sections.political_group_votes_1;
     expect(pg1?.errors.size()).toBe(1);
   });
@@ -173,11 +173,11 @@ describe("addValidationResultToFormState", () => {
     const defaultState = getDefaultDataEntryState();
     const formState = defaultState.formState;
     const dataEntryStructure = defaultState.dataEntryStructure;
-    formState.sections.differences_counts.isSaved = false;
+    formState.sections.differences_counts!.isSaved = false;
     const validationResults: ValidationResult[] = [validationResultMockData.F303];
 
     addValidationResultsToFormState(validationResults, formState, dataEntryStructure, "errors");
 
-    expect(formState.sections.differences_counts.errors.size()).toBe(0);
+    expect(formState.sections.differences_counts!.errors.size()).toBe(0);
   });
 });

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -1,18 +1,10 @@
 import { PollingStationResults, ValidationResult, ValidationResults } from "@/types/generated/openapi";
 import { DataEntryStructure, FormSectionId } from "@/types/types";
+import { extractFieldInfoFromSection, getValueAtPath } from "@/utils/dataEntryMapping";
 import { doesValidationResultApplyToSection, ValidationResultSet } from "@/utils/ValidationResults";
 
 import { ClientState, FormSection, FormState } from "../types/types";
 import { INITIAL_FORM_SECTION_ID } from "./reducer";
-
-export function objectHasOnlyEmptyValues(obj: Record<string, "" | number>): boolean {
-  for (const key in obj) {
-    if (obj[key] !== "" && obj[key] !== 0) {
-      return false;
-    }
-  }
-  return true;
-}
 
 export function formSectionComplete(section: FormSection): boolean {
   return (
@@ -49,28 +41,36 @@ export function getNextSectionID(formState: FormState, currentSectionId: FormSec
   return null;
 }
 
-export function isFormSectionEmpty(section: FormSection, values: PollingStationResults): boolean {
-  if (section.id.startsWith("political_group_votes_")) {
-    const index = parseInt(section.id.replace("political_group_votes_", "")) - 1;
-    const g = values.political_group_votes[index];
-    if (g) {
-      if (g.total !== 0) return false;
-      for (let i = 0, n = g.candidate_votes.length; i < n; i++) {
-        if (g.candidate_votes[i]?.votes !== 0) return false;
-      }
+export function isFormSectionEmpty(
+  dataEntryStructure: DataEntryStructure,
+  section: FormSection,
+  values: PollingStationResults,
+): boolean {
+  const dataEntrySection = dataEntryStructure.find((s) => s.id === section.id);
+  if (!dataEntrySection) {
+    // If section not found in structure, consider it empty
+    return true;
+  }
+
+  const fieldInfoMap = extractFieldInfoFromSection(dataEntrySection);
+  for (const [path, fieldType] of fieldInfoMap) {
+    const value = getValueAtPath(values, path);
+
+    switch (fieldType) {
+      case "boolean":
+        if (value === true) {
+          return false;
+        }
+        break;
+      case "formattedNumber":
+        if (value !== 0 && value !== undefined) {
+          return false;
+        }
+        break;
     }
   }
 
-  switch (section.id) {
-    case "voters_votes_counts":
-      return (
-        objectHasOnlyEmptyValues({ ...values.votes_counts }) && objectHasOnlyEmptyValues({ ...values.voters_counts })
-      );
-    case "differences_counts":
-      return objectHasOnlyEmptyValues({ ...values.differences_counts });
-    default:
-      return true;
-  }
+  return true;
 }
 
 export type DataEntryFormSectionStatus = "empty" | "unaccepted-warnings" | "accepted-warnings" | "errors";

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -110,7 +110,7 @@ export function getInitialFormState(dataEntryStructure: DataEntryStructure): For
 
   return {
     furthest: INITIAL_FORM_SECTION_ID,
-    sections: sections as Record<FormSectionId, FormSection>,
+    sections: sections,
   };
 }
 

--- a/frontend/src/features/data_entry/utils/reducer.test.ts
+++ b/frontend/src/features/data_entry/utils/reducer.test.ts
@@ -142,8 +142,8 @@ test("should handle UPDATE_FORM_SECTION", () => {
   };
 
   const state = dataEntryReducer(oldState, action);
-  expect(state.formState.sections.voters_votes_counts.hasChanges).toBeDefined();
-  expect(state.formState.sections.voters_votes_counts.hasChanges).toEqual(true);
+  expect(state.formState.sections.voters_votes_counts!.hasChanges).toBeDefined();
+  expect(state.formState.sections.voters_votes_counts!.hasChanges).toEqual(true);
 });
 
 test("should handle FORM_SAVE_FAILED", () => {
@@ -219,7 +219,7 @@ describe("onSubmitForm", () => {
         sections: {
           ...defaultState.formState.sections,
           voters_votes_counts: {
-            ...defaultState.formState.sections.voters_votes_counts,
+            ...defaultState.formState.sections.voters_votes_counts!,
             acceptErrorsAndWarnings: false,
             warnings: new ValidationResultSet([validationResultMockData.W201]),
           },

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -77,7 +77,12 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         ...state,
         cache: action.cache,
       };
-    case "UPDATE_FORM_SECTION":
+    case "UPDATE_FORM_SECTION": {
+      const existingSection = state.formState.sections[action.sectionId];
+      if (!existingSection) {
+        throw new Error(`Section ${action.sectionId} not found in form state`);
+      }
+
       return {
         ...state,
         formState: {
@@ -85,12 +90,13 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
           sections: {
             ...state.formState.sections,
             [action.sectionId]: {
-              ...state.formState.sections[action.sectionId],
+              ...existingSection,
               ...action.partialFormSection,
             },
           },
         },
       };
+    }
     case "FORM_SAVE_FAILED":
       return {
         ...state,

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { render, screen } from "@/testing/test-utils";
 import { PollingStationResults } from "@/types/generated/openapi";
-import { DataEntrySection, FormSectionId, PollingStationResultsPath } from "@/types/types";
+import { DataEntrySection } from "@/types/types";
 import { getDataEntryStructureForDifferences } from "@/utils/dataEntryStructure";
 
 import { pollingStationResultsMockData } from "../testing/polling-station-results";
@@ -60,23 +60,23 @@ describe("ResolveDifferencesTables", () => {
     // Helper function to create a checkbox section for testing
     const createCheckboxesSection = (): DataEntrySection => {
       return {
-        id: "test" as FormSectionId,
+        id: "test",
         title: "test",
         short_title: "test",
         subsections: [
           {
             type: "checkboxes",
             short_title: "short title",
-            error_path: "test" as PollingStationResultsPath,
+            error_path: "test",
             error_message: "recounted.error",
             options: [
               {
-                path: "test.yes" as PollingStationResultsPath,
+                path: "test.yes",
                 label: "yes",
                 short_label: "yes",
               },
               {
-                path: "test.no" as PollingStationResultsPath,
+                path: "test.no",
                 label: "no",
                 short_label: "no",
               },

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,20 +1,5 @@
-import { PollingStationResults } from "./generated/openapi";
-
-export type FormSectionId = "voters_votes_counts" | "differences_counts" | `political_group_votes_${number}` | "save";
-
-type ObjectPath<T> = {
-  // For each entry, if it is an object (including optional)
-  [K in keyof T]: NonNullable<T[K]> extends object
-    ? T[K] extends unknown[]
-      ? never // Skip arrays, which are also objects
-      : `${K & string}.${Extract<keyof NonNullable<T[K]>, string>}` // "parent.child" template literal for string keys
-    : K & string; // else, the key itself when it is a string
-}[keyof T]; // Get all values together
-
-export type PollingStationResultsPath =
-  | NonNullable<ObjectPath<PollingStationResults>>
-  | `political_group_votes[${number}].candidate_votes[${number}].votes`
-  | `political_group_votes[${number}].total`;
+export type FormSectionId = string;
+export type PollingStationResultsPath = string;
 
 export type SectionValues = Record<string, string>;
 
@@ -31,7 +16,7 @@ export interface MessageSubsection {
 }
 
 export interface RadioSubsectionOption {
-  value: string;
+  value: "true" | "false";
   /** Label for data entry form view */
   label: string;
   /** Short label for differences view */
@@ -46,7 +31,6 @@ export interface RadioSubsection {
   error: string;
   path: PollingStationResultsPath;
   options: RadioSubsectionOption[];
-  valueType?: "string" | "boolean";
 }
 
 export interface CheckboxesSubsectionOption {

--- a/frontend/src/utils/dataEntryMapping.test.ts
+++ b/frontend/src/utils/dataEntryMapping.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { PollingStationResults } from "@/types/generated/openapi";
-import { DataEntrySection, FormSectionId, PollingStationResultsPath } from "@/types/types";
+import { DataEntrySection } from "@/types/types";
 
 import { mapResultsToSectionValues, mapSectionValues } from "./dataEntryMapping";
 import { differencesSection, votersAndVotesSection } from "./dataEntryStructure";
@@ -35,23 +35,23 @@ const createBasePollingStationResults = (): PollingStationResults => ({
 const createCheckboxesSection = (): DataEntrySection => {
   // Use TypeScript `as` for testing
   return {
-    id: "test" as FormSectionId,
+    id: "test",
     title: "test",
     short_title: "test",
     subsections: [
       {
         type: "checkboxes",
         short_title: "test",
-        error_path: "test" as PollingStationResultsPath,
+        error_path: "test",
         error_message: "error",
         options: [
           {
-            path: "test.yes" as PollingStationResultsPath,
+            path: "test.yes",
             label: "yes",
             short_label: "yes",
           },
           {
-            path: "test.no" as PollingStationResultsPath,
+            path: "test.no",
             label: "no",
             short_label: "no",
           },
@@ -63,9 +63,8 @@ const createCheckboxesSection = (): DataEntrySection => {
 
 // Helper function to create a radio section for testing
 const createRadioSection = (): DataEntrySection => {
-  // Use TypeScript `as` for testing
   return {
-    id: "test" as FormSectionId,
+    id: "test",
     title: "test",
     short_title: "test",
     subsections: [
@@ -73,8 +72,7 @@ const createRadioSection = (): DataEntrySection => {
         type: "radio",
         short_title: "test",
         error: "error",
-        path: "test" as PollingStationResultsPath,
-        valueType: "boolean",
+        path: "test",
         options: [
           {
             value: "true",
@@ -99,20 +97,22 @@ describe("mapSectionValues", () => {
     { input: "", expected: undefined, description: "empty" },
   ])("should handle radio $description", ({ input, expected }) => {
     const radioSection = createRadioSection();
-    const current = createBasePollingStationResults();
+    const current = { test: null };
     const formValues = { test: input };
 
     const result = mapSectionValues(current, formValues, radioSection);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((result as any).test).toBe(expected);
+    expect(result.test).toBe(expected);
   });
 
   test("should use section info to distinguish radio vs inputGrid fields", () => {
-    const current = createBasePollingStationResults();
+    const current = {
+      test: null,
+      test2: null,
+    };
     const formValues = {
       test: "true", // Radio field - should become boolean
-      "voters_counts.poll_card_count": "456", // InputGrid field - should be deformatted to number
+      test2: "456", // InputGrid field - should be deformatted to number
     };
 
     const testSection: DataEntrySection = {
@@ -124,16 +124,15 @@ describe("mapSectionValues", () => {
         {
           type: "inputGrid",
           headers: ["field", "counted_number", "description"],
-          rows: [{ code: "A", path: "voters_counts.poll_card_count", title: "Test Title" }],
+          rows: [{ code: "A", path: "test2", title: "Test Title" }],
         },
       ],
     };
 
     const result = mapSectionValues(current, formValues, testSection);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((result as any).test).toBe(true); // Radio test field becomes boolean
-    expect(result.voters_counts.poll_card_count).toBe(456); // InputGrid field gets deformatted to number
+    expect(result.test).toBe(true); // Radio test field becomes boolean
+    expect(result.test2).toBe(456); // InputGrid field gets deformatted to number
   });
 
   test("should handle formatted numbers correctly when section info is provided", () => {
@@ -163,39 +162,6 @@ describe("mapSectionValues", () => {
 
     expect(result.voters_counts.poll_card_count).toBe(1234); // Should be deformatted to number
     expect(result.voters_counts.proxy_certificate_count).toBe(2567); // Should be deformatted to number
-  });
-
-  test("should handle mixed field types when section is provided", () => {
-    const current = createBasePollingStationResults();
-    const formValues = {
-      test: "true", // Boolean field - special case
-      "voters_counts.poll_card_count": "1.234", // Numeric value - should be deformatted
-      "differences_counts.more_ballots_count": "5", // Another numeric value
-    };
-
-    const mixedSection: DataEntrySection = {
-      id: "voters_votes_counts",
-      title: "Mixed Section",
-      short_title: "Mixed",
-      subsections: [
-        ...createRadioSection().subsections,
-        {
-          type: "inputGrid",
-          headers: ["field", "counted_number", "description"],
-          rows: [
-            { code: "A", path: "voters_counts.poll_card_count", title: "Test Title" },
-            { code: "B", path: "differences_counts.more_ballots_count", title: "Test Title" },
-          ],
-        },
-      ],
-    };
-
-    const result = mapSectionValues(current, formValues, mixedSection);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((result as any).test).toBe(true);
-    expect(result.voters_counts.poll_card_count).toBe(1234);
-    expect(result.differences_counts.more_ballots_count).toBe(5);
   });
 
   test("should handle voters_counts fields", () => {
@@ -491,18 +457,14 @@ describe("mapSectionValues", () => {
   });
 
   test("should handle checkboxes subsection", () => {
-    const current = createBasePollingStationResults();
+    const current = { test: { yes: null, no: null } };
     const formValues = {
       "test.yes": "true",
       "test.no": "false",
     };
 
-    // use `any` because real PollingStationResults doesn't have recounted.yes/recounted.no
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: any = mapSectionValues(current, formValues, createCheckboxesSection());
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const result = mapSectionValues(current, formValues, createCheckboxesSection());
     expect(result.test.yes).toBe(true);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(result.test.no).toBe(false);
   });
 });
@@ -513,20 +475,17 @@ describe("mapResultsToSectionValues", () => {
     { input: false, expected: "false", description: "false" },
     { input: undefined, expected: "", description: "undefined" },
   ])("should handle radio as $description", ({ input, expected }) => {
-    const results = createBasePollingStationResults();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = input;
+    const results = { test: input };
 
     const testSectionWithRadio: DataEntrySection = {
-      id: "test_section" as FormSectionId,
+      id: "test_section",
       title: "Test Section",
       short_title: "Test",
       subsections: [
         {
           type: "radio",
           short_title: "test",
-          path: "test" as PollingStationResultsPath,
-          valueType: "boolean",
+          path: "test",
           error: "error",
           options: [],
         },
@@ -539,10 +498,12 @@ describe("mapResultsToSectionValues", () => {
   });
 
   test("should format only inputGrid values, not radio values", () => {
-    const results = createBasePollingStationResults();
-    results.voters_counts.poll_card_count = 1234; // Should be formatted
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = true; // Should stay as string when converted
+    const results = {
+      test: true,
+      voters_counts: {
+        poll_card_count: 1234,
+      },
+    };
 
     const testSection: DataEntrySection = {
       id: "voters_votes_counts",
@@ -552,8 +513,7 @@ describe("mapResultsToSectionValues", () => {
         {
           type: "radio",
           short_title: "test.short_title",
-          path: "test" as PollingStationResultsPath,
-          valueType: "boolean",
+          path: "test",
           error: "test.error",
           options: [],
         },
@@ -784,13 +744,15 @@ describe("mapResultsToSectionValues", () => {
   });
 
   test("should handle mixed subsections components", () => {
-    const results = createBasePollingStationResults();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = true;
-    results.voters_counts.poll_card_count = 100;
+    const results = {
+      test: true,
+      voters_counts: {
+        poll_card_count: 100,
+      },
+    };
 
     const mixedSection: DataEntrySection = {
-      id: "test" as FormSectionId,
+      id: "test",
       title: "test",
       short_title: "test",
       subsections: [
@@ -813,28 +775,23 @@ describe("mapResultsToSectionValues", () => {
   });
 
   test("should extract checkboxes boolean values to string form", () => {
-    const results = createBasePollingStationResults();
     const checkboxesSection = createCheckboxesSection();
-
     // Test with both true values
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = { yes: true, no: true };
+    const results = { test: { yes: true, no: true } };
 
     let formValues = mapResultsToSectionValues(checkboxesSection, results);
     expect(formValues["test.yes"]).toBe("true");
     expect(formValues["test.no"]).toBe("true");
 
     // Test with both false values
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = { yes: false, no: false };
+    results.test = { yes: false, no: false };
 
     formValues = mapResultsToSectionValues(checkboxesSection, results);
     expect(formValues["test.yes"]).toBe("false");
     expect(formValues["test.no"]).toBe("false");
 
     // Test with mixed values
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    (results as any).test = { yes: true, no: false };
+    results.test = { yes: true, no: false };
 
     formValues = mapResultsToSectionValues(checkboxesSection, results);
     expect(formValues["test.yes"]).toBe("true");

--- a/frontend/src/utils/dataEntryMapping.ts
+++ b/frontend/src/utils/dataEntryMapping.ts
@@ -5,20 +5,14 @@ import { deformatNumber, formatNumber } from "@/utils/format";
 type PathSegment = string | number;
 type PathValue = boolean | number | string | undefined;
 
-export function mapSectionValues(
-  current: PollingStationResults,
-  formValues: SectionValues,
-  section: DataEntrySection,
-): PollingStationResults {
-  const mappedValues: PollingStationResults = structuredClone(current);
+export function mapSectionValues<T>(current: T, formValues: SectionValues, section: DataEntrySection): T {
+  const mappedValues: T = structuredClone(current);
 
-  const fieldInfoMap = new Map<string, "string" | "boolean" | "formattedNumber">();
+  const fieldInfoMap = new Map<string, "boolean" | "formattedNumber">();
   for (const subsection of section.subsections) {
     switch (subsection.type) {
       case "radio": {
-        if (subsection.valueType) {
-          fieldInfoMap.set(subsection.path, subsection.valueType);
-        }
+        fieldInfoMap.set(subsection.path, "boolean");
         break;
       }
       case "inputGrid": {
@@ -44,7 +38,7 @@ export function mapSectionValues(
   return mappedValues;
 }
 
-export function mapResultsToSectionValues(section: DataEntrySection, results: PollingStationResults): SectionValues {
+export function mapResultsToSectionValues(section: DataEntrySection, results: unknown): SectionValues {
   const formValues: SectionValues = {};
 
   for (const subsection of section.subsections) {
@@ -80,15 +74,15 @@ export function getStringValueAtPath(results: PollingStationResults, path: strin
 }
 
 function setValueAtPath(
-  obj: PollingStationResults,
+  obj: unknown,
   path: string,
   value: string,
-  valueType: "string" | "boolean" | "formattedNumber" | undefined,
+  valueType: "boolean" | "formattedNumber" | undefined,
 ): void {
   const segments = parsePathSegments(path);
   const processedValue = processValue(value, valueType);
 
-  let current: unknown = obj;
+  let current = obj;
 
   for (let i = 0; i < segments.length - 1; i++) {
     const segment = segments[i];
@@ -117,7 +111,7 @@ function setValueAtPath(
   }
 }
 
-function getValueAtPath(obj: PollingStationResults, path: string): PathValue {
+function getValueAtPath(obj: unknown, path: string): PathValue {
   const segments = parsePathSegments(path);
 
   const result = segments.reduce<unknown>((current, segment) => {
@@ -135,7 +129,7 @@ function getValueAtPath(obj: PollingStationResults, path: string): PathValue {
 
 function processValue(
   value: string,
-  valueType: "string" | "boolean" | "formattedNumber" | undefined,
+  valueType: "boolean" | "formattedNumber" | undefined,
 ): boolean | number | string | undefined {
   if (valueType === "boolean") {
     if (value === "") {

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -1,6 +1,6 @@
 import { t } from "@/i18n/translate";
 import { ElectionWithPoliticalGroups, PoliticalGroup, PollingStationResults } from "@/types/generated/openapi";
-import { DataEntrySection, DataEntryStructure, FormSectionId, InputGridSubsectionRow } from "@/types/types";
+import { DataEntrySection, DataEntryStructure, InputGridSubsectionRow } from "@/types/types";
 import { getCandidateFullName } from "@/utils/candidate";
 import { formatPoliticalGroupName } from "@/utils/politicalGroup";
 
@@ -139,7 +139,7 @@ export function createPoliticalGroupSections(election: ElectionWithPoliticalGrou
 
     const title = formatPoliticalGroupName(politicalGroup);
     return {
-      id: `political_group_votes_${politicalGroup.number}` as FormSectionId,
+      id: `political_group_votes_${politicalGroup.number}`,
       title: title,
       short_title: title,
       subsections: [


### PR DESCRIPTION
- **Simplify data entry structure types**
  This makes the code more testable because we can use arbirtary types to
  test, not just `PollingStationResults` as used in the backend.
  
  Also removed arbitrary string values for radio subsections, because we
  only need boolean values.
  
  Resolves #1820

- **Use data entry structure in `isFormSectionEmpty`**
  