### PR TITLE
Prevent a user from deleting their own account

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4819,6 +4819,7 @@
           "InvalidVoteCandidate",
           "InvalidVoteGroup",
           "InvalidXml",
+          "OwnAccountCannotBeDeleted",
           "PasswordRejection",
           "PdfGenerationError",
           "PollingStationRepeated",

--- a/backend/src/authentication/api.rs
+++ b/backend/src/authentication/api.rs
@@ -449,7 +449,7 @@ pub async fn user_update(
     ),
 )]
 async fn user_delete(
-    _user: Admin,
+    logged_in_user: Admin,
     State(pool): State<SqlitePool>,
     audit_service: AuditService,
     Path(user_id): Path<u32>,
@@ -460,6 +460,11 @@ async fn user_delete(
             ErrorReference::EntryNotFound,
         ));
     };
+
+    // Prevent user from deleting their own account
+    if logged_in_user.0.id() == user_id {
+        return Err(AuthenticationError::OwnAccountCannotBeDeleted.into());
+    }
 
     let deleted = super::user::delete(&pool, user_id).await?;
 

--- a/backend/src/authentication/error.rs
+++ b/backend/src/authentication/error.rs
@@ -13,6 +13,7 @@ pub enum AuthenticationError {
     Unauthorized,
     Unauthenticated,
     PasswordRejection,
+    OwnAccountCannotBeDeleted,
 }
 
 impl From<password_hash::Error> for AuthenticationError {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -277,7 +277,7 @@ impl IntoResponse for APIError {
                     AuthenticationError::OwnAccountCannotBeDeleted => (
                         StatusCode::FORBIDDEN,
                         to_error(
-                            "Cannot delete the last admin user",
+                            "Cannot delete your own account",
                             ErrorReference::OwnAccountCannotBeDeleted,
                             false,
                         ),

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -48,6 +48,7 @@ pub enum ErrorReference {
     InvalidVoteCandidate,
     InvalidVoteGroup,
     InvalidXml,
+    OwnAccountCannotBeDeleted,
     PasswordRejection,
     PdfGenerationError,
     PollingStationRepeated,
@@ -272,6 +273,14 @@ impl IntoResponse for APIError {
                     AuthenticationError::PasswordRejection => (
                         StatusCode::BAD_REQUEST,
                         to_error("Invalid password", ErrorReference::PasswordRejection, false),
+                    ),
+                    AuthenticationError::OwnAccountCannotBeDeleted => (
+                        StatusCode::FORBIDDEN,
+                        to_error(
+                            "Cannot delete the last admin user",
+                            ErrorReference::OwnAccountCannotBeDeleted,
+                            false,
+                        ),
                     ),
                     // server errors
                     AuthenticationError::Database(_)

--- a/backend/tests/user_integration_test.rs
+++ b/backend/tests/user_integration_test.rs
@@ -331,6 +331,21 @@ async fn test_user_delete(pool: SqlitePool) {
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_prevent_delete_own_account(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let admin_cookie = shared::admin_login(&addr).await;
+
+    let url = format!("http://{addr}/api/user/1");
+    let response = reqwest::Client::new()
+        .delete(&url)
+        .header("cookie", &admin_cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
 async fn test_can_delete_logged_in_user(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let url = format!("http://{addr}/api/user/2");

--- a/frontend/src/features/users/components/update/UserDelete.tsx
+++ b/frontend/src/features/users/components/update/UserDelete.tsx
@@ -26,6 +26,7 @@ export function UserDelete({ user, onDeleted, onError }: UserDeleteProps) {
     void remove().then((result) => {
       if (!isSuccess(result)) {
         onError(result);
+        setShowModal(false);
       } else {
         onDeleted();
       }

--- a/frontend/src/features/users/components/update/UserUpdatePage.tsx
+++ b/frontend/src/features/users/components/update/UserUpdatePage.tsx
@@ -8,6 +8,7 @@ import { Alert } from "@/components/ui/Alert/Alert";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { Loader } from "@/components/ui/Loader/Loader";
 import { useNumericParam } from "@/hooks/useNumericParam";
+import { useUser } from "@/hooks/user/useUser";
 import { t } from "@/i18n/translate";
 import { User, USER_GET_REQUEST_PATH } from "@/types/generated/openapi";
 
@@ -16,6 +17,7 @@ import { UserUpdateForm } from "./UserUpdateForm";
 
 export function UserUpdatePage() {
   const navigate = useNavigate();
+  const loggedInUser = useUser();
   const userId = useNumericParam("userId");
   const { requestState: getUser } = useInitialApiGet<User>(`/api/user/${userId}` satisfies USER_GET_REQUEST_PATH);
   const [error, setError] = useState<AnyApiError>();
@@ -33,6 +35,7 @@ export function UserUpdatePage() {
   }
 
   const user = getUser.data;
+  const itsMe = loggedInUser?.user_id === userId;
 
   function handleSaved({ fullname, username }: User) {
     const updatedMessage = t("users.user_updated_details", { fullname: fullname || username });
@@ -61,12 +64,14 @@ export function UserUpdatePage() {
         <article>
           {error && (
             <FormLayout.Alert>
-              <Alert type="error">{t(`error.api_error.${error.reference}`)}</Alert>
+              <Alert type="error">
+                <p>{t(`error.api_error.${error.reference}`)}</p>
+              </Alert>
             </FormLayout.Alert>
           )}
 
           <UserUpdateForm user={user} onSaved={handleSaved} onAbort={handleAbort} />
-          <UserDelete user={user} onDeleted={handleDeleted} onError={setError} />
+          {!itsMe && <UserDelete user={user} onDeleted={handleDeleted} onError={setError} />}
         </article>
       </main>
     </>

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -30,6 +30,7 @@
     "InvalidVoteCandidate": "De kandidaat van de stem is niet geldig",
     "InvalidVoteGroup": "De politieke partij van de stem is niet geldig",
     "InvalidXml": "De XML is niet geldig",
+    "OwnAccountCannotBeDeleted": "Je kunt je eigen account niet verwijderen",
     "PasswordRejection": "Het opgegeven wachtwoord voldoet niet aan de eisen. Gebruik minimaal 13 karakters.",
     "PdfGenerationError": "Er is een fout opgetreden bij het genereren van de PDF",
     "PollingStationRepeated": "Het stembureau is al ingevoerd",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -702,6 +702,7 @@ export type ErrorReference =
   | "InvalidVoteCandidate"
   | "InvalidVoteGroup"
   | "InvalidXml"
+  | "OwnAccountCannotBeDeleted"
   | "PasswordRejection"
   | "PdfGenerationError"
   | "PollingStationRepeated"


### PR DESCRIPTION
Fixes #1880

Prevent an admin from deleting their own account and thereby being locked out of Abacus.

This also prevents Abacus from ever returning to the "not initialised" state after the first admin is successfully logged in.