### PR TITLE
Print creation time zone (offset) and seconds in PDF footer

### DIFF
--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -10,6 +10,7 @@ use abacus::{
         models::{ModelNa31_2Input, ToPdfFileModel},
     },
     polling_station::PollingStation,
+    report::DEFAULT_DATE_TIME_FORMAT,
     summary::ElectionSummary,
     test_data_gen::{GenerateElectionArgs, RandomRange, parse_range},
 };
@@ -226,7 +227,7 @@ async fn export_election(
             election: election.clone().into(),
             hash: "0000".to_string(),
             creation_date_time: chrono::Utc::now()
-                .format("%d-%m-%Y %H:%M:%S %Z")
+                .format(DEFAULT_DATE_TIME_FORMAT)
                 .to_string(),
         }
         .to_pdf_file_model("file.pdf".to_string());

--- a/backend/src/pdf_gen/typst_tests.rs
+++ b/backend/src/pdf_gen/typst_tests.rs
@@ -28,10 +28,11 @@ use crate::{
         },
     },
     polling_station::structs::{PollingStation, PollingStationType},
+    report::DEFAULT_DATE_TIME_FORMAT,
     summary::{ElectionSummary, PollingStationInvestigations, SumCount, SummaryDifferencesCounts},
 };
 
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime};
 use rand::{Rng, seq::IndexedRandom};
 use test_log::test;
 
@@ -55,7 +56,7 @@ fn random_date(rng: &mut impl rand::Rng) -> NaiveDate {
     .unwrap()
 }
 
-fn random_date_time(rng: &mut impl rand::Rng) -> NaiveDateTime {
+fn random_naive_date_time(rng: &mut impl rand::Rng) -> NaiveDateTime {
     random_date(rng).and_time(
         NaiveTime::from_hms_opt(
             rng.random_range(0..24),
@@ -64,6 +65,12 @@ fn random_date_time(rng: &mut impl rand::Rng) -> NaiveDateTime {
         )
         .unwrap(),
     )
+}
+
+fn random_date_time(rng: &mut impl rand::Rng) -> DateTime<Local> {
+    random_naive_date_time(rng)
+        .and_local_timezone(Local)
+        .unwrap()
 }
 
 fn random_option<T>(rng: &mut impl rand::Rng, value: T, none_where_possible: bool) -> Option<T> {
@@ -228,7 +235,7 @@ fn random_committee_session(
         election_id,
         location: random_string(rng, string_length),
         // a start_date_time is required for our typst models, this is validated in the code
-        start_date_time: Some(random_date_time(rng)),
+        start_date_time: Some(random_naive_date_time(rng)),
         status: random_value(
             rng,
             &[
@@ -423,7 +430,7 @@ async fn test_na_14_2() {
 
         let hash = random_string(&mut rng, 64);
         let creation_date_time = random_date_time(&mut rng)
-            .format("%Y-%m-%dT%H:%M:%S")
+            .format(DEFAULT_DATE_TIME_FORMAT)
             .to_string();
 
         let model = PdfModel::ModelNa14_2(Box::new(ModelNa14_2Input {
@@ -496,7 +503,7 @@ async fn test_na_31_2() {
         let summary = random_election_summary(&mut rng, &election, &polling_stations);
         let hash = random_string(&mut rng, 64);
         let creation_date_time = random_date_time(&mut rng)
-            .format("%Y-%m-%dT%H:%M:%S")
+            .format(DEFAULT_DATE_TIME_FORMAT)
             .to_string();
 
         let model = PdfModel::ModelNa31_2(Box::new(ModelNa31_2Input {
@@ -592,7 +599,7 @@ async fn test_p_2a() {
 
         let hash = random_string(&mut rng, 64);
         let creation_date_time = random_date_time(&mut rng)
-            .format("%Y-%m-%dT%H:%M:%S")
+            .format(DEFAULT_DATE_TIME_FORMAT)
             .to_string();
 
         let model = PdfModel::ModelP2a(Box::new(ModelP2aInput {

--- a/backend/src/report/api.rs
+++ b/backend/src/report/api.rs
@@ -28,6 +28,7 @@ use crate::{
         models::{ModelNa14_2Input, ModelNa31_2Input, ModelP2aInput, PdfFileModel, ToPdfFileModel},
     },
     polling_station::structs::PollingStation,
+    report::DEFAULT_DATE_TIME_FORMAT,
     summary::ElectionSummary,
     zip::{ZipResponse, ZipResponseError, slugify_filename},
 };
@@ -175,7 +176,7 @@ impl ResultsInput {
         let hash = xml_hash.into();
         let creation_date_time = self
             .creation_date_time
-            .format("%d-%m-%Y %H:%M:%S %Z")
+            .format(DEFAULT_DATE_TIME_FORMAT)
             .to_string();
 
         let overview_pdf = if let Some(overview_filename) = self.overview_pdf_filename() {

--- a/backend/src/report/mod.rs
+++ b/backend/src/report/mod.rs
@@ -6,3 +6,6 @@
 mod api;
 
 pub use self::api::*;
+
+/// Default date time format for reports
+pub const DEFAULT_DATE_TIME_FORMAT: &str = "%d-%m-%Y %H:%M:%S %Z";

--- a/backend/templates/inputs/model-na-14-2.json
+++ b/backend/templates/inputs/model-na-14-2.json
@@ -172,7 +172,7 @@
     }
   },
   "hash": "9a41 7d73 0dd2 b6d2 d0a6 ebdd 5360 d2ed de0c 3cc4 22e1 0c13 863e 3241 040d bd14",
-  "creation_date_time": "23-09-2025 22:16",
+  "creation_date_time": "23-09-2025 22:16:00 +02:00",
   "votes_tables": [
     {
       "number": 1,

--- a/backend/templates/inputs/model-na-31-2.json
+++ b/backend/templates/inputs/model-na-31-2.json
@@ -2008,7 +2008,7 @@
     }
   ],
   "hash": "dedf17b4684e1214fcabb770925dc75c624be3380bd3464729c37a80a37940ad",
-  "creation_date_time": "24-06-2025 10:07",
+  "creation_date_time": "24-06-2025 10:07:00 +02:00",
   "votes_tables": [
     {
       "number": 1,

--- a/backend/templates/inputs/model-p-2a.json
+++ b/backend/templates/inputs/model-p-2a.json
@@ -633,5 +633,5 @@
         ]
     ],
     "hash": "9a41 7d73 0dd2 b6d2 d0a6 ebdd 5360 d2ed de0c 3cc4 22e1 0c13 863e 3241 040d bd14",
-    "creation_date_time": "23-09-2025 22:16"
+    "creation_date_time": "23-09-2025 22:16:00 +02:00"
 }


### PR DESCRIPTION
Possible fix for #2424

This prints the time zone at the creation date time in the footer of PDF files:

<img width="870" height="85" alt="Screenshot From 2025-11-11 12-27-21" src="https://github.com/user-attachments/assets/79bc025a-de39-44c0-b8ae-9dcac9974e19" />

Note that the time zome is the one of the server.
