### PR TITLE
Limit Sigrid feedback to PRs targeting `main` branch

### DIFF
--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -2,6 +2,8 @@ name: Sigrid PR Feedback
 
 on:
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Limit Sigrid feedback to PRs targeting `main` branch, so that PRs to the release branch don't get feedback that uses the `main` branch as a baseline.