### PR TITLE
Set minimum package age for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
         patterns: ["*"]
@@ -11,6 +13,11 @@ updates:
     directory: "/backend"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       cargo:
         patterns: ["*"]
@@ -24,6 +31,11 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       npm:
         patterns: ["*"]


### PR DESCRIPTION
Set minimum package age for Dependabot updates. Cargo and npm both support semver, but GitHub Actions doesn't, so there only `default-days` is set.

For more info, see:
- https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-