### PR TITLE
Fix Clippy warnings introduced in Rust 1.91.0

### DIFF
--- a/backend/src/committee_session/status.rs
+++ b/backend/src/committee_session/status.rs
@@ -32,7 +32,9 @@ use crate::{
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[sqlx(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum CommitteeSessionStatus {
+    #[default]
     Created,
     DataEntryNotStarted,
     DataEntryInProgress,
@@ -222,12 +224,6 @@ impl CommitteeSessionStatus {
             }
             CommitteeSessionStatus::DataEntryFinished => Ok(self),
         }
-    }
-}
-
-impl Default for CommitteeSessionStatus {
-    fn default() -> Self {
-        Self::Created
     }
 }
 

--- a/backend/src/data_entry/status.rs
+++ b/backend/src/data_entry/status.rs
@@ -40,7 +40,9 @@ impl From<ValidationResults> for DataEntryTransitionError {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields, tag = "status", content = "state")]
+#[derive(Default)]
 pub enum DataEntryStatus {
+    #[default]
     FirstEntryNotStarted, // First entry has not started yet
     FirstEntryInProgress(FirstEntryInProgress),
     FirstEntryHasErrors(FirstEntryHasErrors),
@@ -684,12 +686,6 @@ impl Display for DataEntryTransitionError {
             }
             DataEntryTransitionError::ValidationError(_) => write!(f, "Validation errors"),
         }
-    }
-}
-
-impl Default for DataEntryStatus {
-    fn default() -> Self {
-        Self::FirstEntryNotStarted
     }
 }
 


### PR DESCRIPTION
The default derive macro is preferred above a trait implementation.