### PR TITLE
Streaming ZIP responses

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -7,6 +7,7 @@ name = "abacus"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "async_zip",
  "axum",
  "axum-extra",
  "chrono",
@@ -26,6 +27,7 @@ dependencies = [
  "strum 0.27.2",
  "test-log",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -35,7 +37,6 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "utoipa-swagger-ui",
- "zip 4.3.0",
 ]
 
 [[package]]
@@ -191,6 +192,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-compression"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +213,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+dependencies = [
+ "async-compression",
+ "chrono",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -982,6 +1012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1141,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-sink"
@@ -2282,6 +2331,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3620,6 +3689,7 @@ checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4297,7 +4367,7 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
- "zip 3.0.0",
+ "zip",
 ]
 
 [[package]]
@@ -4974,21 +5044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zip"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
-dependencies = [
- "arbitrary",
- "chrono",
  "crc32fast",
  "flate2",
  "indexmap",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -61,11 +61,9 @@ argon2 = "0.5.3"
 password-hash = { version = "0.5.0", features = ["getrandom"] }
 rand = "0.9.0"
 cookie = { version = "0.18.1", features = ["percent-encode"] }
-zip = { version = "4.3.0", default-features = false, features = [
-    "deflate",
-    "chrono",
-] }
+async_zip = { version = "0.0.17", features = ["tokio", "deflate", "chrono"] }
 strum = { version = "0.27", features = ["derive"] }
+tokio-stream = "0.1.17"
 
 [dev-dependencies]
 test-log = "0.2.17"

--- a/backend/README.md
+++ b/backend/README.md
@@ -120,6 +120,7 @@ The following dependencies (crates) are used:
 - `sha2`: generating a hash of the EML_NL XML files for inclusion in the PDF.
 - `sqlx`: async SQL library featuring compile-time checked queries.
 - `tokio`: runtime for writing asynchronous applications.
+- `tokio-stream`: used to wrap an channel to an async stream.
 - `tower`: a library of modular and reusable components for building robust networking clients and servers.
 - `tower-http`: Tower middleware and utilities for HTTP clients and servers.
 - `tracing`: a framework for instrumenting Rust programs to collect structured, event-based diagnostic information.
@@ -128,7 +129,7 @@ The following dependencies (crates) are used:
 - `typst-pdf`: a PDF exporter for Typst.
 - `utoipa`: library for documenting REST APIs using OpenAPI.
 - `utoipa-swagger-ui`: Swagger UI for the OpenAPI specification.
-- `zip`: creating a zip of the EML_NL and PDF PV.
+- `async_zip`: creating a zip of the EML_NL and PDF PV.
 - `strum`: Converting enums from their string representation and back
 
 Additionally, the following development dependencies are used:

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -8,6 +8,7 @@ use std::{
 use abacus::{
     committee_session::{
         CommitteeSession, CommitteeSessionCreateRequest, repository::CommitteeSessions,
+        status::CommitteeSessionStatus,
     },
     create_sqlite_pool,
     data_entry::{
@@ -21,7 +22,7 @@ use abacus::{
         PoliticalGroup, VoteCountingMethod, repository::Elections,
     },
     eml::{EML110, EML230, EMLDocument},
-    pdf_gen::models::{ModelNa31_2Input, PdfModel},
+    pdf_gen::models::{ModelNa31_2Input, ToPdfFileModel},
     polling_station::{
         PollingStation, PollingStationRequest, PollingStationType, repository::PollingStations,
     },
@@ -153,13 +154,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // generate the committee session for the election
     let cs_repo = CommitteeSessions::new(pool.clone());
-    let committee_session = cs_repo
+    let mut committee_session = cs_repo
         .create(CommitteeSessionCreateRequest {
             number: 1,
             election_id: election.id,
         })
         .await
         .expect("Failed to create committee session");
+
+    if args.with_data_entry {
+        committee_session = cs_repo
+            .change_status(
+                committee_session.id,
+                CommitteeSessionStatus::DataEntryInProgress,
+            )
+            .await
+            .expect("Failed to update committee session status");
+    }
 
     cs_repo
         .change_number_of_voters(committee_session.id, rng.random_range(args.voters.clone()))
@@ -636,19 +647,20 @@ async fn export_election(
     if export_results_json {
         let election_summary = ElectionSummary::from_results(election, &results)
             .expect("Failed to create election summary");
-        let input = PdfModel::ModelNa31_2(Box::new(ModelNa31_2Input {
+        let input = ModelNa31_2Input {
             committee_session: committee_session.clone(),
             polling_stations: polling_stations.iter().map(Clone::clone).collect(),
             summary: election_summary,
             election: election.clone(),
             hash: "0000".to_string(),
             creation_date_time: chrono::Utc::now().format("%d-%m-%Y %H:%M").to_string(),
-        }));
-        let input_json = input.get_input().expect("Failed to get model input");
+        }
+        .to_pdf_file_model("file.pdf".to_string());
+        let input_json = input.model.get_input().expect("Failed to get model input");
         let results_filename = export_dir.join(format!(
             "input_{}_{}.json",
             election.election_id,
-            input.as_filename()
+            input.model.as_model_name()
         ));
         info!(
             "Writing results JSON file for input to PDF model to {:?}",

--- a/backend/src/document/api.rs
+++ b/backend/src/document/api.rs
@@ -1,5 +1,7 @@
-use axum::extract::{Path, State};
-use axum_extra::response::Attachment;
+use axum::{
+    extract::{Path, State},
+    response::IntoResponse,
+};
 use chrono::Datelike;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
@@ -10,10 +12,10 @@ use crate::{
     error::ErrorReference,
     pdf_gen::{
         generate_pdfs,
-        models::{ModelNa31_2Bijlage1Input, PdfModel},
+        models::{ModelNa31_2Bijlage1Input, ToPdfFileModel},
     },
     polling_station::repository::PollingStations,
-    zip::ZipResponse,
+    zip::ZipStream,
 };
 
 pub fn router() -> OpenApiRouter<AppState> {
@@ -45,15 +47,15 @@ async fn election_download_na_31_2_bijlage1(
     State(elections_repo): State<Elections>,
     State(polling_stations_repo): State<PollingStations>,
     Path(id): Path<u32>,
-) -> Result<Attachment<Vec<u8>>, APIError> {
+) -> Result<impl IntoResponse, APIError> {
     let election = elections_repo.get(id).await?;
     let polling_stations = polling_stations_repo.list(election.id).await?;
-    let response = ZipResponse::with_name(&format!(
+    let zip_filename = format!(
         "{}{}_{}_na_31_2_bijlage1.zip",
         election.category.to_eml_code(),
         election.election_date.year(),
         election.location
-    ));
+    );
 
     if polling_stations.is_empty() {
         return Err(APIError::NotFound(
@@ -65,29 +67,24 @@ async fn election_download_na_31_2_bijlage1(
     let models = polling_stations
         .iter()
         .map(|ps| {
-            PdfModel::ModelNa21_2Bijlage1(Box::new(ModelNa31_2Bijlage1Input {
-                election: election.clone(),
-                polling_station: ps.clone(),
-            }))
-        })
-        .collect::<Vec<_>>();
-
-    let content = generate_pdfs(models).await?;
-
-    let files = content
-        .into_iter()
-        .zip(polling_stations.iter())
-        .map(|(pdf, polling_station)| {
             let name = format!(
                 "Model_Na31-2_{}{}_Stembureau_{}_Bijlage_1.pdf",
                 election.category.to_eml_code(),
                 election.election_date.year(),
-                polling_station.number
+                ps.number
             );
 
-            (name, pdf.buffer)
+            ModelNa31_2Bijlage1Input {
+                election: election.clone(),
+                polling_station: ps.clone(),
+            }
+            .to_pdf_file_model(name)
         })
         .collect::<Vec<_>>();
 
-    response.create_zip(files)
+    let zip_stream = ZipStream::new(&zip_filename).await;
+
+    generate_pdfs(models, zip_stream.sender());
+
+    Ok(zip_stream)
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use sqlx::Error::RowNotFound;
 use tracing::error;
 use utoipa::ToSchema;
-use zip::result::ZipError;
 
 use crate::{
     MAX_BODY_SIZE_MB, apportionment::ApportionmentError,
@@ -94,7 +93,7 @@ pub enum APIError {
     StdError(Box<dyn Error>),
     XmlDeError(DeError),
     XmlError(SeError),
-    ZipError(ZipError),
+    ZipError(String),
 }
 
 impl IntoResponse for APIError {

--- a/backend/src/pdf_gen/embedded/mod.rs
+++ b/backend/src/pdf_gen/embedded/mod.rs
@@ -1,90 +1,132 @@
-mod world;
-
-use std::time::Instant;
-
-use tracing::{debug, info, warn};
-use typst::{diag::SourceDiagnostic, ecow::EcoVec};
+use std::{fmt::Debug, time::Instant};
+use tokio::{sync::mpsc::Sender, task::JoinHandle};
+use tracing::{debug, error, info, warn};
+use typst::{comemo, diag::SourceDiagnostic, ecow::EcoVec};
 use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
 
 use super::{PdfGenResult, models::PdfModel};
-use crate::APIError;
+use crate::{APIError, pdf_gen::models::PdfFileModel, zip::FileEntry};
 
-pub async fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
+mod world;
+
+/// Generates a PDF using the embedded typst library.
+pub async fn generate_pdf(file_model: PdfFileModel) -> Result<PdfGenResult, APIError> {
     Ok(tokio::task::spawn_blocking(move || {
-        let results = generate_pdfs_internal(vec![model])?;
+        let result = compile_pdf(&mut world::PdfWorld::new(), file_model.model);
 
-        Ok::<PdfGenResult, PdfGenError>(
-            results
-                .into_iter()
-                .next()
-                .expect("Expected at least one result"),
-        )
+        // Evict the cache to free up memory + speed up next compile
+        comemo::evict(0);
+
+        result
     })
     .await
     .map_err(PdfGenError::from)??)
 }
 
-pub async fn generate_pdfs(models: Vec<PdfModel>) -> Result<Vec<PdfGenResult>, APIError> {
-    Ok(
-        tokio::task::spawn_blocking(move || generate_pdfs_internal(models))
-            .await
-            .map_err(PdfGenError::from)??,
-    )
+/// Generates a ZIP file containing the PDFs for the provided models.
+/// Uses the embedded typst library to generate the PDFs.
+pub fn generate_pdfs(
+    models: Vec<PdfFileModel>,
+    sender: Sender<FileEntry>,
+) -> JoinHandle<Result<(), PdfGenError>> {
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = generate_pdfs_inner(models, sender) {
+            error!("Error generating PDF: {e:?}");
+
+            return Err(e);
+        }
+
+        Ok(())
+    })
 }
 
-fn generate_pdfs_internal(models: Vec<PdfModel>) -> Result<Vec<PdfGenResult>, PdfGenError> {
-    let start = Instant::now();
+pub fn generate_pdfs_inner(
+    models: Vec<PdfFileModel>,
+    sender: Sender<FileEntry>,
+) -> Result<(), PdfGenError> {
     let mut world = world::PdfWorld::new();
 
-    let pdf_standards =
-        PdfStandards::new(&[PdfStandard::A_2b]).expect("PDF standards should be valid");
+    for file_model in models.into_iter() {
+        let file_name = file_model.file_name;
+        let result = compile_pdf(&mut world, file_model.model);
 
-    let pdf_options = PdfOptions {
-        standards: pdf_standards,
-        ..Default::default()
-    };
+        // Evict the cache to free up memory + speed up next compile
+        comemo::evict(0);
 
-    let mut results = Vec::new();
+        let content = result?;
 
-    for model in models {
-        world.set_input_model(model)?;
-
-        let compile_start = Instant::now();
-        let result = typst::compile(&world);
-        let document = result.output.map_err(PdfGenError::from_typst)?;
-        info!("Compile took {} ms", compile_start.elapsed().as_millis());
-
-        info!("{} warnings", result.warnings.len());
-        result.warnings.iter().for_each(|warning| {
-            warn!("Warning: {:?}", warning);
-        });
-
-        debug!("Generating PDF...");
-        let pdf_gen_start = Instant::now();
-        let buffer = typst_pdf::pdf(&document, &pdf_options).map_err(PdfGenError::from_typst)?;
-        debug!(
-            "PDF generation took {} ms",
-            pdf_gen_start.elapsed().as_millis()
-        );
-
-        results.push(PdfGenResult { buffer });
+        sender
+            .blocking_send(Some((file_name, content.buffer)))
+            .map_err(|_| PdfGenError::ChannelClosed)?;
     }
 
-    info!("Finished in {} ms", start.elapsed().as_millis());
-    Ok(results)
+    sender
+        .blocking_send(None)
+        .map_err(|_| PdfGenError::ChannelClosed)?;
+
+    Ok(())
+}
+
+fn get_pdf_options() -> PdfOptions<'static> {
+    PdfOptions {
+        standards: PdfStandards::new(&[PdfStandard::A_2b]).expect("PDF standards should be valid"),
+        ..Default::default()
+    }
+}
+
+fn compile_pdf(world: &mut world::PdfWorld, model: PdfModel) -> Result<PdfGenResult, PdfGenError> {
+    world.set_input_model(model)?;
+
+    let compile_start = Instant::now();
+    let result = typst::compile(world);
+    let document = result.output.map_err(PdfGenError::from_typst)?;
+    info!(
+        "Compile took {} ms, {} warnings",
+        compile_start.elapsed().as_millis(),
+        result.warnings.len()
+    );
+
+    result.warnings.iter().for_each(|warning| {
+        warn!("Warning: {:?}", warning);
+    });
+
+    let pdf_gen_start = Instant::now();
+    let buffer = typst_pdf::pdf(&document, &get_pdf_options()).map_err(PdfGenError::from_typst)?;
+    debug!(
+        "PDF generation took {} ms",
+        pdf_gen_start.elapsed().as_millis()
+    );
+
+    Ok(PdfGenResult { buffer })
 }
 
 #[derive(Debug)]
 pub enum PdfGenError {
-    Typst(Vec<SourceDiagnostic>),
+    Typst(String),
     Join(tokio::task::JoinError),
     Json(serde_json::Error),
     TemplateNotFound(String),
+    ChannelClosed,
 }
 
 impl PdfGenError {
     fn from_typst(typst_errors: EcoVec<SourceDiagnostic>) -> PdfGenError {
-        PdfGenError::Typst(typst_errors.to_vec())
+        PdfGenError::Typst(
+            typst_errors
+                .into_iter()
+                .map(|e| {
+                    format!(
+                        "Typst error in {:?}: {}",
+                        e.span
+                            .id()
+                            .map(|id| id.vpath().as_rootless_path().display().to_string())
+                            .unwrap_or_default(),
+                        e.message
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
     }
 }
 

--- a/backend/src/pdf_gen/embedded/world.rs
+++ b/backend/src/pdf_gen/embedded/world.rs
@@ -14,6 +14,7 @@ use crate::pdf_gen::PdfGenError;
 use super::super::models::PdfModel;
 
 /// Contains the context for rendering PDFs.
+#[derive(Clone)]
 pub struct PdfWorld {
     sources: Vec<Source>,
     library: LazyHash<Library>,

--- a/backend/src/pdf_gen/external.rs
+++ b/backend/src/pdf_gen/external.rs
@@ -1,37 +1,73 @@
-use std::path::PathBuf;
-
 use rand::{Rng, distr::Alphanumeric};
+use std::{path::PathBuf, time::Instant};
+use tokio::{sync::mpsc::Sender, task::JoinHandle};
+use tracing::{error, info};
 
-use super::{PdfGenResult, models::PdfModel};
-use crate::APIError;
+use super::PdfGenResult;
+use crate::{APIError, pdf_gen::models::PdfFileModel, zip::FileEntry};
 
-pub async fn generate_pdf(model: PdfModel) -> Result<PdfGenResult, APIError> {
+/// Generates a PDF using an external typst binary.
+/// Uses environment variables `ABACUS_TYPST_BIN` (`typst` by default)
+/// and `ABACUS_TEMPLATES_DIR` (`./templates` by default) to
+pub async fn generate_pdf(model: PdfFileModel) -> Result<PdfGenResult, APIError> {
     Ok(generate_pdf_internal(model).await?)
 }
 
-pub async fn generate_pdfs(models: Vec<PdfModel>) -> Result<Vec<PdfGenResult>, APIError> {
-    let mut results = Vec::new();
+/// Create a PDF file for each model in the provided vector and send them through the provided channel.
+pub fn generate_pdfs(
+    models: Vec<PdfFileModel>,
+    sender: Sender<FileEntry>,
+) -> JoinHandle<Result<(), PdfGenError>> {
+    tokio::spawn(async move {
+        for file_model in models.into_iter() {
+            let file_name = file_model.file_name.clone();
+            let start = Instant::now();
 
-    for model in models {
-        results.push(generate_pdf_internal(model).await?);
-    }
+            let content = match generate_pdf_internal(file_model).await {
+                Ok(content) => content,
+                Err(e) => {
+                    error!("Failed to generate PDF {file_name}: {e:?}");
+                    continue;
+                }
+            };
 
-    Ok(results)
+            info!(
+                "Generated PDF {file_name} in {} ms",
+                start.elapsed().as_millis()
+            );
+
+            if let Err(e) = sender.send(Some((file_name, content.buffer))).await {
+                error!("Failed to send PDF: {e:?}");
+
+                return Err(PdfGenError::ChannelClosed);
+            }
+        }
+
+        if let Err(e) = sender.send(None).await {
+            error!("Failed to send finish signal: {e:?}");
+
+            return Err(PdfGenError::ChannelClosed);
+        }
+
+        info!("All PDFs generated and sent to the channel");
+
+        Ok::<(), PdfGenError>(())
+    })
 }
 
 /// Uses environment variables `ABACUS_TYPST_BIN` (`typst` by default) and `ABACUS_TEMPLATES_DIR` (`./templates` by
 /// default) to generate a PDF using an external binary of typst.
-async fn generate_pdf_internal(model: PdfModel) -> Result<PdfGenResult, PdfGenError> {
+async fn generate_pdf_internal(file_model: PdfFileModel) -> Result<PdfGenResult, PdfGenError> {
     // create a temporary copy of the template files
     let tmp_path = tokio::task::spawn_blocking(prep_tmp_templates_dir).await??;
 
     // write json data to model input file
     let json_path = {
         let mut full_path = tmp_path.clone();
-        full_path.push(model.as_input_path());
+        full_path.push(file_model.model.as_input_path());
         full_path
     };
-    let json_data = model.get_input()?;
+    let json_data = file_model.model.get_input()?;
     tokio::fs::write(json_path, json_data).await?;
 
     // construct the typst command to run
@@ -45,7 +81,8 @@ async fn generate_pdf_internal(model: PdfModel) -> Result<PdfGenResult, PdfGenEr
             "--ignore-system-fonts",
             "--font-path",
             "fonts/",
-            model
+            file_model
+                .model
                 .as_template_path()
                 .to_str()
                 .expect("Model template path should always be UTF-8"),
@@ -56,8 +93,16 @@ async fn generate_pdf_internal(model: PdfModel) -> Result<PdfGenResult, PdfGenEr
     // get the command output
     let res = command.output().await?;
 
+    // check if the command was successful
+    if !res.status.success() {
+        return Err(PdfGenError::CompilationFailed(format!(
+            "Typst command failed: {}",
+            String::from_utf8_lossy(&res.stderr)
+        )));
+    }
+
     // remove the temporary directory
-    std::fs::remove_dir_all(&tmp_path)?;
+    tokio::fs::remove_dir_all(&tmp_path).await?;
 
     // return the result
     Ok(PdfGenResult { buffer: res.stdout })
@@ -107,6 +152,8 @@ pub enum PdfGenError {
     Io(std::io::Error),
     Join(tokio::task::JoinError),
     Json(serde_json::Error),
+    CompilationFailed(String),
+    ChannelClosed,
 }
 
 impl From<std::io::Error> for PdfGenError {

--- a/backend/src/pdf_gen/mod.rs
+++ b/backend/src/pdf_gen/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod tests {
             ElectionCategory, ElectionWithPoliticalGroups, VoteCountingMethod,
             tests::election_fixture,
         },
-        pdf_gen::models::PdfModel,
+        pdf_gen::models::ToPdfFileModel,
         polling_station::{PollingStation, PollingStationType},
         summary::ElectionSummary,
     };
@@ -60,7 +60,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn it_generates_a_pdf() {
-        let content = generate_pdf(PdfModel::ModelNa31_2(Box::new(ModelNa31_2Input {
+        let content = generate_pdf(ModelNa31_2Input {
             committee_session: committee_session_fixture(1),
             election: ElectionWithPoliticalGroups {
                 id: 1,
@@ -80,7 +80,7 @@ pub(crate) mod tests {
             hash: "ed36 60eb 017a 0d3a d3ef 72b1 6865 f991 a36a 9f92 72d9 1516 39cd 422b 4756 d161"
                 .to_string(),
             creation_date_time: "04-12-2024 12:08".to_string(),
-        })))
+        }.to_pdf_file_model("file.pdf".into()))
         .await
         .unwrap();
 
@@ -90,7 +90,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn it_generates_a_pdf_with_polling_stations() {
         let election = election_fixture(&[2, 3]);
-        let content = generate_pdf(PdfModel::ModelNa31_2(Box::new(ModelNa31_2Input {
+        let content = generate_pdf(ModelNa31_2Input {
             committee_session: committee_session_fixture(election.id),
             polling_stations: polling_stations_fixture(&election, &[100, 200, 300]),
             election,
@@ -98,7 +98,7 @@ pub(crate) mod tests {
             hash: "ed36 60eb 017a 0d3a d3ef 72b1 6865 f991 a36a 9f92 72d9 1516 39cd 422b 4756 d161"
                 .to_string(),
             creation_date_time: "04-12-2024 12:08".to_string(),
-        })))
+        }.to_pdf_file_model("file.pdf".into()))
         .await
         .unwrap();
 

--- a/backend/src/pdf_gen/models/mod.rs
+++ b/backend/src/pdf_gen/models/mod.rs
@@ -4,6 +4,21 @@ use std::{error::Error, path::PathBuf};
 
 pub use model_na_31_2::*;
 
+pub trait ToPdfFileModel {
+    fn to_pdf_file_model(self, file_name: String) -> PdfFileModel;
+}
+
+pub struct PdfFileModel {
+    pub file_name: String,
+    pub model: PdfModel,
+}
+
+impl PdfFileModel {
+    pub fn new(file_name: String, model: PdfModel) -> Self {
+        Self { file_name, model }
+    }
+}
+
 /// Defines the available models and what their input parameters are.
 pub enum PdfModel {
     ModelNa31_2(Box<ModelNa31_2Input>),
@@ -11,8 +26,8 @@ pub enum PdfModel {
 }
 
 impl PdfModel {
-    /// Get the filename for the input and template
-    pub fn as_filename(&self) -> &'static str {
+    /// Get the name for the input and template
+    pub fn as_model_name(&self) -> &'static str {
         match self {
             Self::ModelNa31_2(_) => "model-na-31-2",
             Self::ModelNa21_2Bijlage1(_) => "model-na-31-2-bijlage1",
@@ -21,7 +36,7 @@ impl PdfModel {
 
     /// Get the path for the template of this model
     pub fn as_template_path(&self) -> PathBuf {
-        let mut pb: PathBuf = [self.as_filename()].iter().collect();
+        let mut pb: PathBuf = [self.as_model_name()].iter().collect();
         pb.set_extension("typ");
 
         pb
@@ -29,7 +44,7 @@ impl PdfModel {
 
     /// Get the path for the input of this model
     pub fn as_input_path(&self) -> PathBuf {
-        let mut pb: PathBuf = ["inputs", self.as_filename()].iter().collect();
+        let mut pb: PathBuf = ["inputs", self.as_model_name()].iter().collect();
         pb.set_extension("json");
 
         pb

--- a/backend/src/pdf_gen/models/model_na_31_2.rs
+++ b/backend/src/pdf_gen/models/model_na_31_2.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    committee_session::CommitteeSession, election::ElectionWithPoliticalGroups,
-    polling_station::structs::PollingStation, summary::ElectionSummary,
+    committee_session::CommitteeSession,
+    election::ElectionWithPoliticalGroups,
+    pdf_gen::models::{PdfFileModel, PdfModel, ToPdfFileModel},
+    polling_station::structs::PollingStation,
+    summary::ElectionSummary,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -15,8 +18,20 @@ pub struct ModelNa31_2Input {
     pub creation_date_time: String,
 }
 
+impl ToPdfFileModel for ModelNa31_2Input {
+    fn to_pdf_file_model(self, file_name: String) -> PdfFileModel {
+        PdfFileModel::new(file_name, PdfModel::ModelNa31_2(Box::new(self)))
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct ModelNa31_2Bijlage1Input {
     pub election: ElectionWithPoliticalGroups,
     pub polling_station: PollingStation,
+}
+
+impl ToPdfFileModel for ModelNa31_2Bijlage1Input {
+    fn to_pdf_file_model(self, file_name: String) -> PdfFileModel {
+        PdfFileModel::new(file_name, PdfModel::ModelNa21_2Bijlage1(Box::new(self)))
+    }
 }

--- a/backend/src/zip/write_stream.rs
+++ b/backend/src/zip/write_stream.rs
@@ -1,0 +1,108 @@
+use axum::body::Bytes;
+use std::{
+    collections::VecDeque,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+use tokio::io::AsyncWrite;
+use tokio_stream::Stream;
+use tracing::error;
+
+/// An async write buffer that also implements the Stream trait.
+/// It allows writing data to a buffer asynchronously and reading it as a stream of bytes.
+/// This is useful for streaming data to a client, such as in a ZIP file response.
+pub struct WriteStream {
+    state: Arc<Mutex<Inner>>,
+}
+
+struct Inner {
+    buffer: VecDeque<Bytes>,
+    waker: Option<Waker>,
+    closed: bool,
+}
+
+impl WriteStream {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(Inner {
+                buffer: VecDeque::new(),
+                waker: None,
+                closed: false,
+            })),
+        }
+    }
+
+    pub fn finish(&self) {
+        let Ok(mut state) = self.state.lock() else {
+            error!("Failed to lock WriteStream state for finishing");
+            return;
+        };
+
+        state.closed = true;
+        if let Some(waker) = state.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl Clone for WriteStream {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl AsyncWrite for WriteStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let Ok(mut state) = self.state.lock() else {
+            return Poll::Ready(Err(std::io::Error::other(
+                "Failed to lock WriteStream state",
+            )));
+        };
+
+        state.buffer.push_back(Bytes::copy_from_slice(buf));
+        if let Some(waker) = state.waker.take() {
+            waker.wake();
+        }
+
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Stream for WriteStream {
+    type Item = Result<Bytes, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Ok(mut state) = self.state.lock() else {
+            return Poll::Ready(Some(Err(std::io::Error::other(
+                "Failed to lock WriteStream state",
+            ))));
+        };
+
+        if let Some(data) = state.buffer.pop_front() {
+            Poll::Ready(Some(Ok(data)))
+        } else if state.closed {
+            Poll::Ready(None)
+        } else {
+            state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -7,6 +7,7 @@ use abacus::{
     committee_session::status::CommitteeSessionStatus,
     election::{ElectionDetailsResponse, ElectionListResponse},
 };
+use async_zip::base::read::mem::ZipFileReader;
 use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use test_log::test;
@@ -300,20 +301,21 @@ async fn test_election_zip_download_works(pool: SqlitePool) {
     );
 
     let bytes = response.bytes().await.unwrap();
-    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
-    {
-        let xml_file = archive
-            .by_name("Telling_GR2024_Heemdamseburg.eml.xml")
-            .unwrap();
-        assert!(xml_file.size() > 0);
-    }
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
 
-    {
-        let pdf_file = archive
-            .by_name("Model_Na31-2_GR2024_Heemdamseburg.pdf")
-            .unwrap();
-        assert!(pdf_file.size() > 0);
-    }
+    let reader = archive.reader_with_entry(1).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Telling_GR2024_Heemdamseburg.eml.xml"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+
+    let reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_Na31-2_GR2024_Heemdamseburg.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "users"))))]
@@ -342,24 +344,21 @@ async fn test_election_na_31_2_bijlage1_download(pool: SqlitePool) {
     );
 
     let bytes = response.bytes().await.unwrap();
+    assert!(bytes.len() > 1024);
 
-    // write to disk and print filename
-    std::fs::write("test_na_31_2_bijlage1.zip", &bytes).unwrap();
-    println!("Wrote test_na_31_2_bijlage1.zip");
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
 
-    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_Na31-2_GR2024_Stembureau_33_Bijlage_1.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
 
-    {
-        let pdf_file = archive
-            .by_name("Model_Na31-2_GR2024_Stembureau_33_Bijlage_1.pdf")
-            .unwrap();
-        assert!(pdf_file.size() > 0);
-    }
-
-    {
-        let pdf_file = archive
-            .by_name("Model_Na31-2_GR2024_Stembureau_34_Bijlage_1.pdf")
-            .unwrap();
-        assert!(pdf_file.size() > 0);
-    }
+    let reader = archive.reader_with_entry(1).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_Na31-2_GR2024_Stembureau_34_Bijlage_1.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
 }

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -12,7 +12,7 @@ import { useUserRole } from "@/hooks/user/useUserRole";
 import { t } from "@/i18n/translate";
 import { cn } from "@/utils/classnames";
 
-import { downloadFrom } from "../utils/download";
+import { directDownload } from "../utils/download";
 import { CommitteeSessionCards } from "./CommitteeSessionCards";
 import { ElectionInformationTable } from "./ElectionInformationTable";
 import cls from "./ElectionManagement.module.css";
@@ -31,10 +31,6 @@ export function ElectionHomePage() {
       abortController.abort(DEFAULT_CANCEL_REASON);
     };
   }, [refetch]);
-
-  const downloadNa31_2Bijlage1 = () => {
-    void downloadFrom(`/api/elections/${election.id}/download_na_31_2_bijlage1`);
-  };
 
   if (isTypist) {
     return <Navigate to="data-entry" />;
@@ -90,7 +86,11 @@ export function ElectionHomePage() {
                 <Table.HeaderCell scope="col">{t("election_management.model_purpose")}</Table.HeaderCell>
               </Table.Header>
               <Table.Body>
-                <Table.ClickRow onClick={downloadNa31_2Bijlage1}>
+                <Table.ClickRow
+                  onClick={() => {
+                    directDownload(`/api/elections/${election.id}/download_na_31_2_bijlage1`);
+                  }}
+                >
                   <Table.Cell>Na 31-2 Bijlage 1</Table.Cell>
                   <Table.Cell>{t("election_management.na_31_2_bijlage_1")}</Table.Cell>
                 </Table.ClickRow>

--- a/frontend/src/features/election_management/components/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/ElectionReportPage.tsx
@@ -14,7 +14,7 @@ import {
 import { committeeSessionLabel } from "@/utils/committeeSession";
 import { formatFullDateWithoutTimezone } from "@/utils/format";
 
-import { downloadFrom } from "../utils/download";
+import { directDownload } from "../utils/download";
 import cls from "./ElectionManagement.module.css";
 
 export function ElectionReportPage() {
@@ -23,11 +23,11 @@ export function ElectionReportPage() {
   const navigate = useNavigate();
 
   function downloadPdfResults() {
-    void downloadFrom(`/api/elections/${election.id}/download_pdf_results`);
+    directDownload(`/api/elections/${election.id}/download_pdf_results`);
   }
 
   function downloadZipResults() {
-    void downloadFrom(`/api/elections/${election.id}/download_zip_results`);
+    directDownload(`/api/elections/${election.id}/download_zip_results`);
   }
 
   function handleResume() {

--- a/frontend/src/features/election_management/utils/download.ts
+++ b/frontend/src/features/election_management/utils/download.ts
@@ -1,36 +1,5 @@
-// Prompt the user to 'download' (i.e. save) a file
-function offerDownload(blob: Blob, filename: string) {
-  const file = new File([blob], filename);
-  const fileUrl = window.URL.createObjectURL(file);
-  const anchorElement = document.createElement("a");
-
-  anchorElement.href = fileUrl;
-  anchorElement.download = filename;
-  anchorElement.hidden = true;
-
-  document.body.appendChild(anchorElement);
-
-  anchorElement.click();
-  anchorElement.remove();
-
-  setTimeout(() => {
-    window.URL.revokeObjectURL(fileUrl);
-  }, 30000);
-}
-
-// Download a file from a URL and offer a download prompt to the user with the result
-export async function downloadFrom(url: string) {
-  let filename: string;
-
-  try {
-    const res = await fetch(url);
-    if (res.status !== 200) {
-      const message = `Download failed: status code ${res.status}`;
-      throw new Error(message);
-    }
-    filename = res.headers.get("Content-Disposition")?.split('filename="')[1]?.slice(0, -1) ?? "document";
-    offerDownload(await res.blob(), filename);
-  } catch (e) {
-    console.error(e);
-  }
+export function directDownload(url: string) {
+  const a = document.createElement("a");
+  a.setAttribute("href", url);
+  a.click();
 }


### PR DESCRIPTION
Merge #1830 first

This adds streaming ZIP support.

- PDF files are sent over a channel when generated
- The newly added `ZipStream` listens to this file channel and adds the files to a zip builder on the fly
- The zip builder writes its resulting bytes via a channel to a streamed (chunked) HTTP response

The advantage is that generated PDF files are not kept in memory, also the resulting ZIP file is not kept in memory, they are directly streamed to the client. This allows generating ZIP files with hundreds of PDF files while only ever keeping a single PDF file in memory.