### PR TITLE
geen aanpassing nummer stembureau

### DIFF
--- a/documentatie/use-cases/gsb-tweede-zitting.md
+++ b/documentatie/use-cases/gsb-tweede-zitting.md
@@ -60,17 +60,22 @@ __Uitbreidingen:__
 1a. Het GSB besluit om n.a.v. een verzoek additionele stembureaus te onderzoeken:  
 &emsp; 1a1. De coördinator GSB selecteert een stembureau en voert "Aanleiding van het onderzoek" (vrije tekst) in de applicatie in.  
 
-1b. De coördinator GSB ontdekt dat een stembureau dat op de vooraf gepubliceerde lijst staat niet in Abacus is opgenomen.  
+1b. De coördinator GSB ontdekt dat een stembureau dat op de vooraf gepubliceerde lijst staat niet in Abacus is opgenomen:  
 &emsp; 1b1. De coördinator GSB voegt het stembureau toe.  
 &emsp; 1b2. Abacus maakt melding op het PV dat het stembureau is toegevoegd.  
 &emsp; 1b3. Het corrigendum corrigeert het aantal stemmen bij dit stembureau van 0 naar het werkelijke aantal.  
 
-1c. De coördinator GSB ontdekt dat het stembureau niet onder de goede naam in Abacus is opgenomen.  
-&emsp; 1c1. De coördinator GSB corrigeert de typfouten.
-&emsp; 1c2. Het nummer van het stembureau kan niet worden aangepast.
+1c. De coördinator GSB ontdekt dat het nummer van een stembureau niet correct in Abacus is opgenomen:  
+&emsp; 1c1. De coördinator zorgt dat de fout vermeld wordt in het PV.
 
-1d. De coördinator GSB ontdekt dat een stembureau ten onrechte is meegenomen in een eerdere zitting.  
-&emsp; 1d1. Het GSB maakt een corrigendum naar 0 stemmen voor dit stembureau.  
+1d. De coördinator GSB ontdekt dat de gegevens van een stembureau niet correct in Abacus zijn opgenomen:  
+&emsp; 1d1. De applicatie laat niet toe dat het nummer van het stembureau wordt aangepast.  
+&emsp; 1d2. De coördinator GSB corrigeert de stembureaugegevens.  
+&emsp; 1d3. De applicatie slaat de gecorrigeerde stembureaugegevens op, alleen voor de huidige zitting.  
+&emsp; 1d4. De coördinator GSB zorgt dat de correctie vermeld wordt in het PV.  
+
+1e. De coördinator GSB ontdekt dat een stembureau ten onrechte is meegenomen in een eerdere zitting:  
+&emsp; 1e1. Het GSB maakt een corrigendum naar 0 stemmen voor dit stembureau.  
 
 
 ## Het GSB behandelt een verzoek tot onderzoek/hertelling (vlieger)


### PR DESCRIPTION
Nummer van het stembureau niet aanpasbaar maken in nieuwe zitting tov eerste zitting. Zo voorkomen we verweesde resultaten. 

relates to epic #1109 
