### PR TITLE
storybook tests for ChoiceList

### DIFF
--- a/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.stories.tsx
+++ b/frontend/src/components/ui/CheckboxAndRadio/ChoiceList.stories.tsx
@@ -1,48 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 
 import { ChoiceList } from "./ChoiceList";
 
 type Props = {
   label: string;
   error?: string;
-};
-
-export const DefaultChoiceListCheckbox: StoryObj<Props> = {
-  render: ({ label, error }) => (
-    <ChoiceList>
-      <ChoiceList.Legend>ChoiceList Checkbox Legend</ChoiceList.Legend>
-      {error && <ChoiceList.Error id="choicelist-error">{error}</ChoiceList.Error>}
-      <ChoiceList.Checkbox id="default-checkbox" defaultChecked={false} label={label} />
-      <ChoiceList.Checkbox id="default-checkbox-with-description" defaultChecked={false} label={label}>
-        This is a description
-      </ChoiceList.Checkbox>
-      <ChoiceList.Checkbox id="default-checkbox-error" defaultChecked={false} label={label} hasError />
-      <ChoiceList.Checkbox id="default-checkbox-disabled" defaultChecked={false} label={label} disabled />
-      <ChoiceList.Checkbox id="default-checkbox-disabled-checked" defaultChecked={true} label={label} disabled />
-      <div style={{ width: 200 }}>
-        <ChoiceList.Checkbox id="default-checkbox-cramped" defaultChecked={false} label={label} />
-      </div>
-    </ChoiceList>
-  ),
-};
-
-export const DefaultChoiceListRadio: StoryObj<Props> = {
-  render: ({ label, error }) => (
-    <ChoiceList>
-      <ChoiceList.Legend>ChoiceList Radio Legend</ChoiceList.Legend>
-      {error && <ChoiceList.Error id="choicelist-error">{error}</ChoiceList.Error>}
-      <ChoiceList.Radio id="default-radio" defaultChecked={false} label={label} />
-      <ChoiceList.Radio id="default-radio-with-description" defaultChecked={false} label={label}>
-        This is a description
-      </ChoiceList.Radio>
-      <ChoiceList.Radio id="default-radio-error" defaultChecked={false} label={label} hasError />
-      <ChoiceList.Radio id="default-radio-disabled" defaultChecked={false} label={label} disabled />
-      <ChoiceList.Radio id="default-radio-disabled-checked" defaultChecked={true} label={label} disabled />
-      <div style={{ width: 200 }}>
-        <ChoiceList.Radio id="default-radio-cramped" defaultChecked={false} label={label} />
-      </div>
-    </ChoiceList>
-  ),
 };
 
 export default {
@@ -56,3 +19,78 @@ export default {
     },
   },
 } satisfies Meta<Props>;
+
+export const DefaultChoiceListCheckbox: StoryObj<Props> = {
+  render: ({ label, error }) => (
+    <ChoiceList>
+      <ChoiceList.Legend>ChoiceList Checkbox Legend</ChoiceList.Legend>
+      {error && <ChoiceList.Error id="choicelist-error">{error}</ChoiceList.Error>}
+      <ChoiceList.Checkbox id="default-checkbox" defaultChecked={false} label={label} />
+      <ChoiceList.Checkbox
+        id="default-checkbox-with-description"
+        defaultChecked={false}
+        label={`${label} (description)`}
+      >
+        This is a description
+      </ChoiceList.Checkbox>
+      <ChoiceList.Checkbox id="default-checkbox-error" defaultChecked={false} label={`${label} (error)`} hasError />
+      <ChoiceList.Checkbox
+        id="default-checkbox-disabled"
+        defaultChecked={false}
+        label={`${label} (disabled)`}
+        disabled
+      />
+      <ChoiceList.Checkbox
+        id="default-checkbox-disabled-checked"
+        defaultChecked={true}
+        label={`${label} (checked)`}
+        disabled
+      />
+      <div style={{ width: 200 }}>
+        <ChoiceList.Checkbox id="default-checkbox-cramped" defaultChecked={false} label={`${label} (cramped)`} />
+      </div>
+    </ChoiceList>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("group", { name: "ChoiceList Checkbox Legend" })).toBeVisible();
+    await expect(
+      canvas.getByText("Dit is een verplichte vraag. Maak een keuze uit de opties hieronder."),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("checkbox", { name: "Ik heb mijn invoer gecontroleerd met het papier en correct overgenomen." }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const DefaultChoiceListRadio: StoryObj<Props> = {
+  render: ({ label, error }) => (
+    <ChoiceList>
+      <ChoiceList.Legend>ChoiceList Radio Legend</ChoiceList.Legend>
+      {error && <ChoiceList.Error id="choicelist-error">{error}</ChoiceList.Error>}
+      <ChoiceList.Radio id="default-radio" defaultChecked={false} label={label} />
+      <ChoiceList.Radio id="default-radio-with-description" defaultChecked={false} label={`${label} (description)`}>
+        This is a description
+      </ChoiceList.Radio>
+      <ChoiceList.Radio id="default-radio-error" defaultChecked={false} label={`${label} (error)`} hasError />
+      <ChoiceList.Radio id="default-radio-disabled" defaultChecked={false} label={`${label} (disabled)`} disabled />
+      <ChoiceList.Radio
+        id="default-radio-disabled-checked"
+        defaultChecked={true}
+        label={`${label} (checked)`}
+        disabled
+      />
+      <div style={{ width: 200 }}>
+        <ChoiceList.Radio id="default-radio-cramped" defaultChecked={false} label={`${label} (cramped)`} />
+      </div>
+    </ChoiceList>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("group", { name: "ChoiceList Radio Legend" })).toBeVisible();
+    await expect(
+      canvas.getByText("Dit is een verplichte vraag. Maak een keuze uit de opties hieronder."),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("radio", { name: "Ik heb mijn invoer gecontroleerd met het papier en correct overgenomen." }),
+    ).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
relates to #1775 

### Scope
- add storybook interaction tests for ChoiceList based on [tests that were removed](https://github.com/kiesraad/abacus/pull/1753/files#diff-d602922fe1b8ef8f85243d43d8a3940d61a44679ec610d3c041151f1a559ed34) in the switch to storybook
- add string to all but the first `label` to be able to locate the topmost checkbox
- move the `export default` to the top of the file


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->