### PR TITLE
Add warning when uploading polling stations with mismatching election id

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4831,6 +4831,9 @@
             "format": "int32",
             "minimum": 0
           },
+          "polling_station_definition_matches_election": {
+            "type": "boolean"
+          },
           "polling_stations": {
             "type": "array",
             "items": {

--- a/backend/src/election/api.rs
+++ b/backend/src/election/api.rs
@@ -156,6 +156,11 @@ pub struct ElectionDefinitionValidateResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     polling_stations: Option<Vec<PollingStationRequest>>,
+
+    #[schema(nullable = false)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub polling_station_definition_matches_election: Option<bool>,
+
     number_of_voters: u32,
 }
 
@@ -205,6 +210,7 @@ pub async fn election_import_validate(
 
     // parse and validate polling stations, and update number of voters
     let polling_stations;
+    let mut polling_station_definition_matches_election = None;
     let mut number_of_voters = 0;
     if let Some(data) = edu.polling_station_data {
         // If polling stations are submitted, file name must be also
@@ -214,6 +220,8 @@ pub async fn election_import_validate(
 
         polling_stations = Some(EML110::from_str(&data)?.get_polling_stations()?);
         number_of_voters = EML110::from_str(&data)?.get_number_of_voters()?;
+        polling_station_definition_matches_election =
+            Some(EML110::from_str(&data)?.polling_station_definition_matches_election(&election)?);
     } else {
         polling_stations = None;
     }
@@ -228,6 +236,7 @@ pub async fn election_import_validate(
         election,
         polling_stations,
         number_of_voters,
+        polling_station_definition_matches_election,
     }))
 }
 

--- a/backend/src/eml/eml_110.rs
+++ b/backend/src/eml/eml_110.rs
@@ -234,6 +234,22 @@ impl EML110 {
         Ok(number_of_voters)
     }
 
+    ///
+    /// Check if the election id from the polling stations file matches the election
+    /// Note: this is optional and should not return an error
+    ///
+    pub fn polling_station_definition_matches_election(
+        &self,
+        election: &crate::election::NewElection,
+    ) -> std::result::Result<bool, EMLImportError> {
+        // we need to be importing from a 110b file
+        if self.base.id != "110b" {
+            return Err(EMLImportError::Needs110b);
+        }
+
+        Ok(election.election_id == self.election_identifier().id)
+    }
+
     pub fn definition_from_abacus_election(
         election: &crate::election::ElectionWithPoliticalGroups,
         transaction_id: &str,

--- a/backend/src/eml/tests/eml110b_not_matching_election_id.eml.xml
+++ b/backend/src/eml/tests/eml110b_not_matching_election_id.eml.xml
@@ -10,13 +10,11 @@
   <ElectionEvent>
     <EventIdentifier/>
     <Election>
-      <ElectionIdentifier Id="GR2022_Test">
-        <ElectionName>Gemeenteraad Test 2022</ElectionName>
-        <ElectionCategory>GR</ElectionCategory>
-        <kr:ElectionSubcategory>GR2</kr:ElectionSubcategory>
-        <kr:ElectionDomain Id="0000">Test</kr:ElectionDomain>
-        <kr:ElectionDate>2022-03-16</kr:ElectionDate>
-        <kr:NominationDate>2022-01-31</kr:NominationDate>
+      <ElectionIdentifier Id="EP2024">
+        <ElectionName>Europees Parlement 2024</ElectionName>
+        <ElectionCategory>EP</ElectionCategory>
+        <kr:ElectionSubcategory>EP</kr:ElectionSubcategory>
+        <kr:ElectionDate>2024-06-06</kr:ElectionDate>
       </ElectionIdentifier>
       <Contest>
         <ContestIdentifier Id="geen"/>

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use abacus::election::ElectionDefinitionValidateResponse;
 use abacus::{
     committee_session::status::CommitteeSessionStatus, election::ElectionWithPoliticalGroups,
 };
@@ -598,6 +599,50 @@ async fn test_election_import_missing_file_name(pool: SqlitePool) {
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_election_polling_stations_not_matching_election(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let admin_cookie = shared::admin_login(&addr).await;
+    let url = format!("http://{addr}/api/elections/import/validate");
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+          "election_hash": [
+                "4291", "a4e7", "c76e", "ed19",
+                "476b", "ae90", "3882", "c2dc",
+                "9162", "1950", "0e13", "0651",
+                "34ff", "c0de", "340a", "4a38"
+          ],
+          "election_data": include_str!("../src/eml/tests/eml110a_test.eml.xml"),
+            "candidate_hash": [
+                "146d", "3784", "efa2", "93b5",
+                "721a", "7578", "a43f", "0636",
+                "7281", "66a0", "acf1", "55d3",
+                "ab25", "083c", "c000", "7096"
+            ],
+            "candidate_data": include_str!("../src/eml/tests/eml230b_test.eml.xml"),
+            "polling_station_data": include_str!("../src/eml/tests/eml110b_not_matching_election_id.eml.xml"),
+            "polling_station_file_name": "eml110b_not_matching_election_id.eml.xml",
+            "number_of_voters": 1234,
+            "counting_method": "CSO",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .json::<ElectionDefinitionValidateResponse>()
+            .await
+            .unwrap()
+            .polling_station_definition_matches_election,
+        Some(false)
+    );
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
 async fn test_election_polling_stations_validate_valid(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let admin_cookie = shared::admin_login(&addr).await;
@@ -631,6 +676,14 @@ async fn test_election_polling_stations_validate_valid(pool: SqlitePool) {
 
     // Ensure the response is what we expect
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .json::<ElectionDefinitionValidateResponse>()
+            .await
+            .unwrap()
+            .polling_station_definition_matches_election,
+        Some(true)
+    );
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]

--- a/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
@@ -103,5 +103,6 @@ export async function uploadPollingStations(page: Page, eml = eml110b) {
 
   const checkDefinitionPage = new CheckPollingStationDefinitionPgObj(page);
   await expect(checkDefinitionPage.header).toBeVisible();
+  await expect(checkDefinitionPage.warning).toBeHidden();
   await checkDefinitionPage.next.click();
 }

--- a/frontend/e2e-tests/page-objects/election/create/CheckPollingStationDefinitionPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CheckPollingStationDefinitionPgObj.ts
@@ -6,6 +6,7 @@ export class CheckPollingStationDefinitionPgObj {
   readonly next: Locator;
   readonly table: Locator;
   readonly stations: Locator;
+  readonly warning: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Controleer stembureaus" });
@@ -13,5 +14,7 @@ export class CheckPollingStationDefinitionPgObj {
     this.next = page.getByRole("button", { name: "Volgende" });
     this.table = page.getByTestId("overview");
     this.stations = this.table.locator("tbody").getByRole("row");
+    this.showMore = page.getByRole("button", { name: /Toon alle \d+ stembureaus/ });
+    this.warning = page.getByRole("strong").filter({ hasText: "Afwijkende verkiezing" });
   }
 }

--- a/frontend/e2e-tests/test-data/eml-files.ts
+++ b/frontend/e2e-tests/test-data/eml-files.ts
@@ -40,6 +40,11 @@ export const eml110b_single = {
   path: "../backend/src/eml/tests/eml110b_1_station.eml.xml",
 };
 
+export const eml110b_not_matching_election = {
+  filename: "eml110b_not_matching_election_id.eml.xml",
+  path: "../backend/src/eml/tests/eml110b_not_matching_election_id.eml.xml",
+};
+
 export const eml230b = {
   filename: "eml230b_test.eml.xml",
   path: "../backend/src/eml/tests/eml230b_test.eml.xml",

--- a/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
@@ -36,6 +36,7 @@ export type ElectionCreateAction =
       response: ElectionDefinitionValidateResponse;
       pollingStationDefinitionData: string;
       pollingStationDefinitionFileName: string;
+      pollingStationDefinitionMatchesElection?: boolean;
     }
   | {
       type: "SET_COUNTING_METHOD_TYPE";
@@ -60,6 +61,7 @@ export interface ElectionCreateState {
   candidateDefinitionRedactedHash?: RedactedEmlHash;
   pollingStationDefinitionData?: string;
   pollingStationDefinitionFileName?: string;
+  pollingStationDefinitionMatchesElection?: boolean;
   countingMethod?: VoteCountingMethod;
   numberOfVoters?: number;
   isNumberOfVotersUserEdited?: boolean;
@@ -72,6 +74,9 @@ function reducer(state: ElectionCreateState, action: ElectionCreateAction): Elec
         ...state,
         election: action.response.election,
         pollingStations: undefined,
+        pollingStationDefinitionData: undefined,
+        pollingStationDefinitionFileName: undefined,
+        pollingStationDefinitionMatchesElection: undefined,
         electionDefinitionRedactedHash: action.response.hash,
         electionDefinitionData: action.electionDefinitionData,
         electionDefinitionFileName: action.electionDefinitionFileName,
@@ -94,6 +99,9 @@ function reducer(state: ElectionCreateState, action: ElectionCreateAction): Elec
         candidateDefinitionData: action.candidateDefinitionData,
         candidateDefinitionFileName: action.candidateDefinitionFileName,
         candidateDefinitionHash: undefined,
+        pollingStationDefinitionData: undefined,
+        pollingStationDefinitionFileName: undefined,
+        pollingStationDefinitionMatchesElection: undefined,
       };
     case "SET_CANDIDATES_DEFINITION_HASH":
       return {
@@ -106,6 +114,7 @@ function reducer(state: ElectionCreateState, action: ElectionCreateAction): Elec
         pollingStations: action.response.polling_stations,
         pollingStationDefinitionData: action.pollingStationDefinitionData,
         pollingStationDefinitionFileName: action.pollingStationDefinitionFileName,
+        pollingStationDefinitionMatchesElection: action.pollingStationDefinitionMatchesElection,
         numberOfVoters: action.response.number_of_voters,
         isNumberOfVotersUserEdited: false,
       };

--- a/frontend/src/features/election_create/components/UploadPollingStationDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadPollingStationDefinition.tsx
@@ -52,6 +52,7 @@ export function UploadPollingStationDefinition() {
           response: response.data,
           pollingStationDefinitionData: data,
           pollingStationDefinitionFileName: currentFile.name,
+          pollingStationDefinitionMatchesElection: response.data.polling_station_definition_matches_election,
         });
         setError(undefined);
       } else if (isError(response)) {
@@ -91,6 +92,19 @@ export function UploadPollingStationDefinition() {
         <Form title={t("election.polling_stations.check.title")}>
           <FormLayout>
             <FormLayout.Section>
+              {state.pollingStationDefinitionMatchesElection === false && (
+                <Alert
+                  type="warning"
+                  title={t("election.polling_station_definition_does_not_match_election.title")}
+                  inline
+                >
+                  <p>
+                    {tx("election.polling_station_definition_does_not_match_election.description", {
+                      file: () => <strong>{state.pollingStationDefinitionFileName}</strong>,
+                    })}
+                  </p>
+                </Alert>
+              )}
               <p>
                 {tx("election.polling_stations.check.description", {
                   file: () => <strong>{state.pollingStationDefinitionFileName}</strong>,
@@ -121,7 +135,6 @@ export function UploadPollingStationDefinition() {
                 <p>{error}</p>
               </Alert>
             )}
-
             <p>{t("election.use_instructions_to_import_polling_stations_eml")}</p>
             <FileInput id="upload-eml" file={file} onChange={(e) => void onFileChange(e)}>
               {t("select_file")}

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -51,6 +51,11 @@
     "file_too_large": "Het bestand <file>filename</file> is te groot. Kies een bestand van maximaal {max_size} Megabyte.",
     "title": "Ongeldig stembureaubestand"
   },
+
+  "polling_station_definition_does_not_match_election": {
+    "title": "Afwijkende verkiezing",
+    "description": "Het bestand <file>filename</file> bevat stembureaus voor een andere verkiezing. Controleer voor je verder gaat of de stembureaus juist zijn."
+  },
   "level_polling_station": "Niveau stembureau",
   "location": "Gebied",
   "manage": "Verkiezingen beheren",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -630,6 +630,7 @@ export interface ElectionDefinitionValidateResponse {
   election: NewElection;
   hash: RedactedEmlHash;
   number_of_voters: number;
+  polling_station_definition_matches_election?: boolean;
   polling_stations?: PollingStationRequest[];
 }
 


### PR DESCRIPTION
While creating a new election, uploadind a polling station file with a different election id should show a warning.

The warning currently looks like this:
<img width="1092" height="565" alt="Screenshot_2025-09-09_09-18-09" src="https://github.com/user-attachments/assets/91c82c0c-63b6-4217-b490-460df11e7ac8" />

To test:

- Create a new election
- Upload a new election and candidates
- For the polling station, upload eml110b_not_matching_election_id.eml.xml
- The warning should be present

Closes https://github.com/kiesraad/abacus/issues/2111