### PR TITLE
Fix flaky test + perform initial (re)fetch on election status page

### DIFF
--- a/frontend/src/features/election_overview/components/OverviewPage.tsx
+++ b/frontend/src/features/election_overview/components/OverviewPage.tsx
@@ -48,7 +48,7 @@ export function OverviewPage() {
   const isNewAccount = location.hash === "#new-account";
   const isAdminOrCoordinator = isAdministrator || isCoordinator;
 
-  useLiveData([refetchElections]);
+  useLiveData(refetchElections);
 
   if (getElections.status === "api-error") {
     throw getElections.error;

--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -32,7 +32,8 @@ export function ElectionStatusPage() {
   const updatePath: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${currentCommitteeSession.id}/committee_sessions/${currentCommitteeSession.id}/status`;
   const { update } = useCrud({ updatePath, throwAllErrors: true });
 
-  useLiveData([refetchElection, refetchStatuses]);
+  useLiveData(refetchElection, true);
+  useLiveData(refetchStatuses, true);
 
   function finishDataEntry() {
     void navigate("../report");

--- a/frontend/src/hooks/useLiveData.ts
+++ b/frontend/src/hooks/useLiveData.ts
@@ -3,16 +3,17 @@ import { useEffect } from "react";
 import { DEFAULT_CANCEL_REASON } from "@/api/ApiClient";
 
 // Hook to refetch live data at regular intervals and on tab visibility change
-export function useLiveData(refetchFunctions: Array<(abortController: AbortController) => Promise<unknown>>) {
+export function useLiveData(
+  refetchFunction: (abortController: AbortController) => Promise<unknown>,
+  initialRefetch: boolean = false,
+) {
   useEffect(() => {
     const abortController = new AbortController();
 
     const refetch = () => {
       // don't refetch if the document is hidden (i.e., user is on another tab)
       if (!document.hidden) {
-        refetchFunctions.forEach((refetchFunction) => {
-          void refetchFunction(abortController);
-        });
+        void refetchFunction(abortController);
       }
     };
 
@@ -22,6 +23,10 @@ export function useLiveData(refetchFunctions: Array<(abortController: AbortContr
     // add visibility change listener to refetch when tab becomes active
     document.addEventListener("visibilitychange", refetch);
 
+    if (initialRefetch) {
+      refetch();
+    }
+
     return () => {
       // cancel any ongoing requests
       abortController.abort(DEFAULT_CANCEL_REASON);
@@ -30,5 +35,5 @@ export function useLiveData(refetchFunctions: Array<(abortController: AbortContr
       // clear up the interval
       clearInterval(refetchInterval);
     };
-  }, [refetchFunctions]);
+  }, [refetchFunction, initialRefetch]);
 }


### PR DESCRIPTION
Fixes #2368

Previously the election and election status is fetched when the election status pagina is first rendered: https://github.com/kiesraad/abacus/pull/2353/files#diff-2ef1b3ecc4a25415f52e42d8d7b9d58b45e4a58c343e8640f84d30d09d2bb480L44

This behavior was changed with the introduction of the useLiveData hook.

This PR adds a optional initial (re)fetch to the hook, and fixes the flaky test #2368.

I have also changed the hook to accept a single function instead of a list, making it possible to do a static analyses of the useEffect dependency list by eslint.