### PR TITLE
Add mocks and handlers for the import election flow

### DIFF
--- a/frontend/src/testing/api-mocks/ElectionMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionMockData.ts
@@ -1,5 +1,6 @@
 import {
   CommitteeSession,
+  ElectionDefinitionValidateResponse,
   ElectionDetailsResponse,
   ElectionListResponse,
   ElectionWithPoliticalGroups,
@@ -287,3 +288,27 @@ export const newElectionMockData = {
   ...electionDetailsMockResponse.election,
   polling_stations: pollingStationMockData,
 } as Required<NewElection>;
+
+export const electionImportMockResponse: ElectionWithPoliticalGroups = {
+  id: 2,
+  name: "Gemeenteraad Test 2022",
+  counting_method: "CSO",
+  election_id: "GR2022_Test",
+  location: "Test",
+  domain_id: "0000",
+  category: "Municipal",
+  number_of_seats: 45,
+  election_date: "2022-03-16",
+  nomination_date: "2022-01-31",
+  political_groups: politicalGroupsMockData,
+};
+
+export const electionImportValidateMockResponse: ElectionDefinitionValidateResponse = {
+  hash: {
+    chunks: new Array<string>(16).fill("0000"),
+    redacted_indexes: [3, 11],
+  },
+  election: electionImportMockResponse,
+  polling_stations: pollingStationMockData,
+  number_of_voters: 612694,
+};

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -32,13 +32,21 @@ import {
   ELECTION_COMMITTEE_SESSION_LIST_REQUEST_PATH,
   ELECTION_DETAILS_REQUEST_PARAMS,
   ELECTION_DETAILS_REQUEST_PATH,
+  ELECTION_IMPORT_REQUEST_BODY,
+  ELECTION_IMPORT_REQUEST_PARAMS,
+  ELECTION_IMPORT_REQUEST_PATH,
+  ELECTION_IMPORT_VALIDATE_REQUEST_BODY,
+  ELECTION_IMPORT_VALIDATE_REQUEST_PARAMS,
+  ELECTION_IMPORT_VALIDATE_REQUEST_PATH,
   ELECTION_LIST_REQUEST_PARAMS,
   ELECTION_LIST_REQUEST_PATH,
   ELECTION_STATUS_REQUEST_PARAMS,
   ELECTION_STATUS_REQUEST_PATH,
+  ElectionDefinitionValidateResponse,
   ElectionDetailsResponse,
   ElectionListResponse,
   ElectionStatusResponse,
+  ElectionWithPoliticalGroups,
   ErrorResponse,
   INITIALISED_REQUEST_PARAMS,
   INITIALISED_REQUEST_PATH,
@@ -104,7 +112,12 @@ import {
   dataEntryStatusDifferences,
   saveDataEntryResponse,
 } from "./DataEntryMockData";
-import { electionDetailsMockResponse, electionListMockResponse } from "./ElectionMockData";
+import {
+  electionDetailsMockResponse,
+  electionImportMockResponse,
+  electionImportValidateMockResponse,
+  electionListMockResponse,
+} from "./ElectionMockData";
 import { statusResponseMock } from "./ElectionStatusMockData";
 import { logMockResponse } from "./LogMockData";
 import { pollingStationMockData } from "./PollingStationMockData";
@@ -207,6 +220,20 @@ export const ElectionStatusRequestHandler = http.get<
   ElectionStatusResponse,
   ELECTION_STATUS_REQUEST_PATH
 >("/api/elections/1/status", () => HttpResponse.json(statusResponseMock, { status: 200 }));
+
+export const ElectionImportRequestHandler = http.post<
+  ParamsToString<ELECTION_IMPORT_REQUEST_PARAMS>,
+  ELECTION_IMPORT_REQUEST_BODY,
+  ElectionWithPoliticalGroups,
+  ELECTION_IMPORT_REQUEST_PATH
+>("/api/elections/import", () => HttpResponse.json(electionImportMockResponse, { status: 201 }));
+
+export const ElectionImportValidateRequestHandler = http.post<
+  ParamsToString<ELECTION_IMPORT_VALIDATE_REQUEST_PARAMS>,
+  ELECTION_IMPORT_VALIDATE_REQUEST_BODY,
+  ElectionDefinitionValidateResponse,
+  ELECTION_IMPORT_VALIDATE_REQUEST_PATH
+>("/api/elections/import/validate", () => HttpResponse.json(electionImportValidateMockResponse, { status: 200 }));
 
 export const LoginHandler = http.post<LOGIN_REQUEST_PARAMS, LOGIN_REQUEST_BODY, LoginResponse, LOGIN_REQUEST_PATH>(
   "/api/user/login",
@@ -395,6 +422,8 @@ export const handlers: HttpHandler[] = [
   ElectionListRequestHandler,
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
+  ElectionImportRequestHandler,
+  ElectionImportValidateRequestHandler,
   LoginHandler,
   PollingStationDataEntryGetDifferencesHandler,
   PollingStationDataEntryGetErrorsHandler,


### PR DESCRIPTION
To be able to go through the [import election flow in the frontend running with MSW](https://543eac99.kiesraad-abacus.pages.dev/elections/create): no need for the right EML file or correct hash codes