### PR TITLE
Prevent deleting the last admin

### DIFF
--- a/backend/.sqlx/query-3289e07f76d7683b334865ad2a8b020984af308c4996f971e865a005dd3ea44c.json
+++ b/backend/.sqlx/query-3289e07f76d7683b334865ad2a8b020984af308c4996f971e865a005dd3ea44c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) FROM users WHERE role = ? AND last_activity_at IS NOT NULL",
+  "describe": {
+    "columns": [
+      {
+        "name": "COUNT(*)",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3289e07f76d7683b334865ad2a8b020984af308c4996f971e865a005dd3ea44c"
+}

--- a/backend/fixtures/users.sql
+++ b/backend/fixtures/users.sql
@@ -1,4 +1,4 @@
-INSERT INTO users (id, username, fullname, role, password_hash, needs_password_change)
+INSERT INTO users (id, username, fullname, role, password_hash, needs_password_change, last_activity_at)
 -- Passwords:
 -- admin: 'AdminPassword01'
 -- admin2: 'Admin2Password01'
@@ -6,9 +6,9 @@ INSERT INTO users (id, username, fullname, role, password_hash, needs_password_c
 -- coordinator2: 'Coordinator2Password01'
 -- typist: 'TypistPassword01'
 -- typist2: 'Typist2Password01'
-VALUES (1, 'admin1', 'Sanne Molenaar', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$trZGY1jE5OSpt+NG9NvY1w$vofrcEyML5A70ZR6EhwdqfLsv81DjkYMJvgXeKFLqQ4', false),
-       (2, 'admin2', 'Jef van Reybrouck', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$T3GsSA2b0DoADC99nNvUiQ$aFbvgSyHJwEly0s88XypgceNNXtJVhBmCD5Eu9/xD7I', false),
-       (3, 'coordinator1', 'Mohammed van der Velden', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$D6QmytaEld06P+sZ1p5osg$RqPv1nE7sosIeEoAl9wA96dC1R9RTO9om9aOYZPi3iw', false),
-       (4, 'coordinator2', 'Mei Chen', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$wgaSTPo3hhk3RTR9eDf/TQ$2wi/gsHEDslt1cqoWzL1zS07Y+5tlYg4V/lp2ZYcS5g', false),
-       (5, 'typist1', 'Sam Kuijpers', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$xQo7+6SEm9qRdViNg3/hsg$nA926/HWrQfih8xx5NPR5PXvtE2DqndImHiPWP7HDdQ', false),
-       (6, 'typist2', 'Aliyah van den Berg', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$wQphZULq5ttINkUDRTSzow$vUVBCYFJOaEMWUYiI0kYLgtlPACYXwikuxWfj+0QM9o', false);
+VALUES (1, 'admin1', 'Sanne Molenaar', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$trZGY1jE5OSpt+NG9NvY1w$vofrcEyML5A70ZR6EhwdqfLsv81DjkYMJvgXeKFLqQ4', false, CURRENT_TIMESTAMP),
+       (2, 'admin2', 'Jef van Reybrouck', 'administrator', '$argon2id$v=19$m=19456,t=2,p=1$T3GsSA2b0DoADC99nNvUiQ$aFbvgSyHJwEly0s88XypgceNNXtJVhBmCD5Eu9/xD7I', false, CURRENT_TIMESTAMP),
+       (3, 'coordinator1', 'Mohammed van der Velden', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$D6QmytaEld06P+sZ1p5osg$RqPv1nE7sosIeEoAl9wA96dC1R9RTO9om9aOYZPi3iw', false, CURRENT_TIMESTAMP),
+       (4, 'coordinator2', 'Mei Chen', 'coordinator', '$argon2id$v=19$m=19456,t=2,p=1$wgaSTPo3hhk3RTR9eDf/TQ$2wi/gsHEDslt1cqoWzL1zS07Y+5tlYg4V/lp2ZYcS5g', false, CURRENT_TIMESTAMP),
+       (5, 'typist1', 'Sam Kuijpers', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$xQo7+6SEm9qRdViNg3/hsg$nA926/HWrQfih8xx5NPR5PXvtE2DqndImHiPWP7HDdQ', false, CURRENT_TIMESTAMP),
+       (6, 'typist2', 'Aliyah van den Berg', 'typist', '$argon2id$v=19$m=19456,t=2,p=1$wQphZULq5ttINkUDRTSzow$vUVBCYFJOaEMWUYiI0kYLgtlPACYXwikuxWfj+0QM9o', false, CURRENT_TIMESTAMP);

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4824,6 +4824,7 @@
           "InvalidVoteCandidate",
           "InvalidVoteGroup",
           "InvalidXml",
+          "LastAdminCannotBeDeleted",
           "PasswordRejection",
           "PdfGenerationError",
           "PollingStationRepeated",

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -13,6 +13,7 @@ pub enum AuthenticationError {
     Unauthorized,
     Unauthenticated,
     PasswordRejection,
+    LastAdminCannotBeDeleted,
 }
 
 impl From<password_hash::Error> for AuthenticationError {

--- a/backend/src/authentication/user.rs
+++ b/backend/src/authentication/user.rs
@@ -385,6 +385,18 @@ pub async fn update_last_activity_at(conn: impl DbConnLike<'_>, user_id: u32) ->
     Ok(())
 }
 
+/// Count the number of admin users that have been active
+pub async fn count_admins(conn: impl DbConnLike<'_>) -> Result<i64, Error> {
+    let count = sqlx::query_scalar!(
+        r#"SELECT COUNT(*) FROM users WHERE role = ? AND last_activity_at IS NOT NULL"#,
+        Role::Administrator
+    )
+    .fetch_one(conn)
+    .await?;
+
+    Ok(count)
+}
+
 #[cfg(test)]
 mod tests {
     use sqlx::SqlitePool;

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -48,6 +48,7 @@ pub enum ErrorReference {
     InvalidVoteCandidate,
     InvalidVoteGroup,
     InvalidXml,
+    LastAdminCannotBeDeleted,
     PasswordRejection,
     PdfGenerationError,
     PollingStationRepeated,
@@ -272,6 +273,14 @@ impl IntoResponse for APIError {
                     AuthenticationError::PasswordRejection => (
                         StatusCode::BAD_REQUEST,
                         to_error("Invalid password", ErrorReference::PasswordRejection, false),
+                    ),
+                    AuthenticationError::LastAdminCannotBeDeleted => (
+                        StatusCode::FORBIDDEN,
+                        to_error(
+                            "Cannot delete the last admin user",
+                            ErrorReference::LastAdminCannotBeDeleted,
+                            false,
+                        ),
                     ),
                     // server errors
                     AuthenticationError::Database(_)

--- a/frontend/src/features/users/components/update/UserDelete.tsx
+++ b/frontend/src/features/users/components/update/UserDelete.tsx
@@ -26,6 +26,7 @@ export function UserDelete({ user, onDeleted, onError }: UserDeleteProps) {
     void remove().then((result) => {
       if (!isSuccess(result)) {
         onError(result);
+        setShowModal(false);
       } else {
         onDeleted();
       }

--- a/frontend/src/features/users/components/update/UserUpdatePage.tsx
+++ b/frontend/src/features/users/components/update/UserUpdatePage.tsx
@@ -61,7 +61,9 @@ export function UserUpdatePage() {
         <article>
           {error && (
             <FormLayout.Alert>
-              <Alert type="error">{t(`error.api_error.${error.reference}`)}</Alert>
+              <Alert type="error">
+                <p>{t(`error.api_error.${error.reference}`)}</p>
+              </Alert>
             </FormLayout.Alert>
           )}
 

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -30,6 +30,7 @@
     "InvalidVoteCandidate": "De kandidaat van de stem is niet geldig",
     "InvalidVoteGroup": "De politieke partij van de stem is niet geldig",
     "InvalidXml": "De XML is niet geldig",
+    "LastAdminCannotBeDeleted": "De laatste beheerder kan niet worden verwijderd",
     "PasswordRejection": "Het opgegeven wachtwoord voldoet niet aan de eisen. Gebruik minimaal 13 karakters.",
     "PdfGenerationError": "Er is een fout opgetreden bij het genereren van de PDF",
     "PollingStationRepeated": "Het stembureau is al ingevoerd",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -703,6 +703,7 @@ export type ErrorReference =
   | "InvalidVoteCandidate"
   | "InvalidVoteGroup"
   | "InvalidXml"
+  | "LastAdminCannotBeDeleted"
   | "PasswordRejection"
   | "PdfGenerationError"
   | "PollingStationRepeated"


### PR DESCRIPTION
Currently, in Abacus, an administrator can delete any user. There is a risk of the administrator accidentally deleting all administrators and thereby "bricking" Abacus.  [Murphy's law](https://en.wikipedia.org/wiki/Murphy%27s_law) teaches us that this will happen.

This PR prevents deleting the last administrator. Note that we only count administrators that have logged in at least once. The user fixtures are updated to be similar to active user accounts, by setting the "last_activity_at".