### PR TITLE
Fixed committee session status change in gen test election

### DIFF
--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -68,6 +68,11 @@ pub async fn create_test_election(
     let polling_stations =
         generate_polling_stations(&mut rng, &committee_session, &election, &mut tx, &args).await;
 
+    info!(
+        "Election generated with election id: {}, election name: '{}'",
+        election.id, election.name
+    );
+
     if !polling_stations.is_empty() {
         committee_session = crate::committee_session::repository::change_status(
             &mut tx,
@@ -77,12 +82,7 @@ pub async fn create_test_election(
         .await?;
     }
 
-    info!(
-        "Election generated with election id: {}, election name: '{}'",
-        election.id, election.name
-    );
-
-    let data_entry_completed = if args.with_data_entry {
+    let data_entry_completed = if args.with_data_entry && !polling_stations.is_empty() {
         committee_session = crate::committee_session::repository::change_status(
             &mut tx,
             committee_session.id,


### PR DESCRIPTION
- Gen test election didn't change the committee session status to `DataEntryNotStarted` when you add an election with polling stations, but without data entry.
- Made sure data entry in gen test election is only done if > 0 polling stations, otherwise the committee session status is changed to `DataEntryInProgress` when this is not allowed without polling stations

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->