### PR TITLE
instructions at first login conditional on role

### DIFF
--- a/frontend/src/features/election_overview/components/OverviewPage.tsx
+++ b/frontend/src/features/election_overview/components/OverviewPage.tsx
@@ -150,7 +150,7 @@ export function OverviewPage() {
       {isNewAccount && (
         <Alert type="success" onClose={closeNewAccountAlert}>
           <strong className="heading-md">{t("account_configured")}</strong>
-          <p>{t("election.start_when_count_list_received")}</p>
+          {isTypist && <p>{t("election.start_when_count_list_received")}</p>}
         </Alert>
       )}
       <main>


### PR DESCRIPTION
### Scope

fixes issue found in https://github.com/kiesraad/abacus/issues/2126

The message "Zodra je een tellijst van een stembureau hebt gekregen kan je beginnen met invoeren." was shown to all user roles upon first log in. This PR makes it so we only show it to typists.

### Typist
<img width="1169" height="519" alt="image" src="https://github.com/user-attachments/assets/a6c8fc33-76ff-43e6-9b40-72d260a1306b" />

### Non-typist
<img width="1050" height="530" alt="image" src="https://github.com/user-attachments/assets/01282719-567c-45fe-9d11-ef052986ef13" />



<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->