### PR TITLE
Show audit log event ID in detail modal

### DIFF
--- a/frontend/src/components/ui/Table/Table.module.css
+++ b/frontend/src/components/ui/Table/Table.module.css
@@ -78,6 +78,10 @@
     }
   }
 
+  tr.active {
+    background: var(--gray-200);
+  }
+
   tr.rowTotal {
     td {
       font-weight: bold;

--- a/frontend/src/components/ui/Table/Table.tsx
+++ b/frontend/src/components/ui/Table/Table.tsx
@@ -75,14 +75,16 @@ function Row({ id, children, className }: { id?: string; children: React.ReactNo
 function ClickRow({
   children,
   onClick,
+  active,
   className,
 }: {
   children: React.ReactNode;
   onClick: () => void;
+  active?: boolean;
   className?: string;
 }) {
   return (
-    <tr className={cn(cls.rowLink, className)} onClick={onClick}>
+    <tr className={cn(cls.rowLink, active && cls.active, className)} onClick={onClick}>
       {children}
     </tr>
   );

--- a/frontend/src/features/logs/components/LogDetailsModal.tsx
+++ b/frontend/src/features/logs/components/LogDetailsModal.tsx
@@ -68,6 +68,8 @@ export function LogDetailsModal({ details, setDetails }: LogDetailsModalProps) {
     >
       <div>
         <dl className={cls.details} role="list">
+          <dt>{t("log.id")}</dt>
+          <dd>{details.id}</dd>
           <dt>{t("log.header.time")}</dt>
           <dd>{formatDateTimeFull(new Date(details.time))}</dd>
           {details.username && (

--- a/frontend/src/features/logs/components/LogsHomePage.tsx
+++ b/frontend/src/features/logs/components/LogsHomePage.tsx
@@ -77,7 +77,7 @@ export function LogsHomePage() {
               </Toolbar.Section>
             )}
           </Toolbar>
-          <LogsTable events={events} setDetails={setDetails} />
+          <LogsTable events={events} details={details} setDetails={setDetails} />
           {pagination && pagination.totalPages > 1 && (
             <Pagination page={pagination.page} totalPages={pagination.totalPages} onPageChange={onPageChange} />
           )}

--- a/frontend/src/features/logs/components/LogsTable.tsx
+++ b/frontend/src/features/logs/components/LogsTable.tsx
@@ -5,10 +5,11 @@ import { formatDateTime } from "@/utils/dateTime";
 
 interface LogsTableProps {
   events: AuditLogEvent[];
+  details: AuditLogEvent | null;
   setDetails: (details: AuditLogEvent) => void;
 }
 
-export function LogsTable({ events, setDetails }: LogsTableProps) {
+export function LogsTable({ events, details, setDetails }: LogsTableProps) {
   return (
     <Table id="users">
       <Table.Header>
@@ -30,6 +31,7 @@ export function LogsTable({ events, setDetails }: LogsTableProps) {
             onClick={() => {
               setDetails(event);
             }}
+            active={event.id === details?.id}
           >
             <Table.Cell>{event.id}</Table.Cell>
             <Table.Cell>{formatDateTime(new Date(event.time), false)}</Table.Cell>

--- a/frontend/src/i18n/locales/nl/log.json
+++ b/frontend/src/i18n/locales/nl/log.json
@@ -123,6 +123,7 @@
     "time": "Tijdstip",
     "user": "Gebruiker: id, gebruikersnaam (rol)"
   },
+  "id": "Activiteitenlog nummer",
   "level": {
     "error": "Fout",
     "info": "Informatie",


### PR DESCRIPTION
Fixes #2460 

This shows the audit event log ID / number in the details modal, when clicking on a row. This also highlights the currently active row:

<img width="1180" height="440" alt="Screenshot From 2025-11-18 10-04-32-1" src="https://github.com/user-attachments/assets/22cc5013-a5a3-47d6-977c-35bdc550442f" />
