### PR TITLE
Make sure dependabot also updates fuzz dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       github-actions:
         patterns: ["*"]
   - package-ecosystem: "cargo"
-    directory: "/backend"
+    directories: ["/backend", "backend/fuzz"]
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
Some time ago we found out that Dependabot only updates the backend dependencies. This PR should make sure it also updates the fuzzer dependencies.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->