### PR TITLE
Updated polling station cannot be deleted error message and log text

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1626,8 +1626,8 @@
               }
             }
           },
-          "422": {
-            "description": "Polling station deletion is not possible",
+          "409": {
+            "description": "Request cannot be completed",
             "content": {
               "application/json": {
                 "schema": {
@@ -5782,6 +5782,7 @@
           "OwnAccountCannotBeDeleted",
           "PasswordRejection",
           "PdfGenerationError",
+          "PollingStationCannotBeDeleted",
           "PollingStationRepeated",
           "PollingStationValidationErrors",
           "RequestPayloadTooLarge",

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -55,6 +55,7 @@ pub enum ErrorReference {
     OwnAccountCannotBeDeleted,
     PasswordRejection,
     PdfGenerationError,
+    PollingStationCannotBeDeleted,
     PollingStationRepeated,
     PollingStationValidationErrors,
     RequestPayloadTooLarge,

--- a/backend/src/polling_station/mod.rs
+++ b/backend/src/polling_station/mod.rs
@@ -18,7 +18,9 @@ use crate::{
         repository::get_election_committee_session,
         status::{CommitteeSessionStatus, change_committee_session_status},
     },
+    data_entry::repository::{data_entry_exists, result_exists},
     eml::{EML110, EMLDocument, EMLImportError},
+    error::ErrorReference,
 };
 
 pub mod repository;
@@ -241,7 +243,7 @@ async fn polling_station_update(
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Polling station not found", body = ErrorResponse),
-        (status = 422, description = "Polling station deletion is not possible", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
     params(
@@ -263,6 +265,15 @@ async fn polling_station_delete(
 
     let polling_station =
         repository::get_for_election(&mut tx, election_id, polling_station_id).await?;
+
+    if data_entry_exists(&mut tx, polling_station.id).await?
+        || result_exists(&mut tx, polling_station.id).await?
+    {
+        return Err(APIError::Conflict(
+            "Polling station cannot be deleted.".to_string(),
+            ErrorReference::PollingStationCannotBeDeleted,
+        ));
+    }
 
     repository::delete(&mut tx, election_id, polling_station_id).await?;
 

--- a/backend/tests/polling_station_integration_test.rs
+++ b/backend/tests/polling_station_integration_test.rs
@@ -377,11 +377,11 @@ async fn test_delete_with_data_entry_fails(pool: SqlitePool) {
 
     assert_eq!(
         response.status(),
-        StatusCode::UNPROCESSABLE_ENTITY,
+        StatusCode::CONFLICT,
         "Unexpected response status"
     );
     let body: ErrorResponse = response.json().await.unwrap();
-    assert_eq!(body.error, "Invalid data");
+    assert_eq!(body.error, "Polling station cannot be deleted.");
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "users"))))]
@@ -393,11 +393,11 @@ async fn test_delete_with_results_fails(pool: SqlitePool) {
 
     assert_eq!(
         response.status(),
-        StatusCode::UNPROCESSABLE_ENTITY,
+        StatusCode::CONFLICT,
         "Unexpected response status"
     );
     let body: ErrorResponse = response.json().await.unwrap();
-    assert_eq!(body.error, "Invalid data");
+    assert_eq!(body.error, "Polling station cannot be deleted.");
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_5_with_results", "users"))))]

--- a/frontend/src/features/logs/components/LogDetailsModal.tsx
+++ b/frontend/src/features/logs/components/LogDetailsModal.tsx
@@ -13,6 +13,7 @@ const SHOULD_TRANSLATE: Record<string, string> = {
   role: "",
   reference: "error.api_error.",
   dataEntryStatus: "status.",
+  level: "log.level.",
 };
 
 // format an audit log event detail value

--- a/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
@@ -144,7 +144,7 @@ describe("PollingStationUpdatePage", () => {
       const deleteAlert = await screen.findByRole("alert");
       expect(within(deleteAlert).getByRole("strong")).toHaveTextContent("Stembureau kan niet verwijderd worden");
       expect(within(deleteAlert).getByRole("paragraph")).toHaveTextContent(
-        "Het stembureau kan niet meer verwijderd worden.",
+        "Er zijn al tellingen ingevoerd. De invoer moet eerst verwijderd worden om dit stembureau te kunnen verwijderen.",
       );
     });
   });

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -37,6 +37,7 @@
     "OwnAccountCannotBeDeleted": "Je kunt je eigen account niet verwijderen",
     "PasswordRejection": "Het opgegeven wachtwoord voldoet niet aan de eisen. Gebruik minimaal 13 karakters.",
     "PdfGenerationError": "Er is een fout opgetreden bij het genereren van de PDF",
+    "PollingStationCannotBeDeleted": "Het stembureau kan niet verwijderd worden, invoer stembureau is al gestart.",
     "PollingStationRepeated": "Het stembureau is al ingevoerd",
     "PollingStationValidationErrors": "Er zijn fouten opgetreden bij het valideren van het stembureau",
     "RequestPayloadTooLarge": "Het bestand is groter dan toegestaan",

--- a/frontend/src/i18n/locales/nl/polling_station.json
+++ b/frontend/src/i18n/locales/nl/polling_station.json
@@ -31,7 +31,7 @@
   "locality": "Plaats",
   "manage": "Stembureaus beheren",
   "message": {
-    "delete_error": "Het stembureau kan niet meer verwijderd worden. De invoerfase is al gestart.",
+    "delete_error": "Er zijn al tellingen ingevoerd. De invoer moet eerst verwijderd worden om dit stembureau te kunnen verwijderen.",
     "delete_error_title": "Stembureau kan niet verwijderd worden",
     "no_polling_stations": "Er zijn nog geen stembureaus ingevoerd voor deze verkiezing. Kies hoe je stembureaus gaat toevoegen.",
     "polling_station_created": "Stembureau {number} ({name}) toegevoegd",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -815,6 +815,7 @@ export type ErrorReference =
   | "OwnAccountCannotBeDeleted"
   | "PasswordRejection"
   | "PdfGenerationError"
+  | "PollingStationCannotBeDeleted"
   | "PollingStationRepeated"
   | "PollingStationValidationErrors"
   | "RequestPayloadTooLarge"


### PR DESCRIPTION
Closes #2289 

- Updated polling station cannot be deleted error message
- Updated polling station cannot be deleted audit log text
- Fixed rendering of audit log event type translation

Updated error message in this PR:
<img width="764" height="195" alt="Image" src="https://github.com/user-attachments/assets/11f19cad-eb9f-4653-8b4f-aa7b71cc4942" />

Updated log (179 & 180 in main and 183 in this PR):
<img width="1074" height="288" alt="Image" src="https://github.com/user-attachments/assets/624efee9-6648-4443-a719-e416bda0c536" />

Updated log event in this PR:
<img width="531" height="928" alt="Image" src="https://github.com/user-attachments/assets/f12f6b56-936c-44de-b494-6acd6817baf4" />

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->