### PR TITLE
Add CSONextSession variant for storing Na 14-2 bijlage 1 results

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4292,6 +4292,38 @@
         },
         "additionalProperties": false
       },
+      "CSONextSessionResults": {
+        "type": "object",
+        "description": "CSONextSessionResults, following the fields in Model Na 14-2 Bijlage 1.\n\nSee \"Model Na 14-2. Corrigendum bij het proces-verbaal van een gemeentelijk stembureau/\nstembureau voor het openbaar lichaam, Bijlage 1: uitkomsten per stembureau\" from the\n[Kiesregeling](https://wetten.overheid.nl/BWBR0034180/2024-04-01#Bijlage1_DivisieNa14.2) or\n[Verkiezingstoolbox](https://www.rijksoverheid.nl/onderwerpen/verkiezingen/verkiezingentoolkit/modellen).",
+        "required": [
+          "voters_counts",
+          "votes_counts",
+          "differences_counts",
+          "political_group_votes"
+        ],
+        "properties": {
+          "differences_counts": {
+            "$ref": "#/components/schemas/DifferencesCounts",
+            "description": "Differences counts (\"Verschil tussen het aantal toegelaten kiezers en het aantal getelde stembiljetten\")"
+          },
+          "political_group_votes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PoliticalGroupCandidateVotes"
+            },
+            "description": "Vote counts per list and candidate (\"Aantal stemmen per lijst en kandidaat\")"
+          },
+          "voters_counts": {
+            "$ref": "#/components/schemas/VotersCounts",
+            "description": "Voters counts (\"Aantal toegelaten kiezers\")"
+          },
+          "votes_counts": {
+            "$ref": "#/components/schemas/VotesCounts",
+            "description": "Votes counts (\"Aantal getelde stembiljetten\")"
+          }
+        },
+        "additionalProperties": false
+      },
       "Candidate": {
         "type": "object",
         "description": "Candidate",
@@ -4406,7 +4438,7 @@
             "$ref": "#/components/schemas/PollingStationResults"
           },
           "previous_results": {
-            "$ref": "#/components/schemas/PollingStationResults"
+            "$ref": "#/components/schemas/CommonPollingStationResults"
           },
           "validation_results": {
             "$ref": "#/components/schemas/ValidationResults"
@@ -4582,6 +4614,38 @@
           },
           "start_time": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CommonPollingStationResults": {
+        "type": "object",
+        "description": "CommonPollingStationResults contains the common fields for polling station results,",
+        "required": [
+          "voters_counts",
+          "votes_counts",
+          "differences_counts",
+          "political_group_votes"
+        ],
+        "properties": {
+          "differences_counts": {
+            "$ref": "#/components/schemas/DifferencesCounts",
+            "description": "Differences counts (\"Verschil tussen het aantal toegelaten kiezers en het aantal getelde stembiljetten\")"
+          },
+          "political_group_votes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PoliticalGroupCandidateVotes"
+            },
+            "description": "Vote counts per list and candidate (\"Aantal stemmen per lijst en kandidaat\")"
+          },
+          "voters_counts": {
+            "$ref": "#/components/schemas/VotersCounts",
+            "description": "Voters counts (\"Aantal toegelaten kiezers\")"
+          },
+          "votes_counts": {
+            "$ref": "#/components/schemas/VotesCounts",
+            "description": "Votes counts (\"Aantal getelde stembiljetten\")"
           }
         },
         "additionalProperties": false
@@ -6274,6 +6338,29 @@
               }
             ],
             "description": "Results for centrally counted (CSO) elections, first election committee session.\nThis contains the data entry values from Model Na 31-2 Bijlage 2."
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CSONextSessionResults",
+                "description": "Results for centrally counted (CSO) elections, any subsequent election committee session.\nThis contains the data entry values from Model Na 14-2 Bijlage 1."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "enum": [
+                      "CSONextSession"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Results for centrally counted (CSO) elections, any subsequent election committee session.\nThis contains the data entry values from Model Na 14-2 Bijlage 1."
           }
         ],
         "description": "PollingStationResults contains the results for a polling station.\n\nThe exact type of results depends on the election counting method and\nwhether this is the first or any subsequent data entry session. Based on\nthis, any of four different models can apply"

--- a/backend/src/apportionment/api.rs
+++ b/backend/src/apportionment/api.rs
@@ -74,12 +74,11 @@ async fn election_apportionment(
             .iter()
             .all(|s| s.status == DataEntryStatusName::Definitive)
     {
-        let results =
-            crate::data_entry::repository::list_entries_with_polling_stations_first_session(
-                &mut conn,
-                current_committee_session.id,
-            )
-            .await?;
+        let results = crate::data_entry::repository::list_entries_for_committee_session(
+            &mut conn,
+            current_committee_session.id,
+        )
+        .await?;
         let election_summary = ElectionSummary::from_results(&election, &results)?;
         let seat_assignment = seat_assignment(election.number_of_seats, &election_summary)?;
         let candidate_nomination = candidate_nomination(

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -210,7 +210,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(export_dir) = args.export_definition {
         let results = if data_entry_completed {
-            abacus::data_entry::repository::list_entries_with_polling_stations_first_session(
+            abacus::data_entry::repository::list_entries_for_committee_session(
                 &mut tx,
                 committee_session.id,
             )
@@ -683,7 +683,7 @@ async fn export_election(
     election: &ElectionWithPoliticalGroups,
     polling_stations: &[PollingStation],
     export_results_json: bool,
-    results: Vec<(PollingStation, CSOFirstSessionResults)>,
+    results: Vec<(PollingStation, PollingStationResults)>,
 ) {
     if export_dir.exists() && !export_dir.is_dir() {
         panic!("Export directory already exists and is not a directory");

--- a/backend/src/committee_session/structs.rs
+++ b/backend/src/committee_session/structs.rs
@@ -32,6 +32,13 @@ pub struct CommitteeSession {
     pub results_pdf: Option<u32>,
 }
 
+impl CommitteeSession {
+    /// Check if this session is the next session to be held
+    pub fn is_next_session(&self) -> bool {
+        self.number > 1
+    }
+}
+
 impl From<CommitteeSession> for audit_log::CommitteeSessionDetails {
     fn from(value: CommitteeSession) -> Self {
         Self {

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -26,9 +26,10 @@ use crate::{
     authentication::{Coordinator, Typist, User},
     committee_session::{CommitteeSession, CommitteeSessionError, status::CommitteeSessionStatus},
     data_entry::{
-        PollingStationResults, VotesCounts, repository::most_recent_results_for_polling_station,
+        CSONextSessionResults, CommonPollingStationResults, PollingStationResults, VotesCounts,
+        repository::most_recent_results_for_polling_station,
     },
-    election::ElectionWithPoliticalGroups,
+    election::{ElectionWithPoliticalGroups, PoliticalGroup},
     error::{ErrorReference, ErrorResponse},
     polling_station::PollingStation,
 };
@@ -65,7 +66,7 @@ pub struct ClaimDataEntryResponse {
     pub validation_results: ValidationResults,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[schema(nullable = false)]
-    pub previous_results: Option<PollingStationResults>,
+    pub previous_results: Option<CommonPollingStationResults>,
 }
 
 pub fn router() -> OpenApiRouter<AppState> {
@@ -113,6 +114,78 @@ fn validate_committee_session_for_typist(
         ));
     }
     Ok(())
+}
+
+fn initial_current_data_entry(
+    user_id: u32,
+    political_groups: &[PoliticalGroup],
+    committee_session: &CommitteeSession,
+    previous_results: Option<&PollingStationResults>,
+) -> CurrentDataEntry {
+    let entry = if committee_session.is_next_session() {
+        if let Some(prev) = previous_results {
+            let mut copy = CSONextSessionResults {
+                voters_counts: prev.voters_counts().clone(),
+                votes_counts: prev.votes_counts().clone(),
+                differences_counts: prev.differences_counts().clone(),
+                political_group_votes: prev.political_group_votes().to_vec(),
+            };
+
+            // clear checkboxes in differences because they always need to be re-entered
+            copy.differences_counts
+                .compare_votes_cast_admitted_voters
+                .admitted_voters_equal_votes_cast = false;
+            copy.differences_counts
+                .compare_votes_cast_admitted_voters
+                .votes_cast_greater_than_admitted_voters = false;
+            copy.differences_counts
+                .compare_votes_cast_admitted_voters
+                .votes_cast_smaller_than_admitted_voters = false;
+            copy.differences_counts
+                .difference_completely_accounted_for
+                .yes = false;
+            copy.differences_counts
+                .difference_completely_accounted_for
+                .no = false;
+
+            PollingStationResults::CSONextSession(copy)
+        } else {
+            PollingStationResults::CSONextSession(CSONextSessionResults {
+                voters_counts: Default::default(),
+                votes_counts: VotesCounts {
+                    political_group_total_votes:
+                        PollingStationResults::default_political_group_total_votes(political_groups),
+                    ..Default::default()
+                },
+                differences_counts: Default::default(),
+                political_group_votes: PollingStationResults::default_political_group_votes(
+                    political_groups,
+                ),
+            })
+        }
+    } else {
+        PollingStationResults::CSOFirstSession(CSOFirstSessionResults {
+            extra_investigation: Default::default(),
+            counting_differences_polling_station: Default::default(),
+            voters_counts: Default::default(),
+            votes_counts: VotesCounts {
+                political_group_total_votes:
+                    PollingStationResults::default_political_group_total_votes(political_groups),
+                ..Default::default()
+            },
+            differences_counts: Default::default(),
+            political_group_votes: PollingStationResults::default_political_group_votes(
+                political_groups,
+            ),
+        })
+    };
+
+    CurrentDataEntry {
+        progress: None,
+        user_id,
+        entry,
+        client_state: None,
+    }
 }
 
 fn validate_committee_session_for_coordinator(
@@ -188,27 +261,18 @@ async fn polling_station_data_entry_claim(
 
     validate_committee_session_for_typist(&committee_session)?;
 
-    let new_data_entry = CurrentDataEntry {
-        progress: None,
-        user_id: user.0.id(),
-        entry: PollingStationResults::CSOFirstSession(CSOFirstSessionResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: Default::default(),
-            voters_counts: Default::default(),
-            votes_counts: VotesCounts {
-                political_group_total_votes:
-                    CSOFirstSessionResults::default_political_group_total_votes(
-                        &election.political_groups,
-                    ),
-                ..Default::default()
-            },
-            differences_counts: Default::default(),
-            political_group_votes: CSOFirstSessionResults::default_political_group_votes(
-                &election.political_groups,
-            ),
-        }),
-        client_state: None,
+    let previous_results = if let Some(id) = polling_station.id_prev_session {
+        most_recent_results_for_polling_station(&mut tx, id).await?
+    } else {
+        None
     };
+
+    let new_data_entry = initial_current_data_entry(
+        user.0.id(),
+        &election.political_groups,
+        &committee_session,
+        previous_results.as_ref(),
+    );
 
     // Transition to the new state
     let new_state = match entry_number {
@@ -244,11 +308,6 @@ async fn polling_station_data_entry_claim(
         .await?;
 
     let client_state = new_state.get_client_state().map(|v| v.to_owned());
-    let previous_results = if let Some(id) = polling_station.id_prev_session {
-        most_recent_results_for_polling_station(&mut tx, id).await?
-    } else {
-        None
-    };
 
     tx.commit().await?;
 
@@ -256,7 +315,7 @@ async fn polling_station_data_entry_claim(
         data: data.clone(),
         client_state,
         validation_results,
-        previous_results,
+        previous_results: previous_results.map(|r| r.as_common()),
     }))
 }
 
@@ -1817,23 +1876,50 @@ mod tests {
         assert!(matches!(status, DataEntryStatus::EntriesDifferent(_)));
     }
 
-    async fn add_results(pool: &SqlitePool, polling_station_id: u32, committee_session_id: u32) {
-        let mut results = CSOFirstSessionResults {
-            extra_investigation: ExtraInvestigation::default(),
-            counting_differences_polling_station: CountingDifferencesPollingStation::default(),
-            voters_counts: VotersCounts::default(),
-            votes_counts: VotesCounts::default(),
-            differences_counts: DifferencesCounts::default(),
-            political_group_votes: vec![],
+    async fn add_results(
+        pool: &SqlitePool,
+        polling_station_id: u32,
+        committee_session_id: u32,
+        political_groups: &[PoliticalGroup],
+        is_first_session: bool,
+    ) {
+        let mut results = if is_first_session {
+            PollingStationResults::CSOFirstSession(CSOFirstSessionResults {
+                extra_investigation: ExtraInvestigation::default(),
+                counting_differences_polling_station: CountingDifferencesPollingStation::default(),
+                voters_counts: VotersCounts::default(),
+                votes_counts: VotesCounts {
+                    political_group_total_votes:
+                        PollingStationResults::default_political_group_total_votes(political_groups),
+                    ..VotesCounts::default()
+                },
+                differences_counts: DifferencesCounts::default(),
+                political_group_votes: PollingStationResults::default_political_group_votes(
+                    political_groups,
+                ),
+            })
+        } else {
+            PollingStationResults::CSONextSession(CSONextSessionResults {
+                voters_counts: VotersCounts::default(),
+                votes_counts: VotesCounts {
+                    political_group_total_votes:
+                        PollingStationResults::default_political_group_total_votes(political_groups),
+                    ..VotesCounts::default()
+                },
+                differences_counts: DifferencesCounts::default(),
+                political_group_votes: PollingStationResults::default_political_group_votes(
+                    political_groups,
+                ),
+            })
         };
-        results.voters_counts.poll_card_count = polling_station_id;
+        results.voters_counts_mut().poll_card_count = polling_station_id;
 
         let mut conn = pool.acquire().await.unwrap();
         insert_test_result(
             &mut conn,
             polling_station_id,
             committee_session_id,
-            &PollingStationResults::CSOFirstSession(results),
+            &results,
         )
         .await
         .unwrap()
@@ -1842,14 +1928,12 @@ mod tests {
     async fn claim_previous_results(
         pool: SqlitePool,
         polling_station_id: u32,
-    ) -> Option<CSOFirstSessionResults> {
+    ) -> Option<CommonPollingStationResults> {
         let response = claim(pool.clone(), polling_station_id, EntryNumber::FirstEntry).await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let result: ClaimDataEntryResponse = serde_json::from_slice(&body).unwrap();
-        result
-            .previous_results
-            .and_then(|p| p.into_cso_first_session())
+        result.previous_results
     }
 
     /// No previous results, should return none
@@ -1861,7 +1945,10 @@ mod tests {
     /// Only a result from committee session 1, should return 1
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
     async fn test_previous_results_from_first_session(pool: SqlitePool) {
-        add_results(&pool, 711, 701).await;
+        let election = crate::election::repository::get(&mut pool.acquire().await.unwrap(), 700)
+            .await
+            .unwrap();
+        add_results(&pool, 711, 701, &election.political_groups, true).await;
         let previous_results = claim_previous_results(pool.clone(), 741).await.unwrap();
         assert_eq!(previous_results.voters_counts.poll_card_count, 711);
     }
@@ -1869,8 +1956,11 @@ mod tests {
     /// Results from committee session 1 and 3, with a gap in between, should return 3
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
     async fn test_previous_results_with_session_gap(pool: SqlitePool) {
-        add_results(&pool, 711, 701).await;
-        add_results(&pool, 731, 703).await;
+        let election = crate::election::repository::get(&mut pool.acquire().await.unwrap(), 700)
+            .await
+            .unwrap();
+        add_results(&pool, 711, 701, &election.political_groups, true).await;
+        add_results(&pool, 731, 703, &election.political_groups, false).await;
         let previous_results = claim_previous_results(pool.clone(), 741).await.unwrap();
         assert_eq!(previous_results.voters_counts.poll_card_count, 731);
     }
@@ -1878,7 +1968,10 @@ mod tests {
     /// Results with only one in committee session 2, should return 2
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
     async fn test_previous_results_from_second_session(pool: SqlitePool) {
-        add_results(&pool, 722, 702).await;
+        let election = crate::election::repository::get(&mut pool.acquire().await.unwrap(), 700)
+            .await
+            .unwrap();
+        add_results(&pool, 722, 702, &election.political_groups, false).await;
         let previous_results = claim_previous_results(pool.clone(), 742).await.unwrap();
         assert_eq!(previous_results.voters_counts.poll_card_count, 722);
     }
@@ -1886,7 +1979,10 @@ mod tests {
     /// Two subsequent results from committee sessions 2 and 3, should return 3rd
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
     async fn test_previous_results_from_last_two_sessions(pool: SqlitePool) {
-        add_results(&pool, 732, 703).await;
+        let election = crate::election::repository::get(&mut pool.acquire().await.unwrap(), 700)
+            .await
+            .unwrap();
+        add_results(&pool, 732, 703, &election.political_groups, false).await;
         let previous_results = claim_previous_results(pool.clone(), 742).await.unwrap();
         assert_eq!(previous_results.voters_counts.poll_card_count, 732);
     }

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -222,6 +222,11 @@ impl DataEntryStatus {
             DataEntryStatus::SecondEntryNotStarted(state) => {
                 if current_data_entry.user_id == state.first_entry_user_id {
                     Err(DataEntryTransitionError::SecondEntryNeedsDifferentUser)
+                } else if !state
+                    .finalised_first_entry
+                    .is_same_model(&current_data_entry.entry)
+                {
+                    Err(DataEntryTransitionError::Invalid)
                 } else {
                     Ok(Self::SecondEntryInProgress(SecondEntryInProgress {
                         first_entry_user_id: state.first_entry_user_id,
@@ -261,6 +266,10 @@ impl DataEntryStatus {
                     return Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser);
                 }
 
+                if !state.first_entry.is_same_model(&current_data_entry.entry) {
+                    return Err(DataEntryTransitionError::Invalid);
+                }
+
                 Ok(Self::FirstEntryInProgress(FirstEntryInProgress {
                     progress: current_data_entry.progress.unwrap_or(0),
                     first_entry_user_id: state.first_entry_user_id,
@@ -288,6 +297,10 @@ impl DataEntryStatus {
             DataEntryStatus::SecondEntryInProgress(state) => {
                 if state.second_entry_user_id != current_data_entry.user_id {
                     return Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser);
+                }
+
+                if !state.second_entry.is_same_model(&current_data_entry.entry) {
+                    return Err(DataEntryTransitionError::Invalid);
                 }
 
                 Ok(Self::SecondEntryInProgress(SecondEntryInProgress {

--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -293,6 +293,11 @@ impl Validate for PollingStationResults {
             PollingStationResults::CSOFirstSession(results) => {
                 results.validate(election, polling_station, validation_results, path)
             }
+            PollingStationResults::CSONextSession(_results) => {
+                // TODO: validate CSONextSessionResults
+                // results.validate(election, polling_station, validation_results, path)
+                Ok(())
+            }
         }
     }
 }

--- a/backend/src/eml/eml_510.rs
+++ b/backend/src/eml/eml_510.rs
@@ -9,7 +9,7 @@ use super::{
     },
 };
 use crate::{
-    data_entry::{CSOFirstSessionResults, PoliticalGroupCandidateVotes},
+    data_entry::{PoliticalGroupCandidateVotes, PollingStationResults},
     polling_station::PollingStation,
     summary::ElectionSummary,
 };
@@ -32,7 +32,7 @@ pub struct EML510 {
 impl EML510 {
     pub fn from_results(
         election: &crate::election::ElectionWithPoliticalGroups,
-        results: &[(PollingStation, CSOFirstSessionResults)],
+        results: &[(PollingStation, PollingStationResults)],
         summary: &ElectionSummary,
         creation_date_time: &chrono::DateTime<chrono::Local>,
     ) -> EML510 {
@@ -210,7 +210,7 @@ impl ReportingUnitVotes {
         election: &crate::election::ElectionWithPoliticalGroups,
         authority_id: &str,
         polling_station: &PollingStation,
-        results: &CSOFirstSessionResults,
+        results: &PollingStationResults,
     ) -> ReportingUnitVotes {
         ReportingUnitVotes {
             reporting_unit_identifier: ReportingUnitIdentifier {
@@ -222,40 +222,40 @@ impl ReportingUnitVotes {
             },
             selections: Selection::from_political_group_votes(
                 election,
-                &results.political_group_votes,
+                results.political_group_votes(),
             ),
-            cast: results.votes_counts.total_votes_cast_count as u64,
-            total_counted: results.votes_counts.total_votes_candidates_count as u64,
+            cast: results.votes_counts().total_votes_cast_count as u64,
+            total_counted: results.votes_counts().total_votes_candidates_count as u64,
             rejected_votes: vec![
                 RejectedVotes::new(
                     RejectedVotesReason::Blank,
-                    results.votes_counts.blank_votes_count as u64,
+                    results.votes_counts().blank_votes_count as u64,
                 ),
                 RejectedVotes::new(
                     RejectedVotesReason::Invalid,
-                    results.votes_counts.invalid_votes_count as u64,
+                    results.votes_counts().invalid_votes_count as u64,
                 ),
             ],
             uncounted_votes: vec![
                 UncountedVotes::new(
                     UncountedVotesReason::PollCard,
-                    results.voters_counts.poll_card_count as u64,
+                    results.voters_counts().poll_card_count as u64,
                 ),
                 UncountedVotes::new(
                     UncountedVotesReason::ProxyCertificate,
-                    results.voters_counts.proxy_certificate_count as u64,
+                    results.voters_counts().proxy_certificate_count as u64,
                 ),
                 UncountedVotes::new(
                     UncountedVotesReason::TotalAdmittedVoters,
-                    results.voters_counts.total_admitted_voters_count as u64,
+                    results.voters_counts().total_admitted_voters_count as u64,
                 ),
                 UncountedVotes::new(
                     UncountedVotesReason::MoreBallots,
-                    results.differences_counts.more_ballots_count as u64,
+                    results.differences_counts().more_ballots_count as u64,
                 ),
                 UncountedVotes::new(
                     UncountedVotesReason::FewerBallots,
-                    results.differences_counts.fewer_ballots_count as u64,
+                    results.differences_counts().fewer_ballots_count as u64,
                 ),
             ],
         }

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -14,7 +14,7 @@ use crate::{
         CommitteeSession, CommitteeSessionError, CommitteeSessionFilesUpdateRequest,
         repository::change_files, status::CommitteeSessionStatus,
     },
-    data_entry::CSOFirstSessionResults,
+    data_entry::PollingStationResults,
     election::ElectionWithPoliticalGroups,
     eml::{EML510, EMLDocument, EmlHash},
     files::{
@@ -43,7 +43,7 @@ struct ResultsInput {
     committee_session: CommitteeSession,
     election: ElectionWithPoliticalGroups,
     polling_stations: Vec<PollingStation>,
-    results: Vec<(PollingStation, CSOFirstSessionResults)>,
+    results: Vec<(PollingStation, PollingStationResults)>,
     summary: ElectionSummary,
     creation_date_time: chrono::DateTime<chrono::Local>,
 }
@@ -59,12 +59,11 @@ impl ResultsInput {
             crate::election::repository::get(conn, committee_session.election_id).await?;
         let polling_stations =
             crate::polling_station::repository::list(conn, committee_session.id).await?;
-        let results =
-            crate::data_entry::repository::list_entries_with_polling_stations_first_session(
-                conn,
-                committee_session.id,
-            )
-            .await?;
+        let results = crate::data_entry::repository::list_entries_for_committee_session(
+            conn,
+            committee_session.id,
+        )
+        .await?;
 
         Ok(ResultsInput {
             committee_session,

--- a/backend/src/summary/mod.rs
+++ b/backend/src/summary/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     APIError,
     data_entry::{
         CSOFirstSessionResults, CandidateVotes, Count, DifferencesCounts,
-        PoliticalGroupCandidateVotes, PoliticalGroupTotalVotes, Validate, ValidationResults,
-        VotersCounts, VotesCounts,
+        PoliticalGroupCandidateVotes, PoliticalGroupTotalVotes, PollingStationResults, Validate,
+        ValidationResults, VotersCounts, VotesCounts,
     },
     election::ElectionWithPoliticalGroups,
     error::ErrorReference,
@@ -55,7 +55,7 @@ impl ElectionSummary {
     /// data from the election for candidates and political groups.
     pub fn from_results(
         election: &ElectionWithPoliticalGroups,
-        results: &[(PollingStation, CSOFirstSessionResults)],
+        results: &[(PollingStation, PollingStationResults)],
     ) -> Result<ElectionSummary, APIError> {
         // running totals
         let mut totals = ElectionSummary::zero();
@@ -118,16 +118,16 @@ impl ElectionSummary {
             }
 
             // add voters and votes to the total
-            totals.voters_counts += &result.voters_counts;
-            totals.votes_counts.add(&result.votes_counts)?;
+            totals.voters_counts += result.voters_counts();
+            totals.votes_counts.add(result.votes_counts())?;
 
             // add any differences noted to the total
             totals
                 .differences_counts
-                .add_polling_station_results(polling_station, &result.differences_counts);
+                .add_polling_station_results(polling_station, result.differences_counts());
 
             // add votes for each political group to the total
-            for pg in result.political_group_votes.iter() {
+            for pg in result.political_group_votes().iter() {
                 let pg_total = totals
                     .political_group_votes
                     .iter_mut()
@@ -139,10 +139,12 @@ impl ElectionSummary {
                 pg_total.add(pg)?;
             }
 
-            // add checkbox states for this polling station
-            totals
-                .polling_station_investigations
-                .append_result(polling_station, result);
+            if let Some(cso_first_result) = result.as_cso_first_session() {
+                // add checkbox states for this polling station
+                totals
+                    .polling_station_investigations
+                    .append_result(polling_station, cso_first_result);
+            }
 
             touched_polling_stations.push(polling_station.number);
         }
@@ -280,8 +282,8 @@ mod tests {
         pdf_gen::tests::polling_stations_fixture,
     };
 
-    fn polling_station_results_fixture_a() -> CSOFirstSessionResults {
-        CSOFirstSessionResults {
+    fn polling_station_results_fixture_a() -> PollingStationResults {
+        PollingStationResults::CSOFirstSession(CSOFirstSessionResults {
             extra_investigation: ValidDefault::valid_default(),
             counting_differences_polling_station: ValidDefault::valid_default(),
             voters_counts: VotersCounts {
@@ -314,11 +316,11 @@ mod tests {
                 PoliticalGroupCandidateVotes::from_test_data_auto(1, &[18, 3]),
                 PoliticalGroupCandidateVotes::from_test_data_auto(2, &[4, 4, 2]),
             ],
-        }
+        })
     }
 
-    fn polling_station_results_fixture_b() -> CSOFirstSessionResults {
-        CSOFirstSessionResults {
+    fn polling_station_results_fixture_b() -> PollingStationResults {
+        PollingStationResults::CSOFirstSession(CSOFirstSessionResults {
             extra_investigation: ExtraInvestigation {
                 extra_investigation_other_reason: YesNo::yes(),
                 ballots_recounted_extra_investigation: YesNo::no(),
@@ -354,7 +356,7 @@ mod tests {
                 PoliticalGroupCandidateVotes::from_test_data_auto(1, &[10, 6]),
                 PoliticalGroupCandidateVotes::from_test_data_auto(2, &[12, 10, 8]),
             ],
-        }
+        })
     }
 
     #[test]
@@ -481,23 +483,23 @@ mod tests {
         let committee_session = committee_session_fixture(election.id);
         let ps = polling_stations_fixture(&election, committee_session.id, &[20; 5]);
         let mut ps_results = polling_station_results_fixture_a();
-        ps_results.political_group_votes[0].total = 999_999_998;
-        ps_results.political_group_votes[0].candidate_votes[0].votes = 999_999_998;
-        ps_results.political_group_votes[0].candidate_votes[1].votes = 0;
-        ps_results.political_group_votes[1].total = 0;
-        ps_results.political_group_votes[1].candidate_votes[0].votes = 0;
-        ps_results.political_group_votes[1].candidate_votes[1].votes = 0;
-        ps_results.political_group_votes[1].candidate_votes[2].votes = 0;
-        ps_results.votes_counts.political_group_total_votes[0].total = 999_999_998;
-        ps_results.votes_counts.political_group_total_votes[1].total = 0;
-        ps_results.votes_counts.total_votes_cast_count = 999_999_998;
-        ps_results.votes_counts.total_votes_candidates_count = 999_999_998;
-        ps_results.votes_counts.blank_votes_count = 0;
-        ps_results.votes_counts.invalid_votes_count = 0;
-        ps_results.voters_counts.poll_card_count = 999_999_998;
-        ps_results.voters_counts.proxy_certificate_count = 0;
-        ps_results.voters_counts.total_admitted_voters_count = 999_999_998;
-        ps_results.differences_counts.more_ballots_count = 0;
+        ps_results.political_group_votes_mut()[0].total = 999_999_998;
+        ps_results.political_group_votes_mut()[0].candidate_votes[0].votes = 999_999_998;
+        ps_results.political_group_votes_mut()[0].candidate_votes[1].votes = 0;
+        ps_results.political_group_votes_mut()[1].total = 0;
+        ps_results.political_group_votes_mut()[1].candidate_votes[0].votes = 0;
+        ps_results.political_group_votes_mut()[1].candidate_votes[1].votes = 0;
+        ps_results.political_group_votes_mut()[1].candidate_votes[2].votes = 0;
+        ps_results.votes_counts_mut().political_group_total_votes[0].total = 999_999_998;
+        ps_results.votes_counts_mut().political_group_total_votes[1].total = 0;
+        ps_results.votes_counts_mut().total_votes_cast_count = 999_999_998;
+        ps_results.votes_counts_mut().total_votes_candidates_count = 999_999_998;
+        ps_results.votes_counts_mut().blank_votes_count = 0;
+        ps_results.votes_counts_mut().invalid_votes_count = 0;
+        ps_results.voters_counts_mut().poll_card_count = 999_999_998;
+        ps_results.voters_counts_mut().proxy_certificate_count = 0;
+        ps_results.voters_counts_mut().total_admitted_voters_count = 999_999_998;
+        ps_results.differences_counts_mut().more_ballots_count = 0;
 
         let results = ps
             .iter()
@@ -513,7 +515,7 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps_results = polling_station_results_fixture_a();
         let mut ps_results2 = ps_results.clone();
-        ps_results2.votes_counts.total_votes_cast_count = 0;
+        ps_results2.votes_counts_mut().total_votes_cast_count = 0;
 
         let totals = ElectionSummary::from_results(
             &election,
@@ -547,7 +549,10 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
-        ps2_result.votes_counts.political_group_total_votes.pop();
+        ps2_result
+            .votes_counts_mut()
+            .political_group_total_votes
+            .pop();
         let totals = ElectionSummary::from_results(
             &election,
             &[(ps[0].clone(), ps1_result), (ps[1].clone(), ps2_result)],
@@ -564,7 +569,7 @@ mod tests {
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
         ps2_result
-            .votes_counts
+            .votes_counts_mut()
             .political_group_total_votes
             .push(PoliticalGroupTotalVotes {
                 number: 3,
@@ -585,10 +590,11 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
+        let pgvote_copy = ps2_result.votes_counts().political_group_total_votes[1].clone();
         ps2_result
-            .votes_counts
+            .votes_counts_mut()
             .political_group_total_votes
-            .push(ps2_result.votes_counts.political_group_total_votes[1].clone());
+            .push(pgvote_copy);
         let totals = ElectionSummary::from_results(
             &election,
             &[(ps[0].clone(), ps1_result), (ps[1].clone(), ps2_result)],
@@ -604,7 +610,7 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
-        ps2_result.votes_counts.political_group_total_votes[1] = PoliticalGroupTotalVotes {
+        ps2_result.votes_counts_mut().political_group_total_votes[1] = PoliticalGroupTotalVotes {
             number: 3,
             total: 0,
         };
@@ -623,7 +629,7 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
-        ps2_result.political_group_votes.pop();
+        ps2_result.political_group_votes_mut().pop();
         let totals = ElectionSummary::from_results(
             &election,
             &[(ps[0].clone(), ps1_result), (ps[1].clone(), ps2_result)],
@@ -640,7 +646,7 @@ mod tests {
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
         ps2_result
-            .political_group_votes
+            .political_group_votes_mut()
             .push(PoliticalGroupCandidateVotes::from_test_data_auto(3, &[0]));
         let totals = ElectionSummary::from_results(
             &election,
@@ -656,13 +662,11 @@ mod tests {
         let committee_session = committee_session_fixture(election.id);
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let mut ps1_result = polling_station_results_fixture_a();
+        let ps1_pgvote_copy = ps1_result.political_group_votes()[1].clone();
         let mut ps2_result = polling_station_results_fixture_b();
-        ps1_result
-            .political_group_votes
-            .push(ps1_result.political_group_votes[1].clone());
-        ps2_result
-            .political_group_votes
-            .push(ps2_result.political_group_votes[1].clone());
+        let ps2_pgvote_copy = ps2_result.political_group_votes()[1].clone();
+        ps1_result.political_group_votes_mut().push(ps1_pgvote_copy);
+        ps2_result.political_group_votes_mut().push(ps2_pgvote_copy);
         let totals = ElectionSummary::from_results(
             &election,
             &[(ps[0].clone(), ps1_result), (ps[1].clone(), ps2_result)],
@@ -678,7 +682,7 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
-        ps2_result.political_group_votes[1] =
+        ps2_result.political_group_votes_mut()[1] =
             PoliticalGroupCandidateVotes::from_test_data_auto(3, &[0]);
         let totals = ElectionSummary::from_results(
             &election,
@@ -695,7 +699,9 @@ mod tests {
         let ps = polling_stations_fixture(&election, committee_session.id, &[20, 20]);
         let ps1_result = polling_station_results_fixture_a();
         let mut ps2_result = polling_station_results_fixture_b();
-        ps2_result.political_group_votes[1].candidate_votes.pop();
+        ps2_result.political_group_votes_mut()[1]
+            .candidate_votes
+            .pop();
         let totals = ElectionSummary::from_results(
             &election,
             &[(ps[0].clone(), ps1_result), (ps[1].clone(), ps2_result)],

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -17,9 +17,9 @@ use abacus::{
         ElectionApportionmentResponse, Fraction, get_total_seats_from_apportionment_result,
     },
     data_entry::{
-        CSOFirstSessionResults, CountingDifferencesPollingStation, DataEntry,
-        PoliticalGroupTotalVotes, PollingStationResults, VotersCounts, VotesCounts, YesNo,
-        status::ClientState,
+        CSOFirstSessionResults, CSONextSessionResults, CountingDifferencesPollingStation,
+        DataEntry, PoliticalGroupTotalVotes, PollingStationResults, VotersCounts, VotesCounts,
+        YesNo, status::ClientState,
     },
 };
 
@@ -129,12 +129,7 @@ async fn test_election_apportionment_works_for_19_or_more_seats(pool: SqlitePool
 
     let data_entry = DataEntry {
         progress: 100,
-        data: PollingStationResults::CSOFirstSession(CSOFirstSessionResults {
-            extra_investigation: Default::default(),
-            counting_differences_polling_station: CountingDifferencesPollingStation {
-                unexplained_difference_ballots_voters: YesNo::no(),
-                difference_ballots_per_list: YesNo::no(),
-            },
+        data: PollingStationResults::CSONextSession(CSONextSessionResults {
             voters_counts: VotersCounts {
                 poll_card_count: 1203,
                 proxy_certificate_count: 2,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -377,6 +377,25 @@ export interface CSOFirstSessionResults {
 }
 
 /**
+ * CSONextSessionResults, following the fields in Model Na 14-2 Bijlage 1.
+ *
+ * See "Model Na 14-2. Corrigendum bij het proces-verbaal van een gemeentelijk stembureau/
+ * stembureau voor het openbaar lichaam, Bijlage 1: uitkomsten per stembureau" from the
+ * [Kiesregeling](https://wetten.overheid.nl/BWBR0034180/2024-04-01#Bijlage1_DivisieNa14.2) or
+ * [Verkiezingstoolbox](https://www.rijksoverheid.nl/onderwerpen/verkiezingen/verkiezingentoolkit/modellen).
+ */
+export interface CSONextSessionResults {
+  /** Differences counts ("Verschil tussen het aantal toegelaten kiezers en het aantal getelde stembiljetten") */
+  differences_counts: DifferencesCounts;
+  /** Vote counts per list and candidate ("Aantal stemmen per lijst en kandidaat") */
+  political_group_votes: PoliticalGroupCandidateVotes[];
+  /** Voters counts ("Aantal toegelaten kiezers") */
+  voters_counts: VotersCounts;
+  /** Votes counts ("Aantal getelde stembiljetten") */
+  votes_counts: VotesCounts;
+}
+
+/**
  * Candidate
  */
 export interface Candidate {
@@ -422,7 +441,7 @@ export interface CandidateVotes {
 export interface ClaimDataEntryResponse {
   client_state: unknown;
   data: PollingStationResults;
-  previous_results?: PollingStationResults;
+  previous_results?: CommonPollingStationResults;
   validation_results: ValidationResults;
 }
 
@@ -484,6 +503,20 @@ export interface CommitteeSessionUpdateRequest {
   location: string;
   start_date: string;
   start_time: string;
+}
+
+/**
+ * CommonPollingStationResults contains the common fields for polling station results,
+ */
+export interface CommonPollingStationResults {
+  /** Differences counts ("Verschil tussen het aantal toegelaten kiezers en het aantal getelde stembiljetten") */
+  differences_counts: DifferencesCounts;
+  /** Vote counts per list and candidate ("Aantal stemmen per lijst en kandidaat") */
+  political_group_votes: PoliticalGroupCandidateVotes[];
+  /** Voters counts ("Aantal toegelaten kiezers") */
+  voters_counts: VotersCounts;
+  /** Votes counts ("Aantal getelde stembiljetten") */
+  votes_counts: VotesCounts;
 }
 
 /**
@@ -1086,7 +1119,9 @@ export interface PollingStationRequestListResponse {
  * whether this is the first or any subsequent data entry session. Based on
  * this, any of four different models can apply
  */
-export type PollingStationResults = CSOFirstSessionResults & { model: "CSOFirstSession" };
+export type PollingStationResults =
+  | (CSOFirstSessionResults & { model: "CSOFirstSession" })
+  | (CSONextSessionResults & { model: "CSONextSession" });
 
 /**
  * Type of Polling station


### PR DESCRIPTION
Not ready for review yet

Resolves #2048 

- Implements a new `CSONextSession` variant for `PollingStationResults` that implements the Na 14-2 bijlage 1 results entry.
- Adds a new `CommonPollingStationResults` struct that implements the common fields for any variant of the results, which is now returned for the previous results in the claim endpoint
- Updates ElectionSummary to make use of the PollingStationResults, thus allowing usage of either variant in EML and PDF generation

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->