### PR TITLE
Prepare input grid for adding corrigendum column

### DIFF
--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
@@ -24,11 +24,7 @@ export function InputGridSubsectionComponent({
 }: InputGridSubsectionProps) {
   return (
     <InputGrid zebra={subsection.zebra}>
-      <InputGrid.Header>
-        <th>{subsection.headers[0]}</th>
-        <th>{subsection.headers[1]}</th>
-        <th>{subsection.headers[2]}</th>
-      </InputGrid.Header>
+      <InputGrid.Header field={subsection.headers[0]} value={subsection.headers[1]} title={subsection.headers[2]} />
       <InputGrid.Body>
         {subsection.rows.map((row: InputGridSubsectionRow) => (
           <InputGridRow

--- a/frontend/src/components/ui/InputGrid/InputGrid.module.css
+++ b/frontend/src/components/ui/InputGrid/InputGrid.module.css
@@ -1,24 +1,27 @@
 .inputGrid {
   width: 100%;
   border-spacing: 0;
+
   th {
     border-bottom: 1px solid var(--bg-gray-darkest);
     font-size: var(--font-size-xs);
     text-align: right;
     padding: 0.75rem 1.5rem;
     color: var(--color-help-text);
-    &:nth-of-type(3) {
+
+    &.title {
       text-align: left;
     }
   }
 
-  &:global(.zebra) {
+  &.zebra {
     tbody tr:nth-of-type(even) {
       background-color: var(--bg-gray-darker);
     }
-    tbody tr:global(.sep_row),
-    tbody tr:global(.sep_total),
-    tbody tr:global(.list_total) {
+
+    tbody tr.separator,
+    tbody tr.totalSeparator,
+    tbody tr.listTotal {
       background-color: var(--bg-gray);
     }
   }
@@ -28,7 +31,8 @@
       border-bottom: 1px solid var(--bg-gray-darkest);
       padding: 0.5rem 1.5rem;
       line-height: 1.25rem;
-      &:first-of-type {
+
+      &.field {
         width: 6.5rem;
         border-right: 1px solid var(--bg-gray-darkest);
         text-align: right;
@@ -36,11 +40,11 @@
         font-weight: bold;
       }
 
-      /* Input */
-      &:nth-of-type(2) {
+      &.value {
         width: 13rem;
         border-right: 1px solid var(--bg-gray-darkest);
         padding: 0;
+
         input {
           width: 100%;
           height: 4.5rem;
@@ -77,14 +81,8 @@
         }
       }
 
-      &:last-of-type {
+      &.title {
         color: var(--color-help-text);
-      }
-
-      &:global(.sep) {
-        border: 0;
-        border-bottom: 1px solid var(--bg-gray-darkest);
-        height: 1.5rem;
       }
     }
 
@@ -95,33 +93,39 @@
       }
     }
 
-    &:global(.list_total) {
-      td:first-of-type {
+    &.separator {
+      td {
+        border: 0;
+        border-bottom: 1px solid var(--bg-gray-darkest);
+        height: 1.5rem;
+      }
+    }
+
+    &.listTotal {
+      td.field {
         border-bottom: 0;
       }
-      td:last-of-type {
+
+      td.title {
         border: 0;
       }
     }
 
-    &:global(.sep_total) {
-      td:first-of-type,
-      td:last-of-type {
+    &.totalSeparator {
+      td.field,
+      td.title {
         border: 0;
       }
-      td:nth-of-type(2) {
+
+      td.value {
         border-right: 0;
       }
     }
 
-    &:global(.is-total) {
-      td:last-of-type {
+    &.total {
+      td.title {
         font-weight: bold;
       }
     }
   }
-}
-
-div:global(#missing-total-error) {
-  padding-left: 6.5rem;
 }

--- a/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
@@ -6,6 +6,10 @@ import { InputGridRow } from "./InputGridRow";
 
 type Props = {
   readOnly: boolean;
+  zebra: boolean;
+  addSeparator: boolean;
+  isListTotal: boolean;
+  isTotal: boolean;
 };
 
 // Create error and warning maps for the stories
@@ -20,11 +24,17 @@ const createErrorsAndWarnings = () => {
 };
 
 export const DefaultGrid: StoryObj<Props> = {
-  render: ({ readOnly }) => {
+  args: {
+    readOnly: false,
+    zebra: false,
+    addSeparator: false,
+    isTotal: true,
+  },
+  render: ({ readOnly, zebra, addSeparator, isTotal }) => {
     const errorsAndWarnings = createErrorsAndWarnings();
 
     return (
-      <InputGrid>
+      <InputGrid zebra={zebra}>
         <InputGrid.Header>
           <th>Veld</th>
           <th>Geteld aantal</th>
@@ -46,6 +56,7 @@ export const DefaultGrid: StoryObj<Props> = {
             title="Input field 2 (Error)"
             defaultValue={2}
             errorsAndWarnings={errorsAndWarnings}
+            addSeparator={addSeparator}
           />
           <InputGridRow
             readOnly={readOnly}
@@ -61,7 +72,7 @@ export const DefaultGrid: StoryObj<Props> = {
             field="D"
             title="Total of all inputs"
             defaultValue={6}
-            isTotal={true}
+            isTotal={isTotal}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGrid.Separator />
@@ -84,12 +95,17 @@ export const DefaultGrid: StoryObj<Props> = {
   },
 };
 
-export const ZebraGrid: StoryObj<Props> = {
-  render: ({ readOnly }) => {
+export const CandidatesGrid: StoryObj<Props> = {
+  args: {
+    readOnly: false,
+    zebra: true,
+    isListTotal: true,
+  },
+  render: ({ readOnly, zebra, isListTotal }) => {
     const errorsAndWarnings = createErrorsAndWarnings();
 
     return (
-      <InputGrid zebra={true}>
+      <InputGrid zebra={zebra}>
         <InputGrid.Header>
           <th>Nummer</th>
           <th>Aantal stemmen</th>
@@ -142,7 +158,7 @@ export const ZebraGrid: StoryObj<Props> = {
             field=""
             title="List Total"
             defaultValue={15}
-            isListTotal={true}
+            isListTotal={isListTotal}
             errorsAndWarnings={errorsAndWarnings}
           />
         </InputGrid.Body>

--- a/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
@@ -35,11 +35,7 @@ export const DefaultGrid: StoryObj<Props> = {
 
     return (
       <InputGrid zebra={zebra}>
-        <InputGrid.Header>
-          <th>Veld</th>
-          <th>Geteld aantal</th>
-          <th>Omschrijving</th>
-        </InputGrid.Header>
+        <InputGrid.Header field="Veld" value="Geteld aantal" title="Omschrijving" />
         <InputGrid.Body>
           <InputGridRow
             readOnly={readOnly}
@@ -106,11 +102,7 @@ export const CandidatesGrid: StoryObj<Props> = {
 
     return (
       <InputGrid zebra={zebra}>
-        <InputGrid.Header>
-          <th>Nummer</th>
-          <th>Aantal stemmen</th>
-          <th>Kandidaat</th>
-        </InputGrid.Header>
+        <InputGrid.Header field="Nummer" value="Aantal stemmen" title="Kandidaat" />
         <InputGrid.Body>
           <InputGridRow
             readOnly={readOnly}

--- a/frontend/src/components/ui/InputGrid/InputGrid.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.tsx
@@ -21,9 +21,13 @@ export function InputGrid({ zebra, children }: InputGridProps) {
   );
 }
 
-InputGrid.Header = ({ children }: { children: InputGridRowCells }) => (
+InputGrid.Header = ({ field, value, title }: { field: string; value: string; title: string }) => (
   <thead>
-    <tr>{children}</tr>
+    <tr>
+      <th className={cls.field}>{field}</th>
+      <th className={cls.value}>{value}</th>
+      <th className={cls.title}>{title}</th>
+    </tr>
   </thead>
 );
 

--- a/frontend/src/components/ui/InputGrid/InputGrid.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.tsx
@@ -1,8 +1,10 @@
-import * as React from "react";
+import { ReactNode, useRef } from "react";
 
 import { cn } from "@/utils/classnames";
 
 import cls from "./InputGrid.module.css";
+
+export type InputGridRowCells = [ReactNode, ReactNode, ReactNode];
 
 export interface InputGridProps {
   zebra?: boolean;
@@ -10,16 +12,16 @@ export interface InputGridProps {
 }
 
 export function InputGrid({ zebra, children }: InputGridProps) {
-  const ref = React.useRef<HTMLTableElement>(null);
+  const ref = useRef<HTMLTableElement>(null);
 
   return (
-    <table role="none" ref={ref} className={cn(cls.inputGrid, { zebra: zebra })}>
+    <table role="none" ref={ref} className={cn(cls.inputGrid, zebra && cls.zebra)}>
       {children}
     </table>
   );
 }
 
-InputGrid.Header = ({ children }: { children: [React.ReactElement, React.ReactElement, React.ReactElement] }) => (
+InputGrid.Header = ({ children }: { children: InputGridRowCells }) => (
   <thead>
     <tr>{children}</tr>
   </thead>
@@ -28,8 +30,8 @@ InputGrid.Header = ({ children }: { children: [React.ReactElement, React.ReactEl
 InputGrid.Body = ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>;
 
 InputGrid.Separator = () => (
-  <tr className="sep_row">
-    <td className="sep" colSpan={3}></td>
+  <tr className={cls.separator}>
+    <td colSpan={3} />
   </tr>
 );
 
@@ -39,32 +41,28 @@ InputGrid.Row = ({
   addSeparator,
   id,
 }: {
-  children: [React.ReactElement, React.ReactElement, React.ReactElement];
+  children: InputGridRowCells;
   isTotal?: boolean;
   addSeparator?: boolean;
   id?: string;
 }) => (
   <>
-    <tr className={isTotal ? "is-total " : ""} id={`row-${id}`}>
+    <tr className={cn(isTotal && cls.total)} id={`row-${id}`}>
       {children}
     </tr>
     {addSeparator && <InputGrid.Separator />}
   </>
 );
 
-InputGrid.ListTotal = ({
-  children,
-  id,
-}: {
-  children: [React.ReactElement, React.ReactElement, React.ReactElement];
-  id?: string;
-}) => (
+InputGrid.ListTotal = ({ children, id }: { children: InputGridRowCells; id?: string }) => (
   <>
-    <tr className="sep_total" id={`row-${id}`}>
-      <td></td>
-      <td></td>
-      <td></td>
+    <tr className={cls.totalSeparator}>
+      <td className={cls.field}></td>
+      <td className={cls.value}></td>
+      <td className={cls.title}></td>
     </tr>
-    <tr className="list_total is-total">{children}</tr>
+    <tr className={cn(cls.listTotal, cls.total)} id={`row-${id}`}>
+      {children}
+    </tr>
   </>
 );

--- a/frontend/src/components/ui/InputGrid/InputGridRow.test.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGridRow.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { render, screen } from "@/testing/test-utils";
 
 import { InputGrid } from "./InputGrid";
+import cls from "./InputGrid.module.css";
 import { InputGridRow, InputGridRowProps } from "./InputGridRow";
 
 const defaultProps: InputGridRowProps = {
@@ -29,13 +30,13 @@ describe("InputGridRow", () => {
     expect(rows.length).toBe(1);
   });
 
-  test("InputGridRow renders a ListTotal in case of isListTotal", async () => {
+  test("InputGridRow renders a separator and list total row in case of isListTotal", async () => {
     renderRow({ isListTotal: true });
 
     const rows = await screen.findAllByRole("row");
     expect(rows.length).toBe(2);
-    expect(rows[0]).toHaveClass("sep_total");
-    expect(rows[1]).toHaveClass("list_total");
+    expect(rows[0]).toHaveClass(cls.totalSeparator as string);
+    expect(rows[1]).toHaveClass(cls.listTotal as string);
   });
 
   test("InputGridRow uses aria-errormessage", async () => {

--- a/frontend/src/components/ui/InputGrid/InputGridRow.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGridRow.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 
+import { cn } from "@/utils/classnames";
+
 import { FormField } from "../FormField/FormField";
 import { NumberInput } from "../NumberInput/NumberInput";
-import { InputGrid } from "./InputGrid";
+import { InputGrid, InputGridRowCells } from "./InputGrid";
 import cls from "./InputGrid.module.css";
 
 export interface InputGridRowProps {
@@ -59,11 +61,11 @@ export function InputGridRow({
     }
   }, [errorMessageId]);
 
-  const children: [React.ReactElement, React.ReactElement, React.ReactElement] = [
-    <td key={`${id}-1`} id={`field-${id}`}>
+  const children: InputGridRowCells = [
+    <td key={`field-${id}`} id={`field-${id}`} className={cls.field}>
       {field}
     </td>,
-    <td key={`${id}-2`} id={`cell-${id}`} className={readOnly ? cls.readOnly : undefined}>
+    <td key={`value-${id}`} id={`value-${id}`} className={cn(cls.value, readOnly && cls.readOnly)}>
       <FormField hasError={!!errorMessageId || hasError} hasWarning={hasWarning}>
         {readOnly ? (
           <span className="font-number">{value !== undefined ? value : defaultValue}</span>
@@ -84,7 +86,7 @@ export function InputGridRow({
         )}
       </FormField>
     </td>,
-    <td key={`${id}-3`} id={`title-${id}`}>
+    <td key={`title-${id}`} id={`title-${id}`} className={cls.title}>
       {title}
     </td>,
   ];

--- a/frontend/src/features/data_entry/components/DataEntrySection.module.css
+++ b/frontend/src/features/data_entry/components/DataEntrySection.module.css
@@ -13,3 +13,8 @@
   flex-direction: column;
   gap: 1.5rem;
 }
+
+.missingTotalError {
+  /* Left aligned with value column in the input grid */
+  padding-left: 6.5rem;
+}

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -114,7 +114,7 @@ export function DataEntrySection() {
         />
 
         {missingTotalError && (
-          <div id="missing-total-error">
+          <div id="missing-total-error" className={cls.missingTotalError}>
             <Alert type="error" small>
               <p>
                 {t(`feedback.F402.typist.title`)}. {t(`feedback.F402.typist.content`)}

--- a/frontend/src/features/data_entry/testing/test.utils.ts
+++ b/frontend/src/features/data_entry/testing/test.utils.ts
@@ -46,7 +46,7 @@ export function overrideServerClaimDataEntryResponse({
 
 export function expectFieldsToBeInvalidAndToHaveAccessibleErrorMessage(fields: Array<string>, feedbackMessage: string) {
   fields.forEach((field) => {
-    const inputField = within(screen.getByTestId(`cell-${field}`)).getByRole("textbox");
+    const inputField = within(screen.getByTestId(`value-${field}`)).getByRole("textbox");
     expect(inputField).toBeInvalid();
     expect(inputField).toHaveAccessibleErrorMessage(feedbackMessage);
   });
@@ -54,14 +54,14 @@ export function expectFieldsToBeInvalidAndToHaveAccessibleErrorMessage(fields: A
 
 export function expectFieldsToHaveIconAndToHaveAccessibleName(fields: Array<string>, accessibleName: string) {
   fields.forEach((field) => {
-    const icon = within(screen.getByTestId(`cell-${field}`)).getByRole("img");
+    const icon = within(screen.getByTestId(`value-${field}`)).getByRole("img");
     expect(icon).toHaveAccessibleName(accessibleName);
   });
 }
 
 export function expectFieldsToBeValidAndToNotHaveAccessibleErrorMessage(fields: Array<string>) {
   fields.forEach((field) => {
-    const inputField = within(screen.getByTestId(`cell-${field}`)).getByRole("textbox");
+    const inputField = within(screen.getByTestId(`value-${field}`)).getByRole("textbox");
     expect(inputField).toBeValid();
     expect(inputField).not.toHaveAccessibleErrorMessage();
   });
@@ -69,7 +69,7 @@ export function expectFieldsToBeValidAndToNotHaveAccessibleErrorMessage(fields: 
 
 export function expectFieldsToNotHaveIcon(fields: Array<string>) {
   fields.forEach((field) => {
-    const icon = within(screen.getByTestId(`cell-${field}`)).queryByRole("img");
+    const icon = within(screen.getByTestId(`value-${field}`)).queryByRole("img");
     expect(icon).toBeNull();
   });
 }


### PR DESCRIPTION
- Refactor input grid to be able to add an extra column for https://github.com/kiesraad/abacus/issues/2051
  - Classes instead of index-based styling
  - CSS modules
- Add props to [storybook](https://755187bd.kiesraad-abacus.pages.dev/storybook/?path=/story/components-ui-inputgrid--default-grid) to see that the styling is not affected
