### PR TITLE
Let Clippy only lint default features in Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,7 @@ pre-commit:
     backend-linter:
       root: "backend/"
       glob: "*.rs"
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
     backend-openapi:
       root: "backend/"
       glob: "*.rs"


### PR DESCRIPTION
@stacktraceghost noticed that after #2262 was merged, the Lefthook Clippy lint errors out when the `dist-storybook` directory doesn't exist. This is because Clippy is running with the `--all-features` argument, which also enables the new `storybook` feature that expects the Storybook build to be done.

We don't really need Clippy to lint all features in Lefthook, also because enabling memory-serve features is noticeably slower. Thus, this PR changes the Lefthook config to only lint default features. Any issues with other features will still be caught by CI.