### PR TITLE
Fixed keyboard hint styling regression

### DIFF
--- a/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.module.css
+++ b/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.module.css
@@ -12,10 +12,12 @@
     border-radius: 0.25rem;
     background: var(--color-hover);
     font-family: inherit;
+    height: 1.75rem;
 
     svg {
       width: 1rem;
       height: 1rem;
+      fill: var(--color-help-text);
     }
 
     span {


### PR DESCRIPTION
Closes #2097 

Adding `align-items: center;` to `.keyboardKeys` in #2045 caused this issue.  
I have now added a set height to the `kbd` and set the svg color to be the same as the text

<img width="363" height="153" alt="Screenshot from 2025-09-05 00-32-24" src="https://github.com/user-attachments/assets/2df0ebb7-f608-4785-867b-df6bce5517e1" />


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->