### PR TITLE
Fix update investigation

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6265,9 +6265,7 @@
       "PollingStationInvestigationUpdateRequest": {
         "type": "object",
         "required": [
-          "reason",
-          "findings",
-          "corrected_results"
+          "reason"
         ],
         "properties": {
           "corrected_results": {

--- a/backend/src/investigation/structs.rs
+++ b/backend/src/investigation/structs.rs
@@ -46,8 +46,12 @@ pub struct PollingStationInvestigationConcludeRequest {
 #[serde(deny_unknown_fields)]
 pub struct PollingStationInvestigationUpdateRequest {
     pub reason: String,
-    pub findings: String,
-    pub corrected_results: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub findings: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub corrected_results: Option<bool>,
 }
 
 pub struct CurrentSessionPollingStationId(pub u32);

--- a/frontend/src/features/investigations/components/InvestigationCard.module.css
+++ b/frontend/src/features/investigations/components/InvestigationCard.module.css
@@ -35,6 +35,7 @@
   pre {
     font-family: var(--font-text), sans-serif;
     margin: 0;
+    white-space: pre-wrap;
   }
 }
 

--- a/frontend/src/features/investigations/components/InvestigationFindings.tsx
+++ b/frontend/src/features/investigations/components/InvestigationFindings.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 import { useNavigate } from "react-router";
 
-import { AnyApiError, isError, isSuccess } from "@/api/ApiResult";
+import { AnyApiError, ApiResult, isError, isSuccess } from "@/api/ApiResult";
 import { useCrud } from "@/api/useCrud";
 import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
@@ -71,7 +71,9 @@ export function InvestigationFindings({ pollingStationId }: InvestigationFinding
 
     const correctedResults = correctedResultsChoice === "yes";
 
-    const save = () => {
+    const save = (): Promise<
+      ApiResult<PollingStationInvestigationConcludeRequest | PollingStationInvestigationUpdateRequest>
+    > => {
       pushMessage({
         title: t("investigations.message.investigation_updated", {
           number: pollingStation.number,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1050,8 +1050,8 @@ export interface PollingStationInvestigationCreateRequest {
 }
 
 export interface PollingStationInvestigationUpdateRequest {
-  corrected_results: boolean;
-  findings: string;
+  corrected_results?: boolean;
+  findings?: string;
   reason: string;
 }
 


### PR DESCRIPTION
The investigation update endpoint did not accept a call without any findings or corrected results.

This PR fixes this by making these fields optional + adds tests to the endpoint.

Also adds a small styling fix in rendering the investigation overview.