### PR TITLE
Enable embed-typst feature in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:22 as frontend-builder
+FROM node:22 AS frontend-builder
 WORKDIR /build
 COPY . .
 WORKDIR /build/frontend
 RUN npm ci --omit=dev
 RUN npm run build
 
-FROM rust:bookworm as backend-builder
+FROM rust:bookworm AS backend-builder
 WORKDIR /build
 COPY ./backend ./backend
 COPY --from=frontend-builder /build/frontend/dist ./frontend/dist
 WORKDIR /build/backend
-RUN cargo build --release --features memory-serve
+RUN cargo build --release --features memory-serve,embed-typst
 
 FROM debian:bookworm-slim
 WORKDIR /abacus


### PR DESCRIPTION
Enable embed-typst feature in our Dockerfile in order to generate PDF files from Abacus in docker.