### PR TITLE
Remove redundant line from use-case

### DIFF
--- a/documentatie/use-cases/airgap.md
+++ b/documentatie/use-cases/airgap.md
@@ -12,9 +12,8 @@ __Uitbreidingen:__
 1a. De server stelt vast dat er een internetverbinding is:  
 &emsp; 1a1. De server blokkeert de invoer en aanpassingen aan de configuratie.  
 &emsp; 1a2. De server logt alle details met betrekking tot de geconstateerde internetverbinding.  
-&emsp; 1a3. De applicatie toont ingelogde coördinatoren en beheerders een foutmelding met vermelding van de bron van het probleem.  
-&emsp; 1a4. De applicatie toont op alle andere clients een paginavullende foutmelding.  
-&emsp; 1a5. De foutmeldingen verdwijnen zodra bij de eerstvolgende check blijkt dat het probleem is verholpen.  
+&emsp; 1a3. De applicatie toont op alle andere clients een paginavullende foutmelding.  
+&emsp; 1a4. De foutmeldingen verdwijnen zodra bij de eerstvolgende check blijkt dat het probleem is verholpen.  
 
 1b. Een client stelt vast dat er een internetverbinding is:  _(could have versie 1.0 GSB)_  
 &emsp; 1b1. De betreffende client stuurt een melding naar de server.  


### PR DESCRIPTION
The airgap use-case states the same in 1a3 and 1b4, but only 1b4 is intended
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->