### PR TITLE
consistent field order in user creation forms

### DIFF
--- a/frontend/e2e-tests/page-objects/authentication/CreateFirstAdminPgObj.ts
+++ b/frontend/e2e-tests/page-objects/authentication/CreateFirstAdminPgObj.ts
@@ -13,7 +13,7 @@ export class CreateFirstAdminPgObj {
     this.header = page.getByRole("heading", { level: 1, name: "Account voor beheerder aanmaken" });
     this.alert = page.getByRole("alert");
     this.fullname = page.getByRole("textbox", { name: "Jouw naam (roepnaam +" });
-    this.username = page.getByRole("textbox", { name: "Gebruikersnaam" });
+    this.username = page.getByRole("textbox", { name: "Kies een gebruikersnaam" });
     this.password = page.getByRole("textbox", { name: "Kies een wachtwoord" });
     this.confirmPassword = page.getByRole("textbox", { name: "Herhaal wachtwoord" });
     this.save = page.getByRole("button", { name: "Opslaan" });

--- a/frontend/src/features/account/components/AccountSetupForm.tsx
+++ b/frontend/src/features/account/components/AccountSetupForm.tsx
@@ -93,19 +93,19 @@ export function AccountSetupForm({ user, onSaved }: AccountSetupFormProps) {
         <FormLayout disabled={isLoading}>
           <FormLayout.Section>
             <InputField
-              name="username"
-              label={t("account.username")}
-              hint={t("account.username_hint")}
-              value={user.username}
-              disabled
-            />
-            <InputField
               name="fullname"
               label={t("account.fullname")}
               subtext={t("account.fullname_subtext")}
               hint={t("account.fullname_hint")}
               error={validationErrors?.fullname}
               defaultValue={user.fullname}
+            />
+            <InputField
+              name="username"
+              label={t("account.username")}
+              hint={t("account.username_hint")}
+              value={user.username}
+              disabled
             />
             <InputField
               name="password"

--- a/frontend/src/features/account/components/CreateFirstAdminForm.test.tsx
+++ b/frontend/src/features/account/components/CreateFirstAdminForm.test.tsx
@@ -18,7 +18,7 @@ describe("CreateFirstAdminForm", () => {
 
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("Jouw naam (roepnaam + achternaam)"), "First Last");
-    await user.type(screen.getByLabelText("Gebruikersnaam"), "firstlast");
+    await user.type(screen.getByLabelText("Kies een gebruikersnaam"), "firstlast");
     await user.type(screen.getByLabelText("Kies een wachtwoord"), "password*password");
     await user.type(screen.getByLabelText("Herhaal wachtwoord"), "password*password");
 
@@ -46,7 +46,7 @@ describe("CreateFirstAdminForm", () => {
     expect(fullnameInput).toBeInvalid();
     expect(fullnameInput).toHaveAccessibleErrorMessage("Dit veld mag niet leeg zijn");
 
-    const usernameInput = screen.getByLabelText("Gebruikersnaam");
+    const usernameInput = screen.getByLabelText("Kies een gebruikersnaam");
     expect(usernameInput).toBeInvalid();
     expect(usernameInput).toHaveAccessibleErrorMessage("Dit veld mag niet leeg zijn");
 
@@ -70,7 +70,7 @@ describe("CreateFirstAdminForm", () => {
 
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("Jouw naam (roepnaam + achternaam)"), "First Last");
-    await user.type(screen.getByLabelText("Gebruikersnaam"), "firstlast");
+    await user.type(screen.getByLabelText("Kies een gebruikersnaam"), "firstlast");
     await user.type(passwordInput, "password");
     await user.type(passwordRepeatInput, "password");
     const submitButton = screen.getByRole("button", { name: "Opslaan" });
@@ -101,7 +101,7 @@ describe("CreateFirstAdminForm", () => {
 
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("Jouw naam (roepnaam + achternaam)"), "First Last");
-    await user.type(screen.getByLabelText("Gebruikersnaam"), "firstlast");
+    await user.type(screen.getByLabelText("Kies een gebruikersnaam"), "firstlast");
     await user.type(screen.getByLabelText("Kies een wachtwoord"), "password*password");
     await user.type(screen.getByLabelText("Herhaal wachtwoord"), "password*password");
     const submitButton = screen.getByRole("button", { name: "Opslaan" });

--- a/frontend/src/features/account/components/CreateFirstAdminForm.tsx
+++ b/frontend/src/features/account/components/CreateFirstAdminForm.tsx
@@ -87,21 +87,19 @@ export function CreateFirstAdminForm({ next }: CreateFirstAdminFormProps) {
           <Form onSubmit={handleSubmit}>
             <FormLayout disabled={isLoading}>
               <FormLayout.Section title={t("initialise.account_details")}>
-                <p>
-                  {t("initialise.store_in_safe_place")} {t("initialise.other_accounts")}
-                </p>
-                <InputField
-                  name="username"
-                  label={t("account.username")}
-                  hint={t("account.choose_username_hint")}
-                  error={validationErrors?.username}
-                />
+                <p>{t("initialise.store_in_safe_place")}</p>
                 <InputField
                   name="fullname"
                   label={t("account.fullname")}
                   subtext={t("account.fullname_subtext")}
                   hint={t("initialise.fullname_hint")}
                   error={validationErrors?.fullname}
+                />
+                <InputField
+                  name="username"
+                  label={t("initialise.username")}
+                  hint={t("initialise.username_hint")}
+                  error={validationErrors?.username}
                 />
                 <InputField
                   name="password"

--- a/frontend/src/features/account/components/InitialiseApplicationPage.test.tsx
+++ b/frontend/src/features/account/components/InitialiseApplicationPage.test.tsx
@@ -38,7 +38,7 @@ describe("InitialiseApplicationPage", () => {
 
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("Jouw naam (roepnaam + achternaam)"), "First Last");
-    await user.type(screen.getByLabelText("Gebruikersnaam"), "firstlast");
+    await user.type(screen.getByLabelText("Kies een gebruikersnaam"), "firstlast");
     await user.type(screen.getByLabelText("Kies een wachtwoord"), "password*password");
     await user.type(screen.getByLabelText("Herhaal wachtwoord"), "password*password");
 
@@ -57,7 +57,7 @@ describe("InitialiseApplicationPage", () => {
     });
 
     await user.type(screen.getByLabelText("Jouw naam (roepnaam + achternaam)"), "First Last");
-    await user.type(screen.getByLabelText("Gebruikersnaam"), "firstlast");
+    await user.type(screen.getByLabelText("Kies een gebruikersnaam"), "firstlast");
     await user.type(screen.getByLabelText("Kies een wachtwoord"), "password*password");
     await user.type(screen.getByLabelText("Herhaal wachtwoord"), "password*password");
 

--- a/frontend/src/features/users/components/create/UserCreateDetailsForm.tsx
+++ b/frontend/src/features/users/components/create/UserCreateDetailsForm.tsx
@@ -105,14 +105,6 @@ export function UserCreateDetailsForm({ role, showFullname, onSubmitted }: UserC
       <Form title={t("users.details_title")} onSubmit={handleSubmit}>
         <FormLayout disabled={isLoading}>
           <FormLayout.Section>
-            <InputField
-              id="username"
-              name="username"
-              label={t("users.username")}
-              hint={t("users.username_hint")}
-              error={validationErrors?.username}
-            />
-
             {showFullname && (
               <InputField
                 id="fullname"
@@ -122,6 +114,14 @@ export function UserCreateDetailsForm({ role, showFullname, onSubmitted }: UserC
                 error={validationErrors?.fullname}
               />
             )}
+
+            <InputField
+              id="username"
+              name="username"
+              label={t("users.username")}
+              hint={t("users.username_hint")}
+              error={validationErrors?.username}
+            />
 
             <InputField
               id="temp_password"

--- a/frontend/src/features/users/components/update/UserUpdateForm.tsx
+++ b/frontend/src/features/users/components/update/UserUpdateForm.tsx
@@ -77,15 +77,6 @@ export function UserUpdateForm({ user, onSaved, onAbort }: UserUpdateFormProps) 
       <Form title={t("users.details_title")} onSubmit={handleSubmit}>
         <FormLayout disabled={isLoading}>
           <FormLayout.Section>
-            <InputField
-              id="username"
-              name="username"
-              disabled={true}
-              value={user.username}
-              label={t("users.username")}
-              hint={t("users.username_hint_disabled")}
-            />
-
             {user.fullname && (
               <InputField
                 id="fullname"
@@ -96,6 +87,15 @@ export function UserUpdateForm({ user, onSaved, onAbort }: UserUpdateFormProps) 
                 error={validationErrors?.fullname}
               />
             )}
+
+            <InputField
+              id="username"
+              name="username"
+              disabled={true}
+              value={user.username}
+              label={t("users.username")}
+              hint={t("users.username_hint_disabled")}
+            />
 
             {editPassword ? (
               <InputField

--- a/frontend/src/i18n/locales/nl/account.json
+++ b/frontend/src/i18n/locales/nl/account.json
@@ -23,6 +23,6 @@
   "setting_up_account": "We gaan je account instellen voor gebruik. Vul onderstaande gegevens in om verder te gaan.",
   "username": "Gebruikersnaam",
   "username_hint": "Je kan deze niet aanpassen. Log volgende keer weer met deze gebruikersnaam in.",
-  "choose_username_hint": "Dit is de naam waarmee je kan inloggen. De invoer is niet hoofdlettergevoelig.",
+  "choose_username_hint": "Dit is de naam waarmee je kan inloggen. De gebruikersnaam is niet hoofdlettergevoelig.",
   "username_login_hint": "De naam op het briefje dat je van de coördinator hebt gekregen."
 }

--- a/frontend/src/i18n/locales/nl/initialise.json
+++ b/frontend/src/i18n/locales/nl/initialise.json
@@ -2,11 +2,10 @@
   "account_details": "Details van het account",
   "admin_configured": "Account van beheerder ingesteld",
   "create_admin_account": "Account voor beheerder aanmaken",
-  "fullname_hint": "Bijvoorbeeld Karel van Tellingen. Accounts in Abacus zijn persoonsgebonden.",
+  "fullname_hint": "Bijvoorbeeld Karel van Tellingen. Accounts in Abacus zijn persoonsgebonden. Je kan straks via gebruikersbeheer accounts aanmaken voor andere beheerders.",
   "installation_success": "Installatie gelukt",
   "login_to_admin_account": "Inloggen met account van beheerder",
   "login_to_finish_setup": "<p>Abacus is nog niet klaar voor gebruik. Log in met het account van de beheerder om de configuratie af te ronden. Ben je de inloggegevens kwijt?</p><p><link>Stel het account van de beheerder opnieuw in.</link></p>",
-  "other_accounts": "Je kan straks via gebruikersbeheer accounts aanmaken voor andere beheerders.",
   "password_hint": "Gebruik minimaal 13 karakters. Het wachtwoord is hoofdlettergevoelig.",
   "password_login_hint": "Het wachtwoord dat je zojuist hebt gekozen",
   "password_rules": "Het wachtwoord moet minimaal 13 karakters lang zijn.",
@@ -14,6 +13,8 @@
   "reconfigure_admin_account": "Ben je de inloggegevens kwijt? <link>Stel het account van de beheerder opnieuw in.</link>",
   "setup_instructions": "<p>Abacus is geïnstalleerd en bijna klaar voor gebruik.</p><p>Voordat je verder gaat moet je als beheerder een account aanmaken. Als eerste beheerder kan je vervolgens:</p><ul><li>Andere gebruikers aanmaken en beheren</li><li>De verkiezing voorbereiden</li></ul>",
   "store_in_safe_place": "Bewaar de gegevens van het account van de beheerder op een veilige plek.",
+  "username": "Kies een gebruikersnaam",
+  "username_hint": "Dit is de naam waarmee je kan inloggen. De gebruikersnaam is niet hoofdlettergevoelig.",
   "username_login_hint": "De naam die je zojuist hebt ingesteld",
   "welcome_title": "Welkom bij Abacus"
 }

--- a/frontend/src/i18n/locales/nl/users.json
+++ b/frontend/src/i18n/locales/nl/users.json
@@ -41,7 +41,7 @@
   "user_updated_details": "De wijzigingen in het account van {fullname} zijn opgeslagen",
   "user_updated": "Wijzigingen opgeslagen",
   "username_hint_disabled": "Dit is de naam waarmee de gebruiker kan inloggen. De gebruikersnaam kan niet gewijzigd worden.",
-  "username_hint": "Dit is de naam waarmee de gebruiker kan inloggen. De invoer is niet hoofdlettergevoelig",
+  "username_hint": "Dit is de naam waarmee de gebruiker kan inloggen. De gebruikersnaam is niet hoofdlettergevoelig",
   "username_not_unique_error": "Er bestaat al een gebruiker met gebruikersnaam {username}",
   "username_unique": "De gebruikersnaam moet uniek zijn",
   "username": "Gebruikersnaam",


### PR DESCRIPTION
### Scope
- Consistent ordering of fullname and username in forms
- Use "Kies een gebruikersnaam" on the first admin form
- Use "gebruikersnaam" instead of "invoer" in the field hints 
- Hint text update: "Je kan straks via gebruikersbeheer accounts aanmaken voor andere beheerders."

fixes issue in found https://github.com/kiesraad/abacus/issues/2126

<img width="531" height="503" alt="image" src="https://github.com/user-attachments/assets/3d4f34e2-4c4d-4a8e-ade6-0df2fcb19e3c" />

<img width="524" height="420" alt="image" src="https://github.com/user-attachments/assets/6588606a-7ed4-4560-9715-9efd22fa1206" />

<img width="543" height="420" alt="image" src="https://github.com/user-attachments/assets/0456010e-8c64-42b9-b330-76d34ce2f5b0" />

<img width="574" height="571" alt="image" src="https://github.com/user-attachments/assets/65bf5fe4-7f62-4f65-8541-06a7548a4739" />


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->