### PR TITLE
remove domain id from election homepage heading

### DIFF
--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -37,9 +37,7 @@ const renderPage = async (userRole: Role) => {
     </TestUserProvider>,
   );
   expect(await screen.findByRole("heading", { level: 1, name: "Gemeenteraadsverkiezingen 2026" })).toBeVisible();
-  expect(
-    await screen.findByRole("heading", { level: 2, name: "Gemeentelijk stembureau 0035 Heemdamseburg" }),
-  ).toBeVisible();
+  expect(await screen.findByRole("heading", { level: 2, name: "Gemeentelijk stembureau Heemdamseburg" })).toBeVisible();
 };
 
 describe("ElectionHomePage", () => {
@@ -309,7 +307,7 @@ describe("ElectionHomePage", () => {
 
     expect(await screen.findByRole("heading", { level: 1, name: "Gemeenteraadsverkiezingen 2026" })).toBeVisible();
     expect(
-      await screen.findByRole("heading", { level: 2, name: "Gemeentelijk stembureau 0035 Heemdamseburg" }),
+      await screen.findByRole("heading", { level: 2, name: "Gemeentelijk stembureau Heemdamseburg" }),
     ).toBeVisible();
 
     const committee_session_cards = await screen.findByTestId("committee-session-cards");

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -165,7 +165,7 @@ export function ElectionHomePage() {
             <div>
               <h2>
                 {/* TODO: Change to conditional GSB/HSB/CSB when implemented */}
-                {t("GSB")} {election.domain_id} {election.location}
+                {t("GSB")} {election.location}
               </h2>
             </div>
           </div>


### PR DESCRIPTION
fixes issue found in https://github.com/kiesraad/abacus/issues/2126

### Scope

Remove the domain id in the heading of the election home page:

### Old
<img width="1000" height="665" alt="image" src="https://github.com/user-attachments/assets/c9e6caf9-119f-4ca2-b9eb-9e6fcc7a6398" />

### New
<img width="891" height="500" alt="image" src="https://github.com/user-attachments/assets/a7cfceaf-365f-4e81-9d8e-231a718ad627" />


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->