### PR TITLE
Style all forms with the same widths constraints

### DIFF
--- a/frontend/src/components/election/NumberOfVotersForm.tsx
+++ b/frontend/src/components/election/NumberOfVotersForm.tsx
@@ -27,7 +27,7 @@ export function NumberOfVotersForm({ defaultValue, instructions, hint, button, o
   return (
     <>
       <Form onSubmit={handleSubmit}>
-        <FormLayout width="medium">
+        <FormLayout>
           <FormLayout.Section title={t("election_management.how_many_voters")}>
             <p>{instructions}</p>
 

--- a/frontend/src/components/ui/CheckboxAndRadio/CheckboxAndRadio.module.css
+++ b/frontend/src/components/ui/CheckboxAndRadio/CheckboxAndRadio.module.css
@@ -1,5 +1,5 @@
 /* Fieldset styling */
-.choiceList {
+:global(.choiceList) {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.tsx
+++ b/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.tsx
@@ -1,7 +1,5 @@
 import { ReactNode, RefObject } from "react";
 
-import { cn } from "@/utils/classnames";
-
 import { Checkbox, CheckboxAndRadioProps, Radio } from "./CheckboxAndRadio";
 import cls from "./CheckboxAndRadio.module.css";
 
@@ -10,7 +8,7 @@ export interface ChoiceListProps {
 }
 
 export function ChoiceList({ children }: ChoiceListProps) {
-  return <fieldset className={cn(cls.choiceList)}>{children}</fieldset>;
+  return <fieldset className="choiceList">{children}</fieldset>;
 }
 
 interface ChoiceListOptionProps extends CheckboxAndRadioProps {

--- a/frontend/src/components/ui/Form/FormLayout.module.css
+++ b/frontend/src/components/ui/Form/FormLayout.module.css
@@ -1,9 +1,20 @@
 .formLayout {
   margin-bottom: var(--space-md);
-}
 
-.formLayout.mediumWidth {
-  max-width: 32rem;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    width: 40rem;
+  }
+
+  legend,
+  p,
+  :global(.choiceList) {
+    width: 32rem;
+  }
 }
 
 .formSection {

--- a/frontend/src/components/ui/Form/FormLayout.stories.tsx
+++ b/frontend/src/components/ui/Form/FormLayout.stories.tsx
@@ -15,7 +15,7 @@ export const DefaultFormLayout: StoryFn = () => (
         </p>
         <FormLayout.Row>
           <InputField name="inp1" label="Input 1" fieldWidth="narrow" />
-          <InputField name="inp2" label="Input 2" fieldWidth="narrow" />
+          <InputField name="inp2" label="Input 2" />
         </FormLayout.Row>
       </FormLayout.Section>
 

--- a/frontend/src/components/ui/Form/FormLayout.stories.tsx
+++ b/frontend/src/components/ui/Form/FormLayout.stories.tsx
@@ -8,10 +8,14 @@ import { FormLayout } from "./FormLayout";
 export const DefaultFormLayout: StoryFn = () => (
   <div>
     <FormLayout>
-      <FormLayout.Section title="Section 1">
+      <FormLayout.Section title="Section title which for a medium width form body is slightly wider">
+        <p>
+          Here is a description of this form, which should have a maximum width set by the width property of this
+          FormLayout and never more than that, even though the title has a larger maximum width.
+        </p>
         <FormLayout.Row>
           <InputField name="inp1" label="Input 1" fieldWidth="narrow" />
-          <InputField name="inp2" label="Input 2" />
+          <InputField name="inp2" label="Input 2" fieldWidth="narrow" />
         </FormLayout.Row>
       </FormLayout.Section>
 
@@ -24,15 +28,22 @@ export const DefaultFormLayout: StoryFn = () => (
         <FormLayout.Field>
           <ChoiceList>
             <ChoiceList.Title>Choose an option</ChoiceList.Title>
-            <ChoiceList.Radio id="option1" label="Option 1" />
-            <ChoiceList.Radio id="option2" label="Option 2" />
-            <ChoiceList.Radio id="option3" label="Option 3" />
+            <ChoiceList.Radio id="option1" label="Option 1">
+              Some radio option with quite a large description about the results of picking this option
+            </ChoiceList.Radio>
+            <ChoiceList.Radio id="option2" label="Option 2">
+              Then there is ofcourse another option which you could pick instead of the first option
+            </ChoiceList.Radio>
+            <ChoiceList.Radio id="option3" label="Option 3">
+              People should be able to choose the third option as well
+            </ChoiceList.Radio>
           </ChoiceList>
         </FormLayout.Field>
         <InputField name="inp5" label="Input 5" />
       </FormLayout.Section>
       <FormLayout.Controls>
-        <Button>Submit</Button>
+        <Button>Submit your changes</Button>
+        <Button variant="secondary">Cancel</Button>
       </FormLayout.Controls>
     </FormLayout>
   </div>

--- a/frontend/src/components/ui/Form/FormLayout.tsx
+++ b/frontend/src/components/ui/Form/FormLayout.tsx
@@ -1,18 +1,15 @@
 import * as React from "react";
 
-import { cn } from "@/utils/classnames";
-
 import cls from "./FormLayout.module.css";
 
 export interface FormLayoutProps {
   children: React.ReactNode;
-  width?: "medium";
   disabled?: boolean;
 }
 
-export function FormLayout({ children, disabled, width }: FormLayoutProps) {
+export function FormLayout({ children, disabled }: FormLayoutProps) {
   return (
-    <div className={cn(cls.formLayout, width === "medium" && cls.mediumWidth)}>
+    <div className={cls.formLayout}>
       <fieldset disabled={disabled} className={cls.rootFieldset}>
         {children}
       </fieldset>

--- a/frontend/src/features/users/components/create/UserCreateDetailsForm.tsx
+++ b/frontend/src/features/users/components/create/UserCreateDetailsForm.tsx
@@ -105,7 +105,7 @@ export function UserCreateDetailsForm({ role, showFullname, onSubmitted }: UserC
       )}
 
       <Form onSubmit={handleSubmit}>
-        <FormLayout width="medium" disabled={saving}>
+        <FormLayout disabled={saving}>
           <FormLayout.Section title={t("users.details_title")}>
             <InputField
               id="username"

--- a/frontend/src/features/users/components/create/UserCreateRolePage.tsx
+++ b/frontend/src/features/users/components/create/UserCreateRolePage.tsx
@@ -47,7 +47,7 @@ export function UserCreateRolePage() {
       </header>
       <main>
         <Form onSubmit={handleSubmit}>
-          <FormLayout width="medium">
+          <FormLayout>
             <FormLayout.Section>
               <ChoiceList>
                 <ChoiceList.Title>{t("users.role_title")}</ChoiceList.Title>
@@ -81,7 +81,9 @@ export function UserCreateRolePage() {
                 </ChoiceList.Radio>
               </ChoiceList>
             </FormLayout.Section>
-            <FormLayout.Section>{t("users.role_hint")}</FormLayout.Section>
+            <FormLayout.Section>
+              <p>{t("users.role_hint")}</p>
+            </FormLayout.Section>
           </FormLayout>
           <FormLayout.Controls>
             <Button size="xl" type="submit">

--- a/frontend/src/features/users/components/create/UserCreateTypePage.tsx
+++ b/frontend/src/features/users/components/create/UserCreateTypePage.tsx
@@ -42,7 +42,7 @@ export function UserCreateTypePage() {
       </header>
       <main>
         <Form onSubmit={handleSubmit}>
-          <FormLayout width="medium">
+          <FormLayout>
             <FormLayout.Section>
               <ChoiceList>
                 <ChoiceList.Title>{t("users.type_title")}</ChoiceList.Title>
@@ -62,7 +62,9 @@ export function UserCreateTypePage() {
                 />
               </ChoiceList>
             </FormLayout.Section>
-            <FormLayout.Section>{t("users.type_hint")}</FormLayout.Section>
+            <FormLayout.Section>
+              <p>{t("users.type_hint")}</p>
+            </FormLayout.Section>
           </FormLayout>
           <FormLayout.Controls>
             <Button size="xl" type="submit">

--- a/frontend/src/features/users/components/update/UserUpdateForm.tsx
+++ b/frontend/src/features/users/components/update/UserUpdateForm.tsx
@@ -79,7 +79,7 @@ export function UserUpdateForm({ user, onSaved, onAbort }: UserUpdateFormProps) 
       )}
 
       <Form onSubmit={handleSubmit}>
-        <FormLayout width="medium" disabled={saving}>
+        <FormLayout disabled={saving}>
           <FormLayout.Section title={t("users.details_title")}>
             <InputField
               id="username"
@@ -111,7 +111,7 @@ export function UserUpdateForm({ user, onSaved, onAbort }: UserUpdateFormProps) 
               />
             ) : (
               <FormLayout.Field label={t("account.password")}>
-                {t("users.change_password_hint")}
+                <p>{t("users.change_password_hint")}</p>
 
                 <Button
                   type="button"


### PR DESCRIPTION
After discussing the different widths in de form designs, a decision has been made and documented [in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=12471-49244&t=S9rICCYaqavTgx4W-4). In short, for all our forms:
- Headers should have a width of 40rem
- Paragraphs should have a width of 32rem
- Other texts, such as long radio labels, should right align with these paragraphs, i.e. radio widget plus text should have a width of 32rem.

Result can be seen on the [storybook of FormLayout](https://41c6dff0.kiesraad-abacus.pages.dev/storybook/?path=/story/components-ui-form-formlayout--default-form-layout).

The following forms are impacted by these changes, and can best be checked in the MSW mock frontend:

- AccountSetupForm.tsx
  https://41c6dff0.kiesraad-abacus.pages.dev/account/setup
- LoginForm.tsx
  https://41c6dff0.kiesraad-abacus.pages.dev/account/login
- PollingStationForm.tsx
  https://41c6dff0.kiesraad-abacus.pages.dev/elections/1/polling-stations/1/update
- UserCreateRolePage.tsx, 
- UserCreateTypePage.tsx, 
- UserCreateDetailsForm.tsx
  https://41c6dff0.kiesraad-abacus.pages.dev/users/create and continue "wizard"
- UserUpdateForm.tsx
  https://41c6dff0.kiesraad-abacus.pages.dev/users/1/update
- NumberOfVotersForm.tsx
  https://41c6dff0.kiesraad-abacus.pages.dev/elections/1/number-of-voters
  