### PR TITLE
Implement design for create first election page

### DIFF
--- a/frontend/src/features/election_overview/components/OverviewPage.tsx
+++ b/frontend/src/features/election_overview/components/OverviewPage.tsx
@@ -8,12 +8,29 @@ import { NavBar } from "@/components/navbar/NavBar";
 import { PageTitle } from "@/components/page_title/PageTitle";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
+import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { Table } from "@/components/ui/Table/Table";
 import { Toolbar } from "@/components/ui/Toolbar/Toolbar";
 import { useElectionList } from "@/hooks/election/useElectionList";
 import { useUserRole } from "@/hooks/user/useUserRole";
-import { t } from "@/i18n/translate";
+import { t, tx } from "@/i18n/translate";
 import { Election } from "@/types/generated/openapi";
+
+function AddFirstElection() {
+  const { isAdministrator } = useUserRole();
+
+  return (
+    <FormLayout>
+      <FormLayout.Section>
+        <h2>{t("election.no_elections_added")}</h2>
+        {tx("election.add_first_election")}
+      </FormLayout.Section>
+      <FormLayout.Controls>
+        {isAdministrator && <Button.Link to={"./create"}>{t("election.create")}</Button.Link>}
+      </FormLayout.Controls>
+    </FormLayout>
+  );
+}
 
 export function OverviewPage() {
   const navigate = useNavigate();
@@ -92,38 +109,39 @@ export function OverviewPage() {
       )}
       <main>
         <article>
-          <Toolbar>
-            {isAdministrator && (
-              <Button.Link variant="secondary" size="sm" to={"./create"}>
-                <IconPlus /> {t("election.create")}
-              </Button.Link>
-            )}
-          </Toolbar>
           {!electionList.length ? (
-            !isAdminOrCoordinator ? (
+            isAdminOrCoordinator ? (
+              <AddFirstElection />
+            ) : (
               <>
                 <h2 className="mb-lg">{t("election.not_ready_for_use")}</h2>
                 <p className="md form-paragraph">{t("election.please_wait_for_coordinator")}</p>
               </>
-            ) : (
-              <h2>{t("election.no_elections_added")}</h2>
-              // TODO: To be expanded in issue #888
             )
           ) : (
-            <Table id="overview">
-              <Table.Header>
-                <Table.HeaderCell>{t("election.title.singular")}</Table.HeaderCell>
-                <Table.HeaderCell>
-                  {!isAdminOrCoordinator ? t("election.location") : t("election.level_polling_station")}
-                </Table.HeaderCell>
-                <Table.HeaderCell>{t("election_status.label")}</Table.HeaderCell>
-              </Table.Header>
-              <Table.Body className="fs-md">
-                {electionList.map((election) => (
-                  <ElectionRow key={election.id} election={election} />
-                ))}
-              </Table.Body>
-            </Table>
+            <>
+              <Toolbar>
+                {isAdministrator && (
+                  <Button.Link variant="secondary" size="sm" to={"./create"}>
+                    <IconPlus /> {t("election.create")}
+                  </Button.Link>
+                )}
+              </Toolbar>
+              <Table id="overview">
+                <Table.Header>
+                  <Table.HeaderCell>{t("election.title.singular")}</Table.HeaderCell>
+                  <Table.HeaderCell>
+                    {!isAdminOrCoordinator ? t("election.location") : t("election.level_polling_station")}
+                  </Table.HeaderCell>
+                  <Table.HeaderCell>{t("election_status.label")}</Table.HeaderCell>
+                </Table.Header>
+                <Table.Body className="fs-md">
+                  {electionList.map((election) => (
+                    <ElectionRow key={election.id} election={election} />
+                  ))}
+                </Table.Body>
+              </Table>
+            </>
           )}
         </article>
       </main>

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -1,6 +1,7 @@
 {
   "create": "Verkiezing toevoegen",
   "add": "Toevoegen: {name}",
+  "add_first_election": "<p>Om Abacus in te richten voor het invoeren van telresulaten, heb je de volgende bestanden nodig:</p><ul><li>Verkiezingsdefinitie (krijg je van de Kiesraad)</li><li>Kandidatenlijsten (krijg je van het centraal stembureau)</li><li>Overzicht stembureaus in jouw gemeente</li></ul><p>Zorg dat de bestanden op deze computer staan voordat je verder gaat.</p>",
   "abort": {
     "action": "Afbreken",
     "description": "<p>De verkiezing wordt pas opgeslagen als je alle stappen doorlopen hebt. Weet je zeker dat je het aanmaken van de verkiezing wilt afbreken?</p>",


### PR DESCRIPTION
Create first election page design implementation.

Fixes #1953

See [for the design](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=13299-10668&t=k2HTkggiFDIEv0Xl-11)

Note that the spacing will be fixed in #1929

Screenshot:

<img width="953" height="633" alt="image" src="https://github.com/user-attachments/assets/8d518198-4e15-49ce-abcc-dfca6bda162b" />
