### PR TITLE
set VotingMethod to SPV in EML 110b test files

### DIFF
--- a/backend/src/eml/tests/eml110b_1_station.eml.xml
+++ b/backend/src/eml/tests/eml110b_1_station.eml.xml
@@ -21,7 +21,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>612694</MaxVotes>
         <PollingPlace Channel="polling">
           <PhysicalLocation>

--- a/backend/src/eml/tests/eml110b_empty_polling_station.eml.xml
+++ b/backend/src/eml/tests/eml110b_empty_polling_station.eml.xml
@@ -21,7 +21,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>612694</MaxVotes>
       </Contest>
     </Election>

--- a/backend/src/eml/tests/eml110b_invalid_number_of_voters.eml.xml
+++ b/backend/src/eml/tests/eml110b_invalid_number_of_voters.eml.xml
@@ -21,7 +21,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>test</MaxVotes>
         <PollingPlace Channel="polling">
           <PhysicalLocation>

--- a/backend/src/eml/tests/eml110b_invalid_polling_station_number_of_voters.xml
+++ b/backend/src/eml/tests/eml110b_invalid_polling_station_number_of_voters.xml
@@ -21,7 +21,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>612694</MaxVotes>
         <PollingPlace Channel="polling">
           <PhysicalLocation>

--- a/backend/src/eml/tests/eml110b_less_than_10_stations.eml.xml
+++ b/backend/src/eml/tests/eml110b_less_than_10_stations.eml.xml
@@ -21,7 +21,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>612694</MaxVotes>
         <PollingPlace Channel="polling">
           <PhysicalLocation>

--- a/backend/src/eml/tests/eml110b_not_matching_election_id.eml.xml
+++ b/backend/src/eml/tests/eml110b_not_matching_election_id.eml.xml
@@ -21,7 +21,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>612694</MaxVotes>
         <PollingPlace Channel="polling">
           <PhysicalLocation>

--- a/backend/src/eml/tests/eml110b_test.eml.xml
+++ b/backend/src/eml/tests/eml110b_test.eml.xml
@@ -23,7 +23,7 @@
         <ReportingUnit>
           <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
         </ReportingUnit>
-        <VotingMethod />
+        <VotingMethod>SPV</VotingMethod>
         <MaxVotes>612694</MaxVotes>
         <PollingPlace Channel="polling">
           <PhysicalLocation>


### PR DESCRIPTION
As @chrismostert pointed out in [this documentation PR](https://github.com/kiesraad/abacus-documentatie/pull/19#pullrequestreview-3478252627), `VotingMethod` in the EML 110b should have a value. So I updated our EML 110b test files accordingly.