### PR TITLE
Bugfix: numbers were not formatted when coming back to data entry section

### DIFF
--- a/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
@@ -42,7 +42,7 @@ export const DefaultGrid: StoryObj<Props> = {
             id="input1"
             field="A"
             title="Input field 1"
-            defaultValue={1}
+            value={1}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -50,7 +50,7 @@ export const DefaultGrid: StoryObj<Props> = {
             id="input2"
             field="B"
             title="Input field 2 (Error)"
-            defaultValue={2}
+            value={2}
             errorsAndWarnings={errorsAndWarnings}
             addSeparator={addSeparator}
           />
@@ -59,7 +59,7 @@ export const DefaultGrid: StoryObj<Props> = {
             id="input3"
             field="C"
             title="Input field 3 (Warning)"
-            defaultValue={3}
+            value={3}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -67,7 +67,7 @@ export const DefaultGrid: StoryObj<Props> = {
             id="total"
             field="D"
             title="Total of all inputs"
-            defaultValue={6}
+            value={6}
             isTotal={isTotal}
             errorsAndWarnings={errorsAndWarnings}
           />
@@ -109,7 +109,7 @@ export const CandidatesGrid: StoryObj<Props> = {
             id="zebra1"
             field="1"
             title="Jacobse, F."
-            defaultValue={1}
+            value={1}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -117,7 +117,7 @@ export const CandidatesGrid: StoryObj<Props> = {
             id="zebra2"
             field="2"
             title="Van Es, T.J. (Error)"
-            defaultValue={2}
+            value={2}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -125,7 +125,7 @@ export const CandidatesGrid: StoryObj<Props> = {
             id="zebra3"
             field="3"
             title="Van Es, K."
-            defaultValue={3}
+            value={3}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -133,7 +133,7 @@ export const CandidatesGrid: StoryObj<Props> = {
             id="zebra4"
             field="4"
             title="Van Yvonne, T. (Warning)"
-            defaultValue={4}
+            value={4}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -141,7 +141,7 @@ export const CandidatesGrid: StoryObj<Props> = {
             id="zebra5"
             field="5"
             title="Van Yvonne, W. (Error)"
-            defaultValue={5}
+            value={5}
             errorsAndWarnings={errorsAndWarnings}
           />
           <InputGridRow
@@ -149,7 +149,7 @@ export const CandidatesGrid: StoryObj<Props> = {
             id="zebra-list-total"
             field=""
             title="List Total"
-            defaultValue={15}
+            value={15}
             isListTotal={isListTotal}
             errorsAndWarnings={errorsAndWarnings}
           />

--- a/frontend/src/components/ui/InputGrid/InputGridRow.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGridRow.tsx
@@ -14,7 +14,6 @@ export interface InputGridRowProps {
   errorsAndWarnings?: Map<string, "error" | "warning">;
   warningsAccepted?: boolean;
   name?: string;
-  defaultValue?: string | number;
   isTotal?: boolean;
   isListTotal?: boolean;
   errorMessageId?: string;
@@ -31,7 +30,6 @@ export function InputGridRow({
   title,
   errorsAndWarnings,
   warningsAccepted,
-  defaultValue,
   isTotal,
   isListTotal,
   id,
@@ -68,13 +66,12 @@ export function InputGridRow({
     <td key={`value-${id}`} id={`value-${id}`} className={cn(cls.value, readOnly && cls.readOnly)}>
       <FormField hasError={!!errorMessageId || hasError} hasWarning={hasWarning}>
         {readOnly ? (
-          <span className="font-number">{value !== undefined ? value : defaultValue}</span>
+          <span className="font-number">{value}</span>
         ) : (
           <NumberInput
             key={id}
             id={id}
             name={name || id}
-            defaultValue={defaultValue}
             autoFocus={autoFocusInput}
             value={value}
             onChange={onChange}

--- a/frontend/src/components/ui/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/ui/NumberInput/NumberInput.test.tsx
@@ -11,8 +11,14 @@ describe("UI Component: number input", () => {
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  test("should format the number", () => {
+  test("should format the number from defaultValue", () => {
     render(<NumberInput id="test" defaultValue={1200} />);
+    const formattedOverlay = screen.getByTestId("test-formatted-overlay");
+    expect(formattedOverlay).toHaveTextContent("1.200");
+  });
+
+  test("should format the number from value", () => {
+    render(<NumberInput id="test" value={1200} />);
     const formattedOverlay = screen.getByTestId("test-formatted-overlay");
     expect(formattedOverlay).toHaveTextContent("1.200");
   });

--- a/frontend/src/components/ui/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/ui/NumberInput/NumberInput.tsx
@@ -28,7 +28,7 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
 ) {
   const [tooltipInvalidValue, setTooltipInvalidValue] = React.useState<string | null>(null);
   const [formattedOverlay, setFormattedOverlay] = React.useState<string | undefined>(
-    inputProps.defaultValue ? formatNumber(inputProps.defaultValue) : "",
+    formatNumber(inputProps.value !== undefined ? inputProps.value : inputProps.defaultValue),
   );
 
   const props = {


### PR DESCRIPTION
Fixes a bug that when you've entered big numbers in data entry, the numbers are not formatted when going back to that section. This was because the `NumberFormat` component only formatted the `defaultValue` prop initially, and the data entry uses the `value` prop.

- Change `NumberInput` to handle both `value` and `defaultValue`
- Use `value` in the `InputGrid` Stories which is how it is used in the application
- Remove the possibility to accidentally use `defaultValue` for `InputGrid`, as it is used as a controlled component since the refactoring to state reducer.


<img width="993" height="401" alt="image" src="https://github.com/user-attachments/assets/3007b8b2-2d9c-47ab-ac73-0ad941be0ab3" />
