### PR TITLE
Changed default button size from md to lg and corrected button sizes when wrong

### DIFF
--- a/frontend/src/components/election/NumberOfVotersForm.tsx
+++ b/frontend/src/components/election/NumberOfVotersForm.tsx
@@ -42,9 +42,7 @@ export function NumberOfVotersForm({ defaultValue, instructions, hint, button, o
             />
 
             <FormLayout.Controls>
-              <Button size="lg" type="submit">
-                {button}
-              </Button>
+              <Button type="submit">{button}</Button>
             </FormLayout.Controls>
           </FormLayout.Section>
         </FormLayout>

--- a/frontend/src/components/error/Error.tsx
+++ b/frontend/src/components/error/Error.tsx
@@ -27,7 +27,6 @@ export function Error({ title, error, children }: ErrorProps) {
             {children}
             <nav>
               <Button
-                size="lg"
                 variant="secondary"
                 leftIcon={<IconArrowLeft />}
                 onClick={() => {

--- a/frontend/src/components/error/ErrorModal.tsx
+++ b/frontend/src/components/error/ErrorModal.tsx
@@ -39,7 +39,9 @@ export function ErrorModal({ error }: ErrorModalProps) {
               <strong>{t(key)}</strong>
             </p>
             <nav>
-              <Button onClick={hideModal}>{t("close_message")}</Button>
+              <Button size="md" onClick={hideModal}>
+                {t("close_message")}
+              </Button>
             </nav>
           </div>
         </Modal>
@@ -59,7 +61,9 @@ export function ErrorModal({ error }: ErrorModalProps) {
         )}
         <p>{error.message}</p>
         <nav>
-          <Button onClick={hideModal}>{t("close_message")}</Button>
+          <Button size="md" onClick={hideModal}>
+            {t("close_message")}
+          </Button>
         </nav>
       </div>
     </Modal>

--- a/frontend/src/components/ui/BottomBar/BottomBar.stories.tsx
+++ b/frontend/src/components/ui/BottomBar/BottomBar.stories.tsx
@@ -12,9 +12,7 @@ export const BottomBarFooter: StoryFn = () => {
   return (
     <BottomBar type="footer">
       <BottomBar.Row>
-        <Button size="lg" onClick={action("on-click")}>
-          Click me
-        </Button>
+        <Button onClick={action("on-click")}>Click me</Button>
       </BottomBar.Row>
     </BottomBar>
   );
@@ -25,9 +23,7 @@ export const BottomBarForm: StoryObj = {
     return (
       <BottomBar type="form">
         <BottomBar.Row>
-          <Button size="lg" onClick={action("on-click")}>
-            Click me
-          </Button>
+          <Button onClick={action("on-click")}>Click me</Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
         </BottomBar.Row>
       </BottomBar>
@@ -50,9 +46,7 @@ export const BottomBarInputGrid: StoryFn = () => {
   return (
     <BottomBar type="inputGrid">
       <BottomBar.Row>
-        <Button size="lg" onClick={action("on-click")}>
-          Click me
-        </Button>
+        <Button onClick={action("on-click")}>Click me</Button>
         <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
       </BottomBar.Row>
     </BottomBar>

--- a/frontend/src/components/ui/Button/Button.tsx
+++ b/frontend/src/components/ui/Button/Button.tsx
@@ -20,7 +20,7 @@ export function Button({
   isDisabled,
   isLoading,
   variant = "primary",
-  size = "md",
+  size = "lg",
   leftIcon,
   rightIcon,
   children,

--- a/frontend/src/components/ui/Modal/Modal.stories.tsx
+++ b/frontend/src/components/ui/Modal/Modal.stories.tsx
@@ -16,7 +16,6 @@ export const DefaultModal: StoryObj = {
     return (
       <>
         <Button
-          size="lg"
           onClick={() => {
             setModalOpen(true);
           }}

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -71,6 +71,7 @@ export function Modal({ title, noFlex = false, onClose, children }: ModalProps):
             title={t("cancel")}
             size="lg"
             variant="tertiary"
+            type="button"
           />
         )}
         <div className={cls.modalBody}>

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -71,7 +71,6 @@ export function Modal({ title, noFlex = false, onClose, children }: ModalProps):
             title={t("cancel")}
             size="lg"
             variant="tertiary"
-            type="button"
           />
         )}
         <div className={cls.modalBody}>

--- a/frontend/src/components/ui/Pagination/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination/Pagination.tsx
@@ -13,6 +13,7 @@ export function Pagination({ page, totalPages, onPageChange }: PaginationProps) 
   return (
     <div className={cls.pagination}>
       <Button
+        size="md"
         disabled={page === 1}
         onClick={() => {
           onPageChange(page - 1);
@@ -22,6 +23,7 @@ export function Pagination({ page, totalPages, onPageChange }: PaginationProps) 
       </Button>
       <span>{t("page_number", { page, totalPages })}</span>
       <Button
+        size="md"
         disabled={page === totalPages}
         onClick={() => {
           onPageChange(page + 1);

--- a/frontend/src/features/account/components/AccountSetupForm.tsx
+++ b/frontend/src/features/account/components/AccountSetupForm.tsx
@@ -148,9 +148,7 @@ export function AccountSetupForm({ user, onSaved }: AccountSetupFormProps) {
           </FormLayout.Section>
           <BottomBar type="footer">
             <BottomBar.Row>
-              <Button type="submit" size="lg">
-                {t("next")}
-              </Button>
+              <Button type="submit">{t("next")}</Button>
             </BottomBar.Row>
           </BottomBar>
         </FormLayout>

--- a/frontend/src/features/account/components/LoginForm.tsx
+++ b/frontend/src/features/account/components/LoginForm.tsx
@@ -115,7 +115,7 @@ export function LoginForm() {
       </FormLayout>
       <BottomBar type="footer">
         <BottomBar.Row>
-          <Button type="submit" size="lg" disabled={loading}>
+          <Button type="submit" disabled={loading}>
             {t("account.login")}
           </Button>
         </BottomBar.Row>

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -118,6 +118,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
         <p>{t("polling_station.save_changes")}</p>
         <nav>
           <Button
+            type="button"
             onClick={() => {
               void onModalSave();
             }}
@@ -126,6 +127,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           </Button>
           <Button
             variant="secondary"
+            type="button"
             onClick={() => {
               onModalDoNoSave();
             }}
@@ -161,6 +163,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           onClick={() => {
             void onAbortModalSave();
           }}
+          type="button"
           disabled={status === "saving"}
         >
           {t("data_entry.abort.save_input")}
@@ -171,6 +174,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           onClick={() => {
             void onAbortModalDelete();
           }}
+          type="button"
           disabled={status === "deleting"}
         >
           {t("data_entry.abort.discard_input")}

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -118,8 +118,6 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
         <p>{t("polling_station.save_changes")}</p>
         <nav>
           <Button
-            size="lg"
-            type="button"
             onClick={() => {
               void onModalSave();
             }}
@@ -127,9 +125,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
             {t("save_changes")}
           </Button>
           <Button
-            size="lg"
             variant="secondary"
-            type="button"
             onClick={() => {
               onModalDoNoSave();
             }}
@@ -165,7 +161,6 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           onClick={() => {
             void onAbortModalSave();
           }}
-          type="button"
           disabled={status === "saving"}
         >
           {t("data_entry.abort.save_input")}
@@ -176,7 +171,6 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           onClick={() => {
             void onAbortModalDelete();
           }}
-          type="button"
           disabled={status === "deleting"}
         >
           {t("data_entry.abort.discard_input")}

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -141,7 +141,7 @@ export function DataEntrySection() {
           </BottomBar.Row>
         )}
         <BottomBar.Row>
-          <Button type="submit" size="lg" disabled={status === "saving"}>
+          <Button type="submit" disabled={status === "saving"}>
             {t("next")}
           </Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -234,7 +234,7 @@ export function CheckAndSaveForm() {
           {!hasErrors && allFeedbackAccepted && (
             <BottomBar type="form">
               <BottomBar.Row>
-                <Button type="submit" size="lg" disabled={status === "finalising"}>
+                <Button type="submit" disabled={status === "finalising"}>
                   {t("save")}
                 </Button>
                 <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
@@ -266,7 +266,7 @@ export function CheckAndSaveForm() {
           </BottomBar.Row>
 
           <BottomBar.Row>
-            <Button type="submit" size="lg" disabled={status === "finalising"}>
+            <Button type="submit" disabled={status === "finalising"}>
               {t("complete")}
             </Button>
             <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -194,6 +194,7 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
         <BottomBar type="form">
           <BottomBar.Row>
             <Button
+              type="button"
               onClick={() => {
                 handleSubmit();
               }}

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -194,8 +194,6 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
         <BottomBar type="form">
           <BottomBar.Row>
             <Button
-              type="button"
-              size="lg"
               onClick={() => {
                 handleSubmit();
               }}

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -67,7 +67,6 @@ export function AbortModal() {
           {t("election.abort.discard_input")}
         </Button>
         <Button
-          size="xl"
           variant="secondary"
           onClick={() => {
             onAbortModalCancel();

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -28,11 +28,7 @@ export function AbortModal() {
     }
 
     // check if nextLocation is outside the create election flow
-    if (!isPartOfCreateElectionFlow(nextLocation.pathname)) {
-      return true;
-    }
-
-    return false;
+    return !isPartOfCreateElectionFlow(nextLocation.pathname);
   });
 
   // Do not show modal when state is not blocked
@@ -66,17 +62,15 @@ export function AbortModal() {
           onClick={() => {
             onAbortModalDelete();
           }}
-          type="button"
         >
           {t("election.abort.discard_input")}
         </Button>
         <Button
-          size="lg"
+          size="xl"
           variant="secondary"
           onClick={() => {
             onAbortModalCancel();
           }}
-          type="button"
         >
           {t("election.abort.keep_input")}
         </Button>

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -62,6 +62,7 @@ export function AbortModal() {
           onClick={() => {
             onAbortModalDelete();
           }}
+          type="button"
         >
           {t("election.abort.discard_input")}
         </Button>
@@ -71,6 +72,7 @@ export function AbortModal() {
           onClick={() => {
             onAbortModalCancel();
           }}
+          type="button"
         >
           {t("election.abort.keep_input")}
         </Button>

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
@@ -90,10 +90,12 @@ export function ElectionReportPage() {
             {t("election_report.there_was_counting_method", { method: t(election.counting_method).toLowerCase() })}.
           </div>
           <div className={cls.reportInfoSection}>
-            <Button onClick={downloadZipResults}>{t("election_report.download_zip")}</Button>
+            <Button size="md" onClick={downloadZipResults}>
+              {t("election_report.download_zip")}
+            </Button>
             <br />
             <br />
-            <Button variant="secondary" onClick={downloadPdfResults}>
+            <Button size="md" variant="secondary" onClick={downloadPdfResults}>
               {t("election_report.download_report")}
             </Button>
           </div>

--- a/frontend/src/features/election_management/components/update/CommitteeSessionDetailsPage.tsx
+++ b/frontend/src/features/election_management/components/update/CommitteeSessionDetailsPage.tsx
@@ -169,7 +169,7 @@ export function CommitteeSessionDetailsPage() {
                 />
               </FormLayout.Row>
               <FormLayout.Controls>
-                <Button size="lg" type="submit">
+                <Button type="submit">
                   {redirectToReportPage ? t("election_management.to_report") : t("save_changes")}
                 </Button>
                 <Button.Link variant="secondary" size="lg" to="..">

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.tsx
@@ -125,9 +125,7 @@ export function ResolveDifferencesPage() {
             </ChoiceList>
             <BottomBar type="form">
               <BottomBar.Row>
-                <Button size="xl" type="submit">
-                  {t("save")}
-                </Button>
+                <Button type="submit">{t("save")}</Button>
               </BottomBar.Row>
             </BottomBar>
           </form>

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.tsx
@@ -91,9 +91,7 @@ export function ResolveErrorsIndexPage() {
             {t("resolve_errors.options.discard_first_entry_description")}
           </ChoiceList.Radio>
         </ChoiceList>
-        <Button size="xl" type="submit">
-          {t("save")}
-        </Button>
+        <Button type="submit">{t("save")}</Button>
       </form>
     </>
   );

--- a/frontend/src/features/users/components/create/UserCreateDetailsForm.tsx
+++ b/frontend/src/features/users/components/create/UserCreateDetailsForm.tsx
@@ -134,9 +134,7 @@ export function UserCreateDetailsForm({ role, showFullname, onSubmitted }: UserC
             />
           </FormLayout.Section>
           <FormLayout.Controls>
-            <Button size="xl" type="submit">
-              {t("save")}
-            </Button>
+            <Button type="submit">{t("save")}</Button>
           </FormLayout.Controls>
         </FormLayout>
       </Form>

--- a/frontend/src/features/users/components/create/UserCreateRolePage.tsx
+++ b/frontend/src/features/users/components/create/UserCreateRolePage.tsx
@@ -84,9 +84,7 @@ export function UserCreateRolePage() {
             </FormLayout.Section>
           </FormLayout>
           <FormLayout.Controls>
-            <Button size="xl" type="submit">
-              {t("continue")}
-            </Button>
+            <Button type="submit">{t("continue")}</Button>
           </FormLayout.Controls>
         </Form>
       </main>

--- a/frontend/src/features/users/components/create/UserCreateTypePage.tsx
+++ b/frontend/src/features/users/components/create/UserCreateTypePage.tsx
@@ -65,9 +65,7 @@ export function UserCreateTypePage() {
             </FormLayout.Section>
           </FormLayout>
           <FormLayout.Controls>
-            <Button size="xl" type="submit">
-              {t("continue")}
-            </Button>
+            <Button type="submit">{t("continue")}</Button>
           </FormLayout.Controls>
         </Form>
       </main>


### PR DESCRIPTION
## Description
- Changed default button size from md to lg
- Corrected button sizes in election import flow from md to lg
- Corrected button sizes in create user flow from xl to lg
- Corrected save button size in CheckAndSave from md to lg
- Corrected button sizes on FinishDataEntryPage from md to lg
- Corrected button sizes on PollingStationForm from md to lg
- Corrected delete button size on PollingStationUpdatePage from md to lg
- Corrected save button size on ResolveErrorsIndexPage from xl to lg
- Corrected save button size on ResolveDifferencesPage from xl to lg
- Corrected submit and cancel button sizes on UserUpdateForm from md to lg

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->