### PR TITLE
Remove dead code related to EML_NL election tree

### DIFF
--- a/backend/src/eml/eml_110.rs
+++ b/backend/src/eml/eml_110.rs
@@ -498,53 +498,6 @@ pub enum VotingMethod {
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Copy)]
-pub enum RegionCategory {
-    #[serde(rename = "DEELGEMEENTE")]
-    SubMunicipality,
-    #[serde(rename = "GEMEENTE")]
-    Municipality,
-    #[serde(rename = "KIESKRING")]
-    ElectoralDistrict,
-    #[serde(rename = "PROVINCIE")]
-    Province,
-    #[serde(rename = "PROVINCIAAL_KIESKRING")]
-    ProvinceElectoralDistrict,
-    #[serde(rename = "PROVINCIAAL_STEMBUREAU")]
-    ProvincePollingStation,
-    #[serde(rename = "STAAT")]
-    State,
-    #[serde(rename = "STEMBUREAU")]
-    PollingStation,
-    #[serde(rename = "WATERSCHAP")]
-    WaterAuthority,
-    #[serde(rename = "WATERSCHAP_KIESKRING")]
-    WaterAuthorityElectoralDistrict,
-    #[serde(rename = "WATERSCHAP_GEMEENTE")]
-    WaterAuthorityMunicipality,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct Committee {
-    #[serde(rename = "@CommitteeCategory")]
-    category: CommitteeCategory,
-    #[serde(rename = "@CommitteeName")]
-    name: Option<String>,
-    #[serde(rename = "@AcceptCentralSubmissions", default)]
-    accept_central_submissions: bool,
-}
-
-#[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Copy)]
-pub enum CommitteeCategory {
-    CSB,
-    HSB,
-    #[serde(rename = "PROV_SB")]
-    PROVSB,
-    PSB,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct RegisteredParty {


### PR DESCRIPTION
Remove dead code related to EML_NL election tree, which was removed in #2147. Clippy started complaining about this since the [Rust 1.90.0](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/) release.