### PR TITLE
Handle abort download by client while streaming a zip

### DIFF
--- a/backend/src/pdf_gen/embedded/mod.rs
+++ b/backend/src/pdf_gen/embedded/mod.rs
@@ -31,7 +31,11 @@ pub fn generate_pdfs(
 ) -> JoinHandle<Result<(), PdfGenError>> {
     tokio::task::spawn_blocking(move || {
         if let Err(e) = generate_pdfs_inner(models, sender) {
-            error!("Error generating PDF: {e:?}");
+            if matches!(e, PdfGenError::ChannelClosed) {
+                error!("Failed to send PDF: {e:?} - the client might have closed the connection");
+            } else {
+                error!("Error generating PDFs: {e:?}");
+            }
 
             return Err(e);
         }

--- a/backend/src/pdf_gen/external.rs
+++ b/backend/src/pdf_gen/external.rs
@@ -44,7 +44,9 @@ pub fn generate_pdfs(
         }
 
         if let Err(e) = sender.send(None).await {
-            error!("Failed to send finish signal: {e:?}");
+            error!(
+                "Failed to send finish signal: {e} - the client might have closed the connection"
+            );
 
             return Err(PdfGenError::ChannelClosed);
         }

--- a/backend/src/pdf_gen/external.rs
+++ b/backend/src/pdf_gen/external.rs
@@ -37,7 +37,7 @@ pub fn generate_pdfs(
             );
 
             if let Err(e) = sender.send(Some((file_name, content.buffer))).await {
-                error!("Failed to send PDF: {e:?}");
+                error!("Failed to send PDF: {e} - the client might have closed the connection");
 
                 return Err(PdfGenError::ChannelClosed);
             }


### PR DESCRIPTION
When streaming a ZIP of PDF files to a client, the client could cancel the download. This change also stop PDF from being generated when a stream is cancelled.