### PR TITLE
Backend investigation tests

### DIFF
--- a/backend/src/investigation/api.rs
+++ b/backend/src/investigation/api.rs
@@ -17,7 +17,6 @@ use crate::{
     audit_log::{AuditEvent, AuditService},
     authentication::Coordinator,
 };
-
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(committee_session_investigation_create))
@@ -49,6 +48,10 @@ async fn committee_session_investigation_create(
     Json(polling_station_investigation): Json<PollingStationInvestigationCreateRequest>,
 ) -> Result<PollingStationInvestigation, APIError> {
     let mut tx = pool.begin_immediate().await?;
+
+    // Throw a 404 if the polling station isn't found in the current committee session
+    let _ = crate::polling_station::repository::get(&mut tx, polling_station_id).await?;
+
     let investigation = create_polling_station_investigation(
         &mut tx,
         polling_station_id,

--- a/backend/src/investigation/mod.rs
+++ b/backend/src/investigation/mod.rs
@@ -6,3 +6,5 @@ pub(crate) use self::{
     api::router, repository::list_investigations_for_committee_session,
     structs::PollingStationInvestigation,
 };
+
+pub use self::structs::PollingStationInvestigationCreateRequest;

--- a/backend/tests/investigation_integration_test.rs
+++ b/backend/tests/investigation_integration_test.rs
@@ -1,0 +1,69 @@
+#![cfg(test)]
+use hyper::StatusCode;
+use serde_json::json;
+use sqlx::SqlitePool;
+use test_log::test;
+
+use crate::utils::serve_api;
+
+pub mod shared;
+pub mod utils;
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]
+async fn test_investigation_creation_and_conlusion(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let url = format!("http://{addr}/api/polling_stations/741/investigations");
+    let coordinator_cookie = shared::coordinator_login(&addr).await;
+    let body = json!({
+        "reason": "Test reason"
+    });
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", coordinator_cookie.clone())
+        .header("Content-Type", "application/json")
+        .body(body.to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = json!({
+        "findings": "Test findings",
+        "corrected_results": false
+    });
+    let url = format!("http://{addr}/api/polling_stations/741/investigations");
+    let response = reqwest::Client::new()
+        .put(&url)
+        .header("cookie", coordinator_cookie)
+        .header("Content-Type", "application/json")
+        .body(body.to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]
+async fn test_investigation_creation_fails_for_wrong_polling_station(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    // 732 is an  existing polling station, but in the wrong committee session
+    let url = format!("http://{addr}/api/polling_stations/732/investigations");
+    let coordinator_cookie = shared::coordinator_login(&addr).await;
+    let body = json!({
+        "reason": "Test reason"
+    });
+
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", coordinator_cookie.clone())
+        .header("Content-Type", "application/json")
+        .body(body.to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/backend/tests/investigation_integration_test.rs
+++ b/backend/tests/investigation_integration_test.rs
@@ -65,5 +65,5 @@ async fn test_investigation_creation_fails_for_wrong_polling_station(pool: Sqlit
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/backend/tests/investigation_integration_test.rs
+++ b/backend/tests/investigation_integration_test.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 use hyper::StatusCode;
+use reqwest::Response;
 use serde_json::json;
 use sqlx::SqlitePool;
 use test_log::test;
@@ -9,61 +10,70 @@ use crate::utils::serve_api;
 pub mod shared;
 pub mod utils;
 
-#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]
-async fn test_investigation_creation_and_conlusion(pool: SqlitePool) {
+async fn create_investigation(pool: SqlitePool, polling_station_id: u32) -> Response {
     let addr = serve_api(pool).await;
-    let url = format!("http://{addr}/api/polling_stations/741/investigations");
+    let url = format!("http://{addr}/api/polling_stations/{polling_station_id}/investigations");
     let coordinator_cookie = shared::coordinator_login(&addr).await;
     let body = json!({
         "reason": "Test reason"
     });
-    let response = reqwest::Client::new()
+    reqwest::Client::new()
         .post(&url)
         .header("cookie", coordinator_cookie.clone())
         .header("Content-Type", "application/json")
         .body(body.to_string())
         .send()
         .await
-        .unwrap();
+        .unwrap()
+}
 
-    assert_eq!(response.status(), StatusCode::OK);
-
+async fn conclude_investigation(pool: SqlitePool, polling_station_id: u32) -> Response {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = shared::coordinator_login(&addr).await;
     let body = json!({
         "findings": "Test findings",
         "corrected_results": false
     });
-    let url = format!("http://{addr}/api/polling_stations/741/investigations");
-    let response = reqwest::Client::new()
+    let url = format!("http://{addr}/api/polling_stations/{polling_station_id}/investigations");
+    reqwest::Client::new()
         .put(&url)
         .header("cookie", coordinator_cookie)
         .header("Content-Type", "application/json")
         .body(body.to_string())
         .send()
         .await
-        .unwrap();
+        .unwrap()
+}
 
-    assert_eq!(response.status(), StatusCode::OK);
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]
+async fn test_investigation_creation_and_conlusion(pool: SqlitePool) {
+    assert_eq!(
+        create_investigation(pool.clone(), 741).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        conclude_investigation(pool.clone(), 741).await.status(),
+        StatusCode::OK
+    );
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]
 async fn test_investigation_creation_fails_for_wrong_polling_station(pool: SqlitePool) {
-    let addr = serve_api(pool).await;
-
     // 732 is an  existing polling station, but in the wrong committee session
-    let url = format!("http://{addr}/api/polling_stations/732/investigations");
-    let coordinator_cookie = shared::coordinator_login(&addr).await;
-    let body = json!({
-        "reason": "Test reason"
-    });
+    assert_eq!(
+        create_investigation(pool.clone(), 732).await.status(),
+        StatusCode::NOT_FOUND
+    );
+}
 
-    let response = reqwest::Client::new()
-        .post(&url)
-        .header("cookie", coordinator_cookie.clone())
-        .header("Content-Type", "application/json")
-        .body(body.to_string())
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]
+async fn test_investigation_creation_fails_on_creating_second_investigation(pool: SqlitePool) {
+    assert_eq!(
+        create_investigation(pool.clone(), 741).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        create_investigation(pool.clone(), 741).await.status(),
+        StatusCode::CONFLICT
+    );
 }


### PR DESCRIPTION
Closes #2146 

dds integration tests for investigations and adds a lookup for the polling station, so we can return a 404 if the polling station doesn't exist, or it exists but is in the wrong session.

As discussed during standup, a check for existing investigations is not necessary, but added a test to verify it.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->