### PR TITLE
Fix polling station home page getting out of date

### DIFF
--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.test.tsx
@@ -434,24 +434,31 @@ describe("Test PollingStationChoiceForm", () => {
   describe("Polling station in progress", () => {
     test("Show polling stations as 'in progress'", async () => {
       server.use(ElectionRequestHandler);
-      overrideOnce("get", "api/elections/1/status", 200, {
-        statuses: [
-          { polling_station_id: 1, status: "empty" },
-          {
-            polling_station_id: 2,
-            status: "first_entry_in_progress",
-            first_entry_user_id: 1,
-            first_entry_progress: 42,
-          },
-          {
-            polling_station_id: 3,
-            status: "first_entry_in_progress",
-            first_entry_user_id: 1,
-            first_entry_progress: 42,
-          },
-          { polling_station_id: 4, status: "definitive", first_entry_user_id: 1, second_entry_user_id: 2 },
-        ],
-      } satisfies ElectionStatusResponse);
+      server.use(
+        http.get("/api/elections/1/status", () =>
+          HttpResponse.json(
+            {
+              statuses: [
+                { polling_station_id: 1, status: "empty" },
+                {
+                  polling_station_id: 2,
+                  status: "first_entry_in_progress",
+                  first_entry_user_id: 1,
+                  first_entry_progress: 42,
+                },
+                {
+                  polling_station_id: 3,
+                  status: "first_entry_in_progress",
+                  first_entry_user_id: 1,
+                  first_entry_progress: 42,
+                },
+                { polling_station_id: 4, status: "definitive", first_entry_user_id: 1, second_entry_user_id: 2 },
+              ],
+            } satisfies ElectionStatusResponse,
+            { status: 200 },
+          ),
+        ),
+      );
 
       await renderPollingStationChoiceForm();
 
@@ -591,16 +598,23 @@ describe("Test PollingStationChoiceForm", () => {
     server.use(ElectionRequestHandler);
     const testPollingStation = pollingStationMockData[0]!;
     // Have the server return an in progress polling station that is owned by a logged-in user.
-    overrideOnce("get", "api/elections/1/status", 200, {
-      statuses: [
-        {
-          polling_station_id: testPollingStation.id,
-          status: "first_entry_in_progress",
-          first_entry_user_id: testUser.user_id,
-          first_entry_progress: 42,
-        },
-      ],
-    } satisfies ElectionStatusResponse);
+    server.use(
+      http.get("/api/elections/1/status", () =>
+        HttpResponse.json(
+          {
+            statuses: [
+              {
+                polling_station_id: testPollingStation.id,
+                status: "first_entry_in_progress",
+                first_entry_user_id: testUser.user_id,
+                first_entry_progress: 42,
+              },
+            ],
+          } satisfies ElectionStatusResponse,
+          { status: 200 },
+        ),
+      ),
+    );
 
     await renderPollingStationChoiceForm();
 

--- a/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationChoiceForm.tsx
@@ -9,13 +9,13 @@ import { Icon } from "@/components/ui/Icon/Icon";
 import { KeyboardKeys } from "@/components/ui/KeyboardKeys/KeyboardKeys";
 import { useElection } from "@/hooks/election/useElection";
 import { useElectionStatus } from "@/hooks/election/useElectionStatus";
+import { useLiveData } from "@/hooks/useLiveData";
 import { useUser } from "@/hooks/user/useUser";
 import type { TranslationPath } from "@/i18n/i18n.types";
 import { t, tx } from "@/i18n/translate";
 import { KeyboardKey } from "@/types/ui";
 import { cn } from "@/utils/classnames";
 import { parseIntUserInput } from "@/utils/strings";
-
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { getPollingStationWithStatusList, getUrlForDataEntry, PollingStationUserStatus } from "../utils/util";
 import cls from "./PollingStationChoice.module.css";
@@ -38,6 +38,8 @@ export function PollingStationChoiceForm({ anotherEntry }: PollingStationChoiceF
   const [alert, setAlert] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
   const electionStatus = useElectionStatus();
+
+  useLiveData(electionStatus.refetch, true);
 
   const refetchStatuses = () => {
     void electionStatus.refetch();


### PR DESCRIPTION
- **Keep feedback message in sync with status**
  Keep the feedback message in the polling station choice form in sync
  with any polling station status updates made after entering a polling
  station number, e.g. when the data entry list is opened triggering a
  refetch.
  

- **Refetch election status when typing**
  Refetch election status when typing the polling station number on the
  data entry home page. This is how the loading indicator was originally
  designed.
  

- **Enable regular refetch**
  This ensures that stale information will get refreshed without user
  action.

Resolves #2749.

~~We need to consider if we want to backport these changes. I think the
code change itself is small enough, but there might be unexpected
performance implications from these additional status refetches.~~
We have decided not to backport these changes to 1.0.

I will refactor the `PollingStationChoiceForm` component to improve
code quality and maintainability in a separate PR.
