### PR TITLE
Fix vertical spacing in election overview empty state 

### DIFF
--- a/frontend/src/features/election_overview/components/OverviewPage.tsx
+++ b/frontend/src/features/election_overview/components/OverviewPage.tsx
@@ -27,8 +27,8 @@ function AddFirstElection() {
   return (
     <FormLayout>
       <FormLayout.Section>
-        <h2>{t("election.no_elections_added")}</h2>
-        {tx("election.add_first_election")}
+        <h2 className="mb-0">{t("election.no_elections_added")}</h2>
+        <div>{tx("election.add_first_election")}</div>
       </FormLayout.Section>
       <FormLayout.Controls>
         {isAdministrator && <Button.Link to={"./create"}>{t("election.create")}</Button.Link>}


### PR DESCRIPTION
## Before
<img width="716" height="682" alt="image" src="https://github.com/user-attachments/assets/31b6651a-e160-455c-8d99-2e34de91c187" />


## After
<img width="745" height="607" alt="image" src="https://github.com/user-attachments/assets/564e4f59-bafd-49f4-9217-6cd504a97065" />
