### PR TITLE
Refetch ElectionStatusPage every 30s

### DIFF
--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -441,4 +441,29 @@ describe("ElectionStatusPage", () => {
     await expectConflictErrorPage();
     expect(console.error).toHaveBeenCalled();
   });
+
+  test("Refetches data every 30 seconds", async () => {
+    vi.useFakeTimers();
+    await renderPage();
+
+    // Wait for the page to be loaded
+    await vi.waitFor(() => {
+      expect(screen.getByRole("heading", { level: 1, name: "Eerste zitting" })).toBeVisible();
+    });
+
+    const electionRequestSpy = spyOnHandler(ElectionRequestHandler);
+    const electionStatusRequestSpy = spyOnHandler(ElectionStatusRequestHandler);
+
+    // Test 3 intervals of 30 seconds each
+    for (let i = 1; i <= 3; i++) {
+      vi.advanceTimersByTime(30_000);
+
+      await vi.waitFor(() => {
+        expect(electionRequestSpy).toHaveBeenCalledTimes(i);
+        expect(electionStatusRequestSpy).toHaveBeenCalledTimes(i);
+      });
+    }
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -37,15 +37,21 @@ export function ElectionStatusPage() {
     throw changeStatusError;
   }
 
-  // re-fetch election when component mounts
+  // re-fetch election and status when component mounts and every 30 seconds
   useEffect(() => {
     const abortController = new AbortController();
 
-    void refetchElection(abortController);
-    void refetchStatuses(abortController);
+    const refetch = () => {
+      void refetchElection(abortController);
+      void refetchStatuses(abortController);
+    };
+
+    refetch();
+    const refetchInterval = setInterval(refetch, 30_000);
 
     return () => {
       abortController.abort(DEFAULT_CANCEL_REASON);
+      clearInterval(refetchInterval);
     };
   }, [refetchElection, refetchStatuses]);
 


### PR DESCRIPTION
Resolves #1458 

This PR adds an interval of 30 seconds to the ElectionStatusPage to refresh the data. A test has been added to validate that the interval is working.