### PR TITLE
Fixed error pages rendering

### DIFF
--- a/frontend/src/components/error/AirGapViolationPage.tsx
+++ b/frontend/src/components/error/AirGapViolationPage.tsx
@@ -1,41 +1,44 @@
 import { ReactElement } from "react";
 
 import errorImage from "@/assets/images/airgap-error.webp";
+import { Footer } from "@/components/footer/Footer";
+import navbarCls from "@/components/navbar/NavBar.module.css";
+import { AppFrame } from "@/components/ui/AppFrame/AppFrame";
+import { AppLayout } from "@/components/ui/AppLayout/AppLayout";
 import { t, tx } from "@/i18n/translate";
 
-import { Footer } from "../footer/Footer";
-import navbarCls from "../navbar/NavBar.module.css";
-import { AppLayout } from "../ui/AppLayout/AppLayout";
 import cls from "./Error.module.css";
 
 export function AirGapViolationPage() {
   return (
-    <AppLayout>
-      <nav aria-label="primary-navigation" className={navbarCls.navBar} />
-      <main>
-        <article className={cls.error}>
-          <section>
-            <h1 id="error-title">{t("error.airgap_violation.title")}</h1>
-            {tx("error.airgap_violation.content", {
-              reload: (content: ReactElement) => (
-                <a
-                  href="/"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    window.location.reload();
-                  }}
-                >
-                  {content}
-                </a>
-              ),
-            })}
-          </section>
-          <aside>
-            <img src={errorImage} alt={t("error.label")} />
-          </aside>
-        </article>
-      </main>
-      <Footer />
-    </AppLayout>
+    <AppFrame>
+      <AppLayout>
+        <nav aria-label="primary-navigation" className={navbarCls.navBar} />
+        <main>
+          <article className={cls.error}>
+            <section>
+              <h1 id="error-title">{t("error.airgap_violation.title")}</h1>
+              {tx("error.airgap_violation.content", {
+                reload: (content: ReactElement) => (
+                  <a
+                    href="/"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      window.location.reload();
+                    }}
+                  >
+                    {content}
+                  </a>
+                ),
+              })}
+            </section>
+            <aside>
+              <img src={errorImage} alt={t("error.label")} />
+            </aside>
+          </article>
+        </main>
+        <Footer />
+      </AppLayout>
+    </AppFrame>
   );
 }

--- a/frontend/src/components/error/FatalErrorPage.tsx
+++ b/frontend/src/components/error/FatalErrorPage.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/components/footer/Footer";
 import { NavBar } from "@/components/navbar/NavBar";
+import { AppFrame } from "@/components/ui/AppFrame/AppFrame";
 import { AppLayout } from "@/components/ui/AppLayout/AppLayout";
 import { TranslationPath } from "@/i18n/i18n.types";
 import { t, tx } from "@/i18n/translate";
@@ -18,37 +19,39 @@ interface FatalErrorPageProps {
 
 export function FatalErrorPage({ title = "error.title", message, code, reference, error }: FatalErrorPageProps) {
   return (
-    <AppLayout>
-      {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
-      <NavBar location={{ pathname: "/" }} />
-      <Error title={t(title)} error={error}>
-        {(code || reference) && (
-          <p>
-            {code && (
-              <>
-                <strong>{code}</strong>&nbsp;
-              </>
-            )}
-            {reference && <strong>{t(`error.api_error.${reference}`)}</strong>}
-          </p>
-        )}
-        {message && <p className="mb-lg">{message}</p>}
-        {isDevelopment && (
-          <>
-            <h6>{t("error.instruction.title")}</h6>
+    <AppFrame>
+      <AppLayout>
+        {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
+        <NavBar location={{ pathname: "/" }} />
+        <Error title={t(title)} error={error}>
+          {(code || reference) && (
             <p>
-              {tx("error.instruction.content", {
-                link: (content) => (
-                  <a href="https://github.com/kiesraad/abacus" target="_blank">
-                    {content}
-                  </a>
-                ),
-              })}
+              {code && (
+                <>
+                  <strong>{code}</strong>&nbsp;
+                </>
+              )}
+              {reference && <strong>{t(`error.api_error.${reference}`)}</strong>}
             </p>
-          </>
-        )}
-      </Error>
-      <Footer />
-    </AppLayout>
+          )}
+          {message && <p className="mb-lg">{message}</p>}
+          {isDevelopment && (
+            <>
+              <h6>{t("error.instruction.title")}</h6>
+              <p>
+                {tx("error.instruction.content", {
+                  link: (content) => (
+                    <a href="https://github.com/kiesraad/abacus" target="_blank">
+                      {content}
+                    </a>
+                  ),
+                })}
+              </p>
+            </>
+          )}
+        </Error>
+        <Footer />
+      </AppLayout>
+    </AppFrame>
   );
 }

--- a/frontend/src/components/error/NotFoundPage.tsx
+++ b/frontend/src/components/error/NotFoundPage.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/components/footer/Footer";
 import { NavBar } from "@/components/navbar/NavBar";
+import { AppFrame } from "@/components/ui/AppFrame/AppFrame";
 import { AppLayout } from "@/components/ui/AppLayout/AppLayout";
 import { TranslationPath } from "@/i18n/i18n.types";
 import { t, tx } from "@/i18n/translate";
@@ -14,14 +15,16 @@ export interface NotFoundPageProps {
 
 export function NotFoundPage({ message, vars, path }: NotFoundPageProps) {
   return (
-    <AppLayout>
-      {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
-      <NavBar location={{ pathname: "/" }} />
-      <Error title={t(message, vars)}>
-        {path && <p>{tx("error.page_not_found", undefined, { path })}</p>}
-        <p>{t("error.not_found_feedback")}</p>
-      </Error>
-      <Footer />
-    </AppLayout>
+    <AppFrame>
+      <AppLayout>
+        {/* Show NavBar for / to avoid call to useElection outside ElectionProvider */}
+        <NavBar location={{ pathname: "/" }} />
+        <Error title={t(message, vars)}>
+          {path && <p>{tx("error.page_not_found", undefined, { path })}</p>}
+          <p>{t("error.not_found_feedback")}</p>
+        </Error>
+        <Footer />
+      </AppLayout>
+    </AppFrame>
   );
 }


### PR DESCRIPTION
The error pages were missing the `<AppFrame>` component which made the main not stretch across the whole page.

Example from main:
<img width="927" height="1011" alt="Screenshot from 2025-12-18 11-28-17" src="https://github.com/user-attachments/assets/72ec71cb-1083-4150-b2cf-5781522c8a04" />

Fixed in this PR:
<img width="927" height="1011" alt="Screenshot from 2025-12-18 11-28-12" src="https://github.com/user-attachments/assets/3094184c-e7ad-4dd8-a264-925d31cbdda2" />

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on h

ow to test? (For example: data setup, triggering specific errors, etc.)
-->