### PR TITLE
Improve audit log filter UX

### DIFF
--- a/frontend/src/features/logs/components/LogFilter.tsx
+++ b/frontend/src/features/logs/components/LogFilter.tsx
@@ -6,6 +6,7 @@ import { t } from "@/i18n/translate";
 
 import { LogFilterState } from "../hooks/useAuditLog";
 import { LogFilterName, useLogFilterOptions } from "../hooks/useLogFilterOptions";
+import { dateToTimestampString, timestampToDateString } from "../utils/dateTime";
 import cls from "./LogsHomePage.module.css";
 
 interface LogFilterProps {
@@ -13,29 +14,6 @@ interface LogFilterProps {
   filterState: LogFilterState;
   setSince: (since: string) => void;
   toggleFilter: (filterName: LogFilterName, value: string, checked: boolean) => void;
-}
-
-// timestamp to local date string
-function timestampToDateString(timestamp: string | undefined): string {
-  if (!timestamp) {
-    return "";
-  }
-
-  const d = new Date();
-  const time = new Date(parseInt(timestamp) * 1000 - d.getTimezoneOffset() * 60000);
-
-  return time.toISOString().slice(0, 16);
-}
-
-// local date string to timestamp
-function dateToTimestampString(date: string): string {
-  if (!date) {
-    return "";
-  }
-
-  const time = new Date(date);
-
-  return Math.round(time.getTime() / 1000).toString();
 }
 
 export function LogFilter({ onClose, setSince, filterState, toggleFilter }: LogFilterProps) {
@@ -47,6 +25,19 @@ export function LogFilter({ onClose, setSince, filterState, toggleFilter }: LogF
         <IconCross /> {t("log.action.close_filter")}
       </Button>
       <div className={cls.filters}>
+        <div>
+          <InputField
+            type="datetime-local"
+            name="since"
+            fieldWidth="parent"
+            value={timestampToDateString(filterState.since)}
+            onChange={(e) => {
+              setSince(dateToTimestampString(e.target.value));
+            }}
+            label={t("log.filter.show_events_since")}
+            margin="mb-lg"
+          />
+        </div>
         {options.map(([filterName, options]) => (
           <div key={filterName}>
             <h3>{t(`log.filter.${filterName}`)}</h3>
@@ -66,19 +57,6 @@ export function LogFilter({ onClose, setSince, filterState, toggleFilter }: LogF
             </ul>
           </div>
         ))}
-        <div>
-          <InputField
-            type="datetime-local"
-            name="since"
-            fieldWidth="parent"
-            value={timestampToDateString(filterState.since)}
-            onChange={(e) => {
-              setSince(dateToTimestampString(e.target.value));
-            }}
-            label={t("log.filter.show_events_since")}
-            margin="mb-lg"
-          />
-        </div>
       </div>
     </nav>
   );

--- a/frontend/src/features/logs/hooks/useLogFilterOptions.ts
+++ b/frontend/src/features/logs/hooks/useLogFilterOptions.ts
@@ -2,7 +2,7 @@ import { useInitialApiGet } from "@/api/useInitialApiGet";
 import { locale, translations } from "@/i18n/i18n";
 import { AUDIT_LOG_LIST_USERS_REQUEST_PATH, AuditLogUser } from "@/types/generated/openapi";
 
-export const LogFilterNames = ["event", "level", "user"] as const;
+export const LogFilterNames = ["level", "user", "event"] as const;
 export type LogFilterName = (typeof LogFilterNames)[number];
 
 export type LogFilterOptions = Array<
@@ -34,10 +34,12 @@ export function useLogFilterOptions(): LogFilterOptions {
         }));
       }
     } else {
-      values = Object.entries(source[filterName]).map(([value, label]) => ({
-        value,
-        label,
-      }));
+      values = Object.entries(source[filterName])
+        .map(([value, label]) => ({
+          value,
+          label,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label));
     }
 
     return [filterName, values];

--- a/frontend/src/features/logs/utils/dateTime.ts
+++ b/frontend/src/features/logs/utils/dateTime.ts
@@ -1,0 +1,22 @@
+// timestamp to local date string
+export function timestampToDateString(timestamp: string | undefined): string {
+  if (!timestamp) {
+    return "";
+  }
+
+  const d = new Date();
+  const time = new Date(parseInt(timestamp) * 1000 - d.getTimezoneOffset() * 60000);
+
+  return time.toISOString().slice(0, 16);
+}
+
+// local date string to timestamp
+export function dateToTimestampString(date: string): string {
+  if (!date) {
+    return "";
+  }
+
+  const time = new Date(date);
+
+  return Math.round(time.getTime() / 1000).toString();
+}


### PR DESCRIPTION
The audit log filter has become a bit messy:

<img width="458" height="687" alt="image" src="https://github.com/user-attachments/assets/f45b2cda-472d-48a2-b50e-15a84dd53145" />

This PR tries to improve the UX by:
- Sorting filter options
- Changing the order of the filter elements

Since the list of event types has grown to a large list, I moved this to the bottom.
I noticed that I use the "since" a lot, so I moved that to the top.

<img width="583" height="953" alt="image" src="https://github.com/user-attachments/assets/d04136c7-fde3-443c-a0e3-3b1db03e3381" />

