### PR TITLE
Fix font include path depth

### DIFF
--- a/backend/src/pdf_gen/filter_input.rs
+++ b/backend/src/pdf_gen/filter_input.rs
@@ -4,8 +4,7 @@ use ttf_parser::Face;
 const TOFU: char = '\u{fffd}';
 
 static FONT: OnceLock<Face<'static>> = OnceLock::new();
-static FONT_BYTES: &[u8] =
-    include_bytes!("../../../backend/templates/fonts/DM_Sans/DMSans-Regular.ttf");
+static FONT_BYTES: &[u8] = include_bytes!("../../templates/fonts/DM_Sans/DMSans-Regular.ttf");
 
 fn get_font() -> &'static Face<'static> {
     FONT.get_or_init(|| Face::parse(FONT_BYTES, 0).expect("Failed to parse font"))


### PR DESCRIPTION
In `backend/src/pdf_gen/filter_input.rs` we reference our default font with `../../../backend/templates/fonts/DM_Sans/DMSans-Regular.ttf`, which is not necessary, we can also use `../../templates/fonts/DM_Sans/DMSans-Regular.ttf`. Removing the assumption that our Rust code lives in a "backend" directory also fixes you docker compose setup, which complained about this include.