### PR TITLE
Do not show "Je wordt bijna uitgelogd" modal after logout

### DIFF
--- a/frontend/src/app/AuthorizationDialog.test.tsx
+++ b/frontend/src/app/AuthorizationDialog.test.tsx
@@ -34,6 +34,16 @@ describe("AuthorizationDialog", () => {
     expect(screen.queryByTestId("modal-title")).toHaveTextContent("Je wordt bijna uitgelogd");
   });
 
+  test("Does not show dialog when the user is not logged in", () => {
+    render(
+      <TestUserProvider userRole={null} overrideExpiration={new Date(Date.now() + 1000)}>
+        <AuthorizationDialog />
+      </TestUserProvider>,
+    );
+
+    expect(screen.queryByTestId("modal-title")).not.toBeInTheDocument();
+  });
+
   test("Dialog can be closed", async () => {
     render(
       <TestUserProvider userRole="typist" overrideExpiration={new Date(Date.now() + 1000)}>

--- a/frontend/src/app/AuthorizationDialog.tsx
+++ b/frontend/src/app/AuthorizationDialog.tsx
@@ -56,6 +56,7 @@ export function AuthorizationDialog() {
   if (
     !loading &&
     sessionValidFor !== null &&
+    user !== null &&
     !hideDialog &&
     sessionValidFor > 0 &&
     sessionValidFor < EXPIRATION_DIALOG_SECONDS


### PR DESCRIPTION
- Fixes https://github.com/kiesraad/abacus/issues/2475
- Check if the user is null when deciding to show the modal