### PR TITLE
Show and save data entry with corrections if previousResults is set

### DIFF
--- a/frontend/src/components/data_entry/DataEntrySubsections.tsx
+++ b/frontend/src/components/data_entry/DataEntrySubsections.tsx
@@ -7,6 +7,7 @@ import { DataEntrySection, SectionValues } from "@/types/types";
 
 export interface DataEntrySubsectionsProps {
   section: DataEntrySection;
+  previousValues?: SectionValues;
   currentValues: SectionValues;
   setValues: (path: string, value: string) => void;
   defaultProps: {
@@ -19,6 +20,7 @@ export interface DataEntrySubsectionsProps {
 
 export function DataEntrySubsections({
   section,
+  previousValues,
   currentValues,
   setValues,
   defaultProps,
@@ -49,6 +51,7 @@ export function DataEntrySubsections({
               <InputGridSubsectionComponent
                 key={`input-grid-${subsectionIdx}`}
                 subsection={subsection}
+                previousValues={previousValues}
                 currentValues={currentValues}
                 setValues={setValues}
                 defaultProps={defaultProps}

--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.stories.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.stories.tsx
@@ -76,7 +76,7 @@ export const InputGridWithPreviousValues: Story = {
   play: async ({ canvas }) => {
     const table = await canvas.findByTestId("input-grid");
     await expect(table).toHaveTableContent([
-      ["Veld", "Eerder geteld aantal", "Geteld aantal", "Omschrijving"],
+      ["Veld", "Oorspronkelijk", "Gecorrigeerd", "Omschrijving"],
       ["A", "1.024", "", "Stempassen"],
       ["B", "32", "", "Volmachtbewijzen"],
       [""],

--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
@@ -44,8 +44,8 @@ export function InputGridSubsectionComponent({
     <InputGrid id={id} zebra={subsection.zebra}>
       <InputGrid.Header
         field={subsection.headers[0]}
-        previous={previousValues && t("data_entry.previous_value")}
-        value={subsection.headers[1]}
+        previous={previousValues && t("data_entry.original")}
+        value={previousValues ? t("data_entry.corrected") : subsection.headers[1]}
         title={subsection.headers[2]}
       />
       <InputGrid.Body>

--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
@@ -2,6 +2,7 @@ import { InputGrid } from "@/components/ui/InputGrid/InputGrid";
 import { InputGridRow } from "@/components/ui/InputGrid/InputGridRow";
 import { t } from "@/i18n/translate";
 import { InputGridSubsection, InputGridSubsectionRow, SectionValues } from "@/types/types";
+import { correctedValue, determineCorrections } from "@/utils/dataEntryMapping";
 
 export interface InputGridSubsectionProps {
   id?: string;
@@ -27,6 +28,12 @@ export function InputGridSubsectionComponent({
   missingTotalError,
   readOnly = false,
 }: InputGridSubsectionProps) {
+  const values = previousValues ? determineCorrections(previousValues, currentValues) : currentValues;
+
+  function handleChange(path: string, value: string) {
+    setValues(path, previousValues ? correctedValue(previousValues[path], value) : value);
+  }
+
   return (
     <InputGrid id={id} zebra={subsection.zebra}>
       <InputGrid.Header
@@ -43,9 +50,9 @@ export function InputGridSubsectionComponent({
             id={`data.${row.path}`}
             title={row.title}
             previousValue={previousValues?.[row.path]}
-            value={currentValues[row.path] || ""}
+            value={values[row.path] || ""}
             onChange={(e) => {
-              setValues(row.path, e.target.value);
+              handleChange(row.path, e.target.value);
             }}
             autoFocusInput={row.autoFocusInput}
             addSeparator={row.addSeparator}

--- a/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/InputGridSubsection.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { InputGrid } from "@/components/ui/InputGrid/InputGrid";
 import { InputGridRow } from "@/components/ui/InputGrid/InputGridRow";
 import { t } from "@/i18n/translate";
@@ -28,9 +30,13 @@ export function InputGridSubsectionComponent({
   missingTotalError,
   readOnly = false,
 }: InputGridSubsectionProps) {
-  const values = previousValues ? determineCorrections(previousValues, currentValues) : currentValues;
+  // When correcting: prevent values that are identical to the previous values to be instantly cleared.
+  const [inputValues, setInputValues] = useState<SectionValues>(() =>
+    previousValues ? determineCorrections(previousValues, currentValues) : currentValues,
+  );
 
   function handleChange(path: string, value: string) {
+    setInputValues({ ...inputValues, [path]: value });
     setValues(path, previousValues ? correctedValue(previousValues[path], value) : value);
   }
 
@@ -50,7 +56,7 @@ export function InputGridSubsectionComponent({
             id={`data.${row.path}`}
             title={row.title}
             previousValue={previousValues?.[row.path]}
-            value={values[row.path] || ""}
+            value={inputValues[row.path] || ""}
             onChange={(e) => {
               handleChange(row.path, e.target.value);
             }}

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -26,6 +26,7 @@ export function DataEntrySection() {
     error,
     formRef,
     onSubmit,
+    previousValues,
     currentValues,
     setValues,
     formSection,
@@ -101,6 +102,7 @@ export function DataEntrySection() {
 
         <DataEntrySubsections
           section={section}
+          previousValues={previousValues}
           currentValues={currentValues}
           setValues={setValues}
           defaultProps={defaultProps}

--- a/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
+++ b/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
@@ -14,6 +14,7 @@ export function useDataEntryFormSection() {
     error,
     cache,
     status,
+    previousResults,
     pollingStationResults,
     dataEntryStructure,
     formState,
@@ -30,6 +31,8 @@ export function useDataEntryFormSection() {
   if (!sectionId || !section) {
     throw new Error(`Form section ${sectionId} not found in data entry structure`);
   }
+
+  const previousValues = previousResults ? mapResultsToSectionValues(section, previousResults) : undefined;
 
   // Local form state
   const [currentValues, setCurrentValues] = React.useState<SectionValues>((): SectionValues => {
@@ -92,6 +95,7 @@ export function useDataEntryFormSection() {
     error,
     formRef,
     onSubmit,
+    previousValues,
     pollingStationResults,
     currentValues,
     dataEntryStructure,

--- a/frontend/src/features/data_entry/testing/mock-data.ts
+++ b/frontend/src/features/data_entry/testing/mock-data.ts
@@ -78,6 +78,7 @@ export function getDefaultDataEntryState(): DataEntryStateLoaded {
     error: null,
     pollingStationResults: getInitialValues(),
     entryNumber: 1,
+    previousResults: null,
     dataEntryStructure: getDataEntryStructure(model, electionMockData),
     formState: {
       furthest: "voters_votes_counts",

--- a/frontend/src/features/data_entry/types/types.ts
+++ b/frontend/src/features/data_entry/types/types.ts
@@ -19,7 +19,8 @@ export interface DataEntryState {
   // api error objects
   error: AnyApiError | null;
 
-  // backend data structure
+  // backend data structures
+  previousResults: DataEntryResults | null;
   pollingStationResults: DataEntryResults | null;
 
   // state of the forms excl. data

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -4,7 +4,6 @@ import { extractFieldInfoFromSection, getValueAtPath } from "@/utils/dataEntryMa
 import { doesValidationResultApplyToSection, ValidationResultSet } from "@/utils/ValidationResults";
 
 import { ClientState, FormSection, FormState } from "../types/types";
-import { INITIAL_FORM_SECTION_ID } from "./reducer";
 
 export function formSectionComplete(section: FormSection): boolean {
   return (
@@ -99,6 +98,11 @@ function createFormSection(id: FormSectionId, index: number): FormSection {
 }
 
 export function getInitialFormState(dataEntryStructure: DataEntryStructure): FormState {
+  const furthest = dataEntryStructure[0]?.id;
+  if (furthest === undefined) {
+    throw new Error("Cannot determine initial furthest section from dataEntryStructure");
+  }
+
   // Create sections from data entry structure plus save section
   const sections: Record<string, FormSection> = {};
 
@@ -108,10 +112,7 @@ export function getInitialFormState(dataEntryStructure: DataEntryStructure): For
 
   sections["save"] = createFormSection("save", dataEntryStructure.length);
 
-  return {
-    furthest: INITIAL_FORM_SECTION_ID,
-    sections: sections,
-  };
+  return { furthest, sections };
 }
 
 export function getClientState(

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -5,8 +5,6 @@ import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 import { ClientState, DataEntryAction, DataEntryState } from "../types/types";
 import { buildFormState, getInitialFormState, getNextSectionID, updateFormStateAfterSubmit } from "./dataEntryUtils";
 
-export const INITIAL_FORM_SECTION_ID = "extra_investigation";
-
 export function getInitialState(
   election: ElectionWithPoliticalGroups,
   pollingStationId: number,
@@ -16,6 +14,7 @@ export function getInitialState(
     election,
     pollingStationId,
     error: null,
+    previousResults: null,
     pollingStationResults: null,
     entryNumber,
     dataEntryStructure: null,
@@ -47,15 +46,21 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
           dataEntryStructure,
           formState,
           targetFormSectionId,
+          previousResults: action.dataEntry.previous_results ?? null,
           pollingStationResults: action.dataEntry.data,
           error: null,
         };
       } else {
+        const targetFormSectionId = dataEntryStructure[0]?.id;
+        if (targetFormSectionId === undefined) {
+          throw new Error("Cannot determine initial section from dataEntryStructure");
+        }
         return {
           ...state,
           dataEntryStructure,
           formState: getInitialFormState(dataEntryStructure),
-          targetFormSectionId: INITIAL_FORM_SECTION_ID,
+          targetFormSectionId,
+          previousResults: action.dataEntry.previous_results ?? null,
           pollingStationResults: action.dataEntry.data,
           error: null,
         };

--- a/frontend/src/i18n/locales/nl/data_entry.json
+++ b/frontend/src/i18n/locales/nl/data_entry.json
@@ -15,6 +15,7 @@
   },
   "continue_after_check": "Je kan alleen verder als je het papieren proces-verbaal hebt gecontroleerd.",
   "continue_with_errors": "Je kan alleen verder als je dit met de coördinator hebt overlegd.",
+  "corrected": "Gecorrigeerd",
   "data_entry_not_possible": "Je kan stembureau {nr} niet invoeren",
   "definitive": "Definitief",
   "entry_different": "Let op: verschil met eerste invoer",
@@ -26,7 +27,7 @@
   "list": {
     "not_found": "Geen lijst gevonden voor {listNumber}"
   },
-  "previous_value": "Eerder geteld aantal",
+  "original": "Oorspronkelijk",
   "pick_polling_station": "Kies een stembureau",
   "second_entry": "2e invoer",
   "success": {

--- a/frontend/src/utils/dataEntryMapping.test.ts
+++ b/frontend/src/utils/dataEntryMapping.test.ts
@@ -4,7 +4,7 @@ import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { PollingStationResults } from "@/types/generated/openapi";
 import { DataEntrySection } from "@/types/types";
 
-import { mapResultsToSectionValues, mapSectionValues } from "./dataEntryMapping";
+import { correctedValue, determineCorrections, mapResultsToSectionValues, mapSectionValues } from "./dataEntryMapping";
 import { createVotersAndVotesSection, differencesSection } from "./dataEntryStructure";
 
 // Helper function to create a base PollingStationResults object for testing
@@ -806,5 +806,37 @@ describe("mapResultsToSectionValues", () => {
     formValues = mapResultsToSectionValues(checkboxesSection, results);
     expect(formValues["test.yes"]).toBe("true");
     expect(formValues["test.no"]).toBe("false");
+  });
+});
+
+describe("correctedValue", () => {
+  test("undefined previousValue return correction", () => {
+    expect(correctedValue(undefined, "10")).toEqual("10");
+  });
+
+  test("empty correction returns previous value", () => {
+    expect(correctedValue("10", "")).toEqual("10");
+  });
+
+  test("empty correction and previous value returns empty", () => {
+    expect(correctedValue("", "")).toEqual("");
+  });
+
+  test("correction not empty return correction", () => {
+    expect(correctedValue("10", "20")).toEqual("20");
+  });
+});
+
+describe("determineCorrections", () => {
+  test("identical previous and current results in empty correction", () => {
+    expect(determineCorrections({ a: "10" }, { a: "10" })).toEqual({ a: "" });
+  });
+
+  test("different previous and current results in correction", () => {
+    expect(determineCorrections({ a: "10" }, { a: "20" })).toEqual({ a: "20" });
+  });
+
+  test("filled previous and empty current results in zero correction", () => {
+    expect(determineCorrections({ a: "10" }, { a: "" })).toEqual({ a: "0" });
   });
 });

--- a/frontend/src/utils/dataEntryMapping.ts
+++ b/frontend/src/utils/dataEntryMapping.ts
@@ -199,3 +199,36 @@ function ensureArrayLength(arr: unknown[], minLength: number): void {
     arr.push({});
   }
 }
+
+/**
+ * Combine the previousValue and correction by returning previousValue if correction is empty and else the correction.
+ * Note that this also returns the correction if it is set to zero.
+ */
+export function correctedValue(previousValue: string | undefined, correction: string): string {
+  if (previousValue === undefined) {
+    return correction;
+  }
+
+  if (correction !== "") {
+    return correction;
+  } else {
+    return previousValue;
+  }
+}
+
+/**
+ * Determine the corrections by comparing previousValues and currentValues.
+ * The correction is set to "", if the current value and the previous value are the same,
+ * and else set to the current value (changing "" into "0").
+ */
+export function determineCorrections(previousValues: SectionValues, currentValues: SectionValues) {
+  const corrections = { ...currentValues };
+  for (const field in previousValues) {
+    if (currentValues[field] === previousValues[field]) {
+      corrections[field] = "";
+    } else if (currentValues[field] === "") {
+      corrections[field] = "0";
+    }
+  }
+  return corrections;
+}


### PR DESCRIPTION
- Resolves https://github.com/kiesraad/abacus/issues/2051
- Resolves https://github.com/kiesraad/abacus/issues/2055
- Add `previousResults` from claim response to data entry reducer state
- Determine and pass on `previousValues` to `InputGridSubsectionComponent`
- Let `InputGridSubsectionComponent` show and save the corrections based on the `previousValues` (saved to backend as consolidated results)
- (extra) do not hard-code `INITIAL_FORM_SECTION_ID` but take the first section of the dataEntryStructure instead

To test:
- Finish a complete first committee session (you could use `full-flow.e2e.ts`)
- (Coordinator) On the election details page, prepare a new session (Nieuwe zitting voorbereiden)
- (Coordinator) On the investigations overview page (Aangevraagde onderzoeken), use the temporary Start button to start data entry
- (Typist) Do the data entry for a next session


Note:
At this moment, the backend claim endpoint returns an empty polling station results as an initial data entry, which causes the input grids to start off with all zeros as corrected values. There will be a future PR where the initial data entry is returned with the previous results for the next session data entry, which will make sure the initial data entry is as expected.