### PR TITLE
Default to port 80 for release builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY --from=backend-builder /build/backend/target/release/abacus /usr/local/bin/
 USER 999
 ENTRYPOINT ["/usr/local/bin/abacus"]
 CMD ["--seed-data"]
-EXPOSE 8080
+EXPOSE 80

--- a/backend/README.md
+++ b/backend/README.md
@@ -195,6 +195,7 @@ Options:
 ```
 
 Note that airgap-detection is forced in our (pre-)releases.
+For release builds the default port number is 80.
 
 A development build also supports the following arguments:
 

--- a/backend/src/app_error.rs
+++ b/backend/src/app_error.rs
@@ -8,6 +8,7 @@ pub enum AppError {
     StdError(Box<dyn std::error::Error>),
     // server specific
     PortAlreadyInUse(u16),
+    PermissionDeniedToBindPort(u16),
     // sqlite specifc
     DatabaseBusy(String),
     DatabaseReadOnly(String),
@@ -136,6 +137,12 @@ impl std::fmt::Display for AppError {
             }
             AppError::PortAlreadyInUse(port) => {
                 write!(f, "Port {port} is in use. Is Abacus already running?")
+            }
+            AppError::PermissionDeniedToBindPort(port) => {
+                write!(
+                    f,
+                    "Permission denied to bind to port {port}. On Unix systems, binding to ports below 1024 requires elevated privileges."
+                )
             }
             AppError::StdError(e) => write!(f, "{}", e),
         }


### PR DESCRIPTION
Fixes #2517 

To test: run `cargo run` vs.  `cargo run --release`