### PR TITLE
Fix flaky full-flow test

### DIFF
--- a/frontend/e2e-tests/page-objects/users/UserCreateDetailsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/users/UserCreateDetailsPgObj.ts
@@ -7,9 +7,9 @@ export class UserCreateDetailsPgObj {
   readonly save: Locator;
 
   constructor(protected readonly page: Page) {
-    this.username = page.getByLabel("Gebruikersnaam");
-    this.fullname = page.getByLabel("Volledige naam");
-    this.password = page.getByLabel("Tijdelijk wachtwoord");
+    this.username = page.getByRole("textbox", { name: "Gebruikersnaam" });
+    this.fullname = page.getByRole("textbox", { name: "Volledige naam" });
+    this.password = page.getByRole("textbox", { name: "Tijdelijk wachtwoord" });
     this.save = page.getByRole("button", { name: "Opslaan" });
   }
 }

--- a/frontend/e2e-tests/page-objects/users/UserCreateRolePgObj.ts
+++ b/frontend/e2e-tests/page-objects/users/UserCreateRolePgObj.ts
@@ -7,9 +7,9 @@ export class UserCreateRolePgObj {
   continue: Locator;
 
   constructor(protected readonly page: Page) {
-    this.administrator = page.getByLabel(/Beheerder/);
-    this.coordinator = page.getByLabel(/Coördinator/);
-    this.typist = page.getByLabel(/Invoerder/);
+    this.administrator = page.getByRole("radio", { name: "Beheerder" });
+    this.coordinator = page.getByRole("radio", { name: "Coördinator" });
+    this.typist = page.getByRole("radio", { name: "Invoerder" });
     this.continue = page.getByRole("button", { name: "Verder" });
   }
 }

--- a/frontend/e2e-tests/page-objects/users/UserCreateTypePgObj.ts
+++ b/frontend/e2e-tests/page-objects/users/UserCreateTypePgObj.ts
@@ -6,8 +6,8 @@ export class UserCreateTypePgObj {
   continue: Locator;
 
   constructor(protected readonly page: Page) {
-    this.withName = page.getByLabel(/Op naam/);
-    this.anonymous = page.getByLabel(/Anonieme gebruikersnaam/);
+    this.withName = page.getByRole("radio", { name: "Op naam" });
+    this.anonymous = page.getByRole("radio", { name: "Anonieme gebruikersnaam" });
     this.continue = page.getByRole("button", { name: "Verder" });
   }
 }

--- a/frontend/e2e-tests/tests/full-flow.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow.e2e.ts
@@ -81,20 +81,16 @@ test.describe("full flow", () => {
       await page.goto(`/users`);
 
       const userListPgObj = new UserListPgObj(page);
-      await expect(userListPgObj.create).toBeVisible();
       await userListPgObj.create.click();
 
       const userCreateRolePgObj = new UserCreateRolePgObj(page);
-      await expect(userCreateRolePgObj.typist).not.toBeChecked();
       await userCreateRolePgObj.typist.click();
       await userCreateRolePgObj.continue.click();
 
       const userCreateTypePgObj = new UserCreateTypePgObj(page);
-      await expect(userCreateTypePgObj.withName).toBeChecked();
       await userCreateTypePgObj.continue.click();
 
       const userCreateDetailsPgObj = new UserCreateDetailsPgObj(page);
-      await expect(userCreateDetailsPgObj.fullname).toBeVisible();
       await userCreateDetailsPgObj.username.fill(username);
       await userCreateDetailsPgObj.fullname.fill(`Typist ${username}`);
       await userCreateDetailsPgObj.password.fill(username.repeat(3));


### PR DESCRIPTION
We've found that the change in the full flow e2e-test in https://github.com/kiesraad/abacus/pull/2626 was flaky:
- [Example 1](https://github.com/kiesraad/abacus/actions/runs/20248405992/job/58135298999)
- [Example 2](https://github.com/kiesraad/abacus/actions/runs/20261832557/job/58176215418) 

~This PR adds some `await expect`'s to make sure we are on the right page before proceeding with the next step.~
This PR changes `getByLabel` by `getByRole` in page objects related to the test.

To reproduce this, add many users by using `const typistUsers = Array.from({ length: 1000 }, (_, i) => `test${i + 1}`);`. If the error doesn't show up locally, it can be reproduced by throttling the CPU. Add the following lines to the changed test and run `npm run test:e2e -- --project chrome --grep "full-flow"`. This will slow down the CPU for Chrome-based browsers by 20x for that test.
```
const context = page.context();
const cdpSession = await context.newCDPSession(page);
await cdpSession.send("Emulation.setCPUThrottlingRate", { rate: 20 });
```

With CPU throttling the test fails at the first loop on my computer. With the fixes from this PR it does not.
