### PR TITLE
If the initial value is zero, show an empty input instead

### DIFF
--- a/frontend/src/components/election/NumberOfVotersForm.stories.tsx
+++ b/frontend/src/components/election/NumberOfVotersForm.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Form: Story = {
   args: {
-    defaultValue: 2000,
+    defaultValue: 0,
     instructions:
       "Voer het aantal kiesgerechtigden in zoals door de gemeenteraad vastgesteld voor de gemeenteraad 2026 in de gemeente Juinen.",
     hint: "Voer een getal in",
@@ -21,12 +21,18 @@ export const Form: Story = {
   },
   play: async ({ args, canvas, userEvent }) => {
     await expect(canvas.getByText(args.instructions)).toBeInTheDocument();
-    await expect(canvas.getByRole("textbox", { name: "Aantal kiesgerechtigden" })).toHaveValue("2000");
     await expect(canvas.getByText(args.hint!)).toBeInTheDocument();
+
+    const inputField = canvas.getByRole("textbox", { name: "Aantal kiesgerechtigden" });
+    await expect(inputField).toHaveValue("");
 
     const button = canvas.getByRole("button");
     await expect(button).toHaveAccessibleName("Opslaan");
 
+    await userEvent.click(button);
+    await expect(args.onSubmit).toHaveBeenCalledWith(0);
+
+    await userEvent.type(inputField, "2000");
     await userEvent.click(button);
     await expect(args.onSubmit).toHaveBeenCalledWith(2000);
   },

--- a/frontend/src/components/election/NumberOfVotersForm.tsx
+++ b/frontend/src/components/election/NumberOfVotersForm.tsx
@@ -38,7 +38,7 @@ export function NumberOfVotersForm({ defaultValue, instructions, hint, button, o
               hint={hint}
               fieldWidth="full-field-with-narrow-input"
               numberInput
-              defaultValue={defaultValue}
+              defaultValue={defaultValue || ""}
             />
 
             <FormLayout.Controls>


### PR DESCRIPTION
- Resolves https://github.com/kiesraad/abacus/issues/1877
- Start with empty input if the initial value is zero
- Cover scenario in storybook test

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->