### PR TITLE
Avoid writing file data to audit log

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5643,19 +5643,11 @@
         "type": "object",
         "required": [
           "file_id",
-          "file_data",
           "file_name",
-          "file_mime_type"
+          "file_mime_type",
+          "file_size_bytes"
         ],
         "properties": {
-          "file_data": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
-            }
-          },
           "file_id": {
             "type": "integer",
             "format": "int32",
@@ -5666,6 +5658,11 @@
           },
           "file_name": {
             "type": "string"
+          },
+          "file_size_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         },
         "additionalProperties": false

--- a/backend/src/audit_log/audit_event.rs
+++ b/backend/src/audit_log/audit_event.rs
@@ -78,9 +78,9 @@ pub struct CommitteeSessionDetails {
 #[serde(deny_unknown_fields)]
 pub struct FileDetails {
     pub file_id: u32,
-    pub file_data: Vec<u8>,
     pub file_name: String,
     pub file_mime_type: String,
+    pub file_size_bytes: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, ToSchema)]

--- a/backend/src/files/mod.rs
+++ b/backend/src/files/mod.rs
@@ -17,12 +17,12 @@ pub struct File {
 }
 
 impl From<File> for FileDetails {
-    fn from(value: File) -> Self {
+    fn from(file: File) -> Self {
         Self {
-            file_id: value.id,
-            file_data: value.data,
-            file_name: value.name,
-            file_mime_type: value.mime_type,
+            file_id: file.id,
+            file_name: file.name,
+            file_mime_type: file.mime_type,
+            file_size_bytes: file.data.len() as u64,
         }
     }
 }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -821,10 +821,10 @@ export interface ExtraInvestigation {
 }
 
 export interface FileDetails {
-  file_data: number[];
   file_id: number;
   file_mime_type: string;
   file_name: string;
+  file_size_bytes: number;
 }
 
 /**


### PR DESCRIPTION
Instead of the complete file, write only the file size to the audit log.

Fixes #2255