### PR TITLE
Implement validation for ExtraInvestigation and CountingDifferencesPollingStation

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6468,6 +6468,10 @@
       "ValidationResultCode": {
         "type": "string",
         "enum": [
+          "F101",
+          "F102",
+          "F111",
+          "F112",
           "F201",
           "F202",
           "F203",

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -816,7 +816,7 @@ async fn election_status(
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use super::*;
     use crate::{
         authentication::Role,
@@ -826,7 +826,7 @@ pub mod tests {
         },
         data_entry::{
             DifferencesCounts, PoliticalGroupCandidateVotes, PoliticalGroupTotalVotes,
-            VotersCounts, VotesCounts,
+            VotersCounts, VotesCounts, structs::tests::ValidDefault,
         },
     };
     use axum::http::StatusCode;
@@ -834,12 +834,12 @@ pub mod tests {
     use sqlx::{SqlitePool, query, query_as};
     use test_log::test;
 
-    pub fn example_data_entry() -> DataEntry {
+    fn example_data_entry() -> DataEntry {
         DataEntry {
             progress: 100,
             data: PollingStationResults {
-                extra_investigation: Default::default(),
-                counting_differences_polling_station: Default::default(),
+                extra_investigation: ValidDefault::valid_default(),
+                counting_differences_polling_station: ValidDefault::valid_default(),
                 voters_counts: VotersCounts {
                     poll_card_count: 99,
                     proxy_certificate_count: 1,

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -685,7 +685,7 @@ mod tests {
     use crate::{
         data_entry::{
             CandidateVotes, PoliticalGroupCandidateVotes, PoliticalGroupTotalVotes, VotersCounts,
-            VotesCounts,
+            VotesCounts, structs::tests::ValidDefault,
         },
         election::{
             Candidate, ElectionCategory, ElectionWithPoliticalGroups, PoliticalGroup,
@@ -696,8 +696,8 @@ mod tests {
 
     fn polling_station_result() -> PollingStationResults {
         PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: Default::default(),
             votes_counts: Default::default(),
             differences_counts: Default::default(),
@@ -880,12 +880,14 @@ mod tests {
     #[test]
     fn first_entry_in_progress_to_second_entry_not_started() {
         // Happy path
-        assert!(matches!(
-            first_entry_in_progress()
-                .finalise_first_entry(&polling_station(), &election(), 0)
-                .unwrap(),
-            DataEntryStatus::SecondEntryNotStarted(_)
-        ));
+        let status = first_entry_in_progress()
+            .finalise_first_entry(&polling_station(), &election(), 0)
+            .unwrap();
+
+        assert_eq!(
+            status.status_name(),
+            DataEntryStatusName::SecondEntryNotStarted
+        );
     }
 
     /// FirstEntryInProgress --> FirstEntryInProgress: error when updating as a different user
@@ -1110,13 +1112,11 @@ mod tests {
     /// is_equal --> Definitive: equal? yes
     #[test]
     fn second_entry_in_progress_finalise_equal() {
-        assert!(matches!(
-            second_entry_in_progress()
-                .finalise_second_entry(&polling_station(), &election(), 0)
-                .unwrap()
-                .0,
-            DataEntryStatus::Definitive(_)
-        ));
+        let status = second_entry_in_progress()
+            .finalise_second_entry(&polling_station(), &election(), 0)
+            .unwrap()
+            .0;
+        assert_eq!(status.status_name(), DataEntryStatusName::Definitive);
     }
 
     #[test]
@@ -1343,8 +1343,8 @@ mod tests {
         // Create valid data without errors, so we transition to SecondEntryNotStarted
         let first_entry = polling_station_result();
         let second_entry = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 1,
                 proxy_certificate_count: 0,

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::{
-    CandidateVotes, Count, DifferencesCounts, PoliticalGroupCandidateVotes, PollingStationResults,
-    VotersCounts, VotesCounts,
+    CandidateVotes, Count, CountingDifferencesPollingStation, DifferencesCounts,
+    ExtraInvestigation, PoliticalGroupCandidateVotes, PollingStationResults, VotersCounts,
+    VotesCounts,
     comparison::Compare,
     status::{DataEntryStatus, FirstEntryInProgress},
 };
@@ -47,6 +48,14 @@ pub struct ValidationResult {
 #[derive(Serialize, Deserialize, ToSchema, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(deny_unknown_fields)]
 pub enum ValidationResultCode {
+    /// CSO: 'Extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
+    F101,
+    /// CSO: 'Extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
+    F102,
+    /// CSO: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
+    F111,
+    /// CSO: 'Verschillen met telresultaten van het stembureau': meerdere antwoorden per vraag
+    F112,
     F201,
     F202,
     F203,
@@ -247,6 +256,20 @@ impl Validate for PollingStationResults {
         validation_results: &mut ValidationResults,
         path: &FieldPath,
     ) -> Result<(), DataError> {
+        self.extra_investigation.validate(
+            election,
+            polling_station,
+            validation_results,
+            &path.field("extra_investigation"),
+        )?;
+
+        self.counting_differences_polling_station.validate(
+            election,
+            polling_station,
+            validation_results,
+            &path.field("counting_differences_polling_station"),
+        )?;
+
         let total_votes_count = self.votes_counts.total_votes_cast_count;
 
         self.votes_counts.validate(
@@ -430,6 +453,62 @@ impl Validate for PollingStationResults {
                     path.field("political_group_votes").to_string(),
                 ],
                 code: ValidationResultCode::F202,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Validate for ExtraInvestigation {
+    fn validate(
+        &self,
+        _election: &ElectionWithPoliticalGroups,
+        _polling_station: &PollingStation,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) -> Result<(), DataError> {
+        if self.extra_investigation_other_reason.is_answered()
+            != self.ballots_recounted_extra_investigation.is_answered()
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.to_string()],
+                code: ValidationResultCode::F101,
+            });
+        }
+        if self.extra_investigation_other_reason.is_invalid()
+            || self.ballots_recounted_extra_investigation.is_invalid()
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.to_string()],
+                code: ValidationResultCode::F102,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Validate for CountingDifferencesPollingStation {
+    fn validate(
+        &self,
+        _election: &ElectionWithPoliticalGroups,
+        _polling_station: &PollingStation,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) -> Result<(), DataError> {
+        if !self.unexplained_difference_ballots_voters.is_answered()
+            || !self.difference_ballots_per_list.is_answered()
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.to_string()],
+                code: ValidationResultCode::F111,
+            });
+        }
+        if self.unexplained_difference_ballots_voters.is_invalid()
+            || self.difference_ballots_per_list.is_invalid()
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.to_string()],
+                code: ValidationResultCode::F112,
             });
         }
         Ok(())
@@ -839,10 +918,284 @@ mod tests {
     use test_log::test;
 
     use super::*;
+    use crate::data_entry::tests::ValidDefault;
     use crate::{
         data_entry::PoliticalGroupTotalVotes, election::tests::election_fixture,
         polling_station::structs::tests::polling_station_fixture,
     };
+
+    mod extra_investigation {
+        use crate::data_entry::{
+            DataError, ExtraInvestigation, Validate, ValidationResult, ValidationResultCode,
+            ValidationResults, YesNo,
+        };
+        use crate::election::tests::election_fixture;
+        use crate::polling_station::structs::tests::polling_station_fixture;
+
+        fn validate(
+            investigation_yes: bool,
+            investigation_no: bool,
+            recounted_yes: bool,
+            recounted_no: bool,
+        ) -> Result<ValidationResults, DataError> {
+            let extra_investigation = ExtraInvestigation {
+                extra_investigation_other_reason: YesNo {
+                    yes: investigation_yes,
+                    no: investigation_no,
+                },
+                ballots_recounted_extra_investigation: YesNo {
+                    yes: recounted_yes,
+                    no: recounted_no,
+                },
+            };
+
+            let mut validation_results = ValidationResults::default();
+            extra_investigation.validate(
+                &election_fixture(&[]),
+                &polling_station_fixture(None),
+                &mut validation_results,
+                &"extra_investigation".into(),
+            )?;
+
+            assert_eq!(validation_results.warnings.len(), 0);
+            Ok(validation_results)
+        }
+
+        #[test]
+        fn test_no_validation_errors() -> Result<(), DataError> {
+            let validation_results = validate(false, false, false, false)?;
+            assert_eq!(validation_results.errors, []);
+
+            let validation_results = validate(true, false, false, true)?;
+            assert_eq!(validation_results.errors, []);
+
+            Ok(())
+        }
+
+        /// CSO | F.101: 'Extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
+        #[test]
+        fn test_f101() -> Result<(), DataError> {
+            let validation_results = validate(false, true, false, false)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F101,
+                    fields: vec!["extra_investigation".into()],
+                }]
+            );
+
+            let validation_results = validate(false, false, false, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F101,
+                    fields: vec!["extra_investigation".into()],
+                }]
+            );
+
+            Ok(())
+        }
+
+        /// CSO | F.102: 'Extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
+        #[test]
+        fn test_f102() -> Result<(), DataError> {
+            let validation_results = validate(true, true, true, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F102,
+                    fields: vec!["extra_investigation".into()],
+                }]
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_multiple_errors() -> Result<(), DataError> {
+            let validation_results = validate(true, true, false, false)?;
+            assert_eq!(
+                validation_results.errors,
+                [
+                    ValidationResult {
+                        code: ValidationResultCode::F101,
+                        fields: vec!["extra_investigation".into()],
+                    },
+                    ValidationResult {
+                        code: ValidationResultCode::F102,
+                        fields: vec!["extra_investigation".into()],
+                    }
+                ]
+            );
+
+            let validation_results = validate(false, false, true, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [
+                    ValidationResult {
+                        code: ValidationResultCode::F101,
+                        fields: vec!["extra_investigation".into()],
+                    },
+                    ValidationResult {
+                        code: ValidationResultCode::F102,
+                        fields: vec!["extra_investigation".into()],
+                    }
+                ]
+            );
+
+            Ok(())
+        }
+    }
+
+    mod counting_differences_polling_station {
+        use crate::data_entry::{
+            CountingDifferencesPollingStation, DataError, Validate, ValidationResult,
+            ValidationResultCode, ValidationResults, YesNo,
+        };
+        use crate::election::tests::election_fixture;
+        use crate::polling_station::structs::tests::polling_station_fixture;
+
+        fn validate(
+            unexplained_yes: bool,
+            unexplained_no: bool,
+            ballots_yes: bool,
+            ballots_no: bool,
+        ) -> Result<ValidationResults, DataError> {
+            let counting_differences_polling_station = CountingDifferencesPollingStation {
+                unexplained_difference_ballots_voters: YesNo {
+                    yes: unexplained_yes,
+                    no: unexplained_no,
+                },
+                difference_ballots_per_list: YesNo {
+                    yes: ballots_yes,
+                    no: ballots_no,
+                },
+            };
+
+            let mut validation_results = ValidationResults::default();
+            counting_differences_polling_station.validate(
+                &election_fixture(&[]),
+                &polling_station_fixture(None),
+                &mut validation_results,
+                &"counting_differences_polling_station".into(),
+            )?;
+
+            assert_eq!(validation_results.warnings.len(), 0);
+            Ok(validation_results)
+        }
+
+        #[test]
+        fn test_no_validation_errors() -> Result<(), DataError> {
+            let validation_results = validate(false, true, false, true)?;
+            assert_eq!(validation_results.errors, []);
+
+            let validation_results = validate(true, false, true, false)?;
+            assert_eq!(validation_results.errors, []);
+
+            Ok(())
+        }
+
+        /// CSO | F.111: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
+        #[test]
+        fn test_f111() -> Result<(), DataError> {
+            let validation_results = validate(false, true, false, false)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F111,
+                    fields: vec!["counting_differences_polling_station".into()],
+                }]
+            );
+
+            let validation_results = validate(false, false, false, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F111,
+                    fields: vec!["counting_differences_polling_station".into()],
+                }]
+            );
+
+            let validation_results = validate(false, false, false, false)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F111,
+                    fields: vec!["counting_differences_polling_station".into()],
+                }]
+            );
+
+            Ok(())
+        }
+
+        // CSO | F.112: 'Verschillen met telresultaten van het stembureau': meerdere antwoorden per vraag
+        #[test]
+        fn test_f112() -> Result<(), DataError> {
+            let validation_results = validate(true, true, false, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F112,
+                    fields: vec!["counting_differences_polling_station".into()],
+                }]
+            );
+
+            let validation_results = validate(false, true, true, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F112,
+                    fields: vec!["counting_differences_polling_station".into()],
+                }]
+            );
+
+            let validation_results = validate(true, true, true, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [ValidationResult {
+                    code: ValidationResultCode::F112,
+                    fields: vec!["counting_differences_polling_station".into()],
+                }]
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_multiple_errors() -> Result<(), DataError> {
+            let validation_results = validate(true, true, false, false)?;
+            assert_eq!(
+                validation_results.errors,
+                [
+                    ValidationResult {
+                        code: ValidationResultCode::F111,
+                        fields: vec!["counting_differences_polling_station".into()],
+                    },
+                    ValidationResult {
+                        code: ValidationResultCode::F112,
+                        fields: vec!["counting_differences_polling_station".into()],
+                    }
+                ]
+            );
+
+            let validation_results = validate(false, false, true, true)?;
+            assert_eq!(
+                validation_results.errors,
+                [
+                    ValidationResult {
+                        code: ValidationResultCode::F111,
+                        fields: vec!["counting_differences_polling_station".into()],
+                    },
+                    ValidationResult {
+                        code: ValidationResultCode::F112,
+                        fields: vec!["counting_differences_polling_station".into()],
+                    }
+                ]
+            );
+
+            Ok(())
+        }
+    }
 
     /// Tests that ValidationResults can be appended together, combining errors and warnings.
     #[test]
@@ -892,8 +1245,8 @@ mod tests {
     fn test_default_values() {
         let mut validation_results = ValidationResults::default();
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: Default::default(),
             votes_counts: VotesCounts {
                 political_group_total_votes: vec![PoliticalGroupTotalVotes {
@@ -936,8 +1289,8 @@ mod tests {
     fn test_incorrect_total_and_difference() {
         let mut validation_results = ValidationResults::default();
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 29,
                 proxy_certificate_count: 2,
@@ -1027,8 +1380,8 @@ mod tests {
         // test F.303 incorrect difference & F.304 should be empty
         validation_results = ValidationResults::default();
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 103,
                 proxy_certificate_count: 2,
@@ -1088,8 +1441,8 @@ mod tests {
         // test F.201 incorrect total, F.203 incorrect total, F.301 incorrect difference, F.302 should be empty & W.203 above threshold in percentage
         validation_results = ValidationResults::default();
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 4,
                 proxy_certificate_count: 2,
@@ -1182,8 +1535,8 @@ mod tests {
         // test F.303 incorrect difference, F.304 should be empty & W.203 above threshold in absolute numbers
         validation_results = ValidationResults::default();
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 100,
                 proxy_certificate_count: 2,
@@ -1257,8 +1610,8 @@ mod tests {
     #[test]
     fn test_differences() {
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 54,
                 proxy_certificate_count: 2,
@@ -1326,8 +1679,8 @@ mod tests {
     #[test]
     fn test_no_differences_expected() {
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 50,
                 proxy_certificate_count: 2,
@@ -1389,8 +1742,8 @@ mod tests {
     #[test]
     fn test_no_differences_expected_and_incorrect_total() {
         let polling_station_results = PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 50,
                 proxy_certificate_count: 2,

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -918,19 +918,20 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::data_entry::tests::ValidDefault;
     use crate::{
-        data_entry::PoliticalGroupTotalVotes, election::tests::election_fixture,
+        data_entry::{PoliticalGroupTotalVotes, tests::ValidDefault}, election::tests::election_fixture,
         polling_station::structs::tests::polling_station_fixture,
     };
 
     mod extra_investigation {
-        use crate::data_entry::{
-            DataError, ExtraInvestigation, Validate, ValidationResult, ValidationResultCode,
-            ValidationResults, YesNo,
-        };
-        use crate::election::tests::election_fixture;
-        use crate::polling_station::structs::tests::polling_station_fixture;
+        use crate::{
+            data_entry::{
+                DataError, ExtraInvestigation, Validate, ValidationResult, ValidationResultCode,
+                ValidationResults, YesNo,
+            };
+            election::tests::election_fixture;
+            polling_station::structs::tests::polling_station_fixture;
+        }
 
         fn validate(
             investigation_yes: bool,
@@ -1048,12 +1049,14 @@ mod tests {
     }
 
     mod counting_differences_polling_station {
-        use crate::data_entry::{
-            CountingDifferencesPollingStation, DataError, Validate, ValidationResult,
-            ValidationResultCode, ValidationResults, YesNo,
-        };
-        use crate::election::tests::election_fixture;
-        use crate::polling_station::structs::tests::polling_station_fixture;
+        use crate::{
+            data_entry::{
+                CountingDifferencesPollingStation, DataError, Validate, ValidationResult,
+                ValidationResultCode, ValidationResults, YesNo,
+            };
+            election::tests::election_fixture;
+            polling_station::structs::tests::polling_station_fixture;
+        }
 
         fn validate(
             unexplained_yes: bool,

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -919,7 +919,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        data_entry::{PoliticalGroupTotalVotes, tests::ValidDefault}, election::tests::election_fixture,
+        data_entry::{PoliticalGroupTotalVotes, tests::ValidDefault},
+        election::tests::election_fixture,
         polling_station::structs::tests::polling_station_fixture,
     };
 
@@ -928,10 +929,10 @@ mod tests {
             data_entry::{
                 DataError, ExtraInvestigation, Validate, ValidationResult, ValidationResultCode,
                 ValidationResults, YesNo,
-            };
-            election::tests::election_fixture;
-            polling_station::structs::tests::polling_station_fixture;
-        }
+            },
+            election::tests::election_fixture,
+            polling_station::structs::tests::polling_station_fixture,
+        };
 
         fn validate(
             investigation_yes: bool,
@@ -1053,10 +1054,10 @@ mod tests {
             data_entry::{
                 CountingDifferencesPollingStation, DataError, Validate, ValidationResult,
                 ValidationResultCode, ValidationResults, YesNo,
-            };
-            election::tests::election_fixture;
-            polling_station::structs::tests::polling_station_fixture;
-        }
+            },
+            election::tests::election_fixture,
+            polling_station::structs::tests::polling_station_fixture,
+        };
 
         fn validate(
             unexplained_yes: bool,

--- a/backend/src/summary/mod.rs
+++ b/backend/src/summary/mod.rs
@@ -231,14 +231,15 @@ mod tests {
 
     use super::*;
     use crate::{
-        data_entry::PoliticalGroupTotalVotes, election::tests::election_fixture,
+        data_entry::{PoliticalGroupTotalVotes, tests::ValidDefault},
+        election::tests::election_fixture,
         pdf_gen::tests::polling_stations_fixture,
     };
 
     fn polling_station_results_fixture_a() -> PollingStationResults {
         PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 30,
                 proxy_certificate_count: 5,
@@ -274,8 +275,8 @@ mod tests {
 
     fn polling_station_results_fixture_b() -> PollingStationResults {
         PollingStationResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            extra_investigation: ValidDefault::valid_default(),
+            counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
                 poll_card_count: 49,
                 proxy_certificate_count: 1,

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -17,8 +17,8 @@ use abacus::{
         ElectionApportionmentResponse, Fraction, get_total_seats_from_apportionment_result,
     },
     data_entry::{
-        DataEntry, PoliticalGroupTotalVotes, PollingStationResults, VotersCounts, VotesCounts,
-        status::ClientState,
+        CountingDifferencesPollingStation, DataEntry, PoliticalGroupTotalVotes,
+        PollingStationResults, VotersCounts, VotesCounts, YesNo, status::ClientState,
     },
 };
 
@@ -34,7 +34,10 @@ async fn test_election_apportionment_works_for_less_than_19_seats(pool: SqlitePo
         progress: 100,
         data: PollingStationResults {
             extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            counting_differences_polling_station: CountingDifferencesPollingStation {
+                unexplained_difference_ballots_voters: YesNo::no(),
+                difference_ballots_per_list: YesNo::no(),
+            },
             voters_counts: VotersCounts {
                 poll_card_count: 1203,
                 proxy_certificate_count: 2,
@@ -127,7 +130,10 @@ async fn test_election_apportionment_works_for_19_or_more_seats(pool: SqlitePool
         progress: 100,
         data: PollingStationResults {
             extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            counting_differences_polling_station: CountingDifferencesPollingStation {
+                unexplained_difference_ballots_voters: YesNo::no(),
+                difference_ballots_per_list: YesNo::no(),
+            },
             voters_counts: VotersCounts {
                 poll_card_count: 1203,
                 proxy_certificate_count: 2,
@@ -229,7 +235,10 @@ async fn test_election_apportionment_error_drawing_of_lots_not_implemented(pool:
         progress: 100,
         data: PollingStationResults {
             extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            counting_differences_polling_station: CountingDifferencesPollingStation {
+                unexplained_difference_ballots_voters: YesNo::no(),
+                difference_ballots_per_list: YesNo::no(),
+            },
             voters_counts: VotersCounts {
                 poll_card_count: 102,
                 proxy_certificate_count: 2,

--- a/backend/tests/data_entries_integration_test.rs
+++ b/backend/tests/data_entries_integration_test.rs
@@ -62,8 +62,8 @@ async fn test_polling_station_data_entry_validation(pool: SqlitePool) {
           "ballots_recounted_extra_investigation": { "yes": false, "no": false },
         },
         "counting_differences_polling_station": {
-          "unexplained_difference_ballots_voters": { "yes": false, "no": false },
-          "difference_ballots_per_list": { "yes": false, "no": false },
+          "unexplained_difference_ballots_voters": { "yes": false, "no": true },
+          "difference_ballots_per_list": { "yes": false, "no": true },
         },
         "voters_counts": {
           "poll_card_count": 4,

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -8,9 +8,9 @@ use abacus::{
         status::CommitteeSessionStatus,
     },
     data_entry::{
-        CandidateVotes, Count, DataEntry, DifferencesCounts, ElectionStatusResponse,
-        PoliticalGroupCandidateVotes, PoliticalGroupTotalVotes, PollingStationResults,
-        VotersCounts, VotesCounts,
+        CandidateVotes, Count, CountingDifferencesPollingStation, DataEntry, DifferencesCounts,
+        ElectionStatusResponse, PoliticalGroupCandidateVotes, PoliticalGroupTotalVotes,
+        PollingStationResults, VotersCounts, VotesCounts, YesNo,
         status::{ClientState, DataEntryStatusName},
     },
     election::{CandidateNumber, PGNumber},
@@ -56,7 +56,10 @@ pub fn example_data_entry(client_state: Option<&str>) -> DataEntry {
         progress: 60,
         data: PollingStationResults {
             extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
+            counting_differences_polling_station: CountingDifferencesPollingStation {
+                difference_ballots_per_list: YesNo::no(),
+                unexplained_difference_ballots_voters: YesNo::no(),
+            },
             voters_counts: VotersCounts {
                 poll_card_count: 102,
                 proxy_certificate_count: 2,

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -441,7 +441,7 @@ test.describe("resume data entry flow", () => {
       await expect(countingDifferencesPollingStationPage.differenceBallotsPerListNo).not.toBeChecked();
       await expect(countingDifferencesPollingStationPage.unexplainedDifferenceBallotsVotersYes).not.toBeChecked();
       await expect(countingDifferencesPollingStationPage.unexplainedDifferenceBallotsVotersNo).not.toBeChecked();
-      await countingDifferencesPollingStationPage.next.click();
+      await countingDifferencesPollingStationPage.fillAndClickNext(noDifferences);
 
       // voters and votes page should have empty fields
       const votersAndVotesPage = new VotersAndVotesPage(page);

--- a/frontend/src/testing/api-mocks/ValidationResultMockData.ts
+++ b/frontend/src/testing/api-mocks/ValidationResultMockData.ts
@@ -5,6 +5,22 @@ type ErrorWarningsMap<Code extends ValidationResultCode> = {
 };
 
 export const validationResultMockData: ErrorWarningsMap<ValidationResultCode> = {
+  F101: {
+    fields: ["data.extra_investigation"],
+    code: "F101",
+  },
+  F102: {
+    fields: ["data.extra_investigation"],
+    code: "F102",
+  },
+  F111: {
+    fields: ["data.counting_differences_polling_station"],
+    code: "F111",
+  },
+  F112: {
+    fields: ["data.counting_differences_polling_station"],
+    code: "F112",
+  },
   F201: {
     fields: [
       "data.voters_counts.poll_card_count",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1159,6 +1159,10 @@ export interface ValidationResult {
 }
 
 export type ValidationResultCode =
+  | "F101"
+  | "F102"
+  | "F111"
+  | "F112"
   | "F201"
   | "F202"
   | "F203"


### PR DESCRIPTION
Implements:
- https://github.com/kiesraad/abacus/issues/1745
- https://github.com/kiesraad/abacus/issues/2016

Changes:
- Add ValidationResultsCode F101, F102, F111, F112
- Add and use `ValidDefaults` for the different sections that represent a valid data entry, to use in tests
- Add helper functions to `YesNo` struct for more convenient assertion and creation
- Implement and use `Validate` for `ExtraInvestigation` and `CountingDifferencesPollingStation`
- Add tests for validation, update data entry tests to use valid input

To test:
- Check validation rules in `validatieregels-plausibiliteitschecks-tellingen.md` for F101, F102 and F111, F112
- Verify that these rules are implemented on the first two pages of data entry
- Verify that these errors are shown to the coordinator when they are accepted by the typist

