### PR TITLE
Free up disk space for backend build

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -28,6 +28,21 @@ jobs:
       CARGO_TERM_COLOR: always
       SQLX_OFFLINE: "true"
     steps:
+      # Free up runner disk space, so that our job has enough space to run
+      # https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
+      - name: Free up runner disk space
+        working-directory: /
+        run: >
+          df -h
+          &&
+          echo "Freeing up disk space..."
+          &&
+          sudo rm -rf
+          /usr/local/.ghcup
+          /usr/share/dotnet
+          /usr/share/swift
+          &&
+          df -h
       - uses: actions/checkout@v5
       # Build frontend so that it can be included in the backend build
       - name: Setup Node


### PR DESCRIPTION
This is a manual backport to the 1.0 release branch of https://github.com/kiesraad/abacus/pull/2545/commits/6162e873b83bcbe03380328ef2f90ec5d1f25bac (part of PR #2545), to fix the failure in the GitHub Actions workflow seen in #2605.