### PR TITLE
Fix default paragraph line-height

### DIFF
--- a/frontend/src/components/ui/Alert/Alert.module.css
+++ b/frontend/src/components/ui/Alert/Alert.module.css
@@ -58,7 +58,6 @@
     word-break: break-word;
 
     p {
-      line-height: 1.5rem;
       margin: 0;
       width: 100%;
     }

--- a/frontend/src/styles/typography.css
+++ b/frontend/src/styles/typography.css
@@ -65,7 +65,6 @@ p {
   margin-top: 0;
   font-size: var(--font-size-md);
   margin-bottom: 0;
-  line-height: 1.75rem;
   color: var(--text-color-body);
 }
 
@@ -73,7 +72,6 @@ p.md {
   width: 39.5rem;
   font-size: var(--font-size-md);
   margin-bottom: 1.5rem;
-  line-height: 1.5rem;
 }
 
 section.md {


### PR DESCRIPTION
> I will make a separate PR to change the default line-height for paragraphs to 1.5rem, [..]
> 
> _Originally posted by @oliver3 in https://github.com/kiesraad/abacus/pull/1966#discussion_r2276117677_

This PR sets the default line-height of paragraph (`<p>`) elements to 1.5rem, which fixes the line height in several paragraphs in the application, e.g.:

- [Verkiezingen](https://ed9093b9.kiesraad-abacus.pages.dev/elections/1)
- [Hoeveel kiesgerechtigden telt de gemeente?](https://ed9093b9.kiesraad-abacus.pages.dev/elections/1/number-of-voters)
- [Gebruiker toevoegen](https://ed9093b9.kiesraad-abacus.pages.dev/users/create)
- ...

