### PR TITLE
Fix Alert styling

### DIFF
--- a/frontend/src/components/ui/Alert/Alert.module.css
+++ b/frontend/src/components/ui/Alert/Alert.module.css
@@ -54,12 +54,13 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    max-width: 48rem;
+    max-width: 40rem;
     word-break: break-word;
 
     p {
       line-height: 1.5rem;
       margin: 0;
+      width: 100%;
     }
 
     button {

--- a/frontend/src/components/ui/Form/FormLayout.module.css
+++ b/frontend/src/components/ui/Form/FormLayout.module.css
@@ -52,6 +52,7 @@
 .formAlert {
   overflow: hidden;
   margin-top: -2.5rem;
+  margin-bottom: 2rem;
   margin-left: -5rem;
   margin-right: -5rem;
 }

--- a/frontend/src/features/account/components/LoginForm.tsx
+++ b/frontend/src/features/account/components/LoginForm.tsx
@@ -76,7 +76,7 @@ export function LoginForm() {
       <FormLayout>
         {notification && (
           <FormLayout.Alert>
-            <Alert type="notify" margin="mb-lg">
+            <Alert type="notify">
               <h2>{t(`${notification}_title`)}</h2>
               <p>{tx(notification)}</p>
             </Alert>
@@ -84,7 +84,7 @@ export function LoginForm() {
         )}
         {error && (
           <FormLayout.Alert>
-            <Alert type="error" margin="mb-lg">
+            <Alert type="error">
               <h2>{t(`error.api_error.${error.reference}`)}</h2>
             </Alert>
           </FormLayout.Alert>


### PR DESCRIPTION
- Resolves #1869
  -  Spacing was missing when using `FormLayout.Alert`, added a margin-bottom to that element

- Resolves #1888
  - Adjusted max-width to 40rem (according to design)
  - Width got overridden `formLayout p`, so the `width: 100%` makes sure we use our own max-width