### PR TITLE
Update polling station API for coordinator file import

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1338,6 +1338,155 @@
         }
       }
     },
+    "/api/elections/{election_id}/polling_stations/import": {
+      "post": {
+        "summary": "Import file with Polling Stations",
+        "operationId": "polling_station_import",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PollingStationsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Polling stations imported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PollingStationListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/elections/{election_id}/polling_stations/validate-import": {
+      "post": {
+        "summary": "Validate a file with Polling Stations",
+        "operationId": "polling_station_validate_import",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PollingStationFileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Polling stations validated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PollingStationRequestListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/elections/{election_id}/polling_stations/{polling_station_id}": {
       "get": {
         "summary": "Get a [PollingStation]",
@@ -5395,6 +5544,17 @@
         },
         "additionalProperties": false
       },
+      "PollingStationFileRequest": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      },
       "PollingStationListResponse": {
         "type": "object",
         "description": "Polling station list response",
@@ -5448,6 +5608,20 @@
         },
         "additionalProperties": false
       },
+      "PollingStationRequestListResponse": {
+        "type": "object",
+        "required": [
+          "polling_stations"
+        ],
+        "properties": {
+          "polling_stations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PollingStationRequest"
+            }
+          }
+        }
+      },
       "PollingStationResults": {
         "type": "object",
         "description": "PollingStationResults, following the fields in Model Na 31-2 Bijlage 2.\n\nSee \"Model Na 31-2. Proces-verbaal van een gemeentelijk stembureau/stembureau voor het openbaar\nlichaam in een gemeente/openbaar lichaam waar een centrale stemopneming wordt verricht,\nBijlage 2: uitkomsten per stembureau\" from the\n[Kiesregeling](https://wetten.overheid.nl/BWBR0034180/2024-04-01#Bijlage1_DivisieNa31.2) or\n[Verkiezingstoolbox](https://www.rijksoverheid.nl/onderwerpen/verkiezingen/verkiezingentoolkit/modellen).",
@@ -5493,6 +5667,24 @@
           "Special",
           "Mobile"
         ]
+      },
+      "PollingStationsRequest": {
+        "type": "object",
+        "required": [
+          "file_name",
+          "polling_stations"
+        ],
+        "properties": {
+          "file_name": {
+            "type": "string"
+          },
+          "polling_stations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PollingStationRequest"
+            }
+          }
+        }
       },
       "PreferenceThreshold": {
         "type": "object",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -104,6 +104,19 @@ export interface POLLING_STATION_CREATE_REQUEST_PARAMS {
 export type POLLING_STATION_CREATE_REQUEST_PATH = `/api/elections/${number}/polling_stations`;
 export type POLLING_STATION_CREATE_REQUEST_BODY = PollingStationRequest;
 
+// /api/elections/{election_id}/polling_stations/import
+export interface POLLING_STATION_IMPORT_REQUEST_PARAMS {
+  election_id: number;
+}
+export type POLLING_STATION_IMPORT_REQUEST_PATH = `/api/elections/${number}/polling_stations/import`;
+export type POLLING_STATION_IMPORT_REQUEST_BODY = PollingStationsRequest;
+
+// /api/elections/{election_id}/polling_stations/validate-import
+export type POLLING_STATION_VALIDATE_IMPORT_REQUEST_PARAMS = Record<string, never>;
+export type POLLING_STATION_VALIDATE_IMPORT_REQUEST_PATH =
+  `/api/elections/{election_id}/polling_stations/validate-import`;
+export type POLLING_STATION_VALIDATE_IMPORT_REQUEST_BODY = PollingStationFileRequest;
+
 // /api/elections/{election_id}/polling_stations/{polling_station_id}
 export interface POLLING_STATION_GET_REQUEST_PARAMS {
   election_id: number;
@@ -905,6 +918,10 @@ export interface PollingStationDetails {
   pollingStationType?: string;
 }
 
+export interface PollingStationFileRequest {
+  data: string;
+}
+
 /**
  * Polling station list response
  */
@@ -923,6 +940,10 @@ export interface PollingStationRequest {
   number_of_voters?: number;
   polling_station_type?: PollingStationType;
   postal_code: string;
+}
+
+export interface PollingStationRequestListResponse {
+  polling_stations: PollingStationRequest[];
 }
 
 /**
@@ -951,6 +972,11 @@ export interface PollingStationResults {
  * Type of Polling station
  */
 export type PollingStationType = "FixedLocation" | "Special" | "Mobile";
+
+export interface PollingStationsRequest {
+  file_name: string;
+  polling_stations: PollingStationRequest[];
+}
 
 export interface PreferenceThreshold {
   /** Preference threshold as a number of votes */


### PR DESCRIPTION
To keep this PR small, it contains only API / backend changes;
- the frontend will be implemented in https://github.com/kiesraad/abacus/issues/1632
- adding an audit event will be implemented in https://github.com/kiesraad/abacus/issues/1915.

This PR adds two API endpoints for polling stations:
-  /api/elections/{election_id}/polling_stations/validate-import
-  /api/elections/{election_id}/polling_stations/import

These endpoints will be used when the coordinator imports a file with polling stations for an existing election. The flow is similar to the step in the election creation flow. 