### PR TITLE
Add cli version / use exe version for installer

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -134,7 +134,6 @@ The following dependencies (crates) are used:
 - `async_zip`: creating a zip of the EML_NL and PDF PV.
 - `strum`: Converting enums from their string representation and back
 
-
 Additionally, the following development dependencies are used:
 
 - `test-log`: show tracing messages while running tests
@@ -191,6 +190,7 @@ Options:
   -p, --port <PORT>          Server port, optional [env: ABACUS_PORT=] [default: 8080]
   -d, --database <DATABASE>  Location of the database file, will be created if it doesn't exist [env: ABACUS_DATABASE=] [default: db.sqlite]
   -a, --airgap-detection     Enable airgap detection [env: ABACUS_AIRGAP_DETECTION=]
+  -V, --version              Show version
   -h, --help                 Print help
 ```
 

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -47,6 +47,10 @@ struct Args {
     #[cfg(not(feature = "airgap-detection"))]
     #[arg(short, long, env = "ABACUS_AIRGAP_DETECTION")]
     airgap_detection: bool,
+
+    /// Show version
+    #[arg(short = 'V', long)]
+    version: bool,
 }
 
 /// Main entry point for the application. Sets up the database, and starts the
@@ -69,6 +73,11 @@ async fn run() -> Result<(), AppError> {
         .init();
 
     let args = Args::parse();
+    if args.version {
+        println!(env!("ABACUS_GIT_VERSION"));
+        return Ok(());
+    }
+
     let pool = create_sqlite_pool(
         &args.database,
         #[cfg(feature = "dev-database")]

--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -3,10 +3,7 @@
 
 #define GetVersion() \
   Local[0] = \
-    "/S /C pushd """ + SourcePath + """ && " + \
-    "(git.exe describe --tags --exact-match HEAD > version.txt 2>nul " + \
-    "|| for /f %a in ('git.exe rev-parse --short HEAD') do echo dev-%a > version.txt) " + \
-    "&& popd", \
+    "/S /C pushd """ + SourcePath + """ && """ +  MyAppExeName + """ -V > version.txt && popd", \
   Local[1] = Exec("cmd.exe", Local[0], "C:\\", , SW_HIDE), \
   Local[2] = FileOpen(AddBackslash(SourcePath) + "version.txt"), \
   Local[3] = FileRead(Local[2]), \


### PR DESCRIPTION
This PR adds `-V` / `--version` to show the version info:

```
> abacus.exe -V
1.0.0-dirty
```

The InnoSetup script will now use this value as the version. 