### PR TITLE
Disable airgap-detection argument when airgap-detection is forced

### DIFF
--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -32,6 +32,7 @@ struct Args {
     reset_database: bool,
 
     /// Enable airgap detection
+    #[cfg(not(feature = "airgap-detection"))]
     #[arg(short, long, env = "ABACUS_AIRGAP_DETECTION")]
     airgap_detection: bool,
 }
@@ -66,7 +67,11 @@ async fn run() -> Result<(), AppError> {
     .await?;
 
     // Enable airgap detection if the feature is enabled or if the command line argument is set.
-    let enable_airgap_detection = args.airgap_detection || cfg!(feature = "airgap-detection");
+    #[cfg(feature = "airgap-detection")]
+    let enable_airgap_detection = true;
+
+    #[cfg(not(feature = "airgap-detection"))]
+    let enable_airgap_detection = args.airgap_detection;
 
     let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, args.port));
 


### PR DESCRIPTION
When the airgap detection cargo feature is enabled, airgap detection is *forced* (you cannot disable it). This makes including the  `--airgap-detection` CLI flag unnecessary and possibly confusing. This PR removed the flag from our CLI when the feature is enabled.