### PR TITLE
Fix logic bottom bar type inputGrid

### DIFF
--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -40,9 +40,9 @@ export function DataEntrySection() {
 
   const formId = section.id + "_form";
 
-  const bottomBarType = section.subsections.some((subsection) => subsection.type === "inputGrid")
-    ? "inputGrid"
-    : "form";
+  const lastSubsection = section.subsections[section.subsections.length - 1];
+  const bottomBarType = lastSubsection?.type === "inputGrid" ? "inputGrid" : "form";
+
   const keyboardHintText = section.id.startsWith("political_group_votes_") ? t("candidates_votes.goto_totals") : null;
 
   // Missing totals error for political group votes form


### PR DESCRIPTION
- Fixes issue found in https://github.com/kiesraad/abacus/issues/2211
- Bottom bar should be of type "inputGrid" (button shifted right and with white background) when the subsection immediately above is of type inputGrid, not if any subsection is inputGrid
- This fixes the bottom bar in the "Verschillen D & H" section

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->