### PR TITLE
Input grid previous values

### DIFF
--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.stories.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.stories.tsx
@@ -1,16 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
 import { useArgs } from "storybook/preview-api";
+import { expect } from "storybook/test";
 
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
-import { SectionValues } from "@/types/types";
-import { getDataEntryStructure } from "@/utils/dataEntryStructure";
+import { InputGridSubsection, SectionValues } from "@/types/types";
+import { createVotersAndVotesSection } from "@/utils/dataEntryStructure";
 
 import { InputGridSubsectionComponent } from "./InputGridSubsection";
 
-const inputGridSubsection = getDataEntryStructure("CSOFirstSession", electionMockData)
-  .flatMap((section) => section.subsections)
-  .find((subsection) => subsection.type === "inputGrid")!;
+const inputGridSubsection = createVotersAndVotesSection(electionMockData).subsections[0] as InputGridSubsection;
 
 const meta = {
   component: InputGridSubsectionComponent,
@@ -44,5 +43,53 @@ export const InputGrid: Story = {
     };
 
     return <InputGridSubsectionComponent {...args} currentValues={currentValues} setValues={setValues} />;
+  },
+};
+
+export const InputGridWithPreviousValues: Story = {
+  args: {
+    setValues: () => {},
+    previousValues: {
+      "voters_counts.poll_card_count": "1024",
+      "voters_counts.proxy_certificate_count": "32",
+      "voters_counts.total_admitted_voters_count": "1056",
+      "votes_counts.political_group_total_votes[0].total": "880",
+      "votes_counts.political_group_total_votes[1].total": "121",
+      "votes_counts.total_votes_candidates_count": "1001",
+      "votes_counts.blank_votes_count": "",
+      "votes_counts.invalid_votes_count": "23",
+      "votes_counts.total_votes_cast_count": "1056",
+    },
+  },
+  render: function Render(args) {
+    const [{ currentValues }, updateArgs] = useArgs<{ currentValues: SectionValues }>();
+
+    const setValues = (path: string, value: string) => {
+      action("setValues")(path, value);
+      updateArgs({ currentValues: { ...currentValues, [path]: value } });
+    };
+
+    return (
+      <InputGridSubsectionComponent id="input-grid" {...args} currentValues={currentValues} setValues={setValues} />
+    );
+  },
+  play: async ({ canvas }) => {
+    const table = await canvas.findByTestId("input-grid");
+    await expect(table).toHaveTableContent([
+      ["Veld", "Eerder geteld aantal", "Geteld aantal", "Omschrijving"],
+      ["A", "1.024", "", "Stempassen"],
+      ["B", "32", "", "Volmachtbewijzen"],
+      [""],
+      ["D", "1.056", "", "Totaal toegelaten kiezers"],
+      [""],
+      ["E.1", "880", "", "Totaal Lijst 1 - Vurige Vleugels Partij"],
+      ["E.2", "121", "", "Totaal Lijst 2 - Wijzen van Water en Wind"],
+      [""],
+      ["E", "1.001", "", "Totaal stemmen op kandidaten"],
+      ["F", "", "", "Blanco stemmen"],
+      ["G", "23", "", "Ongeldige stemmen"],
+      [""],
+      ["H", "1.056", "", "Totaal uitgebrachte stemmen"],
+    ]);
   },
 };

--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
@@ -1,9 +1,12 @@
 import { InputGrid } from "@/components/ui/InputGrid/InputGrid";
 import { InputGridRow } from "@/components/ui/InputGrid/InputGridRow";
+import { t } from "@/i18n/translate";
 import { InputGridSubsection, InputGridSubsectionRow, SectionValues } from "@/types/types";
 
 export interface InputGridSubsectionProps {
+  id?: string;
   subsection: InputGridSubsection;
+  previousValues?: SectionValues;
   currentValues: SectionValues;
   setValues: (path: string, value: string) => void;
   defaultProps: {
@@ -15,7 +18,9 @@ export interface InputGridSubsectionProps {
 }
 
 export function InputGridSubsectionComponent({
+  id,
   subsection,
+  previousValues,
   currentValues,
   setValues,
   defaultProps,
@@ -23,8 +28,13 @@ export function InputGridSubsectionComponent({
   readOnly = false,
 }: InputGridSubsectionProps) {
   return (
-    <InputGrid zebra={subsection.zebra}>
-      <InputGrid.Header field={subsection.headers[0]} value={subsection.headers[1]} title={subsection.headers[2]} />
+    <InputGrid id={id} zebra={subsection.zebra}>
+      <InputGrid.Header
+        field={subsection.headers[0]}
+        previous={previousValues && t("data_entry.previous_value")}
+        value={subsection.headers[1]}
+        title={subsection.headers[2]}
+      />
       <InputGrid.Body>
         {subsection.rows.map((row: InputGridSubsectionRow) => (
           <InputGridRow
@@ -32,6 +42,7 @@ export function InputGridSubsectionComponent({
             field={row.code || ""}
             id={`data.${row.path}`}
             title={row.title}
+            previousValue={previousValues?.[row.path]}
             value={currentValues[row.path] || ""}
             onChange={(e) => {
               setValues(row.path, e.target.value);

--- a/frontend/src/components/ui/InputGrid/InputGrid.module.css
+++ b/frontend/src/components/ui/InputGrid/InputGrid.module.css
@@ -40,6 +40,22 @@
         font-weight: bold;
       }
 
+      &.previous {
+        width: 13rem;
+        border-right: 1px solid var(--bg-gray-darkest);
+        text-align: right;
+        padding: 1rem 1.5rem;
+        font-weight: bold;
+        font-size: var(--font-size-lg);
+        color: var(--gray-600);
+
+        &.corrected {
+          color: var(--gray-500);
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cline x1='0' y1='0' x2='100' y2='100' stroke='%23D0D5DD' /%3E%3Cline x1='0' y1='100' x2='100' y2='0' stroke='%23D0D5DD' /%3E%3C/svg%3E");
+          background-size: 100% 100%;
+        }
+      }
+
       &.value {
         width: 13rem;
         border-right: 1px solid var(--bg-gray-darkest);
@@ -48,7 +64,6 @@
         input {
           width: 100%;
           height: 4.5rem;
-          border: 2px solid transparent;
           &:focus,
           &:focus-visible {
             outline: none;
@@ -59,6 +74,7 @@
         input,
         :global(.formatted-overlay) {
           text-align: right;
+          border: 2px solid transparent;
           padding: 1rem 1.5rem;
           font-size: var(--font-size-lg);
           font-style: normal;
@@ -66,6 +82,13 @@
 
         :global(.formatted-overlay) {
           color: var(--gray-600);
+          /* Cover whole input for the background color */
+          inset: 0;
+        }
+
+        &.corrected :global(.formatted-overlay) {
+          color: black;
+          background-color: var(--color-success-bg);
         }
 
         &.readOnly span {

--- a/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.stories.tsx
@@ -159,6 +159,70 @@ export const CandidatesGrid: StoryObj<Props> = {
   },
 };
 
+export const GridWithPreviousValues: StoryObj<Props> = {
+  args: {
+    readOnly: false,
+    zebra: false,
+    addSeparator: false,
+    isTotal: true,
+  },
+  render: ({ readOnly, zebra, addSeparator, isTotal }) => {
+    const errorsAndWarnings = createErrorsAndWarnings();
+
+    return (
+      <InputGrid zebra={zebra}>
+        <InputGrid.Header field="Veld" previous="Vorig aantal" value="Geteld aantal" title="Omschrijving" />
+        <InputGrid.Body>
+          <InputGridRow
+            readOnly={readOnly}
+            id="input1"
+            field="A"
+            title="Input field 1"
+            previousValue={"1111"}
+            value={""}
+            errorsAndWarnings={errorsAndWarnings}
+          />
+          <InputGridRow
+            readOnly={readOnly}
+            id="input2"
+            field="B"
+            title="Input field 2 (Error)"
+            previousValue={"12"}
+            value={"0"}
+            errorsAndWarnings={errorsAndWarnings}
+            addSeparator={addSeparator}
+          />
+          <InputGridRow
+            readOnly={readOnly}
+            id="input3"
+            field="C"
+            title="Input field 3 (Warning)"
+            previousValue={"13"}
+            value={"1010"}
+            errorsAndWarnings={errorsAndWarnings}
+          />
+          <InputGridRow
+            readOnly={readOnly}
+            id="total"
+            field="D"
+            title="Total of all inputs"
+            previousValue={"36"}
+            value={""}
+            isTotal={isTotal}
+            errorsAndWarnings={errorsAndWarnings}
+          />
+        </InputGrid.Body>
+      </InputGrid>
+    );
+  },
+
+  play: async ({ canvasElement }) => {
+    // Test that the grid table is visible - table has role="none" so use querySelector
+    const grid = canvasElement.querySelector("table");
+    await expect(grid).toBeVisible();
+  },
+};
+
 export default {
   argTypes: {
     readOnly: {

--- a/frontend/src/components/ui/InputGrid/InputGrid.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGrid.tsx
@@ -4,38 +4,48 @@ import { cn } from "@/utils/classnames";
 
 import cls from "./InputGrid.module.css";
 
-export type InputGridRowCells = [ReactNode, ReactNode, ReactNode];
-
 export interface InputGridProps {
+  id?: string;
   zebra?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-export function InputGrid({ zebra, children }: InputGridProps) {
+export function InputGrid({ id, zebra, children }: InputGridProps) {
   const ref = useRef<HTMLTableElement>(null);
 
   return (
-    <table role="none" ref={ref} className={cn(cls.inputGrid, zebra && cls.zebra)}>
+    <table id={id} role="none" ref={ref} className={cn(cls.inputGrid, zebra && cls.zebra)}>
       {children}
     </table>
   );
 }
 
-InputGrid.Header = ({ field, value, title }: { field: string; value: string; title: string }) => (
+InputGrid.Header = ({
+  field,
+  previous,
+  value,
+  title,
+}: {
+  field: string;
+  previous?: string;
+  value: string;
+  title: string;
+}) => (
   <thead>
     <tr>
       <th className={cls.field}>{field}</th>
+      {previous && <th className={cls.previous}>{previous}</th>}
       <th className={cls.value}>{value}</th>
       <th className={cls.title}>{title}</th>
     </tr>
   </thead>
 );
 
-InputGrid.Body = ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>;
+InputGrid.Body = ({ children }: { children: ReactNode }) => <tbody>{children}</tbody>;
 
-InputGrid.Separator = () => (
+InputGrid.Separator = ({ showPrevious }: { showPrevious?: boolean }) => (
   <tr className={cls.separator}>
-    <td colSpan={3} />
+    <td colSpan={showPrevious ? 4 : 3} />
   </tr>
 );
 
@@ -44,24 +54,35 @@ InputGrid.Row = ({
   isTotal,
   addSeparator,
   id,
+  showPrevious,
 }: {
-  children: InputGridRowCells;
+  children: ReactNode;
   isTotal?: boolean;
   addSeparator?: boolean;
   id?: string;
+  showPrevious?: boolean;
 }) => (
   <>
     <tr className={cn(isTotal && cls.total)} id={`row-${id}`}>
       {children}
     </tr>
-    {addSeparator && <InputGrid.Separator />}
+    {addSeparator && <InputGrid.Separator showPrevious={showPrevious} />}
   </>
 );
 
-InputGrid.ListTotal = ({ children, id }: { children: InputGridRowCells; id?: string }) => (
+InputGrid.ListTotal = ({
+  children,
+  id,
+  showPrevious,
+}: {
+  children: ReactNode;
+  id?: string;
+  showPrevious?: boolean;
+}) => (
   <>
     <tr className={cls.totalSeparator}>
       <td className={cls.field}></td>
+      {showPrevious && <td className={cls.previous}></td>}
       <td className={cls.value}></td>
       <td className={cls.title}></td>
     </tr>

--- a/frontend/src/components/ui/InputGrid/InputGridRow.tsx
+++ b/frontend/src/components/ui/InputGrid/InputGridRow.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
+import { ReactNode } from "react";
 
 import { cn } from "@/utils/classnames";
+import { formatNumber } from "@/utils/number";
 
 import { FormField } from "../FormField/FormField";
 import { NumberInput } from "../NumberInput/NumberInput";
-import { InputGrid, InputGridRowCells } from "./InputGrid";
+import { InputGrid } from "./InputGrid";
 import cls from "./InputGrid.module.css";
 
 export interface InputGridRowProps {
@@ -14,6 +16,7 @@ export interface InputGridRowProps {
   errorsAndWarnings?: Map<string, "error" | "warning">;
   warningsAccepted?: boolean;
   name?: string;
+  previousValue?: string;
   isTotal?: boolean;
   isListTotal?: boolean;
   errorMessageId?: string;
@@ -30,6 +33,7 @@ export function InputGridRow({
   title,
   errorsAndWarnings,
   warningsAccepted,
+  previousValue,
   isTotal,
   isListTotal,
   id,
@@ -43,6 +47,8 @@ export function InputGridRow({
   const hasError = errorsAndWarnings?.get(id) === "error";
   const hasWarning = errorsAndWarnings?.get(id) === "warning";
   const hasUnacceptedWarning = hasWarning && !warningsAccepted;
+  const showPrevious = previousValue !== undefined;
+  const corrected = showPrevious && value !== "";
 
   const errorMessage =
     errorMessageId || (hasError ? "feedback-error" : hasUnacceptedWarning ? "feedback-warning" : undefined);
@@ -59,38 +65,51 @@ export function InputGridRow({
     }
   }, [errorMessageId]);
 
-  const children: InputGridRowCells = [
-    <td key={`field-${id}`} id={`field-${id}`} className={cls.field}>
-      {field}
-    </td>,
-    <td key={`value-${id}`} id={`value-${id}`} className={cn(cls.value, readOnly && cls.readOnly)}>
-      <FormField hasError={!!errorMessageId || hasError} hasWarning={hasWarning}>
-        {readOnly ? (
-          <span className="font-number">{value}</span>
-        ) : (
-          <NumberInput
-            key={id}
-            id={id}
-            name={name || id}
-            autoFocus={autoFocusInput}
-            value={value}
-            onChange={onChange}
-            aria-labelledby={`field-${id} title-${id}`}
-            aria-invalid={errorMessage !== undefined}
-            aria-errormessage={errorMessage}
-            ref={inputRef}
-          />
-        )}
-      </FormField>
-    </td>,
-    <td key={`title-${id}`} id={`title-${id}`} className={cls.title}>
-      {title}
-    </td>,
-  ];
+  const children: ReactNode = (
+    <>
+      <td key={`field-${id}`} id={`field-${id}`} className={cls.field}>
+        {field}
+      </td>
+      {previousValue !== undefined && (
+        <td key={`previous-${id}`} id={`previous-${id}`} className={cn(cls.previous, corrected && cls.corrected)}>
+          {formatNumber(previousValue)}
+        </td>
+      )}
+      <td
+        key={`value-${id}`}
+        id={`value-${id}`}
+        className={cn(cls.value, readOnly && cls.readOnly, corrected && cls.corrected)}
+      >
+        <FormField hasError={!!errorMessageId || hasError} hasWarning={hasWarning}>
+          {readOnly ? (
+            <span className="font-number">{value}</span>
+          ) : (
+            <NumberInput
+              key={id}
+              id={id}
+              name={name || id}
+              autoFocus={autoFocusInput}
+              value={value}
+              onChange={onChange}
+              aria-labelledby={`field-${id} title-${id}`}
+              aria-invalid={errorMessage !== undefined}
+              aria-errormessage={errorMessage}
+              ref={inputRef}
+            />
+          )}
+        </FormField>
+      </td>
+      <td key={`title-${id}`} id={`title-${id}`} className={cls.title}>
+        {title}
+      </td>
+    </>
+  );
   return isListTotal ? (
-    <InputGrid.ListTotal id={id}>{children}</InputGrid.ListTotal>
+    <InputGrid.ListTotal id={id} showPrevious={showPrevious}>
+      {children}
+    </InputGrid.ListTotal>
   ) : (
-    <InputGrid.Row isTotal={isTotal} addSeparator={addSeparator} id={id}>
+    <InputGrid.Row isTotal={isTotal} addSeparator={addSeparator} id={id} showPrevious={showPrevious}>
       {children}
     </InputGrid.Row>
   );

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.stories.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesTables.stories.tsx
@@ -6,6 +6,7 @@ import { ResolveDifferencesAction } from "@/types/generated/openapi";
 import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 
 import { pollingStationResultsMockData } from "../testing/polling-station-results";
+import cls from "./ResolveDifferences.module.css";
 import { ResolveDifferencesTables } from "./ResolveDifferencesTables";
 
 type Props = {
@@ -20,13 +21,13 @@ const structure = getDataEntryStructure("CSOFirstSession", electionMockData);
 export const DefaultResolveDifferencesTables: StoryObj<Props> = {
   render: ({ action }) => {
     return (
-      <>
+      <main className={cls.resolveDifferences}>
         <Alert type="notify" small>
           <p>Previewing the result of an action can be seen using the Controls below</p>
         </Alert>
 
         <ResolveDifferencesTables first={first} second={second} action={action} structure={structure} />
-      </>
+      </main>
     );
   },
 };

--- a/frontend/src/i18n/locales/nl/data_entry.json
+++ b/frontend/src/i18n/locales/nl/data_entry.json
@@ -26,6 +26,7 @@
   "list": {
     "not_found": "Geen lijst gevonden voor {listNumber}"
   },
+  "previous_value": "Eerder geteld aantal",
   "pick_polling_station": "Kies een stembureau",
   "second_entry": "2e invoer",
   "success": {


### PR DESCRIPTION
- Part of https://github.com/kiesraad/abacus/issues/2051
- Add previous values column to `InputGrid`, if there are previous values
- Show styling if the previous value is corrected by entering a new value according to [Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=10924-5084&m=dev)
- Add previous values property to `InputGridSubsection`
- Add Storybook stories and tests
- Fix ResolveDifferencesTables styling in storybook broken in https://github.com/kiesraad/abacus/pull/1898

To test:
- check Storybook