### PR TITLE
Fix SHA-256 hash in PV

### DIFF
--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -61,14 +61,6 @@
   )
 }
 
-/// Add dashes to a text every `every` characters
-#let add-dashes(text, every: 4) = {
-  if text == none {
-    return
-  }
-
-  text.clusters().chunks(every).map(c => c.join("")).join("-")
-}
 
 /// Format a number with thousands separator
 #let fmt-number(

--- a/backend/templates/inputs/model-na-31-2.json
+++ b/backend/templates/inputs/model-na-31-2.json
@@ -5631,6 +5631,6 @@
             "locality": "Hovenerwoud"
         }
     ],
-    "hash": "dedf17b4684e1214fcabb770925dc75c624be3380bd3464729c37a80a37940ad",
+    "hash": "dedf 17b4 684e 1214 fcab b770 925d c75c 624b e338 0bd3 4647 29c3 7a80 a379 40ad",
     "creation_date_time": "24-06-2025 10:07"
 }

--- a/backend/templates/model-na-31-1.typ
+++ b/backend/templates/model-na-31-1.typ
@@ -12,7 +12,7 @@
 
 #show: doc => conf(doc, header: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
-  #add-dashes(input.hash)
+  #input.hash
 ])
 
 #set heading(numbering: none)

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -12,7 +12,7 @@
 
 #show: doc => conf(doc, header: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
-  #add-dashes(input.hash)
+  #input.hash
 ])
 
 #set heading(numbering: none)


### PR DESCRIPTION
Only format in backend, not also in Typst. Fixes #1977.

The backend formats the hash using spaces instead of dashes,but it's easy to change if needed:

https://github.com/kiesraad/abacus/blob/75e4640971ed0927bcbd08fec951120b6d02956f/backend/src/eml/hash.rs#L38-L42