### PR TITLE
Prevent password from showing on first login

### DIFF
--- a/frontend/src/features/account/components/FirstLoginForm.tsx
+++ b/frontend/src/features/account/components/FirstLoginForm.tsx
@@ -87,7 +87,7 @@ export function FirstLoginForm({ prev }: FirstLoginFormProps) {
                   hint={t("initialise.username_login_hint")}
                   required={true}
                   value={username}
-                  disabled={loading}
+                  readOnly={loading}
                   onChange={(e) => {
                     setUsername(e.target.value);
                   }}
@@ -99,7 +99,7 @@ export function FirstLoginForm({ prev }: FirstLoginFormProps) {
                   type="password"
                   required={true}
                   value={password}
-                  disabled={loading}
+                  readOnly={loading}
                   onChange={(e) => {
                     setPassword(e.target.value);
                   }}


### PR DESCRIPTION
Prevent password from showing on first login by changing form fields from `disabled` to `readOnly` on load. Fixes #1975.
