### PR TITLE
Fix signout does not work during election creation bug

### DIFF
--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -8,7 +8,7 @@ import { t, tx } from "@/i18n/translate";
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 
 export function AbortModal() {
-  const { state, dispatch } = useElectionCreateContext();
+  const { state } = useElectionCreateContext();
   const user = useUser();
 
   // path check to see if the current location is part of the create election flow
@@ -48,7 +48,6 @@ export function AbortModal() {
 
   // when delete was chosen, clear state and proceed
   const onAbortModalDelete = () => {
-    dispatch({ type: "RESET" });
     blocker.proceed();
   };
 

--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -516,6 +516,7 @@ describe("Election create pages", () => {
 
     // The modal should have triggered
     expect(await screen.findByRole("heading", { level: 3, name: "Niet opgeslagen wijzigingen" })).toBeVisible();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     // Delete button should move away from the import page
     const deleteButton = screen.getByText("Verkiezing niet opslaan");

--- a/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
@@ -45,9 +45,6 @@ export type ElectionCreateAction =
       type: "SET_NUMBER_OF_VOTERS";
       numberOfVoters: number;
       isNumberOfVotersUserEdited: boolean;
-    }
-  | {
-      type: "RESET";
     };
 
 export interface ElectionCreateState {
@@ -123,9 +120,6 @@ function reducer(state: ElectionCreateState, action: ElectionCreateAction): Elec
         numberOfVoters: action.numberOfVoters,
         isNumberOfVotersUserEdited: action.isNumberOfVotersUserEdited,
       };
-    // Empty the state
-    case "RESET":
-      return {};
   }
 }
 


### PR DESCRIPTION
The dispatch({ type: "RESET" }) lead to a navigation, which blocks the navigation from the blocker.proceed().

But as it turns out, explicitly clearing the state is not necessary because navigating away from the election create will clear the state in any case. So the dispatch can just be removed; the behavior of the back and forward buttons remains unchanged.

Note: I intended to add a test to cover this case, but logging out during a test breaks subsequent/parallel tests.

Fixes https://github.com/kiesraad/abacus/issues/2088