### PR TITLE
Clickable status categories and sticky nav

### DIFF
--- a/frontend/src/components/ui/ProgressBar/Progress.module.css
+++ b/frontend/src/components/ui/ProgressBar/Progress.module.css
@@ -15,7 +15,10 @@ div.progress {
   }
 }
 
-span:global(.item) {
+span:global(.item),
+a:global(.item) {
+  text-decoration: none;
+  color: inherit;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/frontend/src/features/election_status/components/ElectionStatus.module.css
+++ b/frontend/src/features/election_status/components/ElectionStatus.module.css
@@ -43,6 +43,11 @@
     margin: 0;
     flex: 0 0 19.5rem;
   }
+
+  nav {
+    position: sticky;
+    top: 0;
+  }
 }
 
 .statusArticle {

--- a/frontend/src/features/election_status/components/ElectionStatus.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.tsx
@@ -72,14 +72,15 @@ export function ElectionStatus({
             <div id="polling-stations-per-status" className="column">
               <h3>{t("election_status.polling_stations_per_status")}</h3>
               {statusCategories.map((cat) => (
-                <span
+                <a
                   className="item"
                   key={`item-progress-${categoryColorClass[cat]}`}
                   id={`item-progress-${categoryColorClass[cat]}`}
+                  href={`#item-table-${categoryColorClass[cat]}`}
                 >
                   <Circle size="xxs" color={categoryColorClass[cat]} />
                   {t(`status.${cat}`)} ({categoryCounts[cat]})
-                </span>
+                </a>
               ))}
             </div>
             <div id="progress" className="column">
@@ -96,7 +97,7 @@ export function ElectionStatus({
             )}
             {statuses.length > 0 &&
               tableCategories.map((cat) => (
-                <div key={`item-table-${categoryColorClass[cat]}`}>
+                <div key={`item-table-${categoryColorClass[cat]}`} id={`item-table-${categoryColorClass[cat]}`}>
                   <span className="item">
                     <Circle size="xs" color={categoryColorClass[cat]} />
                     <h3>

--- a/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatusPage.test.tsx
@@ -1,6 +1,6 @@
 import * as ReactRouter from "react-router";
 
-import { render as rtlRender, within } from "@testing-library/react";
+import { render as rtlRender, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -433,6 +433,47 @@ describe("ElectionStatusPage", () => {
 
     await expectConflictErrorPage();
     expect(console.error).toHaveBeenCalled();
+  });
+
+  test("Clicking progress status scrolls corresponding table into view via element link", async () => {
+    vi.spyOn(useUser, "useUser").mockReturnValue(getCoordinatorUser());
+
+    await renderPage();
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Statusoverzicht steminvoer" })).toBeVisible();
+
+    const navigations = screen.getAllByRole("navigation");
+    const statusLinks = within(navigations[1]!).getAllByRole("link");
+
+    expect(statusLinks[0]!.textContent).toEqual("Fouten en waarschuwingen (2)");
+    statusLinks[0]!.click();
+    await waitFor(() => {
+      expect(window.location.hash).toEqual("#item-table-errors-and-warnings");
+    });
+
+    expect(statusLinks[1]!.textContent).toEqual("Invoer bezig (2)");
+    statusLinks[1]!.click();
+    await waitFor(() => {
+      expect(window.location.hash).toEqual("#item-table-in-progress");
+    });
+
+    expect(statusLinks[2]!.textContent).toEqual("Eerste invoer klaar (1)");
+    statusLinks[2]!.click();
+    await waitFor(() => {
+      expect(window.location.hash).toEqual("#item-table-first-entry-finished");
+    });
+
+    expect(statusLinks[3]!.textContent).toEqual("Eerste en tweede invoer klaar (1)");
+    statusLinks[3]!.click();
+    await waitFor(() => {
+      expect(window.location.hash).toEqual("#item-table-definitive");
+    });
+
+    expect(statusLinks[4]!.textContent).toEqual("Werkvoorraad (2)");
+    statusLinks[4]!.click();
+    await waitFor(() => {
+      expect(window.location.hash).toEqual("#item-table-not-started");
+    });
   });
 
   test("Refetches data every 30 seconds", async () => {


### PR DESCRIPTION
Closes #2253

Made statuses clickable and scroll corresponding table into view. Made statuses nav sticky.

<img width="1204" height="883" alt="Screenshot from 2025-11-10 16-26-03" src="https://github.com/user-attachments/assets/93ab5bde-70c4-4372-ae98-fd7e02a354ff" />

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->