### PR TITLE
Limit Sigrid feedback to PRs targeting `main` branch (backport of #2609)

### DIFF
--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -2,6 +2,8 @@ name: Sigrid PR Feedback
 
 on:
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Backport #2609 to the 1.0 release branch: limit Sigrid feedback to PRs targeting `main` branch.