### PR TITLE
Create audit log event when importing polling stations as coordinator

### DIFF
--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -206,6 +206,7 @@ pub enum EMLImportError {
     Needs110b,
     Needs230b,
     NumberOfSeatsNotInRange,
+    NumberOfPollingStationsNotInRange,
     OnlyMunicipalSupported,
     TooManyPoliticalGroups,
 }


### PR DESCRIPTION
When the coordinator import polling stations from a file, create an audit event for the import.

See also: https://github.com/kiesraad/abacus/pull/1949