### PR TITLE
Increase precision for audit log event datetime

### DIFF
--- a/backend/migrations/7_audit_log.sql
+++ b/backend/migrations/7_audit_log.sql
@@ -11,5 +11,5 @@ CREATE TABLE audit_log
     username           TEXT            ,
     user_fullname      TEXT            ,
     user_role          TEXT            ,
-    time               TEXT            NOT NULL DEFAULT CURRENT_TIMESTAMP
+    time               TEXT            NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
 ) STRICT;


### PR DESCRIPTION
Increased the precision of the datetime for the audit log events to miliseconds (3 decimals).

<img width="505" height="165" alt="Screenshot_2025-08-26_08-44-48" src="https://github.com/user-attachments/assets/b338b6db-02f4-4ce4-938f-096cf2a68b4e" />

This should fix the sorting issue. The audit log interface is unchanged and still does not show seconds:

<img width="1019" height="579" alt="Screenshot_2025-08-26_08-44-52" src="https://github.com/user-attachments/assets/03233616-c4b2-483d-b90a-89408fe352ec" />

Fixes https://github.com/kiesraad/abacus/issues/1978