### PR TITLE
Add fallback handler for unmatched `/api` routes

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,12 +1,13 @@
 use std::{error::Error, future::Future, net::SocketAddr, str::FromStr};
 
 use airgap::AirgapDetection;
-#[cfg(feature = "memory-serve")]
-use axum::http::StatusCode;
 use axum::{
     Router,
     extract::{DefaultBodyLimit, FromRef},
+    http::StatusCode,
     middleware,
+    response::IntoResponse,
+    routing::any,
     serve::ListenerExt,
 };
 use hyper::http::{HeaderName, HeaderValue, header};
@@ -98,14 +99,24 @@ pub fn openapi_router() -> OpenApiRouter<AppState> {
 fn axum_router_from_openapi(router: OpenApiRouter<AppState>) -> Router<AppState> {
     // Serve the OpenAPI documentation at /api-docs if the openapi feature is enabled
     #[cfg(feature = "openapi")]
-    {
+    let router = {
         let (router, openapi) = router.split_for_parts();
         router.merge(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", openapi))
-    }
+    };
 
     // Serve without OpenAPI documentation if the openapi feature is disabled
     #[cfg(not(feature = "openapi"))]
-    Router::from(router)
+    let router = Router::from(router);
+
+    // Add fallback for unmatched /api/* routes to return 404
+    // This must come before the frontend memory-serve routes
+    async fn api_fallback_handler() -> impl IntoResponse {
+        (StatusCode::NOT_FOUND, "Not Found")
+    }
+    router
+        .route("/api", any(api_fallback_handler))
+        .route("/api/", any(api_fallback_handler))
+        .route("/api/{*path}", any(api_fallback_handler))
 }
 
 /// Add middleware to trace all HTTP requests and extend the user's session lifetime if needed
@@ -469,6 +480,38 @@ mod test {
                 let response = reqwest::get(format!("{base_url}/")).await.unwrap();
                 assert_eq!(response.headers()["cache-control"], "max-age:300, private");
             }
+        })
+        .await;
+    }
+
+    /// Check that unknown API routes return 404
+    /// Note that this test is mostly designed for using with the memory-serve feature enabled.
+    #[test(sqlx::test)]
+    async fn test_api_fallback_route(pool: SqlitePool) {
+        run_server_test(pool, |base_url| async move {
+            // Test non-existent API endpoints
+            let response = reqwest::get(format!("{base_url}/api")).await.unwrap();
+            assert_eq!(response.status(), 404);
+
+            let response = reqwest::get(format!("{base_url}/api/")).await.unwrap();
+            assert_eq!(response.status(), 404);
+
+            let response = reqwest::get(format!("{base_url}/api/nonexistent"))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 404);
+
+            let response = reqwest::get(format!("{base_url}/api/some/nested/path"))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 404);
+
+            // Test that valid API endpoints still work
+            let response = reqwest::get(format!("{base_url}/api/whoami"))
+                .await
+                .unwrap();
+            // Should return 401 (Unauthorized) since we're not logged in
+            assert_eq!(response.status(), 401);
         })
         .await;
     }


### PR DESCRIPTION
Add explicit 404 fallback handler for unmatched `/api` routes, to prevent the frontend `index.html` from being served on these paths by the `memory-serve` fallback handler. 