### PR TITLE
Bugfix: StickyNav behaviour

### DIFF
--- a/frontend/src/components/ui/AppLayout/StickyNav.tsx
+++ b/frontend/src/components/ui/AppLayout/StickyNav.tsx
@@ -14,7 +14,8 @@ export function StickyNav({ children }: StickyNavProps) {
     if (nav) {
       const updateTopOffset = () => {
         const navTop = nav.getBoundingClientRect().top;
-        nav.style.setProperty("--sticky-nav-top-offset", `${navTop}px`);
+        nav.style.setProperty("--sticky-nav-top-offset", `${Math.max(0, navTop)}px`);
+        nav.style.paddingTop = navTop < 0 ? `${-navTop}px` : "";
       };
 
       window.addEventListener("resize", updateTopOffset);

--- a/frontend/src/components/ui/ProgressList/ProgressList.module.css
+++ b/frontend/src/components/ui/ProgressList/ProgressList.module.css
@@ -175,6 +175,8 @@ section.scroll {
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  min-height: 12rem;
+
   ul {
     width: 100%;
     flex: 1;


### PR DESCRIPTION
As noticed [here](https://github.com/kiesraad/abacus/pull/2120#issuecomment-3273848104), the StickyNav menu moves upwards when you reach the end of the page (A).

Next to that:
- B: The political group list doesn't have a minimum height
- C: The menu can get cut off (make your viewport 300px height and scroll fully down on a data entry page)
<img width="444" height="288" alt="image" src="https://github.com/user-attachments/assets/ccaa6382-8cb5-477e-9503-76d1b9ea4661" />

This PR fixes issues A + B by:
- Not allowing a negative value to the max-height calculation (`--sticky-nav-top-offset`)
- Adding padding when `<StickyNav>` itself starts to move out of screen (because it is part of `<main>`)
- Setting a min-height for the scrollable ProgressList section

This PR does not fix C. 