### PR TITLE
Check autofocus all data entry pages / fix 

### DIFF
--- a/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.tsx
+++ b/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.tsx
@@ -29,6 +29,7 @@ ChoiceList.Checkbox = ({
   label,
   children,
   disabled,
+  autoFocus,
   defaultChecked,
   hasError,
   reference,
@@ -40,6 +41,7 @@ ChoiceList.Checkbox = ({
     name={name}
     label={label}
     disabled={disabled}
+    autoFocus={autoFocus}
     defaultChecked={defaultChecked}
     hasError={hasError}
     ref={reference}

--- a/frontend/src/features/data_entry/components/DataEntrySection.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.test.tsx
@@ -1,6 +1,6 @@
 import * as reactRouter from "react-router";
 
-import { userEvent } from "@testing-library/user-event";
+import { UserEvent, userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import * as useUser from "@/hooks/user/useUser";
@@ -9,10 +9,11 @@ import {
   PollingStationDataEntryClaimHandler,
   PollingStationDataEntrySaveHandler,
 } from "@/testing/api-mocks/RequestHandlers";
+import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
 import { overrideOnce, server } from "@/testing/server";
-import { renderReturningRouter, screen, waitFor, within } from "@/testing/test-utils";
+import { renderReturningRouter, screen, spyOnHandler, waitFor, within } from "@/testing/test-utils";
 import { getTypistUser } from "@/testing/user-mock-data";
-import { ErrorResponse } from "@/types/generated/openapi";
+import { ErrorResponse, SaveDataEntryResponse } from "@/types/generated/openapi";
 import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 
 import { DataEntryProvider } from "./DataEntryProvider";
@@ -76,7 +77,9 @@ describe("DataEntrySection", () => {
 
       expect(screen.queryByText(/B1-.*/)).not.toBeInTheDocument();
     });
+  });
 
+  describe("Session paused", () => {
     test("Redirect when committee session is paused is returned on claim", async () => {
       overrideOnce("post", "/api/polling_stations/1/data_entries/1/claim", 409, {
         error: "Committee session data entry is paused",
@@ -118,6 +121,58 @@ describe("DataEntrySection", () => {
       await user.click(backToOverviewButton);
 
       expect(router.state.location.pathname).toEqual("/elections");
+    });
+  });
+
+  test("Shift+enter submits", async () => {
+    const user = userEvent.setup();
+    renderComponent("extra_investigation");
+
+    const saveHandler = spyOnHandler(PollingStationDataEntrySaveHandler);
+    await user.keyboard("{shift>}{enter}{/shift}");
+
+    expect(saveHandler).toHaveBeenCalledOnce();
+  });
+
+  describe("Shift+enter with validation warnings/errors", () => {
+    let user: UserEvent;
+    let acceptErrorsAndWarningsCheckbox: HTMLInputElement;
+
+    beforeEach(async () => {
+      user = userEvent.setup();
+      overrideOnce("post", "/api/polling_stations/1/data_entries/1", 200, {
+        validation_results: { errors: [], warnings: [validationResultMockData.W001] },
+      } satisfies SaveDataEntryResponse);
+      renderComponent("voters_votes_counts");
+
+      const submitButton = await screen.findByRole("button", { name: "Volgende" });
+      await user.click(submitButton);
+
+      acceptErrorsAndWarningsCheckbox = await screen.findByRole("checkbox", {
+        name: "Ik heb mijn invoer gecontroleerd met het papier en correct overgenomen.",
+      });
+    });
+
+    test("focuses on checkbox when pressed shift+enter", async () => {
+      expect(acceptErrorsAndWarningsCheckbox).not.toHaveFocus();
+
+      await user.keyboard("{shift>}{enter}{/shift}");
+      expect(acceptErrorsAndWarningsCheckbox).toHaveFocus();
+    });
+
+    test("focuses on checkbox again after refocusing to another element and pressing shift+enter", async () => {
+      expect(acceptErrorsAndWarningsCheckbox).not.toHaveFocus();
+      await user.keyboard("{shift>}{enter}{/shift}");
+      expect(acceptErrorsAndWarningsCheckbox).toHaveFocus();
+
+      // Refocus to first input
+      const firstInput = await screen.findByRole("textbox", { name: "A Stempassen" });
+      await user.click(firstInput);
+      expect(acceptErrorsAndWarningsCheckbox).not.toHaveFocus();
+
+      // Try again
+      await user.keyboard("{shift>}{enter}{/shift}");
+      expect(acceptErrorsAndWarningsCheckbox).toHaveFocus();
     });
   });
 });

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -62,7 +62,7 @@ export function DataEntrySection() {
         acceptCheckboxRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
       });
     }
-  }, [formSection.acceptErrorsAndWarningsError]);
+  }, [formSection]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router";
 
-import { userEvent } from "@testing-library/user-event";
+import { UserEvent, userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
@@ -206,50 +206,66 @@ describe("Test CheckAndSaveForm", () => {
     ).toBeInTheDocument();
   });
 
-  test("Can't complete data entry without accepting errors", async () => {
-    const defaultState = customFormState();
-    const mockFormState: FormState = {
-      ...defaultState,
-      sections: {
-        ...defaultState.sections,
-        voters_votes_counts: {
-          ...defaultState.sections.voters_votes_counts!,
-          errors: new ValidationResultSet([validationResultMockData.F201]),
-          warnings: new ValidationResultSet([validationResultMockData.W203]),
-          acceptErrorsAndWarnings: true,
+  describe("CheckAndSaveForm accept warnings", () => {
+    let user: UserEvent;
+    let completeButton: HTMLButtonElement;
+    let acceptErrorsCheckbox: HTMLInputElement;
+
+    beforeEach(async () => {
+      const defaultState = customFormState();
+      const mockFormState: FormState = {
+        ...defaultState,
+        sections: {
+          ...defaultState.sections,
+          voters_votes_counts: {
+            ...defaultState.sections.voters_votes_counts!,
+            errors: new ValidationResultSet([validationResultMockData.F201]),
+            warnings: new ValidationResultSet([validationResultMockData.W203]),
+            acceptErrorsAndWarnings: true,
+          },
         },
-      },
-    };
+      };
 
-    const defaultValues = getEmptyDataEntryRequest().data;
-    overrideServerClaimDataEntryResponse({
-      formState: mockFormState,
-      pollingStationResults: defaultValues,
-      validationResults: { errors: [validationResultMockData.F201], warnings: [validationResultMockData.W203] },
+      const defaultValues = getEmptyDataEntryRequest().data;
+      overrideServerClaimDataEntryResponse({
+        formState: mockFormState,
+        pollingStationResults: defaultValues,
+        validationResults: { errors: [validationResultMockData.F201], warnings: [validationResultMockData.W203] },
+      });
+      renderForm();
+
+      user = userEvent.setup();
+      completeButton = await screen.findByRole("button", { name: "Afronden" });
+      expect(completeButton).toBeInTheDocument();
+
+      acceptErrorsCheckbox = screen.getByRole("checkbox", {
+        name: "Ik heb de fouten besproken met de coördinator",
+      });
+      expect(acceptErrorsCheckbox).toBeInTheDocument();
     });
-    renderForm();
 
-    const completeButton = await screen.findByRole("button", { name: "Afronden" });
-    expect(completeButton).toBeInTheDocument();
+    test("hitting shift+enter should focus checkbox", async () => {
+      expect(acceptErrorsCheckbox).not.toHaveFocus();
 
-    const acceptErrorsCheckbox = screen.getByRole("checkbox", {
-      name: "Ik heb de fouten besproken met de coördinator",
+      await user.keyboard("{shift>}{enter}{/shift}");
+      expect(acceptErrorsCheckbox).toHaveFocus();
     });
-    expect(acceptErrorsCheckbox).toBeInTheDocument();
 
-    await userEvent.click(completeButton);
+    test("Can't complete data entry without accepting errors", async () => {
+      await userEvent.click(completeButton);
 
-    const errorMessage = await screen.findByRole("alert");
-    expect(errorMessage).toHaveTextContent("Je kan alleen verder als je dit met de coördinator hebt overlegd.");
+      const errorMessage = await screen.findByRole("alert");
+      expect(errorMessage).toHaveTextContent("Je kan alleen verder als je dit met de coördinator hebt overlegd.");
 
-    await userEvent.click(acceptErrorsCheckbox);
+      await userEvent.click(acceptErrorsCheckbox);
 
-    expect(acceptErrorsCheckbox).toBeChecked();
-    const finalise = spyOnHandler(PollingStationDataEntryFinaliseHandler);
+      expect(acceptErrorsCheckbox).toBeChecked();
+      const finalise = spyOnHandler(PollingStationDataEntryFinaliseHandler);
 
-    await userEvent.click(completeButton);
+      await userEvent.click(completeButton);
 
-    expect(finalise).toHaveBeenCalledOnce();
+      expect(finalise).toHaveBeenCalledOnce();
+    });
   });
 });
 

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -41,6 +41,7 @@ export function CheckAndSaveForm() {
     pollingStationId,
     entryNumber,
   } = useDataEntryContext();
+  const acceptCheckboxRef = React.useRef<HTMLInputElement>(null);
 
   const params = useParams<{ sectionId: FormSectionId }>();
   const sectionId = params.sectionId ?? null;
@@ -79,6 +80,16 @@ export function CheckAndSaveForm() {
     }
     return [sections, hasWarnings, hasErrors, allFeedbackAccepted];
   }, [formState]);
+
+  // Scroll unaccepted warnings/errors checkbox into view when error for it is triggered
+  React.useEffect(() => {
+    if (isConfirmedError) {
+      acceptCheckboxRef.current?.focus();
+      requestAnimationFrame(() => {
+        acceptCheckboxRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
+    }
+  }, [isConfirmedError]);
 
   // save the current state, without finalising (for the abort dialog)
   const onSubmit = async (options?: SubmitCurrentFormOptions) => {
@@ -262,8 +273,9 @@ export function CheckAndSaveForm() {
           <BottomBar.Row>
             <Checkbox
               id="check_and_save_form_errors_confirmed"
+              ref={acceptCheckboxRef}
               checked={isConfirmed}
-              hasError={false}
+              hasError={!!isConfirmedError}
               onChange={(e) => {
                 setIsConfirmed(e.target.checked);
               }}


### PR DESCRIPTION
Resolves #1976

- Autofocus added to checkboxes, "Extra onderzoek" & "Verschillen met stembureau" now autofocuses on first checkbox

Other issues found and fixed:
- When there were warning/errors on page "Controleren en opslaan", shift+enter would not highlight and focus the checkbox "Ik heb de fouten besproken met de coördinator". This has been fixed
- When pressing shift+enter when there were warning/errors on data entry pages, it would focus on the checkbox, however only the first time. After focusing on another field and again pressing shift+enter, nothing would happen. This has also been fixed.

Tests have been added to check if shift+enter focusing (first time and after) is working in component `DataEntrySection`.