### PR TITLE
Fix flaky test AddInvestigationLayout

### DIFF
--- a/frontend/src/features/investigations/components/AddInvestigationLayout.test.tsx
+++ b/frontend/src/features/investigations/components/AddInvestigationLayout.test.tsx
@@ -147,8 +147,8 @@ describe("AddInvestigationLayout", () => {
 
       const user = userEvent.setup();
       const modal = await screen.findByTestId("modal-dialog");
-      const modalNav = within(modal).getByRole("navigation");
-      const cancelButton = await within(modalNav).findByRole("button", { name: "Annuleren" });
+      const modalNav = await within(modal).findByRole("navigation");
+      const cancelButton = within(modalNav).getByRole("button", { name: "Annuleren" });
       await user.click(cancelButton);
 
       expect(updateCommitteeSession).not.toHaveBeenCalled();
@@ -169,8 +169,8 @@ describe("AddInvestigationLayout", () => {
       await user.click(continueButton);
 
       const modal = await screen.findByTestId("modal-dialog");
-      const modalNav = within(modal).getByRole("navigation");
-      const cancelButton = await within(modalNav).findByRole("button", { name: "Annuleren" });
+      const modalNav = await within(modal).findByRole("navigation");
+      const cancelButton = within(modalNav).getByRole("button", { name: "Annuleren" });
       await user.click(cancelButton);
 
       expect(updateCommitteeSession).not.toHaveBeenCalled();


### PR DESCRIPTION
One of the tests in `AddInvestigationLayout.tsx` turned out to be very slightly [flaky](https://github.com/kiesraad/abacus/actions/runs/18903100879/job/53954761297?pr=2360). 

Locally I've executed five runs of 200 times the same test:
1. No errors
2. 1 error (9th)
3. No errors
4. 1 error (halfway)
5. No errors

So it happens very rarely. My assumption is that the navigation role in the modal can't be found because a render is still happening, even though the modal can be found already. Even the error message shows the modal including navigation part already. It feels like a race condition.

I've adjusted the tests to await for the navigation role. Then retested the same 5 runs of 200 times:
1. No errors
2. No errors
3. No errors
4. No errors
5. No errors

After which I did one run of 10.000 times without failures. 