### PR TITLE
Remove unused `SummaryDifferenceCountsCompare` struct

### DIFF
--- a/backend/src/summary/mod.rs
+++ b/backend/src/summary/mod.rs
@@ -154,26 +154,6 @@ impl ElectionSummary {
 /// Contains a summary of the differences, containing which polling stations had differences.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-pub struct SummaryDifferenceCountsCompareVotesCastAdmittedVoters {
-    pub admitted_voters_equal_votes_cast: bool,
-    pub votes_cast_greater_than_admitted_voters: bool,
-    pub votes_cast_smaller_than_admitted_voters: bool,
-}
-
-impl SummaryDifferenceCountsCompareVotesCastAdmittedVoters {
-    /// Initialize a new differences count with all counts set to zero.
-    pub fn zero() -> SummaryDifferenceCountsCompareVotesCastAdmittedVoters {
-        SummaryDifferenceCountsCompareVotesCastAdmittedVoters {
-            admitted_voters_equal_votes_cast: Default::default(),
-            votes_cast_greater_than_admitted_voters: Default::default(),
-            votes_cast_smaller_than_admitted_voters: Default::default(),
-        }
-    }
-}
-
-/// Contains a summary of the differences, containing which polling stations had differences.
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
 pub struct SummaryDifferencesCounts {
     pub more_ballots_count: SumCount,
     pub fewer_ballots_count: SumCount,


### PR DESCRIPTION
Remove the `SummaryDifferenceCountsCompare` struct that was unused after (but not removed in) #2072.