### PR TITLE
Explicitly install `clippy` and `rustfmt` in CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -48,7 +48,8 @@ jobs:
         run: >
           rustup update stable &&
           rustup default stable &&
-          rustup target add x86_64-unknown-linux-musl
+          rustup target add x86_64-unknown-linux-musl &&
+          rustup component add --toolchain stable clippy rustfmt
       - name: Cargo cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
         with:


### PR DESCRIPTION
Explicitly install clippy and rustfmt in CI to fix error that occurs since today:

```
error: 'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.
To install, run `rustup component add rustfmt`
```

Couldn't find a related issue or commit in https://github.com/actions/runner.