### PR TITLE
Ignore invalid empty responses, fix requestState handling

### DIFF
--- a/frontend/src/features/account/components/InitialiseApplicationPage.test.tsx
+++ b/frontend/src/features/account/components/InitialiseApplicationPage.test.tsx
@@ -78,7 +78,7 @@ describe("InitialiseApplicationPage", () => {
   });
 
   test("Go to login if an account was already created", async () => {
-    overrideOnce("get", "/api/initialise/admin-exists", 200, "");
+    overrideOnce("get", "/api/initialise/admin-exists", 204, "");
 
     render(<InitialiseApplicationPage />);
 

--- a/frontend/src/features/dev/components/DevHomePage.tsx
+++ b/frontend/src/features/dev/components/DevHomePage.tsx
@@ -27,12 +27,15 @@ function Links() {
   const { requestState: getElections } = useInitialApiGet<ElectionListResponse>(
     `/api/elections` satisfies ELECTION_LIST_REQUEST_PATH,
   );
-  if (getElections.status === "api-error") {
-    throw getElections.error;
-  }
+
   if (getElections.status === "loading") {
     return <Loader />;
   }
+
+  if (getElections.status !== "success") {
+    throw getElections.error;
+  }
+
   const electionList = getElections.data.elections;
   const committeeSessions = getElections.data.committee_sessions;
 

--- a/frontend/src/features/election_overview/components/OverviewPage.tsx
+++ b/frontend/src/features/election_overview/components/OverviewPage.tsx
@@ -50,12 +50,12 @@ export function OverviewPage() {
 
   useLiveData(refetchElections);
 
-  if (getElections.status === "api-error") {
-    throw getElections.error;
-  }
-
   if (getElections.status === "loading") {
     return <Loader />;
+  }
+
+  if (getElections.status !== "success") {
+    throw getElections.error;
   }
 
   const committeeSessionList = getElections.data.committee_sessions;


### PR DESCRIPTION
This checks for unexpected empty 200 responses and converts them to an AbortedError. We observed these when using FireFox and Abacus is being throttled / suspended on a hidden tab. In this case Abacus should not show a full page error but ignore the responsive of the aborted request.

Final change (together with #2354, #2353, #2355) to prevent Abacus from showing a full page error on throttled / aborted requests: #2307

This PR also corrects how requestState is handled in the election overview page and the dev page.
