### PR TITLE
Proposal: additional webserver without fixtures for e2e

### DIFF
--- a/frontend/e2e-tests/tests/no-fixtures/initialisation.e2e.ts
+++ b/frontend/e2e-tests/tests/no-fixtures/initialisation.e2e.ts
@@ -1,0 +1,21 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../../fixtures";
+
+test.describe("initialisation", () => {
+  test.use({
+    baseURL: "http://127.0.0.1:8082",
+  });
+
+  test("it should redirect to the welcome page", async ({ page }) => {
+    // use the webserver without fixtures
+    await page.goto("/account/login");
+
+    // expect the titles to contain a welcome message
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Welkom bij Abacus");
+    await expect(page.getByRole("heading", { level: 2 })).toContainText("Installatie gelukt");
+
+    // the path should be the initialise path
+    await expect(page).toHaveURL("/account/initialise");
+  });
+});


### PR DESCRIPTION
This adds an additional backend when running our e2e tests, which allows us to test abacus without any fixtures loaded. We need this to test the initialization flow.

The disadvantage of this approach is the extra time it takes to startup an additional backend. Also, this backend might not be needed for all test shards.

Any remarks or alternative ideas welcome!