### PR TITLE
Form storybook tests

### DIFF
--- a/frontend/src/components/ui/Form/Form.stories.tsx
+++ b/frontend/src/components/ui/Form/Form.stories.tsx
@@ -1,33 +1,49 @@
 import { FormEvent, useState } from "react";
 
-import type { Meta, StoryFn } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Form } from "./Form";
 
-export const DefaultForm: StoryFn = () => {
-  const [formSubmitted, setFormSubmitted] = useState(false);
+export interface StoryProps {
+  title?: string;
+}
 
-  function handleFormSubmit(event: FormEvent) {
-    event.preventDefault();
-    setFormSubmitted(true);
-  }
+export default {
+  args: {
+    title: "Form title",
+  },
+  argTypes: {
+    title: {
+      options: ["Form title", undefined],
+      control: { type: "radio" },
+    },
+  },
+} satisfies Meta<StoryProps>;
 
-  return (
-    <>
-      <div className="mb-lg">
-        <Form title="Form" onSubmit={handleFormSubmit}>
-          <input id="inp1" />
-          <br />
-          <input id="inp2" />
-          <br />
-          <input id="inp3" />
-          <br />
-          <button type="submit">Submit</button>
-        </Form>
-        {formSubmitted && "Submitted!"}
-      </div>
-    </>
-  );
+export const DefaultForm: StoryObj<StoryProps> = {
+  render: ({ title }) => {
+    const [formSubmitted, setFormSubmitted] = useState(false);
+
+    function handleFormSubmit(event: FormEvent) {
+      event.preventDefault();
+      setFormSubmitted(true);
+    }
+
+    return (
+      <>
+        <div className="mb-lg">
+          <Form title={title} onSubmit={handleFormSubmit}>
+            <input id="inp1" />
+            <br />
+            <input id="inp2" />
+            <br />
+            <input id="inp3" />
+            <br />
+            <button type="submit">Submit</button>
+          </Form>
+          {formSubmitted && "Submitted!"}
+        </div>
+      </>
+    );
+  },
 };
-
-export default {} satisfies Meta;

--- a/frontend/src/components/ui/Form/Form.test.tsx
+++ b/frontend/src/components/ui/Form/Form.test.tsx
@@ -12,8 +12,21 @@ describe("UI Component: Form", () => {
       </Form>,
     );
 
-    expect(screen.getByText("Form title")).toBeInTheDocument();
-    expect(screen.getByTestId("test")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Form title" })).toBeVisible();
+    expect(screen.getByRole("heading", { level: 2, name: "Form title" })).toBeVisible();
+    expect(screen.getByTestId("test")).toBeVisible();
+  });
+
+  test("Form renders without title and with children", () => {
+    render(
+      <Form>
+        <input id="test" />
+      </Form>,
+    );
+
+    expect(screen.getByRole("group")).toBeVisible();
+    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+    expect(screen.getByTestId("test")).toBeVisible();
   });
 
   test("Ref is forwarded", () => {


### PR DESCRIPTION
relates to #1775 

### Scope
- add titleless Form to storybook stories
- extend vitest tests of Form component

I decided not to refactor the vitest tests to storybook interaction tests, because I don't know how to do this for the "Ref is forwarded" test. And the component is simple enough that I don't think there's a significant risk that the storybook stories will diverge from the vitest tests.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->