### PR TITLE
Better airgap instruction, 30s check interval

### DIFF
--- a/backend/src/airgap/detect.rs
+++ b/backend/src/airgap/detect.rs
@@ -37,7 +37,7 @@ const DOMAINS: [&str; 3] = [
     "surfnet.nl",
 ];
 
-pub const AIRGAP_DETECTION_INTERVAL: u64 = 60; // interval in seconds
+pub const AIRGAP_DETECTION_INTERVAL: u64 = 30; // interval in seconds
 
 impl AirgapDetection {
     /// Creates a new AirgapDetection instance that does not perform any detection.

--- a/frontend/src/i18n/format.tsx
+++ b/frontend/src/i18n/format.tsx
@@ -12,7 +12,7 @@ interface Element {
   children: AST;
 }
 
-export const DEFAULT_ALLOWED_TAGS = ["ul", "li", "p", "strong", "em", "code", "h2", "h3", "h4", "Link"];
+export const DEFAULT_ALLOWED_TAGS = ["ul", "ol", "li", "p", "strong", "em", "code", "h2", "h3", "h4", "Link"];
 
 const DEFAULT_RENDER_FUNCTIONS: Record<string, RenderFunction> = {
   Link: (element, attributes) => <Link to={attributes?.to || "."}>{element}</Link>,

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -1,6 +1,6 @@
 {
   "airgap_violation": {
-    "content": "<p>Abacus is geblokkeerd omdat de applicatie is verbonden met het internet.</p><ul><li>Wijzigingen zijn niet mogelijk</li><li>Alle werkplekken zijn vergrendeld</li></ul><h3>Wat te doen?</h3><ul><li>Verbreek de internetverbinding</li><li><reload>Herlaad de pagina</reload></li></ul><p>Pas daarna kan Abacus weer gebruikt worden.</p>",
+    "content": "<p>Abacus is geblokkeerd omdat de applicatie is verbonden met het internet.</p><ul><li>Wijzigingen zijn niet mogelijk</li><li>Alle werkplekken zijn vergrendeld</li></ul><h3>Wat te doen?</h3><ol><li>Verbreek de internetverbinding</li><li>Wacht 30 seconden</li><li><reload>Herlaad de pagina</reload></li></ol><p>Pas daarna kan Abacus weer gebruikt worden.</p>",
     "reload": "Probeer opnieuw",
     "title": "Abacus zit op slot"
   },


### PR DESCRIPTION
The current airgap error page instructs the user to disable their internet connection and refresh the page. This could cause confusion since the airgap status is only checked every 60 seconds, so it could take up to 60 seconds before abacus becomes responsive again:

<img width="556" height="370" alt="Screenshot From 2025-10-20 10-11-51" src="https://github.com/user-attachments/assets/6e995426-a8b2-4640-91b3-967aea32f613" />

This PR changes the check status from 60 seconds to 30 seconds (which is not a problem since we perform the checks concurrently now and have a 10 second timeout).
It adds the line "Wacht 30 seconden" to instruct the user to wait before refreshing the page and access abacus again:

<img width="556" height="370" alt="Screenshot From 2025-10-20 10-15-20" src="https://github.com/user-attachments/assets/11e95daf-bb7b-40e4-958d-796a77e90aed" />


