### PR TITLE
Add audit log for imported polling stations for admin

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4640,6 +4640,9 @@
           },
           "polling_station_data": {
             "type": "string"
+          },
+          "polling_station_file_name": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -4674,15 +4677,15 @@
               "type": "string"
             }
           },
-          "file_name": {
-            "type": "string"
-          },
           "number_of_voters": {
             "type": "integer",
             "format": "int32",
             "minimum": 0
           },
           "polling_station_data": {
+            "type": "string"
+          },
+          "polling_station_file_name": {
             "type": "string"
           }
         },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4674,6 +4674,9 @@
               "type": "string"
             }
           },
+          "file_name": {
+            "type": "string"
+          },
           "number_of_voters": {
             "type": "integer",
             "format": "int32",

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::{
     APIError, AppState, ErrorResponse,
-    audit_log::{AuditEvent, AuditService},
+    audit_log::{AuditEvent, AuditService, PollingStationImportDetails},
     authentication::{Admin, User},
     committee_session::{CommitteeSession, CommitteeSessionCreateRequest},
     election::VoteCountingMethod,
@@ -278,6 +278,9 @@ pub struct ElectionAndCandidatesDefinitionImportRequest {
     #[schema(nullable = false)]
     #[serde(skip_serializing_if = "Option::is_none")]
     number_of_voters: Option<u32>,
+    #[schema(nullable = false)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file_name: Option<String>,
 }
 
 /// Uploads election definition, validates it, saves it to the database, and returns the created election
@@ -312,7 +315,13 @@ pub async fn election_import(
     // Process polling stations
     let mut polling_places = None;
     let mut number_of_voters = 0;
+
     if let Some(polling_station_data) = edu.polling_station_data {
+        // If polling stations are submitted, file name must be also
+        if edu.file_name.is_none() {
+            return Err(APIError::EmlImportError(EMLImportError::MissingFileName));
+        }
+
         number_of_voters = EML110::from_str(&polling_station_data)?.get_number_of_voters()?;
         polling_places = Some(EML110::from_str(&polling_station_data)?.get_polling_stations()?);
     }
@@ -336,7 +345,20 @@ pub async fn election_import(
 
     // Create polling stations
     if let Some(places) = polling_places {
+        let number_of_polling_stations = places.len();
         crate::polling_station::repository::create_many(&pool, election.id, places).await?;
+
+        audit_service
+            .log(
+                &AuditEvent::PollingStationsImported(PollingStationImportDetails {
+                    import_election_id: election.id,
+                    import_file_name: edu.file_name.ok_or(EMLImportError::MissingFileName)?,
+                    import_number_of_polling_stations: u64::try_from(number_of_polling_stations)
+                        .map_err(|_| EMLImportError::NumberOfPollingStationsNotInRange)?,
+                }),
+                None,
+            )
+            .await?;
     }
 
     // Create first committee session for the election

--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -201,11 +201,13 @@ pub enum EMLImportError {
     MissingSubcategory,
     MissingElectionTree,
     MissingElectionDomain,
+    MissingFileName,
     MissingPollingStations,
     Needs110a,
     Needs110b,
     Needs230b,
     NumberOfSeatsNotInRange,
+    NumberOfPollingStationsNotInRange,
     OnlyMunicipalSupported,
     TooManyPoliticalGroups,
 }

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -394,7 +394,7 @@ async fn test_election_import_save(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
-            "file_name": "eml110b_test.eml.xml",
+            "polling_station_file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -428,7 +428,7 @@ async fn test_election_import_save_empty_stubs(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
-            "file_name": "eml110b_test.eml.xml",
+            "polling_station_file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -462,7 +462,7 @@ async fn test_election_import_save_empty_candidate_stubs(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
-            "file_name": "eml110b_test.eml.xml",
+            "polling_station_file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -496,7 +496,7 @@ async fn test_election_import_save_wrong_hash(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
-            "file_name": "eml110b_test.eml.xml",
+            "polling_station_file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -562,6 +562,7 @@ async fn test_election_polling_stations_validate_valid(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
+            "polling_station_file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -569,6 +570,39 @@ async fn test_election_polling_stations_validate_valid(pool: SqlitePool) {
 
     // Ensure the response is what we expect
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_polling_stations_validate_missing_filename(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let admin_cookie = shared::admin_login(&addr).await;
+    let url = format!("http://{addr}/api/elections/import/validate");
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+          "election_hash": [
+              "84c9", "caba", "ff33", "6c42",
+              "9825", "b20c", "2ba9", "1ceb",
+              "3c61", "9b99", "8af1", "a57e",
+              "cf00", "8930", "9bce", "0c33"
+          ],
+          "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "candidate_hash": [
+                "6a53", "d681", "aa15", "d6c3",
+                "375a", "48c2", "29c8", "7dcf",
+                "09b2", "5a55", "34a8", "4854",
+                "7643", "3b8f", "cd3e", "6e97"
+            ],
+            "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
+            "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -394,6 +394,7 @@ async fn test_election_import_save(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
+            "file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -427,6 +428,7 @@ async fn test_election_import_save_empty_stubs(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
+            "file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -460,6 +462,7 @@ async fn test_election_import_save_empty_candidate_stubs(pool: SqlitePool) {
             ],
             "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
             "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
+            "file_name": "eml110b_test.eml.xml",
         }))
         .send()
         .await
@@ -482,6 +485,40 @@ async fn test_election_import_save_wrong_hash(pool: SqlitePool) {
                 "84c9", "caba", "ff33", "6c42",
                 "1234", "b20c", "2ba9", "1ceb",
                 "3c61", "9b99", "f0a6", "a57e",
+                "cf00", "8930", "9bce", "0c33"
+            ],
+            "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "candidate_hash": [
+                "6a53", "d681", "aa15", "d6c3",
+                "375a", "48c2", "29c8", "7dcf",
+                "09b2", "5a55", "34a8", "4854",
+                "7643", "3b8f", "cd3e", "6e97"
+            ],
+            "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
+            "polling_station_data": include_str!("../src/eml/tests/eml110b_test.eml.xml"),
+            "file_name": "eml110b_test.eml.xml",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_import_missing_file_name(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    let url = format!("http://{addr}/api/elections/import");
+    let admin_cookie = shared::admin_login(&addr).await;
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+            "election_hash": [
+                "84c9", "caba", "ff33", "6c42",
+                "9825", "b20c", "2ba9", "1ceb",
+                "3c61", "9b99", "8af1", "a57e",
                 "cf00", "8930", "9bce", "0c33"
             ],
             "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),

--- a/frontend/src/features/election_create/components/CheckAndSave.tsx
+++ b/frontend/src/features/election_create/components/CheckAndSave.tsx
@@ -28,7 +28,7 @@ export function CheckAndSave() {
       candidate_data: state.candidateDefinitionData,
       candidate_hash: state.candidateDefinitionHash,
       polling_station_data: state.pollingStationDefinitionData,
-      file_name: state.pollingStationDefinitionFileName,
+      polling_station_file_name: state.pollingStationDefinitionFileName,
     });
 
     if (isSuccess(response)) {

--- a/frontend/src/features/election_create/components/CheckAndSave.tsx
+++ b/frontend/src/features/election_create/components/CheckAndSave.tsx
@@ -28,6 +28,7 @@ export function CheckAndSave() {
       candidate_data: state.candidateDefinitionData,
       candidate_hash: state.candidateDefinitionHash,
       polling_station_data: state.pollingStationDefinitionData,
+      file_name: state.pollingStationDefinitionFileName,
     });
 
     if (isSuccess(response)) {

--- a/frontend/src/features/election_create/components/UploadPollingStationDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadPollingStationDefinition.tsx
@@ -46,6 +46,7 @@ export function UploadPollingStationDefinition() {
         candidate_hash: state.candidateDefinitionHash,
         candidate_data: state.candidateDefinitionData,
         polling_station_data: data,
+        polling_station_file_name: currentFile.name,
       });
 
       if (isSuccess(response)) {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -568,6 +568,7 @@ export interface ElectionAndCandidatesDefinitionImportRequest {
   counting_method?: VoteCountingMethod;
   election_data: string;
   election_hash: string[];
+  file_name?: string;
   number_of_voters?: number;
   polling_station_data?: string;
 }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -560,6 +560,7 @@ export interface ElectionAndCandidateDefinitionValidateRequest {
   election_hash?: string[];
   number_of_voters?: number;
   polling_station_data?: string;
+  polling_station_file_name?: string;
 }
 
 export interface ElectionAndCandidatesDefinitionImportRequest {
@@ -568,9 +569,9 @@ export interface ElectionAndCandidatesDefinitionImportRequest {
   counting_method?: VoteCountingMethod;
   election_data: string;
   election_hash: string[];
-  file_name?: string;
   number_of_voters?: number;
   polling_station_data?: string;
+  polling_station_file_name?: string;
 }
 
 /**


### PR DESCRIPTION
When the admin creates a new election with polling stations, create an audit log event for the import.
If an election is created without polling stations, do not create the event.

See also: https://github.com/kiesraad/abacus/pull/1950
Closes: https://github.com/kiesraad/abacus/issues/1632