### PR TITLE
Shorten validation functions

### DIFF
--- a/backend/src/data_entry/validation.rs
+++ b/backend/src/data_entry/validation.rs
@@ -245,181 +245,184 @@ pub trait ValidateRoot: Validate {
     }
 }
 
-fn validate_differences_checkboxes(
-    differences_counts: &DifferencesCounts,
-    total_voters_count: u32,
-    total_votes_count: u32,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    let equal_checked = differences_counts
-        .compare_votes_cast_admitted_voters
-        .admitted_voters_equal_votes_cast;
-    let greater_than_checked = differences_counts
-        .compare_votes_cast_admitted_voters
-        .votes_cast_greater_than_admitted_voters;
-    let smaller_than_checked = differences_counts
-        .compare_votes_cast_admitted_voters
-        .votes_cast_smaller_than_admitted_voters;
+impl DifferencesCounts {
+    fn validate_differences_checkboxes(
+        &self,
+        total_voters_count: u32,
+        total_votes_count: u32,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) {
+        let equal_checked = self
+            .compare_votes_cast_admitted_voters
+            .admitted_voters_equal_votes_cast;
+        let greater_than_checked = self
+            .compare_votes_cast_admitted_voters
+            .votes_cast_greater_than_admitted_voters;
+        let smaller_than_checked = self
+            .compare_votes_cast_admitted_voters
+            .votes_cast_smaller_than_admitted_voters;
 
-    if equal_checked && (total_voters_count != total_votes_count) {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field("compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast")
-                    .to_string(),
-            ],
-            code: ValidationResultCode::F301,
-            context: None,
-        });
-    }
-
-    if greater_than_checked && total_votes_count <= total_voters_count {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field(
-                    "compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
-                )
-                .to_string(),
-            ],
-            code: ValidationResultCode::F302,
-            context: None,
-        });
-    }
-
-    if smaller_than_checked && total_votes_count >= total_voters_count {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field(
-                    "compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
-                )
-                .to_string(),
-            ],
-            code: ValidationResultCode::F303,
-            context: None,
-        });
-    }
-
-    // Check if all or multiple fields are checked or none at all.
-    let compare_matches = [equal_checked, greater_than_checked, smaller_than_checked]
-        .into_iter()
-        .filter(|b| *b)
-        .count();
-
-    if compare_matches != 1 {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![path.field("compare_votes_cast_admitted_voters").to_string()],
-            code: ValidationResultCode::F304,
-            context: None,
-        });
-    }
-}
-
-fn validate_no_differences(
-    differences_counts: &DifferencesCounts,
-    total_voters_count: u32,
-    total_votes_count: u32,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    if total_voters_count == total_votes_count
-        && (differences_counts.more_ballots_count != 0
-            || differences_counts.fewer_ballots_count != 0)
-    {
-        let mut fields = vec![];
-        if differences_counts.more_ballots_count != 0 {
-            fields.push(path.field("more_ballots_count").to_string());
-        }
-        if differences_counts.fewer_ballots_count != 0 {
-            fields.push(path.field("fewer_ballots_count").to_string());
-        }
-
-        if !fields.is_empty() {
+        if equal_checked && (total_voters_count != total_votes_count) {
             validation_results.errors.push(ValidationResult {
-                fields,
-                code: ValidationResultCode::F305,
+                fields: vec![
+                    path.field(
+                        "compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+                    )
+                    .to_string(),
+                ],
+                code: ValidationResultCode::F301,
+                context: None,
+            });
+        }
+
+        if greater_than_checked && total_votes_count <= total_voters_count {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![
+                    path.field(
+                        "compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+                    )
+                      .to_string(),
+                ],
+                code: ValidationResultCode::F302,
+                context: None,
+            });
+        }
+
+        if smaller_than_checked && total_votes_count >= total_voters_count {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![
+                    path.field(
+                        "compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+                    )
+                      .to_string(),
+                ],
+                code: ValidationResultCode::F303,
+                context: None,
+            });
+        }
+
+        // Check if all or multiple fields are checked or none at all.
+        let compare_matches = [equal_checked, greater_than_checked, smaller_than_checked]
+            .into_iter()
+            .filter(|b| *b)
+            .count();
+
+        if compare_matches != 1 {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.field("compare_votes_cast_admitted_voters").to_string()],
+                code: ValidationResultCode::F304,
                 context: None,
             });
         }
     }
-}
 
-fn validate_votes_count_larger_than_voters_count(
-    differences_counts: &DifferencesCounts,
-    total_voters_count: u32,
-    total_votes_count: u32,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    if total_votes_count > total_voters_count
-        && differences_counts.more_ballots_count != (total_votes_count - total_voters_count)
-    {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![path.field("more_ballots_count").to_string()],
-            code: ValidationResultCode::F306,
-            context: None,
-        });
+    fn validate_no_differences(
+        &self,
+        total_voters_count: u32,
+        total_votes_count: u32,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) {
+        if total_voters_count == total_votes_count
+            && (self.more_ballots_count != 0 || self.fewer_ballots_count != 0)
+        {
+            let mut fields = vec![];
+            if self.more_ballots_count != 0 {
+                fields.push(path.field("more_ballots_count").to_string());
+            }
+            if self.fewer_ballots_count != 0 {
+                fields.push(path.field("fewer_ballots_count").to_string());
+            }
+
+            if !fields.is_empty() {
+                validation_results.errors.push(ValidationResult {
+                    fields,
+                    code: ValidationResultCode::F305,
+                    context: None,
+                });
+            }
+        }
     }
 
-    if total_votes_count > total_voters_count && differences_counts.fewer_ballots_count != 0 {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field("more_ballots_count").to_string(),
-                path.field("fewer_ballots_count").to_string(),
-            ],
-            code: ValidationResultCode::F307,
-            context: None,
-        });
-    }
-}
+    fn validate_votes_count_larger_than_voters_count(
+        &self,
+        total_voters_count: u32,
+        total_votes_count: u32,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) {
+        if total_votes_count > total_voters_count
+            && self.more_ballots_count != (total_votes_count - total_voters_count)
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.field("more_ballots_count").to_string()],
+                code: ValidationResultCode::F306,
+                context: None,
+            });
+        }
 
-fn validate_votes_count_smaller_than_voters_count(
-    differences_counts: &DifferencesCounts,
-    total_voters_count: u32,
-    total_votes_count: u32,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    if total_votes_count < total_voters_count
-        && differences_counts.fewer_ballots_count != (total_voters_count - total_votes_count)
-    {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![path.field("fewer_ballots_count").to_string()],
-            code: ValidationResultCode::F308,
-            context: None,
-        });
+        if total_votes_count > total_voters_count && self.fewer_ballots_count != 0 {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![
+                    path.field("more_ballots_count").to_string(),
+                    path.field("fewer_ballots_count").to_string(),
+                ],
+                code: ValidationResultCode::F307,
+                context: None,
+            });
+        }
     }
 
-    if total_votes_count < total_voters_count && differences_counts.more_ballots_count != 0 {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field("more_ballots_count").to_string(),
-                path.field("fewer_ballots_count").to_string(),
-            ],
-            code: ValidationResultCode::F309,
-            context: None,
-        });
-    }
-}
+    fn validate_votes_count_smaller_than_voters_count(
+        &self,
+        total_voters_count: u32,
+        total_votes_count: u32,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) {
+        if total_votes_count < total_voters_count
+            && self.fewer_ballots_count != (total_voters_count - total_votes_count)
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![path.field("fewer_ballots_count").to_string()],
+                code: ValidationResultCode::F308,
+                context: None,
+            });
+        }
 
-fn validate_accounted_for(
-    differences_counts: &DifferencesCounts,
-    total_voters_count: u32,
-    total_votes_count: u32,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    let accounted_for = &differences_counts.difference_completely_accounted_for;
-    if (total_voters_count != total_votes_count)
-        && (accounted_for.is_empty() || (accounted_for.is_both()))
-    {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field("difference_completely_accounted_for")
-                    .to_string(),
-            ],
-            code: ValidationResultCode::F310,
-            context: None,
-        });
+        if total_votes_count < total_voters_count && self.more_ballots_count != 0 {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![
+                    path.field("more_ballots_count").to_string(),
+                    path.field("fewer_ballots_count").to_string(),
+                ],
+                code: ValidationResultCode::F309,
+                context: None,
+            });
+        }
+    }
+
+    fn validate_accounted_for(
+        &self,
+        total_voters_count: u32,
+        total_votes_count: u32,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) {
+        let accounted_for = &self.difference_completely_accounted_for;
+        if (total_voters_count != total_votes_count)
+            && (accounted_for.is_empty() || (accounted_for.is_both()))
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![
+                    path.field("difference_completely_accounted_for")
+                        .to_string(),
+                ],
+                code: ValidationResultCode::F310,
+                context: None,
+            });
+        }
     }
 }
 
@@ -430,40 +433,35 @@ pub fn validate_differences_counts(
     validation_results: &mut ValidationResults,
     differences_counts_path: &FieldPath,
 ) -> Result<(), DataError> {
-    validate_differences_checkboxes(
-        differences_counts,
+    differences_counts.validate_differences_checkboxes(
         total_voters_count,
         total_votes_count,
         validation_results,
         differences_counts_path,
     );
 
-    validate_no_differences(
-        differences_counts,
+    differences_counts.validate_no_differences(
         total_voters_count,
         total_votes_count,
         validation_results,
         differences_counts_path,
     );
 
-    validate_votes_count_larger_than_voters_count(
-        differences_counts,
+    differences_counts.validate_votes_count_larger_than_voters_count(
         total_voters_count,
         total_votes_count,
         validation_results,
         differences_counts_path,
     );
 
-    validate_votes_count_smaller_than_voters_count(
-        differences_counts,
+    differences_counts.validate_votes_count_smaller_than_voters_count(
         total_voters_count,
         total_votes_count,
         validation_results,
         differences_counts_path,
     );
 
-    validate_accounted_for(
-        differences_counts,
+    differences_counts.validate_accounted_for(
         total_voters_count,
         total_votes_count,
         validation_results,
@@ -568,61 +566,63 @@ impl Validate for PollingStationResults {
     }
 }
 
-fn validate_political_group_votes_errors(
-    results: &CommonPollingStationResults,
-    political_group_candidate_votes: &PoliticalGroupCandidateVotes,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) -> Result<(), DataError> {
-    let political_group_total_votes = results
-        .votes_counts
-        .political_group_total_votes
-        .iter()
-        .find(|political_group_total_votes| {
-            political_group_total_votes.number == political_group_candidate_votes.number
-        })
-        .ok_or(DataError::new("political group total votes should exist"))?;
+impl CommonPollingStationResults {
+    fn validate_political_group_votes_errors(
+        &self,
+        political_group_candidate_votes: &PoliticalGroupCandidateVotes,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) -> Result<(), DataError> {
+        let political_group_total_votes = self
+            .votes_counts
+            .political_group_total_votes
+            .iter()
+            .find(|political_group_total_votes| {
+                political_group_total_votes.number == political_group_candidate_votes.number
+            })
+            .ok_or(DataError::new("political group total votes should exist"))?;
 
-    // all candidate votes, cast to u64 to avoid overflow
-    let candidate_votes_sum: u64 = political_group_candidate_votes
-        .candidate_votes
-        .iter()
-        .map(|cv| cv.votes as u64)
-        .sum::<u64>();
+        // all candidate votes, cast to u64 to avoid overflow
+        let candidate_votes_sum: u64 = political_group_candidate_votes
+            .candidate_votes
+            .iter()
+            .map(|cv| cv.votes as u64)
+            .sum::<u64>();
 
-    if (candidate_votes_sum > 0 || political_group_total_votes.total > 0)
-        && political_group_candidate_votes.total == 0
-    {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![path.field("total").to_string()],
-            code: ValidationResultCode::F401,
-            context: Some(ValidationResultContext {
-                political_group_number: Some(political_group_total_votes.number),
-            }),
-        });
-    } else {
-        if political_group_candidate_votes.total as u64 != candidate_votes_sum {
-            validation_results.errors.push(ValidationResult {
-                fields: vec![path.to_string()],
-                code: ValidationResultCode::F402,
-                context: Some(ValidationResultContext {
-                    political_group_number: Some(political_group_candidate_votes.number),
-                }),
-            });
-        }
-
-        if political_group_candidate_votes.total != political_group_total_votes.total {
+        if (candidate_votes_sum > 0 || political_group_total_votes.total > 0)
+            && political_group_candidate_votes.total == 0
+        {
             validation_results.errors.push(ValidationResult {
                 fields: vec![path.field("total").to_string()],
-                code: ValidationResultCode::F403,
+                code: ValidationResultCode::F401,
                 context: Some(ValidationResultContext {
-                    political_group_number: Some(political_group_candidate_votes.number),
+                    political_group_number: Some(political_group_total_votes.number),
                 }),
             });
-        }
-    }
+        } else {
+            if political_group_candidate_votes.total as u64 != candidate_votes_sum {
+                validation_results.errors.push(ValidationResult {
+                    fields: vec![path.to_string()],
+                    code: ValidationResultCode::F402,
+                    context: Some(ValidationResultContext {
+                        political_group_number: Some(political_group_candidate_votes.number),
+                    }),
+                });
+            }
 
-    Ok(())
+            if political_group_candidate_votes.total != political_group_total_votes.total {
+                validation_results.errors.push(ValidationResult {
+                    fields: vec![path.field("total").to_string()],
+                    code: ValidationResultCode::F403,
+                    context: Some(ValidationResultContext {
+                        political_group_number: Some(political_group_candidate_votes.number),
+                    }),
+                });
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Validate for CommonPollingStationResults {
@@ -697,7 +697,7 @@ impl Validate for CommonPollingStationResults {
 
         for (i, pgcv) in self.political_group_votes.iter().enumerate() {
             let pgcv_path = path.field("political_group_votes").index(i);
-            validate_political_group_votes_errors(self, pgcv, validation_results, &pgcv_path)?;
+            self.validate_political_group_votes_errors(pgcv, validation_results, &pgcv_path)?;
         }
 
         Ok(())
@@ -811,90 +811,82 @@ impl Validate for VotersCounts {
     }
 }
 
-fn validate_votes_counts_errors(
-    votes_counts: &VotesCounts,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    let political_group_total_votes_sum: u64 = votes_counts
-        .political_group_total_votes
-        .iter()
-        .map(|pgv| pgv.total as u64)
-        .sum::<u64>();
-    if political_group_total_votes_sum != votes_counts.total_votes_candidates_count as u64 {
-        let mut fields: Vec<String> = votes_counts
+impl VotesCounts {
+    fn validate_votes_counts_errors(
+        &self,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
+    ) {
+        let political_group_total_votes_sum: u64 = self
             .political_group_total_votes
             .iter()
-            .enumerate()
-            .map(|(i, _)| {
-                path.field("political_group_total_votes")
-                    .index(i)
-                    .field("total")
-                    .to_string()
-            })
-            .collect();
-        fields.push(path.field("total_votes_candidates_count").to_string());
+            .map(|pgv| pgv.total as u64)
+            .sum::<u64>();
+        if political_group_total_votes_sum != self.total_votes_candidates_count as u64 {
+            let mut fields: Vec<String> = self
+                .political_group_total_votes
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    path.field("political_group_total_votes")
+                        .index(i)
+                        .field("total")
+                        .to_string()
+                })
+                .collect();
+            fields.push(path.field("total_votes_candidates_count").to_string());
 
-        validation_results.errors.push(ValidationResult {
-            fields,
-            code: ValidationResultCode::F202,
-            context: None,
-        });
+            validation_results.errors.push(ValidationResult {
+                fields,
+                code: ValidationResultCode::F202,
+                context: None,
+            });
+        }
+
+        if self.total_votes_candidates_count + self.blank_votes_count + self.invalid_votes_count
+            != self.total_votes_cast_count
+        {
+            validation_results.errors.push(ValidationResult {
+                fields: vec![
+                    path.field("total_votes_candidates_count").to_string(),
+                    path.field("blank_votes_count").to_string(),
+                    path.field("invalid_votes_count").to_string(),
+                    path.field("total_votes_cast_count").to_string(),
+                ],
+                code: ValidationResultCode::F203,
+                context: None,
+            });
+        }
     }
 
-    if votes_counts.total_votes_candidates_count
-        + votes_counts.blank_votes_count
-        + votes_counts.invalid_votes_count
-        != votes_counts.total_votes_cast_count
-    {
-        validation_results.errors.push(ValidationResult {
-            fields: vec![
-                path.field("total_votes_candidates_count").to_string(),
-                path.field("blank_votes_count").to_string(),
-                path.field("invalid_votes_count").to_string(),
-                path.field("total_votes_cast_count").to_string(),
-            ],
-            code: ValidationResultCode::F203,
-            context: None,
-        });
-    }
-}
-
-fn validate_votes_counts_warnings(
-    votes_counts: &VotesCounts,
-    validation_results: &mut ValidationResults,
-    path: &FieldPath,
-) {
-    if above_percentage_threshold(
-        votes_counts.blank_votes_count,
-        votes_counts.total_votes_cast_count,
-        3,
+    fn validate_votes_counts_warnings(
+        &self,
+        validation_results: &mut ValidationResults,
+        path: &FieldPath,
     ) {
-        validation_results.warnings.push(ValidationResult {
-            fields: vec![path.field("blank_votes_count").to_string()],
-            code: ValidationResultCode::W201,
-            context: None,
-        });
-    }
+        if above_percentage_threshold(self.blank_votes_count, self.total_votes_cast_count, 3) {
+            validation_results.warnings.push(ValidationResult {
+                fields: vec![path.field("blank_votes_count").to_string()],
+                code: ValidationResultCode::W201,
+                context: None,
+            });
+        }
 
-    if above_percentage_threshold(
-        votes_counts.invalid_votes_count,
-        votes_counts.total_votes_cast_count,
-        3,
-    ) {
-        validation_results.warnings.push(ValidationResult {
-            fields: vec![path.field("invalid_votes_count").to_string()],
-            code: ValidationResultCode::W202,
-            context: None,
-        });
-    }
+        if above_percentage_threshold(self.invalid_votes_count, self.total_votes_cast_count, 3) {
+            validation_results.warnings.push(ValidationResult {
+                fields: vec![path.field("invalid_votes_count").to_string()],
+                code: ValidationResultCode::W202,
+                context: None,
+            });
+        }
 
-    if votes_counts.total_votes_cast_count == 0 {
-        validation_results.warnings.push(ValidationResult {
-            fields: vec![path.field("total_votes_cast_count").to_string()],
-            code: ValidationResultCode::W204,
-            context: None,
-        });
+        if self.total_votes_cast_count == 0 {
+            validation_results.warnings.push(ValidationResult {
+                fields: vec![path.field("total_votes_cast_count").to_string()],
+                code: ValidationResultCode::W204,
+                context: None,
+            });
+        }
     }
 }
 
@@ -938,9 +930,9 @@ impl Validate for VotesCounts {
             &path.field("total_votes_cast_count"),
         )?;
 
-        validate_votes_counts_errors(self, validation_results, path);
+        self.validate_votes_counts_errors(validation_results, path);
 
-        validate_votes_counts_warnings(self, validation_results, path);
+        self.validate_votes_counts_warnings(validation_results, path);
 
         Ok(())
     }


### PR DESCRIPTION
## Description
Functions improved (removed `#[allow(clippy::too_many_lines)]`):
- `src/`
  - `data_entry/validation.rs`: 
    - [x] `validate_differences_counts`
    - [x] `CommonPollingStationResults`: `validate`
    - [x] `VotesCounts`: `validate`
    - [x] `test_f305_more_and_fewer_ballots_count`
    - [x] `test_f307_votes_greater_than_voters`
    - [x] `test_f401`

7 instances of `#[allow(clippy::too_many_lines)]` left in the codebase of which 3 related to generating test elections
<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->