### PR TITLE
Fix flaky election creation tests

### DIFF
--- a/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/OverviewPgObj.ts
@@ -9,7 +9,6 @@ export class OverviewPgObj {
   readonly alert: Locator;
   readonly create: Locator;
   readonly elections: Locator;
-  readonly electionsCreatedState: Locator;
 
   constructor(protected readonly page: Page) {
     this.navBar = new NavBar(page);
@@ -18,6 +17,9 @@ export class OverviewPgObj {
     this.alert = page.getByRole("heading", { name: "Je account is ingesteld" });
     this.create = page.getByRole("link", { name: "Verkiezing toevoegen" });
     this.elections = page.getByTestId("overview").locator("tbody").getByRole("row");
-    this.electionsCreatedState = this.elections.filter({ hasText: "Zitting voorbereiden" });
+  }
+
+  findElectionRowById(electionId: number) {
+    return this.page.getByTestId(`election-row-${electionId}`);
   }
 }

--- a/frontend/src/components/ui/Table/Table.tsx
+++ b/frontend/src/components/ui/Table/Table.tsx
@@ -64,15 +64,21 @@ function Body({ children, className }: { children: React.ReactNode; className?: 
 }
 
 function Row({
+  id,
   children,
   increasedPadding,
   className,
 }: {
+  id?: string;
   children: React.ReactNode;
   increasedPadding?: boolean;
   className?: string;
 }) {
-  return <tr className={cn(increasedPadding && cls.increasedPadding, className)}>{children}</tr>;
+  return (
+    <tr id={id} className={cn(increasedPadding && cls.increasedPadding, className)}>
+      {children}
+    </tr>
+  );
 }
 
 function ClickRow({
@@ -91,7 +97,17 @@ function ClickRow({
   );
 }
 
-function LinkRow({ children, to, className }: { children: React.ReactNode; to: To; className?: string }) {
+function LinkRow({
+  id,
+  children,
+  to,
+  className,
+}: {
+  id?: string;
+  children: React.ReactNode;
+  to: To;
+  className?: string;
+}) {
   const navigate = useNavigate();
 
   function handleClick() {
@@ -99,7 +115,7 @@ function LinkRow({ children, to, className }: { children: React.ReactNode; to: T
   }
 
   return (
-    <tr className={cn(cls.rowLink, className)} onClick={handleClick}>
+    <tr id={id} className={cn(cls.rowLink, className)} onClick={handleClick}>
       {children}
     </tr>
   );

--- a/frontend/src/features/election_overview/components/OverviewPage.tsx
+++ b/frontend/src/features/election_overview/components/OverviewPage.tsx
@@ -58,13 +58,13 @@ export function OverviewPage() {
     }
     if (electionLink) {
       return (
-        <Table.LinkRow key={election.id} to={electionLink}>
+        <Table.LinkRow id={`election-row-${election.id}`} key={election.id} to={electionLink}>
           <ElectionRowContent />
         </Table.LinkRow>
       );
     } else {
       return (
-        <Table.Row>
+        <Table.Row id={`election-row-${election.id}`}>
           <ElectionRowContent />
         </Table.Row>
       );


### PR DESCRIPTION
Fix two flaky election creation tests;

- it uploads an election file, candidate list and polling stations
- it uploads an election file, candidate list but skips polling stations

Fixed by adding a test id to all rows in the election overview, and using the election id in the response after creating a new election to select and check the specific row.