### PR TITLE
Prevent multiple messages on investigation overview page

### DIFF
--- a/frontend/src/components/messages/Messages.test.tsx
+++ b/frontend/src/components/messages/Messages.test.tsx
@@ -8,9 +8,10 @@ import { Messages } from "./Messages";
 
 describe("Messages component", () => {
   const popMessages: Mock<() => Message[]> = vi.fn(() => []);
+  const hasMessages: Mock<() => boolean> = vi.fn(() => false);
 
   beforeEach(() => {
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages, hasMessages });
   });
 
   test("should render message", async () => {

--- a/frontend/src/components/polling_station/PollingStationsPreview.test.tsx
+++ b/frontend/src/components/polling_station/PollingStationsPreview.test.tsx
@@ -13,7 +13,11 @@ import { PollingStationsPreview } from "./PollingStationsPreview";
 describe("PollingStationsPreview", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, PollingStationListRequestHandler);
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
   });
 
   test("Show polling stations", async () => {

--- a/frontend/src/features/investigations/components/InvestigationFindingsPage.test.tsx
+++ b/frontend/src/features/investigations/components/InvestigationFindingsPage.test.tsx
@@ -48,7 +48,11 @@ describe("InvestigationFindingsPage", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, ElectionStatusRequestHandler);
     vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage,
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
   });
 
   test("Renders a form", async () => {

--- a/frontend/src/features/investigations/components/InvestigationPrintCorrigendumPage.test.tsx
+++ b/frontend/src/features/investigations/components/InvestigationPrintCorrigendumPage.test.tsx
@@ -46,7 +46,11 @@ describe("InvestigationPrintCorrigendumPage", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, ElectionStatusRequestHandler);
     vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage,
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
   });
 
   test("Renders the correct headers and a download button", async () => {

--- a/frontend/src/features/investigations/components/InvestigationReasonPage.test.tsx
+++ b/frontend/src/features/investigations/components/InvestigationReasonPage.test.tsx
@@ -49,7 +49,11 @@ describe("InvestigationReasonPage", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, ElectionStatusRequestHandler);
     vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage,
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
   });
 
   test("Renders a form", async () => {

--- a/frontend/src/features/investigations/components/forms/InvestigationFindings.tsx
+++ b/frontend/src/features/investigations/components/forms/InvestigationFindings.tsx
@@ -29,6 +29,7 @@ const ACCEPTED = "accepted";
 
 export function InvestigationFindings({ pollingStationId }: InvestigationFindingsProps) {
   const navigate = useNavigate();
+  const { hasMessages } = useMessages();
   const { election, investigation, pollingStation, refetch } = useElection(pollingStationId);
   const { pushMessage } = useMessages();
   const concludePath = `/api/polling_stations/${pollingStationId}/investigation/conclude`;
@@ -106,12 +107,15 @@ export function InvestigationFindings({ pollingStationId }: InvestigationFinding
     const response = await save();
 
     if (isSuccess(response)) {
-      pushMessage({
-        title: t("investigations.message.investigation_updated", {
-          number: pollingStation.number,
-          name: pollingStation.name,
-        }),
-      });
+      // Only push a message if there are no messages yet (e.g. from creating this investigation)
+      if (!hasMessages()) {
+        pushMessage({
+          title: t("investigations.message.investigation_updated", {
+            number: pollingStation.number,
+            name: pollingStation.name,
+          }),
+        });
+      }
 
       await refetch();
       await navigate(`/elections/${election.id}/investigations`);

--- a/frontend/src/features/polling_stations/components/PollingStationCreatePage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationCreatePage.test.tsx
@@ -11,7 +11,11 @@ import { PollingStationCreatePage } from "./PollingStationCreatePage";
 describe("PollingStationCreatePage", () => {
   test("Shows form", async () => {
     server.use(ElectionRequestHandler);
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
 
     render(
       <ElectionProvider electionId={1}>

--- a/frontend/src/features/polling_stations/components/PollingStationImportPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationImportPage.test.tsx
@@ -16,7 +16,11 @@ describe("PollingStationImportPage", () => {
   });
 
   test("Shows form", async () => {
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
 
     render(
       <ElectionProvider electionId={1}>
@@ -32,7 +36,11 @@ describe("PollingStationImportPage", () => {
     const filename = "foo.txt";
     const file = new File(["foo"], filename, { type: "text/plain" });
 
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
 
     overrideOnce("post", "/api/elections/1/polling_stations/validate-import", 400, {
       error: "Invalid XML",
@@ -63,7 +71,11 @@ describe("PollingStationImportPage", () => {
     const filename = "foo.txt";
     const file = new File(["foo"], filename, { type: "text/plain" });
 
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
 
     overrideOnce("post", "/api/elections/1/polling_stations/validate-import", 413, {
       error: "12",
@@ -94,7 +106,11 @@ describe("PollingStationImportPage", () => {
     const filename = "foo.txt";
     const file = new File(["foo"], filename, { type: "text/plain" });
 
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
     overrideOnce("post", "/api/elections/1/polling_stations/validate-import", 200, {
       polling_stations: pollingStationRequestMockData,
     });

--- a/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationListPage.test.tsx
@@ -12,7 +12,11 @@ import { PollingStationListPage } from "./PollingStationListPage";
 describe("PollingStationListPage", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, PollingStationListRequestHandler);
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage: vi.fn(), popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage: vi.fn(),
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
   });
 
   test("Show polling stations", async () => {

--- a/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
@@ -36,7 +36,11 @@ describe("PollingStationUpdatePage", () => {
   beforeEach(() => {
     server.use(ElectionRequestHandler, PollingStationGetHandler, PollingStationUpdateHandler);
     vi.spyOn(ReactRouter, "useParams").mockReturnValue({ pollingStationId: "1" });
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage,
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
   });
 
   test("Shows form", async () => {

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -48,9 +48,10 @@ function overrideResponseStatus(status: DataEntryStatusName) {
 
 describe("ResolveDifferencesPage", () => {
   const pushMessage = vi.fn();
+  const hasMessages = vi.fn();
 
   beforeEach(() => {
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []), hasMessages });
     vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
     vi.spyOn(ReactRouter, "useParams").mockReturnValue({ pollingStationId: "3" });
     vi.spyOn(ReactRouter, "useLocation").mockReturnValue({

--- a/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.test.tsx
+++ b/frontend/src/features/resolve_errors/components/ResolveErrorsIndexPage.test.tsx
@@ -40,11 +40,12 @@ const renderPage = async () => {
 
 describe("ResolveErrorsPage", () => {
   const pushMessage = vi.fn();
+  const hasMessages = vi.fn();
 
   beforeEach(() => {
     vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
     vi.spyOn(ReactRouter, "useParams").mockReturnValue({ pollingStationId: "5" });
-    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []) });
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({ pushMessage, popMessages: vi.fn(() => []), hasMessages });
     server.use(
       ElectionRequestHandler,
       ElectionStatusRequestHandler,

--- a/frontend/src/hooks/messages/MessagesContext.ts
+++ b/frontend/src/hooks/messages/MessagesContext.ts
@@ -11,6 +11,7 @@ export interface Message {
 export interface iMessageContext {
   pushMessage: (message: Message) => void;
   popMessages: () => Message[];
+  hasMessages: () => boolean;
 }
 
 export const MessagesContext = createContext<iMessageContext | undefined>(undefined);

--- a/frontend/src/hooks/messages/MessagesProvider.tsx
+++ b/frontend/src/hooks/messages/MessagesProvider.tsx
@@ -13,5 +13,11 @@ export function MessagesProvider({ children }: { children: ReactNode }) {
     return messages.current.splice(0);
   }
 
-  return <MessagesContext.Provider value={{ pushMessage, popMessages }}>{children}</MessagesContext.Provider>;
+  function hasMessages() {
+    return messages.current.length > 0;
+  }
+
+  return (
+    <MessagesContext.Provider value={{ pushMessage, popMessages, hasMessages }}>{children}</MessagesContext.Provider>
+  );
 }


### PR DESCRIPTION
Fixes #2197

This PR introduces the function `hasMessages`, that can be used to check whether there are any flash messages. In the investigation add/edit wizard this is used to prevent multiple messages on the investigation overview page (see the issue).