### PR TITLE
no keyboard hints in election creation screens

### DIFF
--- a/frontend/src/features/election_create/components/CheckHash.tsx
+++ b/frontend/src/features/election_create/components/CheckHash.tsx
@@ -5,10 +5,8 @@ import { Button } from "@/components/ui/Button/Button";
 import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { InputField } from "@/components/ui/InputField/InputField";
-import { KeyboardKeys } from "@/components/ui/KeyboardKeys/KeyboardKeys";
 import { t } from "@/i18n/translate";
 import { RedactedEmlHash } from "@/types/generated/openapi";
-import { KeyboardKey } from "@/types/ui";
 import { formatFullDateWithoutTimezone } from "@/utils/dateTime";
 
 import { RedactedHash, Stub } from "./RedactedHash";
@@ -123,7 +121,6 @@ export function CheckHash({ date, title, header, description, redactedHash, erro
           </FormLayout.Section>
           <FormLayout.Controls>
             <Button type="submit">{t("next")}</Button>
-            <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />
           </FormLayout.Controls>
         </FormLayout>
       </Form>


### PR DESCRIPTION
See this discussion in Figma: https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp?node-id=14634-17569#1409360753

tl;dr In the election creation screens the Shift+Enter keyboard hint does not make sense in most screens. So @jorisleker suggested to remove them from all election creation pages.

The two screens where using the keyboard to "Volgende" are the screens where you enter the hash. Both Enter and Shift+Enter do work there to submit.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->