### PR TITLE
Determine version based on git tag

### DIFF
--- a/backend/build.rs
+++ b/backend/build.rs
@@ -1,3 +1,5 @@
+use std::process::{Command, ExitStatus};
+
 fn main() {
     #[cfg(any(feature = "memory-serve", feature = "storybook"))]
     {
@@ -9,4 +11,84 @@ fn main() {
         ];
         memory_serve::load_names_directories(sources, true);
     }
+
+    // check if the repository is dirty (if there is any)
+    let is_dirty = if let Ok((_, status)) =
+        run_command("git", &["diff-index", "--quiet", "HEAD", "--"], false)
+    {
+        !status.success()
+    } else {
+        false
+    };
+    let dirty_postfix = if is_dirty { "-dirty" } else { "" };
+
+    // determine the git commit (if there is any)
+    let git_rev_raw = run_command_out("git", &["rev-parse", "HEAD"], true).ok();
+    let git_rev = git_rev_raw
+        .as_deref()
+        .map(|rev| format!("{rev}{dirty_postfix}"));
+
+    // determine if there is a tag for this commit (if we found a commit previously)
+    let git_version = if let Some(git_rev_raw) = &git_rev_raw {
+        run_command_out(
+            "git",
+            &[
+                "describe",
+                "--tags",
+                "--exact-match",
+                "--abbrev=0",
+                "--match",
+                "v*",
+                git_rev_raw,
+            ],
+            true,
+        )
+        .ok()
+        .map(|tag| tag.trim_start_matches('v').to_owned())
+    } else {
+        None
+    };
+
+    // fallback to short commit hash if no tag found
+    let git_version = git_version.unwrap_or_else(|| {
+        git_rev
+            .as_deref()
+            .map(|rev| format!("dev-{}", &rev[..7]))
+            .unwrap_or_else(|| "-".to_owned())
+    });
+    let git_version = format!("{git_version}{dirty_postfix}");
+
+    // output
+    println!(
+        "cargo:rustc-env=ABACUS_GIT_REV={}",
+        git_rev.unwrap_or("-".to_owned())
+    );
+    println!("cargo:rustc-env=ABACUS_GIT_VERSION={}", git_version);
+}
+
+fn run_command(
+    cmd: &str,
+    args: &[&str],
+    err_on_fail: bool,
+) -> std::io::Result<(String, ExitStatus)> {
+    let res = Command::new(cmd).args(args).output()?;
+    match String::from_utf8(res.stdout) {
+        Ok(data) => {
+            let trimmed = data.trim().to_owned();
+            if err_on_fail && !res.status.success() {
+                Err(std::io::Error::other(format!(
+                    "Command '{}' failed with error code: {}",
+                    cmd,
+                    res.status.code().unwrap_or(-1)
+                )))
+            } else {
+                Ok((trimmed, res.status))
+            }
+        }
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
+}
+
+fn run_command_out(cmd: &str, args: &[&str], err_on_fail: bool) -> std::io::Result<String> {
+    run_command(cmd, args, err_on_fail).map(|(out, _)| out)
 }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3945,6 +3945,21 @@
         },
         "additionalProperties": false
       },
+      "ApplicationStartedDetails": {
+        "type": "object",
+        "required": [
+          "version",
+          "commit"
+        ],
+        "properties": {
+          "commit": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
       "AuditEvent": {
         "oneOf": [
           {
@@ -4662,18 +4677,25 @@
             }
           },
           {
-            "type": "object",
-            "required": [
-              "event_type"
-            ],
-            "properties": {
-              "event_type": {
-                "type": "string",
-                "enum": [
-                  "ApplicationStarted"
-                ]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationStartedDetails"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "event_type"
+                ],
+                "properties": {
+                  "event_type": {
+                    "type": "string",
+                    "enum": [
+                      "ApplicationStarted"
+                    ]
+                  }
+                }
               }
-            }
+            ]
           },
           {
             "allOf": [

--- a/backend/src/audit_log/audit_event.rs
+++ b/backend/src/audit_log/audit_event.rs
@@ -214,11 +214,17 @@ pub enum AuditEvent {
     AirGapViolationDetected,
     AirGapViolationResolved,
     // system events
-    ApplicationStarted,
+    ApplicationStarted(ApplicationStartedDetails),
     // api errors
     Error(ErrorDetails),
     #[default]
     UnknownEvent,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, ToSchema)]
+pub struct ApplicationStartedDetails {
+    pub version: String,
+    pub commit: String,
 }
 
 impl From<serde_json::Value> for AuditEvent {
@@ -264,7 +270,7 @@ impl AuditEvent {
             AuditEvent::DataEntryDeleted(_) => AuditEventLevel::Info,
             AuditEvent::DataEntryFinalised(_) => AuditEventLevel::Success,
             AuditEvent::ResultDeleted(_) => AuditEventLevel::Success,
-            AuditEvent::ApplicationStarted => AuditEventLevel::Info,
+            AuditEvent::ApplicationStarted(_) => AuditEventLevel::Info,
             AuditEvent::Error(ErrorDetails { level, .. }) => *level,
             AuditEvent::UnknownEvent => AuditEventLevel::Warning,
             AuditEvent::DataEntryDiscardedFirst(_) => AuditEventLevel::Info,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -271,6 +271,10 @@ pub async fn start_server(
     listener: TcpListener,
     enable_airgap_detection: bool,
 ) -> Result<(), AppError> {
+    info!(
+        "Starting Abacus GR26 (version {})",
+        env!("ABACUS_GIT_VERSION")
+    );
     let airgap_detection = if enable_airgap_detection {
         info!("Airgap detection is enabled, starting airgap detection task...");
 
@@ -367,7 +371,10 @@ pub async fn shutdown_signal() {
 async fn log_app_started(conn: &mut SqliteConnection, db_path: &str) -> Result<(), AppError> {
     Ok(audit_log::create(
         conn,
-        &audit_log::AuditEvent::ApplicationStarted,
+        &audit_log::AuditEvent::ApplicationStarted(audit_log::ApplicationStartedDetails {
+            version: env!("ABACUS_GIT_VERSION").to_string(),
+            commit: env!("ABACUS_GIT_REV").to_string(),
+        }),
         None,
         None,
         None,

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -7,10 +7,13 @@ export function Footer() {
     gitBranchShort = gitBranch.substring(0, 32) + "…";
   }
   const gitCommit = __GIT_COMMIT__;
+  const gitVersion = __GIT_VERSION__ ?? (gitCommit ? "dev-" + gitCommit.substring(0, 7) : "-");
 
   return (
     <footer>
-      <section>Kiesraad - Abacus GR26 ({t("version")} 1.0.0)</section>
+      <section>
+        Kiesraad - Abacus GR26 ({t("version")} {gitVersion})
+      </section>
       {__SHOW_DEV_PAGE__ && (
         <section>
           <strong>{t("server")}</strong> {__API_MSW__ ? "Mock Service Worker" : "Live"}&nbsp;&nbsp;{" "}

--- a/frontend/src/i18n/locales/nl/log.json
+++ b/frontend/src/i18n/locales/nl/log.json
@@ -47,6 +47,7 @@
   "field": {
     "committee_session_id": "Zitting-ID",
     "corrected_results": "Gecorrigeerde uitkomst",
+    "commit": "Commit",
     "created_at": "Aangemaakt op",
     "data_entry_progress": "Voortgang",
     "data_entry_status": "Status",
@@ -106,7 +107,8 @@
     "session_status": "Zitting status",
     "user_agent": "User agent",
     "user_id": "Gebruikers-ID",
-    "username": "Gebruikersnaam"
+    "username": "Gebruikersnaam",
+    "version": "Versie"
   },
   "filter": {
     "event": "Gebeurtenis",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -325,6 +325,11 @@ export interface AccountUpdateRequest {
   username: string;
 }
 
+export interface ApplicationStartedDetails {
+  commit: string;
+  version: string;
+}
+
 export type AuditEvent =
   | (UserLoggedInDetails & { event_type: "UserLoggedIn" })
   | (UserLoginFailedDetails & { event_type: "UserLoginFailed" })
@@ -361,7 +366,7 @@ export type AuditEvent =
   | (DataEntryDetails & { event_type: "DataEntryDiscardedBoth" })
   | { event_type: "AirGapViolationDetected" }
   | { event_type: "AirGapViolationResolved" }
-  | { event_type: "ApplicationStarted" }
+  | (ApplicationStartedDetails & { event_type: "ApplicationStarted" })
   | (ErrorDetails & { event_type: "Error" })
   | { event_type: "UnknownEvent" };
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,5 +3,6 @@ declare const __APP_VERSION__: string | undefined;
 declare const __GIT_DIRTY__: boolean | undefined;
 declare const __GIT_BRANCH__: string | undefined;
 declare const __GIT_COMMIT__: string | undefined;
+declare const __GIT_VERSION__: string | undefined;
 declare const __INCLUDE_STORYBOOK_LINK__: boolean;
 declare const __SHOW_DEV_PAGE__: boolean;


### PR DESCRIPTION
Fixes #2516 

I've updated the 'Abacus is gestart' audit log event with git commit hash and version as well. The version will be based upon the git tag on the current commit. If no commit is available we use the `dev-[short hash]` format instead. If the repository is dirty (i.e. there are changes) we add the postfix `-dirty` as well, to make sure we don't build any accidental changes into a release version.

## Footer
<img width="404" height="135" alt="footer" src="https://github.com/user-attachments/assets/7546e9a2-3640-460a-8d4e-54da6b8e3e42" />

## Audit event
<img width="520" height="608" alt="event" src="https://github.com/user-attachments/assets/0ffbdd76-978f-4bc8-8066-eb0721d0f6a6" />

## Console log message
<img width="774" height="557" alt="console" src="https://github.com/user-attachments/assets/e2e4c155-57a2-4af5-921f-13db2e0097ea" />
