### PR TITLE
Add fixture with second committee session to seed data

### DIFF
--- a/backend/fixtures/election_5_with_results.sql
+++ b/backend/fixtures/election_5_with_results.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, counting_method, election_id, location, domain_id, category, number_of_seats, election_date, nomination_date, political_groups)
-VALUES (5, 'Test Election >= 19 seats', 'CSO', 'GroteStad_2026', 'Grote Stad', '0000', 'Municipal', 23, '2026-03-18', '2026-02-02',
+VALUES (5, 'Corrigendum 2026', 'CSO', 'GroteStad_2026', 'Grote Stad', '0000', 'Municipal', 23, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,

--- a/backend/src/fixtures.rs
+++ b/backend/src/fixtures.rs
@@ -21,7 +21,7 @@ macro_rules! load_fixtures {
 ///
 /// This list should be updated manually when a new fixture is added that
 /// needs to be loaded when seeding fixtures.
-const FIXTURES: &[Fixture] = load_fixtures!(["election_1", "users"]);
+const FIXTURES: &[Fixture] = load_fixtures!(["election_1", "election_5_with_results", "users"]);
 
 /// The data contained in a fixture file
 struct Fixture {

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -63,7 +63,7 @@ async fn test_election_details_works(pool: SqlitePool) {
         CommitteeSessionStatus::DataEntryInProgress
     );
     assert_eq!(body.committee_sessions.len(), 2);
-    assert_eq!(body.election.name, "Test Election >= 19 seats");
+    assert_eq!(body.election.name, "Corrigendum 2026");
     assert_eq!(body.polling_stations.len(), 1);
     assert!(
         body.polling_stations


### PR DESCRIPTION
Add `election_5_with_results.sql` which contains a completed first committee session and a started second committee session, to the seed data. This allows us to more easily test corrigendum features on the Abacus test environment.

<img width="1034" height="321" alt="image" src="https://github.com/user-attachments/assets/3b66ae4e-12e5-46d2-954e-07b73dc5bbfa" />

---

<img width="1032" height="596" alt="image" src="https://github.com/user-attachments/assets/90265fac-fce5-4eb1-8ba3-555ff5dc519c" />
