### PR TITLE
Return 204 on successful but empty API responses

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -413,7 +413,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": "Committee session updated successfully"
           },
           "400": {
@@ -496,7 +496,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "Committee session deleted successfully"
           },
           "401": {
@@ -783,7 +783,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": "Committee session status changed successfully"
           },
           "401": {
@@ -878,7 +878,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": "Committee session number of voters changed successfully"
           },
           "401": {
@@ -1593,7 +1593,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "Polling station deleted successfully"
           },
           "401": {
@@ -1724,7 +1724,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Created test election"
           },
           "500": {
@@ -1744,7 +1744,7 @@
       "get": {
         "operationId": "admin_exists",
         "responses": {
-          "200": {
+          "204": {
             "description": "First admin user exists"
           },
           "403": {
@@ -1843,7 +1843,7 @@
         "summary": "Check whether the application is initialised (an admin user exists + has logged in at least once)",
         "operationId": "initialised",
         "responses": {
-          "200": {
+          "204": {
             "description": "The application is initialised"
           },
           "418": {
@@ -2106,7 +2106,7 @@
         "summary": "Logout endpoint, deletes the session cookie",
         "operationId": "logout",
         "responses": {
-          "200": {
+          "204": {
             "description": "Successful logout, or user was already logged out"
           },
           "500": {
@@ -3131,7 +3131,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "Polling station investigation deleted successfully"
           },
           "401": {
@@ -3651,7 +3651,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "User deleted successfully"
           },
           "401": {

--- a/backend/src/authentication/mod.rs
+++ b/backend/src/authentication/mod.rs
@@ -225,7 +225,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
         assert_eq!(
             response.headers()["clear-site-data"],
             r#""cookies","storage""#
@@ -255,7 +255,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
         assert_eq!(
             response.headers()["clear-site-data"],
             r#""cookies","storage""#
@@ -304,7 +304,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // try to get the current user again, should return 401
         let response = app

--- a/backend/src/authentication/user_api.rs
+++ b/backend/src/authentication/user_api.rs
@@ -209,7 +209,7 @@ pub async fn user_update(
     delete,
     path = "/api/user/{user_id}",
     responses(
-        (status = 200, description = "User deleted successfully"),
+        (status = 204, description = "User deleted successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "User not found", body = ErrorResponse),
@@ -255,7 +255,7 @@ async fn user_delete(
 
         tx.commit().await?;
 
-        Ok(StatusCode::OK)
+        Ok(StatusCode::NO_CONTENT)
     } else {
         tx.rollback().await?;
 

--- a/backend/src/committee_session/api.rs
+++ b/backend/src/committee_session/api.rs
@@ -125,7 +125,7 @@ pub async fn committee_session_create(
     delete,
     path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}",
     responses(
-        (status = 200, description = "Committee session deleted successfully"),
+        (status = 204, description = "Committee session deleted successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Committee session not found", body = ErrorResponse),
@@ -168,7 +168,7 @@ pub async fn committee_session_delete(
 
         tx.commit().await?;
 
-        Ok(StatusCode::OK)
+        Ok(StatusCode::NO_CONTENT)
     } else {
         tx.rollback().await?;
 
@@ -184,7 +184,7 @@ pub async fn committee_session_delete(
     path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}",
     request_body = CommitteeSessionUpdateRequest,
     responses(
-        (status = 200, description = "Committee session updated successfully"),
+        (status = 204, description = "Committee session updated successfully"),
         (status = 400, description = "Bad request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
@@ -246,7 +246,7 @@ pub async fn committee_session_update(
 
     tx.commit().await?;
 
-    Ok(StatusCode::OK)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Change the number of voters of a [CommitteeSession].
@@ -255,7 +255,7 @@ pub async fn committee_session_update(
     path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}/voters",
     request_body = CommitteeSessionNumberOfVotersChangeRequest,
     responses(
-        (status = 200, description = "Committee session number of voters changed successfully"),
+        (status = 204, description = "Committee session number of voters changed successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Committee session not found", body = ErrorResponse),
@@ -299,7 +299,7 @@ pub async fn committee_session_number_of_voters_change(
 
     tx.commit().await?;
 
-    Ok(StatusCode::OK)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Change the status of a [CommitteeSession].
@@ -308,7 +308,7 @@ pub async fn committee_session_number_of_voters_change(
     path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}/status",
     request_body = CommitteeSessionStatusChangeRequest,
     responses(
-        (status = 200, description = "Committee session status changed successfully"),
+        (status = 204, description = "Committee session status changed successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Committee session not found", body = ErrorResponse),
@@ -345,7 +345,7 @@ pub async fn committee_session_status_change(
     .await?;
     tx.commit().await?;
 
-    Ok(StatusCode::OK)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[cfg(test)]

--- a/backend/src/investigation/api.rs
+++ b/backend/src/investigation/api.rs
@@ -310,7 +310,7 @@ async fn polling_station_investigation_update(
     delete,
     path = "/api/polling_stations/{polling_station_id}/investigation",
     responses(
-        (status = 200, description = "Polling station investigation deleted successfully"),
+        (status = 204, description = "Polling station investigation deleted successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Investigation not found", body = ErrorResponse),
@@ -376,7 +376,7 @@ async fn polling_station_investigation_delete(
 
         tx.commit().await?;
 
-        Ok(StatusCode::OK)
+        Ok(StatusCode::NO_CONTENT)
     } else {
         tx.commit().await?;
 

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -235,7 +235,7 @@ async fn polling_station_update(
     delete,
     path = "/api/elections/{election_id}/polling_stations/{polling_station_id}",
     responses(
-        (status = 200, description = "Polling station deleted successfully"),
+        (status = 204, description = "Polling station deleted successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Polling station not found", body = ErrorResponse),
@@ -287,7 +287,7 @@ async fn polling_station_delete(
 
     tx.commit().await?;
 
-    Ok(StatusCode::OK)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, ToSchema)]

--- a/backend/src/test_data_gen/api.rs
+++ b/backend/src/test_data_gen/api.rs
@@ -13,7 +13,7 @@ pub fn router() -> OpenApiRouter<AppState> {
     post,
     path = "/api/generate_test_election",
     responses(
-        (status = 200, description = "Created test election"),
+        (status = 201, description = "Created test election"),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
     request_body = GenerateElectionArgs,

--- a/backend/tests/authorization_test.rs
+++ b/backend/tests/authorization_test.rs
@@ -14,7 +14,8 @@ fn expected_response_code(path: &str) -> StatusCode {
         "/api/login" | "/api/initialise/first-admin" | "/api/generate_test_election" => {
             StatusCode::UNSUPPORTED_MEDIA_TYPE
         }
-        "/api/logout" | "/api/initialised" => StatusCode::OK,
+        "/api/logout" => StatusCode::OK,
+        "/api/initialised" => StatusCode::NO_CONTENT,
         "/api/initialise/admin-exists" => StatusCode::FORBIDDEN,
         _ => StatusCode::UNAUTHORIZED,
     }

--- a/backend/tests/committee_session_integration_test.rs
+++ b/backend/tests/committee_session_integration_test.rs
@@ -112,7 +112,7 @@ async fn test_committee_session_delete_ok_status_created(pool: SqlitePool) {
 
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 
@@ -376,7 +376,7 @@ async fn test_committee_session_update_works(pool: SqlitePool) {
     // Ensure the response is what we expect
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 }
@@ -481,7 +481,7 @@ async fn test_committee_session_status_change_works(pool: SqlitePool) {
     // Ensure the response is what we expect
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 }
@@ -511,7 +511,7 @@ async fn test_committee_session_status_change_finished_to_in_progress_deletes_fi
     // Ensure the response is what we expect
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 
@@ -559,7 +559,7 @@ async fn test_committee_session_status_change_finished_to_in_progress_deletes_fi
     // Ensure the response is what we expect
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 
@@ -652,7 +652,7 @@ async fn test_committee_session_number_of_voters_change_works(pool: SqlitePool) 
     // Ensure the response is what we expect
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 }

--- a/backend/tests/investigation_integration_test.rs
+++ b/backend/tests/investigation_integration_test.rs
@@ -136,7 +136,7 @@ async fn test_create_conclude_update_delete(pool: SqlitePool) {
 
     assert_eq!(
         delete_investigation(&addr, 741).await.status(),
-        StatusCode::OK
+        StatusCode::NO_CONTENT
     );
     let election_details = get_election(&addr, election_id).await;
     assert_eq!(election_details.investigations.len(), 0);
@@ -168,7 +168,7 @@ async fn test_deletion_setting_committee_session_back_to_created_status(pool: Sq
     // Delete one investigation
     assert_eq!(
         delete_investigation(&addr, 742).await.status(),
-        StatusCode::OK
+        StatusCode::NO_CONTENT
     );
 
     let committee_session =
@@ -181,7 +181,7 @@ async fn test_deletion_setting_committee_session_back_to_created_status(pool: Sq
     // Delete last investigation
     assert_eq!(
         delete_investigation(&addr, 741).await.status(),
-        StatusCode::OK
+        StatusCode::NO_CONTENT
     );
 
     let committee_session =
@@ -295,7 +295,7 @@ async fn test_deletion_removes_polling_station_from_status(pool: SqlitePool) {
         delete_investigation(&addr, polling_station_id)
             .await
             .status(),
-        StatusCode::OK
+        StatusCode::NO_CONTENT
     );
 
     let statuses = get_statuses(&addr, &cookie, election_id).await;
@@ -887,7 +887,11 @@ where
     );
 
     let status = action().await.status();
-    assert!(status == StatusCode::OK || status == StatusCode::CREATED);
+    assert!(
+        status == StatusCode::OK
+            || status == StatusCode::NO_CONTENT
+            || status == StatusCode::CREATED
+    );
 
     let committee_session =
         shared::get_election_committee_session(addr, &cookie, election_id).await;
@@ -965,7 +969,7 @@ async fn test_finished_to_created_on_delete_last(pool: SqlitePool) {
     );
 
     let status = delete_investigation(&addr, 741).await.status();
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(status, StatusCode::NO_CONTENT);
 
     let committee_session =
         shared::get_election_committee_session(&addr, &cookie, election_id).await;

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -328,7 +328,7 @@ async fn test_delete_ok(pool: SqlitePool) {
 
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 
@@ -350,7 +350,7 @@ async fn test_delete_ok(pool: SqlitePool) {
     let response = delete_polling_station(&addr, election_id, 1).await;
     assert_eq!(
         response.status(),
-        StatusCode::OK,
+        StatusCode::NO_CONTENT,
         "Unexpected response status"
     );
 

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -333,7 +333,7 @@ pub async fn change_status_committee_session(
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
 pub async fn get_statuses(

--- a/backend/tests/user_integration_test.rs
+++ b/backend/tests/user_integration_test.rs
@@ -341,7 +341,7 @@ async fn test_user_delete(pool: SqlitePool) {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
     let response = reqwest::Client::new()
         .delete(&url)
@@ -396,7 +396,7 @@ async fn test_can_delete_logged_in_user(pool: SqlitePool) {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
@@ -568,7 +568,7 @@ async fn test_coordinator_can_only_delete_typists(pool: SqlitePool) {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
     let admin_url = format!("http://{addr}/api/user/1");
     let response = reqwest::Client::new()


### PR DESCRIPTION
Currently our API uses a mix of 200, 201 and 204 response codes to indicate success.

In order to be more consistent and help us differentiate between empty and non-empty responses, this PR configures a 204 for all successful but empty responses.