### PR TITLE
Small improvements election_7 tests

### DIFF
--- a/backend/src/data_entry/repository.rs
+++ b/backend/src/data_entry/repository.rs
@@ -554,16 +554,10 @@ mod tests {
             assert_eq!(results.len(), 2);
 
             assert_eq!(results[0].0.id, 742);
-            assert_eq!(
-                results[0].1.voters_counts().total_admitted_voters_count,
-                297
-            );
+            assert_eq!(results[0].1.voters_counts().proxy_certificate_count, 4);
 
             assert_eq!(results[1].0.id, 741);
-            assert_eq!(
-                results[1].1.voters_counts().total_admitted_voters_count,
-                297
-            );
+            assert_eq!(results[1].1.voters_counts().proxy_certificate_count, 3);
         }
 
         /// Test with 4th session, one polling station with investigation, corrected results=true and results exist

--- a/backend/tests/committee_session_integration_test.rs
+++ b/backend/tests/committee_session_integration_test.rs
@@ -92,6 +92,7 @@ async fn test_committee_session_delete_ok_status_created(pool: SqlitePool) {
 
     let committee_session =
         get_election_committee_session(&addr, &coordinator_cookie, election_id).await;
+    assert_eq!(committee_session.id, 704);
     assert_eq!(committee_session.status, CommitteeSessionStatus::Created);
 
     let url = format!(
@@ -112,6 +113,7 @@ async fn test_committee_session_delete_ok_status_created(pool: SqlitePool) {
 
     let committee_session =
         get_election_committee_session(&addr, &coordinator_cookie, election_id).await;
+    assert_eq!(committee_session.id, 703);
     assert_eq!(
         committee_session.status,
         CommitteeSessionStatus::DataEntryFinished
@@ -791,11 +793,10 @@ async fn test_committee_session_investigations_list_works(pool: SqlitePool) {
     let body: serde_json::Value = response.json().await.unwrap();
     let investigations = body["investigations"].as_array().unwrap();
     assert_eq!(investigations.len(), 1);
-    let map = investigations
-        .iter()
-        .map(|inv| inv["polling_station_id"].as_u64().unwrap())
-        .collect::<Vec<u64>>();
-    assert_eq!(map, vec![721]);
+    assert_eq!(
+        investigations[0]["polling_station_id"].as_u64().unwrap(),
+        721
+    );
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_7_four_sessions", "users"))))]

--- a/backend/tests/investigation_integration_test.rs
+++ b/backend/tests/investigation_integration_test.rs
@@ -487,18 +487,6 @@ async fn test_creation_for_committee_session_with_created_status(pool: SqlitePoo
     let cookie = shared::coordinator_login(&addr).await;
     let election_id = 7;
 
-    shared::change_status_committee_session(
-        &addr,
-        &cookie,
-        election_id,
-        704,
-        CommitteeSessionStatus::Created,
-    )
-    .await;
-    let committee_session =
-        shared::get_election_committee_session(&addr, &cookie, election_id).await;
-    assert_eq!(committee_session.status, CommitteeSessionStatus::Created);
-
     assert_eq!(
         shared::create_investigation(&addr, 741).await.status(),
         StatusCode::CREATED


### PR DESCRIPTION
[As promised](https://github.com/kiesraad/abacus/pull/2422#issuecomment-3541699828) a review of the `election_7_four_sessions` fixture tests. Some small changes:

- `test_delete_files_on_resume_no_files` / `test_delete_files_on_resume_with_files` changed a previous committee session from finished to in progress. Adjusted this to use `election_5_with_results` with transitions from `DataEntryInProgress -> DataEntryFinished -> DataEntryInProgress`. Added a comment to clarify that we don't expect `FileDeleted` events in the first test.
- `test_next_one_investigation_no_corrected_results` adjusted assertion to differentiate between returned data entries
- `test_committee_session_delete_ok_status_created` added assertions to check returned committee session
- `test_creation_for_committee_session_with_created_status` removed state transition to created, since that is the current state. 