### PR TITLE
Remove unneeded triggers and preconditions from use cases

### DIFF
--- a/documentatie/use-cases/beheerder.md
+++ b/documentatie/use-cases/beheerder.md
@@ -88,7 +88,6 @@ __Niveau:__ gebruikersdoel, zee, 🌊
 
 __Precondities:__
 
-- De lijst met gepubliceerde stembureaus is beschikbaar.
 - De stembureaus zijn niet tijdens [het inrichten van de applicatie](#de-beheerder-richt-de-applicatie-in-voor-gsb-enof-csb-wolk) ingevoerd.
 - De invoerfase van de zitting is nog niet gestart. Na het starten van de invoerfase kan alleen de [coördinator nog wijzigingen in de lijst met stembureaus aanbrengen](./gsb-eerste-zitting.md#de-coördinator-gsb-bewerkt-de-stembureaus-tijdens-de-eerste-of-nieuwe-zitting-zee).
 

--- a/documentatie/use-cases/beheerder.md
+++ b/documentatie/use-cases/beheerder.md
@@ -35,8 +35,6 @@ __Niveau:__ gebruikersdoel, zee, 🌊
 
 ### Hoofdscenario en uitbreidingen
 
-__Trigger:__ De Kiesraad maakt de applicatie beschikbaar.
-
 __Hoofdscenario:__
 
 1. De beheerder bereidt één computer als Abacus-server voor.

--- a/documentatie/use-cases/gsb-invoer-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-invoer-eerste-zitting.md
@@ -50,10 +50,6 @@ __Uitbreidingen:__
 
 __Niveau:__ gebruikersdoel, zee, 🌊
 
-__Precondities:__
-
-- De coördinator GSB is ingelogd in de applicatie.
-
 ### Hoofdscenario en uitbreidingen
 
 __Hoofdscenario:__
@@ -121,10 +117,6 @@ __Uitbreidingen:__
 ## De eerste of tweede invoerder voert de resultaten van de telling in (zee)
 
 __Niveau:__ gebruikersdoel, zee, 🌊
-
-__Precondities:__
-
-- De invoerder is ingelogd in de applicatie.
 
 ### Hoofdscenario en uitbreidingen
 

--- a/documentatie/use-cases/gsb-invoer-eerste-zitting.md
+++ b/documentatie/use-cases/gsb-invoer-eerste-zitting.md
@@ -218,11 +218,9 @@ __Niveau:__ subfunctie, vis, 🐟
 
 ### Hoofdscenario en uitbreidingen
 
-__Trigger:__ De controles geven een of meerdere foutmeldingen vanwege de [validatieregels voor fouten](./validatieregels-plausibiliteitschecks-tellingen.md#validatieregels-geven-fouten) en/of een of meerdere waarschuwingen vanwege de [plausibiliteitschecks](./validatieregels-plausibiliteitschecks-tellingen.md#plausibiliteitschecks-geven-waarschuwingen).
+*Foutmelding*: De ingevoerde waardes kunnen niet correct zijn. Bijvoorbeeld: het totaal van de stemmen op een lijst komt niet overeen met de som van de stemmen van de kandidaten op die lijst. Zie de [validatieregels voor fouten](./validatieregels-plausibiliteitschecks-tellingen.md#validatieregels-geven-fouten) voor de volledige lijst.
 
-*Foutmelding*: De ingevoerde waardes kunnen niet correct zijn. Bijvoorbeeld: het totaal van de stemmen op een lijst komt niet overeen met de som van de stemmen van de kandidaten op die lijst.
-
-*Waarschuwing*: De ingevoerde waardes zijn mogelijk niet correct. Bijvoorbeeld: er is een groot aantal blanco stemmen of de tweede invoer klopt niet met de eerste invoer.
+*Waarschuwing*: De ingevoerde waardes zijn mogelijk niet correct. Bijvoorbeeld: er is een groot aantal blanco stemmen of de tweede invoer klopt niet met de eerste invoer. Zie de [plausibiliteitschecks](./validatieregels-plausibiliteitschecks-tellingen.md#plausibiliteitschecks-geven-waarschuwingen) voor de volledige lijst.
 
 __Hoofdscenario:__  
 Voor elke fout of waarschuwing:  

--- a/documentatie/use-cases/gsb-tweede-zitting.md
+++ b/documentatie/use-cases/gsb-tweede-zitting.md
@@ -8,8 +8,6 @@ __Niveau:__ hoog-over, wolk, ☁️
 
 ### Hoofdscenario en uitbreidingen
 
-__Trigger:__ één of meer stembureaus moeten herteld worden n.a.v. verzoek CSB
-
 __Hoofdscenario:__  
 1. Het GSB ontvangt één of meerdere verzoeken tot onderzoek/hertelling van het CSB.
 2. [De coördinator GSB bereidt de documenten voor de zitting voor.](#de-coördinator-gsb-bereidt-de-documenten-voor-de-zitting-voor-zee)


### PR DESCRIPTION
### Scope

We weren't very consistent in how we use "trigger" and "preconditie" in the use cases. So I removed the ones that were not adding any value to the use cases.

Note that according to the Alistair Cockburn book a "preconditie" is something checked/enforced by the application.