### PR TITLE
Add frontend check for account setup page

### DIFF
--- a/frontend/src/features/account/components/AccountSetupPage.test.tsx
+++ b/frontend/src/features/account/components/AccountSetupPage.test.tsx
@@ -1,16 +1,20 @@
 import * as ReactRouter from "react-router";
 
+import { render as rtlRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
 import * as useApiState from "@/api/useApiState";
 import { ApiState } from "@/api/ApiProviderContext";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { AccountUpdateRequestHandler } from "@/testing/api-mocks/RequestHandlers";
 import { loginResponseMockData } from "@/testing/api-mocks/UserMockData";
+import { Providers } from "@/testing/Providers";
 import { server } from "@/testing/server";
-import { render, screen } from "@/testing/test-utils";
+import { expectConflictErrorPage, render, screen, setupTestRouter } from "@/testing/test-utils";
 import { LoginResponse } from "@/types/generated/openapi";
 
+import { accountRoutes } from "../routes";
 import { AccountSetupPage } from "./AccountSetupPage";
 
 const navigate = vi.fn();
@@ -19,7 +23,10 @@ const setUser = vi.fn();
 describe("AccountSetupPage", () => {
   test("Update user in api state and navigate to data entry", async () => {
     server.use(AccountUpdateRequestHandler);
-    vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
+    vi.spyOn(ReactRouter, "Navigate").mockImplementation((props) => {
+      navigate(props.to);
+      return null;
+    });
     vi.spyOn(useApiState, "useApiState").mockReturnValue({
       user: {} as Partial<LoginResponse>,
       setUser,
@@ -28,7 +35,7 @@ describe("AccountSetupPage", () => {
     render(<AccountSetupPage />);
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText("Jouw naam (roepnaam + achternaam)"), "First Last");
+    await user.type(screen.getByRole("textbox", { name: "Jouw naam (roepnaam + achternaam)" }), "First Last");
     await user.type(screen.getByLabelText("Kies nieuw wachtwoord"), "password*password");
     await user.type(screen.getByLabelText("Herhaal wachtwoord"), "password*password");
 
@@ -37,5 +44,44 @@ describe("AccountSetupPage", () => {
 
     expect(navigate).toHaveBeenCalledWith("/elections#new-account");
     expect(setUser).toHaveBeenCalledWith(loginResponseMockData);
+  });
+
+  test("Redirect to login page when user is not set", () => {
+    vi.spyOn(ReactRouter, "Navigate").mockImplementation((props) => {
+      navigate(props.to, props.state);
+      return null;
+    });
+    vi.spyOn(useApiState, "useApiState").mockReturnValue({
+      user: null,
+      setUser,
+    } as Partial<ApiState> as ApiState);
+
+    render(<AccountSetupPage />);
+
+    expect(navigate).toHaveBeenCalledWith("/account/login", { unauthorized: true });
+  });
+
+  test("Shows error page with forbidden message when user is not incomplete", async () => {
+    // error is expected
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const router = setupTestRouter([
+      {
+        Component: null,
+        errorElement: <ErrorBoundary />,
+        children: [{ path: "account", children: accountRoutes }],
+      },
+    ]);
+
+    vi.spyOn(useApiState, "useApiState").mockReturnValue({
+      user: { fullname: "Full Name", needs_password_change: false, role: "typist" } as Partial<LoginResponse>,
+      setUser,
+    } as Partial<ApiState> as ApiState);
+
+    await router.navigate("/account/setup");
+
+    rtlRender(<Providers router={router} />);
+
+    await expectConflictErrorPage();
+    expect(console.error).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/account/components/AccountSetupPage.tsx
+++ b/frontend/src/features/account/components/AccountSetupPage.tsx
@@ -1,5 +1,7 @@
-import { Navigate, useNavigate } from "react-router";
+import { useState } from "react";
+import { Navigate } from "react-router";
 
+import { ApplicationError } from "@/api/ApiResult";
 import { useApiState } from "@/api/useApiState";
 import { PageTitle } from "@/components/page_title/PageTitle";
 import { t } from "@/i18n/translate";
@@ -8,16 +10,24 @@ import { LoginResponse } from "@/types/generated/openapi";
 import { AccountSetupForm } from "./AccountSetupForm";
 
 export function AccountSetupPage() {
-  const navigate = useNavigate();
   const { user, setUser } = useApiState();
+  const [setupComplete, setSetupComplete] = useState(false);
 
   function handleSaved(user: LoginResponse) {
     setUser(user);
-    void navigate("/elections#new-account");
+    setSetupComplete(true);
+  }
+
+  if (setupComplete) {
+    return <Navigate to="/elections#new-account" />;
   }
 
   if (!user) {
     return <Navigate to="/account/login" state={{ unauthorized: true }} />;
+  }
+
+  if (user.fullname && !user.needs_password_change) {
+    throw new ApplicationError(t("error.forbidden_message"), "Forbidden");
   }
 
   return (


### PR DESCRIPTION
Related to #2602 

Decided to do this change in a separate PR, see [comment](https://github.com/kiesraad/abacus/pull/2632#discussion_r2626372561).

This PR adds a frontend check if the user is actually incomplete. If this is not the case, the user will see this error screen:
<img width="1223" height="578" alt="image" src="https://github.com/user-attachments/assets/0bc2d744-8817-456d-907d-241dc0ba004a" />

Tests have been added.