### PR TITLE
Add error handling for application level errors

### DIFF
--- a/backend/src/app_error.rs
+++ b/backend/src/app_error.rs
@@ -1,0 +1,56 @@
+#[derive(Debug)]
+pub enum AppError {
+    PortAlreadyInUse(u16),
+    Database(sqlx::Error),
+    DatabaseMigration(sqlx::migrate::MigrateError),
+    Io(std::io::Error),
+    Environment(tracing_subscriber::filter::FromEnvError),
+    StdError(Box<dyn std::error::Error>),
+}
+
+impl std::error::Error for AppError {}
+
+impl From<std::io::Error> for AppError {
+    fn from(err: std::io::Error) -> Self {
+        AppError::Io(err)
+    }
+}
+
+impl From<sqlx::Error> for AppError {
+    fn from(err: sqlx::Error) -> Self {
+        AppError::Database(err)
+    }
+}
+
+impl From<sqlx::migrate::MigrateError> for AppError {
+    fn from(err: sqlx::migrate::MigrateError) -> Self {
+        AppError::DatabaseMigration(err)
+    }
+}
+
+impl From<tracing_subscriber::filter::FromEnvError> for AppError {
+    fn from(err: tracing_subscriber::filter::FromEnvError) -> Self {
+        AppError::Environment(err)
+    }
+}
+
+impl From<Box<dyn std::error::Error>> for AppError {
+    fn from(err: Box<dyn std::error::Error>) -> Self {
+        AppError::StdError(err)
+    }
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppError::Database(e) => write!(f, "Database error: {}", e),
+            AppError::DatabaseMigration(e) => write!(f, "Database migration error: {}", e),
+            AppError::Io(e) => write!(f, "IO error: {}", e),
+            AppError::Environment(e) => write!(f, "Environment error: {}", e),
+            AppError::PortAlreadyInUse(port) => {
+                write!(f, "Port {port} is in use. Is Abacus already running?",)
+            }
+            AppError::StdError(e) => write!(f, "{}", e),
+        }
+    }
+}

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -1,4 +1,5 @@
 use abacus::{
+    AppError,
     committee_session::CommitteeSession,
     create_sqlite_pool,
     data_entry::PollingStationResults,
@@ -11,7 +12,6 @@ use abacus::{
 };
 use clap::Parser;
 use std::{
-    error::Error,
     ops::Range,
     path::{Path, PathBuf},
 };
@@ -105,7 +105,7 @@ impl From<Args> for GenerateElectionArgs {
 /// Main entry point for the application. Sets up the database, and starts the
 /// API server and in-memory file router on port 8080.
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), AppError> {
     // setup logging
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/backend/src/data_entry/repository.rs
+++ b/backend/src/data_entry/repository.rs
@@ -486,8 +486,7 @@ mod tests {
     }
 
     mod list_results_for_committee_session {
-        use super::super::*;
-        use super::create_test_results;
+        use super::{super::*, create_test_results};
         use crate::{
             investigation::insert_test_investigation,
             polling_station::repository::insert_test_polling_station,
@@ -801,8 +800,7 @@ mod tests {
     }
 
     mod are_results_complete_for_committee_session {
-        use super::super::*;
-        use super::create_test_results;
+        use super::{super::*, create_test_results};
         use crate::{
             data_entry::repository::insert_test_result,
             investigation::{

--- a/backend/src/fixtures.rs
+++ b/backend/src/fixtures.rs
@@ -1,6 +1,8 @@
 use sqlx::SqlitePool;
 use tracing::info;
 
+use crate::AppError;
+
 /// Macro to convert a single fixture name to the contents of a fixture file
 macro_rules! load_fixture {
     ($fixture:literal) => {
@@ -30,7 +32,7 @@ struct Fixture {
 
 /// Function that loads the fixture data into the given connection
 /// Each fixture may contain multiple SQL statements.
-pub async fn seed_fixture_data(pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn seed_fixture_data(pool: &SqlitePool) -> Result<(), AppError> {
     for fixture in FIXTURES {
         sqlx::raw_sql(fixture.data).execute(pool).await?;
     }


### PR DESCRIPTION
The Abacus backend defines an APIError to unify all errors and error responses originating from the Abacus API. However, we do not have such an error type for application level errors. Previously mainly `Box<dyn Error>` was passed around resulting in less control on how the error is presented to the user.

This PR introduces the AppError, which is rendered in a uniform manner when calling the Abacus binary. This would also allow us to provide more specific error messages, like is done for the "address in use" error in this PR.

To test: start abacus twice and see a nicer error message.

Old:
```
Error: Os { code: 98, kind: AddrInUse, message: "Address already in use" }
```

New:
```
2025-10-29T09:34:21.678578Z ERROR abacus: Port 8080 is in use. Is Abacus already running?
```


