### PR TITLE
Fix bug in pause election URL

### DIFF
--- a/frontend/src/features/election_status/components/ElectionStatusPage.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.tsx
@@ -29,7 +29,7 @@ export function ElectionStatusPage() {
   const { statuses, refetch: refetchStatuses } = useElectionStatus();
   const { isCoordinator } = useUserRole();
   const [showPauseModal, setShowPauseModal] = useState(false);
-  const updatePath: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${currentCommitteeSession.id}/committee_sessions/${currentCommitteeSession.id}/status`;
+  const updatePath: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${currentCommitteeSession.election_id}/committee_sessions/${currentCommitteeSession.id}/status`;
   const { update } = useCrud({ updatePath, throwAllErrors: true });
 
   useLiveData(refetchElection, true);


### PR DESCRIPTION
Changing the committee session from the election status page has a bug. The incorrect ID is passed in the URL, this fixes that bug.