### PR TITLE
use cases: create new session before preparing session

### DIFF
--- a/documentatie/use-cases/gsb-tweede-zitting.md
+++ b/documentatie/use-cases/gsb-tweede-zitting.md
@@ -10,35 +10,36 @@ __Niveau:__ hoog-over, wolk, ☁️
 
 __Hoofdscenario:__  
 1. Het GSB ontvangt één of meerdere verzoeken tot onderzoek/hertelling van het CSB.
-2. [De coördinator GSB bereidt de documenten voor de zitting voor.](#de-coördinator-gsb-bereidt-de-documenten-voor-de-zitting-voor-zee)
-3. Het GSB opent de zitting. (Wanneer dat gebeurt is een afweging van het GSB: liefst pas als alle verzoeken binnen zijn, maar ook niet te lang wachten)
-4. De coördinator GSB geeft in de applicatie aan dat de zitting is geopend en voert de locatie en starttijd in. Hiermee wordt de vorige zitting in de applicatie gesloten.
-5. (voor elk verzoek) [Het GSB behandelt een verzoek tot onderzoek/hertelling.](#het-gsb-behandelt-een-verzoek-tot-onderzoekhertelling-vlieger)
-6. De coördinator GSB maakt de GSB PVs en het EML_NL-bestand aan: P 2a (verslag tweede zitting), Na 14-2 (corrigendum GSB).
-7. Het GSB voert de andere onderdelen van het GSB-corrigendum in.
-8. Het GSB leest de PV's voor: P 2a (verslag tweede zitting), Na 14-2 (corrigendum GSB), Na 14-1 versie 2 (DSO, één per SB) of Na 14-2 Bijlage 1 (CSO, één bijlage per SB).
-9. Het GSB ondertekent de PV's.
-10. Het GSB sluit de zitting.
-11. Het GSB stelt de benodigde bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
+2. De coördinator GSB maakt de nieuwe zitting aan in de applicate. Hiermee wordt de vorige zitting in de applicatie gesloten.
+3. [De coördinator GSB bereidt de documenten voor de zitting voor.](#de-coördinator-gsb-bereidt-de-documenten-voor-de-zitting-voor-zee)
+4. Het GSB opent de zitting. (Wanneer dat gebeurt is een afweging van het GSB: liefst pas als alle verzoeken binnen zijn, maar ook niet te lang wachten)
+5. De coördinator GSB voert de locatie en starttijd van de zitting in.
+6. (voor elk verzoek) [Het GSB behandelt een verzoek tot onderzoek/hertelling.](#het-gsb-behandelt-een-verzoek-tot-onderzoekhertelling-vlieger)
+7. De coördinator GSB maakt de GSB PVs en het EML_NL-bestand aan: P 2a (verslag tweede zitting), Na 14-2 (corrigendum GSB).
+8. Het GSB voert de andere onderdelen van het GSB-corrigendum in.
+9. Het GSB leest de PV's voor: P 2a (verslag tweede zitting), Na 14-2 (corrigendum GSB), Na 14-1 versie 2 (DSO, één per SB) of Na 14-2 Bijlage 1 (CSO, één bijlage per SB).
+10. Het GSB ondertekent de PV's.
+11. Het GSB sluit de zitting.
+12. Het GSB stelt de benodigde bestanden beschikbaar aan het CSB voor de uitslagvaststelling.
 
 __Uitbreidingen:__
 
-3a. Er is al een open zitting:  
-&emsp; 3a1. De applicatie opent geen nieuwe zitting.
+2a. Er is al een open zitting:  
+&emsp; 2a1. De applicatie opent geen nieuwe zitting.
 
-3b. De coördinator GSB opent per ongeluk de zitting in de applicatie:  
-&emsp; 3b1. De coördinator GSB verwijdert de geopende zitting.  
-&emsp;&emsp; 3b1a. Er is al invoer voor de geopende zitting:  
-&emsp;&emsp;&emsp; 3b1a1. De applicatie verwijdert de geopende zitting niet.
+2b. De coördinator GSB opent per ongeluk de zitting in de applicatie:  
+&emsp; 2b1. De coördinator GSB verwijdert de geopende zitting.  
+&emsp;&emsp; 2b1a. Er is al invoer voor de geopende zitting:  
+&emsp;&emsp;&emsp; 2b1a1. De applicatie verwijdert de geopende zitting niet.
 
-3c. Er is geen eerste zitting in de applicatie:  
-&emsp; 3c1. De coördinator importeert het EML_NL bestand van de eerste zitting.
+2c. Er is geen eerste zitting in de applicatie:  
+&emsp; 2c1. De coördinator importeert het EML_NL bestand van de eerste zitting.
 
 4-7a. Het GSB schorst de zitting, omdat er mogelijk nog een verzoek komt:
 
-7a. Het GSB stelt een probleem vast met het PV:  
-&emsp; 7a1. Het GSB stelt het bezwaar vast.  
-&emsp; 7a2. Het GSB gaat over tot hertelling.
+9a. Het GSB stelt een probleem vast met het PV:  
+&emsp; 9a1. Het GSB stelt het bezwaar vast.  
+&emsp; 9a2. Het GSB gaat over tot hertelling.
 
 ## De coördinator GSB bereidt de documenten voor de zitting voor (zee)
 


### PR DESCRIPTION
relates to https://github.com/kiesraad/abacus/issues/1997

The coordinator needs to create the new session before they can create the 'empty' corrigendums. That was not what the use cases said, so I fixed it.


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->