### PR TITLE
Reduce the frontend usage of PollingStationResults type

### DIFF
--- a/frontend/src/features/data_entry/types/types.ts
+++ b/frontend/src/features/data_entry/types/types.ts
@@ -5,10 +5,9 @@ import {
   ClaimDataEntryResponse,
   DataEntryStatusResponse,
   ElectionWithPoliticalGroups,
-  PollingStationResults,
   ValidationResults,
 } from "@/types/generated/openapi";
-import { DataEntryStructure, FormSectionId, SectionValues } from "@/types/types";
+import { DataEntryResults, DataEntryStructure, FormSectionId, SectionValues } from "@/types/types";
 import { ValidationResultSet } from "@/utils/ValidationResults";
 
 export interface DataEntryState {
@@ -21,7 +20,7 @@ export interface DataEntryState {
   error: AnyApiError | null;
 
   // backend data structure
-  pollingStationResults: PollingStationResults | null;
+  pollingStationResults: DataEntryResults | null;
 
   // state of the forms excl. data
   dataEntryStructure: DataEntryStructure;
@@ -46,7 +45,7 @@ export interface DataEntryStateAndActions extends DataEntryState {
 }
 
 export interface DataEntryStateAndActionsLoaded extends DataEntryStateAndActions {
-  pollingStationResults: PollingStationResults;
+  pollingStationResults: DataEntryResults;
 }
 
 export type DataEntryDispatch = Dispatch<DataEntryAction>;
@@ -70,7 +69,7 @@ export type DataEntryAction =
     }
   | {
       type: "FORM_SAVED";
-      data: PollingStationResults;
+      data: DataEntryResults;
       validationResults: ValidationResults;
       sectionId: FormSectionId;
       aborting: boolean;

--- a/frontend/src/features/data_entry/utils/actions.ts
+++ b/frontend/src/features/data_entry/utils/actions.ts
@@ -1,6 +1,11 @@
 import { ApiClient } from "@/api/ApiClient";
 import { ApiResult, isSuccess } from "@/api/ApiResult";
-import { DataEntry, DataEntryStatusResponse, SaveDataEntryResponse } from "@/types/generated/openapi";
+import {
+  DataEntry,
+  DataEntryStatusResponse,
+  PollingStationResults,
+  SaveDataEntryResponse,
+} from "@/types/generated/openapi";
 import { FormSectionId, SectionValues } from "@/types/types";
 import { mapSectionValues } from "@/utils/dataEntryMapping";
 
@@ -88,7 +93,8 @@ export function onSubmitForm(
 
     const response: ApiResult<SaveDataEntryResponse> = await client.postRequest(requestPath, {
       progress,
-      data,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      data: data as PollingStationResults,
       client_state: clientState,
     } satisfies DataEntry);
 

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -1,5 +1,5 @@
-import { PollingStationResults, ValidationResult, ValidationResults } from "@/types/generated/openapi";
-import { DataEntryStructure, FormSectionId } from "@/types/types";
+import { ValidationResult, ValidationResults } from "@/types/generated/openapi";
+import { DataEntryResults, DataEntryStructure, FormSectionId } from "@/types/types";
 import { extractFieldInfoFromSection, getValueAtPath } from "@/utils/dataEntryMapping";
 import { doesValidationResultApplyToSection, ValidationResultSet } from "@/utils/ValidationResults";
 
@@ -44,7 +44,7 @@ export function getNextSectionID(formState: FormState, currentSectionId: FormSec
 export function isFormSectionEmpty(
   dataEntryStructure: DataEntryStructure,
   section: FormSection,
-  values: PollingStationResults,
+  results: DataEntryResults,
 ): boolean {
   const dataEntrySection = dataEntryStructure.find((s) => s.id === section.id);
   if (!dataEntrySection) {
@@ -54,7 +54,7 @@ export function isFormSectionEmpty(
 
   const fieldInfoMap = extractFieldInfoFromSection(dataEntrySection);
   for (const [path, fieldType] of fieldInfoMap) {
-    const value = getValueAtPath(values, path);
+    const value = getValueAtPath(results, path);
 
     switch (fieldType) {
       case "boolean":

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesOverview.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesOverview.tsx
@@ -1,12 +1,11 @@
 import { ProgressList } from "@/components/ui/ProgressList/ProgressList";
-import { PollingStationResults } from "@/types/generated/openapi";
-import { DataEntryStructure } from "@/types/types";
+import { DataEntryResults, DataEntryStructure } from "@/types/types";
 
 import { sectionHasDifferences } from "../utils/differences";
 
 interface ResolveDifferencesOverviewProps {
-  first: PollingStationResults;
-  second: PollingStationResults;
+  first: DataEntryResults;
+  second: DataEntryResults;
   structure: DataEntryStructure;
 }
 

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.test.tsx
@@ -155,14 +155,14 @@ describe("ResolveDifferencesTables", () => {
           yes: true,
           no: true,
         },
-      } as unknown as PollingStationResults;
+      };
 
       const secondResults = {
         test: {
           yes: false,
           no: false,
         },
-      } as unknown as PollingStationResults;
+      };
 
       render(<ResolveDifferencesTables first={firstResults} second={secondResults} structure={[checkboxSection]} />);
 

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.tsx
@@ -1,13 +1,19 @@
 import { t } from "@/i18n/translate";
-import { PollingStationResults, ResolveDifferencesAction } from "@/types/generated/openapi";
-import { DataEntrySection, DataEntryStructure, RadioSubsectionOption, SectionValues } from "@/types/types";
+import { ResolveDifferencesAction } from "@/types/generated/openapi";
+import {
+  DataEntryResults,
+  DataEntrySection,
+  DataEntryStructure,
+  RadioSubsectionOption,
+  SectionValues,
+} from "@/types/types";
 import { mapResultsToSectionValues } from "@/utils/dataEntryMapping";
 
 import { DifferencesTable } from "./DifferencesTable";
 
 export interface ResolveDifferencesTablesProps {
-  first: PollingStationResults;
-  second: PollingStationResults;
+  first: DataEntryResults;
+  second: DataEntryResults;
   structure: DataEntryStructure;
   action?: ResolveDifferencesAction;
 }
@@ -24,8 +30,8 @@ export function ResolveDifferencesTables({ first, second, action, structure }: R
 
 interface SectionTableProps {
   section: DataEntrySection;
-  first: PollingStationResults;
-  second: PollingStationResults;
+  first: DataEntryResults;
+  second: DataEntryResults;
   action?: ResolveDifferencesAction;
 }
 

--- a/frontend/src/features/resolve_differences/utils/differences.ts
+++ b/frontend/src/features/resolve_differences/utils/differences.ts
@@ -1,11 +1,10 @@
-import { PollingStationResults } from "@/types/generated/openapi";
-import { DataEntrySection } from "@/types/types";
+import { DataEntryResults, DataEntrySection } from "@/types/types";
 import { mapResultsToSectionValues } from "@/utils/dataEntryMapping";
 
 export function sectionHasDifferences(
   section: DataEntrySection,
-  first: PollingStationResults,
-  second: PollingStationResults,
+  first: DataEntryResults,
+  second: DataEntryResults,
 ): boolean {
   const firstValues = mapResultsToSectionValues(section, first);
   const secondValues = mapResultsToSectionValues(section, second);

--- a/frontend/src/features/resolve_errors/components/ReadOnlyDataEntrySection.tsx
+++ b/frontend/src/features/resolve_errors/components/ReadOnlyDataEntrySection.tsx
@@ -2,8 +2,8 @@ import { DataEntrySubsections } from "@/components/data_entry/DataEntrySubsectio
 import { SectionNumber } from "@/components/ui/Badge/SectionNumber";
 import { Feedback } from "@/components/ui/Feedback/Feedback";
 import { Form } from "@/components/ui/Form/Form";
-import { PollingStationResults, ValidationResults } from "@/types/generated/openapi";
-import { DataEntrySection, SectionValues } from "@/types/types";
+import { ValidationResults } from "@/types/generated/openapi";
+import { DataEntryResults, DataEntrySection, SectionValues } from "@/types/types";
 import { mapResultsToSectionValues } from "@/utils/dataEntryMapping";
 import { getValidationResultSetForSection, mapValidationResultSetsToFields } from "@/utils/ValidationResults";
 
@@ -11,7 +11,7 @@ import cls from "./ReadOnlyDataEntrySection.module.css";
 
 interface ReadOnlyDataEntrySectionProps {
   section: DataEntrySection;
-  data: PollingStationResults;
+  data: DataEntryResults;
   validationResults: ValidationResults;
 }
 

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -95,3 +95,5 @@ export interface DataEntrySection {
 }
 
 export type DataEntryStructure = DataEntrySection[];
+
+export type DataEntryResults = object;


### PR DESCRIPTION
Reduce the dependency on `PollingStationResults` by introducing a new type `DataEntryResult` (which is object for now), and using that instead, in preparation of Epic https://github.com/kiesraad/abacus/issues/1885

Also some argument renames to try and make things more clear.