### PR TITLE
Updated resolve differences view

### DIFF
--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
@@ -17,6 +17,16 @@ describe("ResolveDifferencesTables", () => {
   test("renders the resolve differences tables", async () => {
     render(<ResolveDifferencesTables first={first} second={second} structure={structure} />);
 
+    const extraInvestigationTable = await screen.findByRole("table", {
+      name: "Extra onderzoek",
+    });
+    expect(extraInvestigationTable).toBeVisible();
+    expect(extraInvestigationTable).toHaveTableContent([
+      ["Veld", "Eerste invoer", "Tweede invoer", "Omschrijving"],
+      ["", "Nee", "Ja", "Extra onderzoek vanwege andere reden dan onverklaard verschil?"],
+      ["", "-", "Nee", "Stembiljetten na onderzoek (deels) herteld?"],
+    ]);
+
     const votersVotesCountsTable = await screen.findByRole("table", {
       name: "Toegelaten kiezers en uitgebrachte stemmen",
     });

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
@@ -33,6 +33,12 @@ function SectionTable({ section, first, second, action }: SectionTableProps) {
   let title = section.title;
   const firstValues = mapResultsToSectionValues(section, first);
   const secondValues = mapResultsToSectionValues(section, second);
+  const checkboxRows: Array<{
+    code: string;
+    first: string;
+    second: string;
+    description: string;
+  }> = [];
 
   return (
     <div>
@@ -71,13 +77,6 @@ function SectionTable({ section, first, second, action }: SectionTableProps) {
             );
           }
           case "checkboxes": {
-            const headers = [
-              t("resolve_differences.headers.field"),
-              t("resolve_differences.headers.first_entry"),
-              t("resolve_differences.headers.second_entry"),
-              t("resolve_differences.headers.description"),
-            ];
-
             const getSelectedOptions = (values: SectionValues) => {
               return subsection.options
                 .filter((option) => values[option.path] === "true")
@@ -92,15 +91,30 @@ function SectionTable({ section, first, second, action }: SectionTableProps) {
               description: subsection.short_title,
             };
 
-            return (
-              <DifferencesTable
-                key={`${section.id}-${subsectionIdx}`}
-                title={title}
-                headers={headers}
-                rows={[row]}
-                action={action}
-              />
-            );
+            checkboxRows.push(row);
+
+            if (
+              checkboxRows.length ===
+              section.subsections.filter((subsection) => subsection.type === "checkboxes").length
+            ) {
+              const headers = [
+                t("resolve_differences.headers.field"),
+                t("resolve_differences.headers.first_entry"),
+                t("resolve_differences.headers.second_entry"),
+                t("resolve_differences.headers.description"),
+              ];
+
+              return (
+                <DifferencesTable
+                  key={`${section.id}-${subsectionIdx}`}
+                  title={title}
+                  headers={headers}
+                  rows={checkboxRows}
+                  action={action}
+                />
+              );
+            }
+            break;
           }
           case "inputGrid": {
             const headers = [

--- a/frontend/src/features/resolve_differences/testing/polling-station-results.ts
+++ b/frontend/src/features/resolve_differences/testing/polling-station-results.ts
@@ -28,12 +28,12 @@ export function pollingStationResultsMockData(first: boolean): PollingStationRes
     },
     extra_investigation: {
       extra_investigation_other_reason: {
-        yes: false,
-        no: false,
+        yes: !first,
+        no: first,
       },
       ballots_recounted_extra_investigation: {
         yes: false,
-        no: false,
+        no: !first,
       },
     },
     political_group_votes: [

--- a/frontend/src/i18n/locales/nl/extra_investigation.json
+++ b/frontend/src/i18n/locales/nl/extra_investigation.json
@@ -5,10 +5,10 @@
   "validation_error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
   "extra_investigation_other_reason": {
     "title": "Heeft het gemeentelijk stembureau extra onderzoek gedaan vanwege een andere reden dan een onverklaard verschil?",
-    "short_title": "Extra onderzoek andere reden"
+    "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?"
   },
   "ballots_recounted_extra_investigation": {
     "title": "Zijn de stembiljetten naar aanleiding van het extra onderzoek (gedeeltelijk) herteld?",
-    "short_title": "Stembiljetten herteld"
+    "short_title": "Stembiljetten na onderzoek (deels) herteld?"
   }
 }


### PR DESCRIPTION
Fixes #1868 

All checkboxes subsection are now rendered in one single table.

Was:
<img width="1056" height="644" alt="Screenshot 2025-08-07 at 11 44 01" src="https://github.com/user-attachments/assets/e4a74659-ae39-4ed9-b993-c14cc17625bf" />

Is:
<img width="1031" height="552" alt="Screenshot 2025-08-07 at 11 44 22" src="https://github.com/user-attachments/assets/f492aaf2-95e4-4135-87b9-a80613f0d1cc" />


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->