### PR TITLE
Validate during importing that EML contains sequential pg and candidate numbers

### DIFF
--- a/backend/src/eml/common.rs
+++ b/backend/src/eml/common.rs
@@ -208,6 +208,15 @@ pub enum EMLImportError {
     NumberOfPollingStationsNotInRange,
     OnlyMunicipalSupported,
     TooManyPoliticalGroups,
+    PoliticalGroupNumbersNotSequential {
+        expected: u32,
+        found: u32,
+    },
+    CandidateNumbersNotSequential {
+        political_group_number: u32,
+        expected: u32,
+        found: u32,
+    },
 }
 
 /// Name and id of the specific contest


### PR DESCRIPTION
This still only shows the generic error that importing failed, but it appears we never really made a good way to display detailed error information in the frontend, so I would suggest that is not part of this (especially given that we can remove this functionality as soon as we properly support gaps in pg and candidate numbers).