### PR TITLE
Fix empty fragments and set lint rule to warn

### DIFF
--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -63,6 +63,7 @@
         "noSvgWithoutTitle": "off"
       },
       "complexity": {
+        "noUselessFragments": "warn",
         "noImportantStyles": "off"
       },
       "correctness": {

--- a/frontend/src/components/navbar/NavBarLinks.tsx
+++ b/frontend/src/components/navbar/NavBarLinks.tsx
@@ -47,7 +47,7 @@ function ElectionManagementLinks({ location }: NavBarLinksProps) {
   const { currentCommitteeSession, election } = useElection();
 
   if (location.pathname.match(/^\/elections\/\d+\/?$/)) {
-    return <></>;
+    return null;
   }
 
   return (
@@ -108,5 +108,5 @@ export function NavBarLinks({ location }: NavBarLinksProps) {
     return <ElectionManagementLinks location={location} />;
   }
 
-  return <></>;
+  return null;
 }

--- a/frontend/src/components/ui/Icon/StatusIcon.tsx
+++ b/frontend/src/components/ui/Icon/StatusIcon.tsx
@@ -24,6 +24,6 @@ export function StatusIcon({ status }: { status: MenuStatus }) {
     case "error":
       return <IconError aria-label={t("contains_error")} />; // "Ingevoerd, met openstaande fouten"
     default:
-      return <></>;
+      return null;
   }
 }

--- a/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.tsx
+++ b/frontend/src/components/ui/KeyboardKeys/KeyboardKeys.tsx
@@ -15,7 +15,7 @@ export interface KeyboardKeysProps {
   keys: KeyboardKey[];
 }
 
-function renderKey(keyboardKey: KeyboardKey, index: number): JSX.Element {
+function renderKey(keyboardKey: KeyboardKey, index: number): JSX.Element | null {
   switch (keyboardKey) {
     case KeyboardKey.Enter:
       return (
@@ -44,7 +44,7 @@ function renderKey(keyboardKey: KeyboardKey, index: number): JSX.Element {
         </kbd>
       );
     default:
-      return <></>;
+      return null;
   }
 }
 

--- a/frontend/src/features/election_create/components/RedactedHash.tsx
+++ b/frontend/src/features/election_create/components/RedactedHash.tsx
@@ -25,7 +25,7 @@ export function RedactedHash({ hash, stubs }: RedactedHashProps) {
           // Either render a stub marker, or just return the prefix and chunk text
           if (stubIndex !== -1) {
             const stub = stubs[stubIndex];
-            if (!stub) return <></>;
+            if (!stub) return null;
             const selected = stub.selected;
             const error = stub.error.length > 0;
 


### PR DESCRIPTION
Replace empty fragments by null and set `noUselessFragments` rule to warning severity level.

Relates to #2695.