### PR TITLE
Show error page on data entry claim errors

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2822,6 +2822,16 @@
               }
             }
           },
+          "422": {
+            "description": "Invalid data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {

--- a/backend/src/data_entry/api.rs
+++ b/backend/src/data_entry/api.rs
@@ -255,6 +255,7 @@ impl ResolveDifferencesAction {
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 422, description = "Invalid data", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
     params(

--- a/frontend/src/features/data_entry/components/DataEntryProvider.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProvider.tsx
@@ -61,8 +61,8 @@ export function DataEntryProvider({ election, pollingStation, entryNumber, child
   if (!isStateLoaded(stateAndActions)) {
     // if sectionId is set the corresponsing section will render an error modal if needed
     // otherwise we have to throw the error here to show the full page error
-    // this is the case when the data entry claim failed initially
-    if (!sectionId && stateAndActions.error) {
+    // this is the case when the data entry claim failed initially on invalid data
+    if (!sectionId && stateAndActions.error instanceof ApiError && stateAndActions.error.reference === "InvalidData") {
       throw stateAndActions.error;
     }
 


### PR DESCRIPTION
In the `DataEntryPage` component, API errors are either rendered by `CheckAndSaveForm` or `DataEntrySection` (in an error modal). This is done so the user is not navigated away from the data entry when an error occurs.

However when the initial data is not loaded yet, the `DataEntryPage` does not render its child components. Thereby, if a claim fails no error is rendered (Abacus will show a blank page).

This PR makes sure we will throw errors and thus show a full page error if we are not rendering  `CheckAndSaveForm` or `DataEntrySection`.