### PR TITLE
Fix handling of time zones in the frontend

### DIFF
--- a/frontend/e2e-tests/tests/full-flow.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow.e2e.ts
@@ -126,7 +126,7 @@ test.describe("full flow", () => {
     await electionDetails.fillForm("Pannerdam", "18-03-2026", "21:34");
 
     await expect(electionHomePage.header).toContainText("Gemeenteraad Test 2022");
-    await expect(page.getByText("woensdag 18 maart 2026 21:34")).toBeVisible();
+    await expect(page.getByText("woensdag 18 maart 2026 om 21:34")).toBeVisible();
     await electionHomePage.startButton.click();
 
     const electionStatus = new ElectionStatus(page);

--- a/frontend/src/features/election_create/components/CheckHash.tsx
+++ b/frontend/src/features/election_create/components/CheckHash.tsx
@@ -7,7 +7,7 @@ import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { InputField } from "@/components/ui/InputField/InputField";
 import { t } from "@/i18n/translate";
 import { RedactedEmlHash } from "@/types/generated/openapi";
-import { formatFullDateWithoutTimezone } from "@/utils/dateTime";
+import { formatDateFull } from "@/utils/dateTime";
 
 import { RedactedHash, Stub } from "./RedactedHash";
 
@@ -89,7 +89,7 @@ export function CheckHash({ date, title, header, description, redactedHash, erro
               <p>
                 <strong>{title}</strong>
                 <br />
-                <span className="capitalize-first">{formatFullDateWithoutTimezone(new Date(date))}</span>
+                <span className="capitalize-first">{formatDateFull(new Date(date))}</span>
               </p>
               <div>
                 <span>

--- a/frontend/src/features/election_management/components/CommitteeSessionCard.test.tsx
+++ b/frontend/src/features/election_management/components/CommitteeSessionCard.test.tsx
@@ -164,9 +164,9 @@ describe("UI component: CommitteeSessionCard", () => {
       expect(screen.getByText(expectedSubtitle)).toBeVisible();
 
       if (!isCurrentSession) {
-        expect(screen.getByText("zondag 9 november 2025 09:15")).toBeVisible();
+        expect(screen.getByText("zondag 9 november 2025 om 09:15")).toBeVisible();
       } else {
-        expect(screen.queryByText("zondag 9 november 2025 09:15")).not.toBeInTheDocument();
+        expect(screen.queryByText("zondag 9 november 2025 om 09:15")).not.toBeInTheDocument();
       }
 
       const buttons = screen.queryAllByRole("button");

--- a/frontend/src/features/election_management/components/CommitteeSessionCard.tsx
+++ b/frontend/src/features/election_management/components/CommitteeSessionCard.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
 import { committeeSessionLabel } from "@/utils/committeeSession";
-import { formatFullDateTimeWithoutTimezone } from "@/utils/dateTime";
+import { formatDateTimeFull } from "@/utils/dateTime";
 
 import cls from "./CommitteeSessionCard.module.css";
 
@@ -106,7 +106,7 @@ export function CommitteeSessionCard({
   const label = committeeSessionLabel(committeeSession.number);
   const status = CommitteeSessionStatusLabel(committeeSession.status, "coordinator");
   const date = committeeSession.start_date_time
-    ? formatFullDateTimeWithoutTimezone(new Date(committeeSession.start_date_time))
+    ? formatDateTimeFull(new Date(committeeSession.start_date_time))
     : undefined;
   const buttonLinks: ButtonLink[] = [];
   let cardButton = undefined;

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
 import { committeeSessionLabel } from "@/utils/committeeSession";
-import { formatFullDateWithoutTimezone } from "@/utils/dateTime";
+import { formatDateTimeFull } from "@/utils/dateTime";
 
 import cls from "../ElectionManagement.module.css";
 
@@ -83,14 +83,8 @@ export function ElectionReportPage() {
             </h2>
             <div className={cls.reportInfoSection}>
               {t("election_report.committee_session_started", {
-                date: committeeSession.start_date_time
-                  ? formatFullDateWithoutTimezone(new Date(committeeSession.start_date_time))
-                  : "",
-                time: committeeSession.start_date_time
-                  ? new Date(committeeSession.start_date_time).toLocaleTimeString("nl-NL", {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })
+                date_time: committeeSession.start_date_time
+                  ? formatDateTimeFull(new Date(committeeSession.start_date_time))
                   : "",
               })}
               .<br />

--- a/frontend/src/i18n/locales/nl/election_report.json
+++ b/frontend/src/i18n/locales/nl/election_report.json
@@ -1,5 +1,5 @@
 {
-  "committee_session_started": "De zitting begon op {date} om {time}",
+  "committee_session_started": "De zitting begon op {date_time}",
   "counting_results": "Telresultaten",
   "download_report": "Download los proces-verbaal",
   "download_zip": "Download proces-verbaal met telbestand",

--- a/frontend/src/utils/dateTime.test.ts
+++ b/frontend/src/utils/dateTime.test.ts
@@ -4,9 +4,9 @@ import { t } from "@/i18n/translate";
 
 import {
   convertNLDateToISODate,
+  formatDateFull,
   formatDateTime,
   formatDateTimeFull,
-  formatFullDateWithoutTimezone,
   formatTimeToGo,
   isValidNLDate,
   isValidTime,
@@ -51,7 +51,7 @@ describe("DateTime util", () => {
     [new Date("Sat Jun 03 2023 14:26:13 GMT+0200"), /\d+ juni 2023/],
     [new Date("Sat Dec 18 2010 23:27:11 GMT+0100"), /\d+ december 2010/],
   ])("Format date %s as %s", (input: Date, expected: RegExp) => {
-    expect(formatFullDateWithoutTimezone(input)).toMatch(expected);
+    expect(formatDateFull(input)).toMatch(expected);
   });
 
   test.each([

--- a/frontend/src/utils/dateTime.ts
+++ b/frontend/src/utils/dateTime.ts
@@ -22,37 +22,20 @@ function isYesterday(date: Date): boolean {
   );
 }
 
-export function formatFullDateWithoutTimezone(date: Date) {
+export function formatDateFull(date: Date) {
   return new Intl.DateTimeFormat(t("date_locale"), {
     weekday: "long",
     day: "numeric",
     month: "long",
     year: "numeric",
-    timeZone: "UTC",
   }).format(date);
-}
-
-export function formatFullDateTimeWithoutTimezone(date: Date) {
-  const dateFormat = new Intl.DateTimeFormat(t("date_locale"), {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(date);
-
-  const timeFormat = new Intl.DateTimeFormat(t("date_locale"), {
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
-
-  return `${dateFormat} ${timeFormat}`;
 }
 
 export function formatDateTimeFull(date: Date) {
   return date.toLocaleTimeString(t("date_locale"), {
     hour: "numeric",
     minute: "numeric",
+    weekday: "long",
     day: "numeric",
     month: "long",
     year: "numeric",


### PR DESCRIPTION
Fixes #2398

The Abacus backend serializes two types of date times:

- `DateTime<Utc>` which wil be serialized as `2025-11-10T10:46:19.662Z`
- `NaiveDateTime` (for the committee session start) which will be serialized as `2025-10-10T10:46:19`

The Javascript `Date` class will assume the local timezone if no timezone is specified (in the `NaiveDateTime` scenario).
Our previous `formatFullDateWithoutTimezone` function would assume UTC in this case, which resulted in a incorrect timezone assumption in the case of the committee session start date-time.

This PR removes the assumption that a missing timezone specifier defaults to UTC, since the date-times passed from the backend now always either specify the (UTC) timezone or are explicitly naive. This change also removes the need to call the a specific format function in the frontend.

Note that our Typst templates always naively render date/times as passed by the input JSON. Since we only render either plain dates or naive date-times, this is the correct behavior. If we would have to render UTC date-times in the templates a conversion step would be needed.