### PR TITLE
Show dash for empty polling station type

### DIFF
--- a/frontend/src/features/polling_stations/components/PollingStationListPage.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.tsx
@@ -78,7 +78,9 @@ export function PollingStationListPage() {
                     <Table.NumberCell>{station.number}</Table.NumberCell>
                     <Table.Cell className="break-word">{station.name}</Table.Cell>
                     <Table.Cell>
-                      {station.polling_station_type && labelForPollingStationType[station.polling_station_type]}
+                      {station.polling_station_type && labelForPollingStationType[station.polling_station_type]
+                        ? labelForPollingStationType[station.polling_station_type]
+                        : "–"}
                     </Table.Cell>
                   </Table.LinkRow>
                 ))}


### PR DESCRIPTION
Adds a '-' in the Soort column, when no polling station type is known

<img width="1604" height="503" alt="Screenshot_2025-09-23_11-16-09" src="https://github.com/user-attachments/assets/ac9db6d9-496b-4d56-8e2a-ee8cee31e50a" />
