### PR TITLE
Fixed committee session card links ordering when data entry paused

### DIFF
--- a/documentatie/flowcharts/committee-session-state.md
+++ b/documentatie/flowcharts/committee-session-state.md
@@ -12,11 +12,11 @@ stateDiagram-v2
   Created --> DataEntryNotStarted: add <br/> PS/Inv
   DataEntryNotStarted --> DataEntryInProgress: click start <br/> data entry
   DataEntryNotStarted --> Created: delete last <br/> PS/Inv
-  DataEntryInProgress --> Created: delete last <br/> PS/Inv*
+  DataEntryInProgress --> Created: delete last <br/> PS/Inv
   DataEntryInProgress --> DataEntryFinished: click finish <br/> data entry
   DataEntryInProgress --> DataEntryPaused: click pause <br/> data entry
   DataEntryPaused --> DataEntryInProgress: click resume <br/> data entry
-  DataEntryPaused --> Created: delete last <br/> PS/Inv*
+  DataEntryPaused --> Created: delete last <br/> PS/Inv
   DataEntryPaused --> DataEntryFinished: click finish <br/> data entry
   DataEntryFinished --> DataEntryInProgress: add new <br/> PS/Inv
   DataEntryFinished --> DataEntryInProgress: click resume <br/> data entry/update Inv

--- a/frontend/src/features/election_management/components/CommitteeSessionCard.test.tsx
+++ b/frontend/src/features/election_management/components/CommitteeSessionCard.test.tsx
@@ -73,8 +73,8 @@ const testCases: TestCases = {
       },
       data_entry_paused: {
         buttonsCurrentSession: [
-          "Aangevraagde onderzoeken",
           "Hervatten of voortgang bekijken",
+          "Aangevraagde onderzoeken",
           "Details van de zitting",
         ],
       },
@@ -112,7 +112,7 @@ const testCases: TestCases = {
         actionButton: "Bekijk voortgang",
       },
       data_entry_paused: {
-        buttonsCurrentSession: ["Aangevraagde onderzoeken", "Bekijk voortgang"],
+        buttonsCurrentSession: ["Bekijk voortgang", "Aangevraagde onderzoeken"],
       },
       data_entry_finished: {
         buttonsCurrentSession: ["Aangevraagde onderzoeken", "Invoer bekijken"],

--- a/frontend/src/features/election_management/components/CommitteeSessionCard.tsx
+++ b/frontend/src/features/election_management/components/CommitteeSessionCard.tsx
@@ -170,7 +170,6 @@ export function CommitteeSessionCard({
       }
       break;
     case "data_entry_paused":
-      addIf(investigationsButtonLink, isCurrentSession && isNextSession);
       addIf(
         {
           id: committeeSession.id,
@@ -179,6 +178,7 @@ export function CommitteeSessionCard({
         },
         isCurrentSession,
       );
+      addIf(investigationsButtonLink, isCurrentSession && isNextSession);
       addIf(detailsButtonLink, isCurrentSession && isCoordinator);
       break;
     case "data_entry_finished":


### PR DESCRIPTION
- When next session and data entry is paused, the resume link should be the first link, see: https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=9485-34701&m=dev
- Also removed the 2 forgotten asterisks in the flowchart

Rendering in main:
<img width="458" height="354" alt="image" src="https://github.com/user-attachments/assets/14802ee5-66fe-4b0b-8151-aa47fede6f6f" />

Rendering in this PR:
<img width="458" height="354" alt="image" src="https://github.com/user-attachments/assets/ab827aee-a701-4874-a799-393bbde67a93" />

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->