### PR TITLE
Fix backend fuzzer CI cargo cache

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Cargo cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
-          workspaces: "backend -> fuzz -> target"
+          workspaces: "backend/fuzz -> target"
           shared-key: "fuzzer"
       - name: Install cargo fuzz
         run: cargo install cargo-fuzz


### PR DESCRIPTION
Resolves #2662 

The backend fuzzer job considered the wrong lock files in the `Cargo cache` step due to a misconfiguration in the workspace parameter. This caused a non-full match, which deleted the `backend/fuzz` folder thus deleting the `Cargo.toml/Cargo.lock` files and causing the error.

See the issue for a lengthy explanation.