### PR TITLE
Do not show delete polling station button when data entry exists

### DIFF
--- a/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationUpdatePage.test.tsx
@@ -5,9 +5,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import * as useMessages from "@/hooks/messages/useMessages";
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
+import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
 import { getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
   ElectionRequestHandler,
+  ElectionStatusRequestHandler,
   PollingStationDeleteHandler,
   PollingStationGetHandler,
   PollingStationUpdateHandler,
@@ -25,7 +27,9 @@ function renderPage(userRole: Role) {
   return render(
     <TestUserProvider userRole={userRole}>
       <ElectionProvider electionId={1}>
-        <PollingStationUpdatePage />
+        <ElectionStatusProvider electionId={1}>
+          <PollingStationUpdatePage />
+        </ElectionStatusProvider>
       </ElectionProvider>
     </TestUserProvider>,
   );
@@ -48,7 +52,12 @@ describe("PollingStationUpdatePage", () => {
   const pushMessage = vi.fn();
 
   beforeEach(() => {
-    server.use(ElectionRequestHandler, PollingStationGetHandler, PollingStationUpdateHandler);
+    server.use(
+      ElectionRequestHandler,
+      ElectionStatusRequestHandler,
+      PollingStationGetHandler,
+      PollingStationUpdateHandler,
+    );
     vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
     vi.spyOn(ReactRouter, "Navigate").mockImplementation((props) => {
       navigate(props.to);
@@ -107,7 +116,7 @@ describe("PollingStationUpdatePage", () => {
 
       // Should have text explaining why
       expect(await screen.findByText("Stembureau verwijderen niet mogelijk")).toBeVisible();
-      expect(await screen.findByText("Er zijn al tellingen ingevoerd.")).toBeVisible();
+      expect(await screen.findByText("Er zijn al tellingen ingevoerd in een eerdere zitting.")).toBeVisible();
     });
 
     test("Returns to list page with a message", async () => {

--- a/frontend/src/features/polling_stations/components/PollingStationUpdatePage.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationUpdatePage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Navigate, useNavigate } from "react-router";
+import { Link, Navigate, useNavigate } from "react-router";
 
 import { IconTrash } from "@/components/generated/icons";
 import { PageTitle } from "@/components/page_title/PageTitle";
@@ -7,10 +7,11 @@ import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { Loader } from "@/components/ui/Loader/Loader";
 import { useElection } from "@/hooks/election/useElection";
+import { useElectionStatus } from "@/hooks/election/useElectionStatus";
 import { useMessages } from "@/hooks/messages/useMessages";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { useUserRole } from "@/hooks/user/useUserRole";
-import { t } from "@/i18n/translate";
+import { t, tx } from "@/i18n/translate";
 import { PollingStation } from "@/types/generated/openapi";
 
 import { usePollingStationGet } from "../hooks/usePollingStationGet";
@@ -26,6 +27,8 @@ export function PollingStationUpdatePage() {
   const { pushMessage } = useMessages();
 
   const { requestState } = usePollingStationGet(election.id, pollingStationId);
+  const electionStatuses = useElectionStatus();
+  const status = electionStatuses.statuses.find((status) => status.polling_station_id === pollingStationId);
   const [showDeleteModal, setShowDeleteModal] = React.useState(false);
 
   function toggleShowDeleteModal() {
@@ -35,8 +38,6 @@ export function PollingStationUpdatePage() {
   const [error, setError] = React.useState<[string, string] | undefined>(undefined);
 
   const parentUrl = `/elections/${election.id}/polling-stations`;
-  const isPreExistingPollingStation =
-    requestState.status === "success" && requestState.data.id_prev_session !== undefined;
 
   function closeError() {
     setError(undefined);
@@ -80,6 +81,10 @@ export function PollingStationUpdatePage() {
     }
   }, [error]);
 
+  const link = (title: React.ReactElement) => (
+    <Link to={`/elections/${election.id}/status/${pollingStationId}/detail`}>{title}</Link>
+  );
+
   if (
     isAdministrator &&
     currentCommitteeSession.status !== "created" &&
@@ -119,12 +124,12 @@ export function PollingStationUpdatePage() {
                 />
 
                 <div className="mt-md-lg">
-                  {isPreExistingPollingStation ? (
-                    <>
+                  {requestState.data.id_prev_session !== undefined ? (
+                    <section className="sm">
                       <strong>{t("polling_station.delete_not_possible.title")}</strong>
-                      <p>{t("polling_station.delete_not_possible.message")}</p>
-                    </>
-                  ) : (
+                      <p>{t("polling_station.delete_not_possible.pre_existing_polling_station")}</p>
+                    </section>
+                  ) : status && status.status === "first_entry_not_started" ? (
                     <>
                       <Button variant="tertiary-destructive" leftIcon={<IconTrash />} onClick={toggleShowDeleteModal}>
                         {t("polling_station.delete")}
@@ -139,6 +144,11 @@ export function PollingStationUpdatePage() {
                         />
                       )}
                     </>
+                  ) : (
+                    <section className="sm">
+                      <strong>{t("polling_station.delete_not_possible.title")}</strong>
+                      <p>{tx("polling_station.delete_not_possible.delete_existing_data_entry", { link })}</p>
+                    </section>
                   )}
                 </div>
               </>

--- a/frontend/src/i18n/locales/nl/polling_station.json
+++ b/frontend/src/i18n/locales/nl/polling_station.json
@@ -17,7 +17,8 @@
   },
   "delete_not_possible": {
     "title": "Stembureau verwijderen niet mogelijk",
-    "message": "Er zijn al tellingen ingevoerd."
+    "pre_existing_polling_station": "Er zijn al tellingen ingevoerd in een eerdere zitting.",
+    "delete_existing_data_entry": "Er zijn al tellingen ingevoerd. <link>Verwijder eerst de invoer</link> om dit stembureau te kunnen verwijderen."
   },
   "details": "Details van het stembureau",
   "empty": "Er zijn nog geen stembureaus ingevoerd voor deze verkiezing. Kies hoe je stembureaus gaat toevoegen.",


### PR DESCRIPTION
**First merge #2452 and then rebase onto main**

Closes #2438 

- Replaced delete button with link to data entry in case data entry exists for a polling station

N.B. Separate administrator copy is not needed because they cannot see this page when the data entry has started

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->