### PR TITLE
Only print vite environment in CI

### DIFF
--- a/frontend/vite-prod.config.ts
+++ b/frontend/vite-prod.config.ts
@@ -45,12 +45,15 @@ export default defineConfig(({ command }) => {
     ...gitDetails,
   };
 
-  // eslint-disable-next-line no-console
-  console.log("Vite build environment:");
-  Object.entries(define).forEach(([key, value]) => {
+  // print environment variables on CI
+  if (process.env.CI) {
     // eslint-disable-next-line no-console
-    console.log(`${key}: ${value}`);
-  });
+    console.log("Vite build environment:");
+    Object.entries(define).forEach(([key, value]) => {
+      // eslint-disable-next-line no-console
+      console.log(`${key}: ${value}`);
+    });
+  }
 
   return {
     build: {


### PR DESCRIPTION
The following debug print:
```
Vite build environment:
__API_MSW__: false
__APP_VERSION__: "0.0.1"
__INCLUDE_STORYBOOK_LINK__: false
__SHOW_DEV_PAGE__: true
__GIT_DIRTY__: undefined
__GIT_BRANCH__: undefined
__GIT_COMMIT__: undefined
```
is a bit spammy during development. This PR makes sure it is only printed when vite is called from our CI.
