### PR TITLE
Added refetch statuses to investigation overview

### DIFF
--- a/frontend/src/features/investigations/components/InvestigationCard.tsx
+++ b/frontend/src/features/investigations/components/InvestigationCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { MouseEvent, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import { IconCheckmark, IconMinus, IconPencil, IconPrinter } from "@/components/generated/icons";
@@ -27,7 +27,7 @@ export function InvestigationCard({ investigation }: InvestigationCardProps) {
     setShowModal(false);
   };
 
-  const goToFindings = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const goToFindings = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
 
     if (currentCommitteeSession.status === "data_entry_not_started") {

--- a/frontend/src/features/investigations/components/InvestigationsOverviewPage.tsx
+++ b/frontend/src/features/investigations/components/InvestigationsOverviewPage.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
 import { useNavigate } from "react-router";
 
+import { DEFAULT_CANCEL_REASON } from "@/api/ApiClient";
 import { isSuccess, NotFoundError } from "@/api/ApiResult";
 import { useCrud } from "@/api/useCrud";
 import { IconPlus } from "@/components/generated/icons";
@@ -8,6 +10,7 @@ import { PageTitle } from "@/components/page_title/PageTitle";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { useElection } from "@/hooks/election/useElection";
+import { useElectionStatus } from "@/hooks/election/useElectionStatus";
 import { useUserRole } from "@/hooks/user/useUserRole";
 import { t } from "@/i18n/translate";
 import {
@@ -22,6 +25,7 @@ import { InvestigationCard } from "./InvestigationCard";
 export function InvestigationsOverviewPage() {
   const { currentCommitteeSession } = useElection();
   const { investigations, currentInvestigations, handledInvestigations } = useInvestigations();
+  const { refetch: refetchStatuses } = useElectionStatus();
   const { isCoordinator } = useUserRole();
   const navigate = useNavigate();
   const updatePath: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/committee_sessions/${currentCommitteeSession.id}/status`;
@@ -41,6 +45,17 @@ export function InvestigationsOverviewPage() {
   if (currentCommitteeSession.number < 2) {
     throw new NotFoundError();
   }
+
+  // re-fetch statuses when component mounts
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    void refetchStatuses(abortController);
+
+    return () => {
+      abortController.abort(DEFAULT_CANCEL_REASON);
+    };
+  }, [refetchStatuses]);
 
   return (
     <>


### PR DESCRIPTION
found in https://github.com/kiesraad/abacus/issues/2274

Fixes bug that adding an investigation with `corrected results: yes` shows on the overview page as:
<img width="645" height="337" alt="image" src="https://github.com/user-attachments/assets/b019ea02-8be3-4cd0-bd36-cf92c53dd510" />

And after a refresh as:
<img width="645" height="337" alt="image" src="https://github.com/user-attachments/assets/2179af9a-4bfa-44df-85b5-02cd3ec9e774" />

Fixed by adding a refetch of the polling station statuses to a `useEffect` on the overview page.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->