### PR TITLE
clarify how to calculate W.203

### DIFF
--- a/documentatie/use-cases/validatieregels-plausibiliteitschecks-tellingen.md
+++ b/documentatie/use-cases/validatieregels-plausibiliteitschecks-tellingen.md
@@ -417,6 +417,8 @@ Veld markeren: G
 - 2% of meer: abs(toegelaten kiezers - uitgebrachte stemmen) / uitgebrachte stemmen \>= 0.02
 - 15 of meer: abs(toegelaten kiezers - uitgebrachte stemmen) \>= 15
 
+_N.B. Voor "2% of meer" delen we door uitgebrachte stemmen, consistent met de berekening van W.201 (blanco stemmen) en W.202 (ongeldige stemmen). Het is dus niet nodig de 2% ook te berekenen door te delen door toegelaten kiezers._
+
 > Invoerder: **Controleer aantal toegelaten kiezers en aantal uitgebrachte stemmen** (W.203)  
 > Check of je het papieren proces-verbaal goed hebt overgenomen.
 


### PR DESCRIPTION
Warning W.203 states that the difference between admitted voters and number of votes should not be larger than 2% or than 15. However it's not specified of what the 2% should be: of the admitted voters or of the number of votes. (hat tip to @stacktraceghost for raising the question)

I checked with @chrismostert and @lode-coder and they replied it should be 2% of the number of votes, similar to how the 3% of blank votes and 3% of invalid votes are calculated.

So I added a comment to our "Validatieregels en plausibiliteitschecks voor invoer tellingen" document with that decision.