### PR TITLE
Remove Lefthook from pnpm

### DIFF
--- a/documentatie/ontwikkelproces/GitHub-werkwijze.md
+++ b/documentatie/ontwikkelproces/GitHub-werkwijze.md
@@ -23,9 +23,10 @@ Er zijn meerdere manieren om deze stappen te zetten.
     - Implementeer de functionaliteit die wordt beschreven in het issue.
     - Test de functionaliteit, schrijf zover zinvol tests (unit, integration etc).
     - Push ook tussentijdse commits naar GitHub.
-    - Dit project gebruikt [Lefthook] om de Git pre-commit hook te beheren. Lefthook zal
-      automatisch geïnstalleerd worden wanneer `pnpm install` wordt uitgevoerd in de `frontend`
-      directory.
+    - Dit project gebruikt [Lefthook] om de Git pre-commit hook te beheren.
+      Lefthook moet daarvoor worden [geïnstalleerd][lefthook-install], waarna
+      `lefthook install` kan worden uitgevoerd om de Git pre-commit hook in te
+      stellen.
 
 - Maak een pull request (PR) aan:
     - Als de branch commits bevat die al eerder gemerged zijn, kun je die verwijderen met een _interactive rebase_:
@@ -46,5 +47,6 @@ Er zijn meerdere manieren om deze stappen te zetten.
 
 [draft pull request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
 [Lefthook]: https://github.com/evilmartians/lefthook
+[lefthook-install]: https://lefthook.dev/installation/
 [merge queue]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue
 ["Pull Requests (PRs)"]: /documentatie/ontwikkelproces/pull-requests.md

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -136,7 +136,6 @@ The application uses the following dependencies:
 
 - `typescript`: Strongly typed layer on top of JavaScript
 - `msw`: Mock Service Worker for mocking the server, client side
-- `lefthook`: git hook automation
 - `cross-env`: for building on Windows
 
 #### Testing / linting dependencies

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,6 @@
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-storybook": "10.1.10",
     "jsdom": "27.3.0",
-    "lefthook": "2.0.12",
     "msw": "2.12.4",
     "playwright": "1.57.0",
     "storybook": "10.1.10",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -115,9 +115,6 @@ importers:
       jsdom:
         specifier: 27.3.0
         version: 27.3.0
-      lefthook:
-        specifier: 2.0.12
-        version: 2.0.12
       msw:
         specifier: 2.12.4
         version: 2.12.4(@types/node@22.19.3)(typescript@5.9.3)
@@ -1924,60 +1921,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  lefthook-darwin-arm64@2.0.12:
-    resolution: {integrity: sha512-tuBz1sNLien+nKKb8BDopKjS6EnbXU8rQzhMVBY+bnVfsTiYDfbBr4wo/IzA5TcwoTL/b5somCJhljEw6DvSyg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  lefthook-darwin-x64@2.0.12:
-    resolution: {integrity: sha512-FnuUMPPRMJyTEPXg6PotSrFJ8qf8FDLhhD1zLh74D+9Cye5j9n3lcrCQEjXubPT8du/GZLxMBjjffRbcZ8eYDA==}
-    cpu: [x64]
-    os: [darwin]
-
-  lefthook-freebsd-arm64@2.0.12:
-    resolution: {integrity: sha512-DXElB0qR5e6a8cXkFNYakhwCieypbfh6Y4QG39pzMnLsG03g/nhe093o6owfiUZ4mUFyDM6+0xmy0steOooF2g==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  lefthook-freebsd-x64@2.0.12:
-    resolution: {integrity: sha512-iJN1ZxFeaDi4Fi3b9jcW9wgyNl19LOv2NaVOaAi/tG6mlIn196cmSdXkOA3+943ZbqbdfV9I+bBcIKwneXDA3Q==}
-    cpu: [x64]
-    os: [freebsd]
-
-  lefthook-linux-arm64@2.0.12:
-    resolution: {integrity: sha512-byvmO4Iri6P0COwM8c3lGgeCV3Q0hh1XJpRfrcZDr4Wslq9O63t6J3T6i87oOtY+UjC9pXLl6xGk6hlUcHZ3BQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  lefthook-linux-x64@2.0.12:
-    resolution: {integrity: sha512-KBaiinmf336rA+/dmYs7H7TTeAOByB0CyLA7k8IecTCuaiuKr6ez7ktSjht19poa5G+V0mts4GgEGcx6HViR0w==}
-    cpu: [x64]
-    os: [linux]
-
-  lefthook-openbsd-arm64@2.0.12:
-    resolution: {integrity: sha512-1QBMXX1UW5rtgC4TB52OKWB7Rz/kCBRB+bKKLT/gDD79aPzLgJANTitQQzgFNIWoa7aM9UvzvIAJzOo6FcFIbg==}
-    cpu: [arm64]
-    os: [openbsd]
-
-  lefthook-openbsd-x64@2.0.12:
-    resolution: {integrity: sha512-zPcvUzs65GexRA37UHmaZqWuEGSU/zpBaPIY98MybXzzcJfCIf+O0oUQe2riMllwYGvNW0B1y3NOYRziDNe/vA==}
-    cpu: [x64]
-    os: [openbsd]
-
-  lefthook-windows-arm64@2.0.12:
-    resolution: {integrity: sha512-kgwxguS2GssoHM4SMTp+ArD/Gjg9q5MinD6iI5vSFpuJygD13ZWiXQQfESMHq9y/v1XkD0BdHTJej49dx8P+Vw==}
-    cpu: [arm64]
-    os: [win32]
-
-  lefthook-windows-x64@2.0.12:
-    resolution: {integrity: sha512-Tf/VtSOtF3rBTc9dzRWROa+HuhqaiIV+Xp+1gzlx5+uCueLM0m87Rz6yd4IN5mL7TrDaNkiRXI3FvjCp0dUE4Q==}
-    cpu: [x64]
-    os: [win32]
-
-  lefthook@2.0.12:
-    resolution: {integrity: sha512-I2FdA9cdnq1icwlNz4RADs7exuqe47q1N9+p2LmcP/WfchWh16mvTB82OAD7w7zK9GxblS9GpF7pASaOSl4c7A==}
-    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -4451,49 +4394,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  lefthook-darwin-arm64@2.0.12:
-    optional: true
-
-  lefthook-darwin-x64@2.0.12:
-    optional: true
-
-  lefthook-freebsd-arm64@2.0.12:
-    optional: true
-
-  lefthook-freebsd-x64@2.0.12:
-    optional: true
-
-  lefthook-linux-arm64@2.0.12:
-    optional: true
-
-  lefthook-linux-x64@2.0.12:
-    optional: true
-
-  lefthook-openbsd-arm64@2.0.12:
-    optional: true
-
-  lefthook-openbsd-x64@2.0.12:
-    optional: true
-
-  lefthook-windows-arm64@2.0.12:
-    optional: true
-
-  lefthook-windows-x64@2.0.12:
-    optional: true
-
-  lefthook@2.0.12:
-    optionalDependencies:
-      lefthook-darwin-arm64: 2.0.12
-      lefthook-darwin-x64: 2.0.12
-      lefthook-freebsd-arm64: 2.0.12
-      lefthook-freebsd-x64: 2.0.12
-      lefthook-linux-arm64: 2.0.12
-      lefthook-linux-x64: 2.0.12
-      lefthook-openbsd-arm64: 2.0.12
-      lefthook-openbsd-x64: 2.0.12
-      lefthook-windows-arm64: 2.0.12
-      lefthook-windows-x64: 2.0.12
 
   levn@0.4.1:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild
-  - lefthook
   - msw
   - unrs-resolver
 blockExoticSubdeps: true


### PR DESCRIPTION
Remove Lefthook from pnpm, in favour of explicit manual installation. Currently we rely on the implicit post-install hook executed by the Lefthook frontend pnpm dependency during `pnpm install`.