### PR TITLE
Skip blank lines in function length lint

### DIFF
--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -61,7 +61,8 @@
         "noExcessiveLinesPerFunction": {
           "level": "warn",
           "options": {
-            "maxLines": 50
+            "maxLines": 50,
+            "skipBlankLines": true
           }
         },
         "noExcessiveCognitiveComplexity": {

--- a/frontend/scripts/openapi/generator.ts
+++ b/frontend/scripts/openapi/generator.ts
@@ -139,7 +139,6 @@ function addDefinition(name: string, v: ReferenceObject | SchemaObject) {
   return result.join("\n");
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 function tsType(s: ReferenceObject | SchemaObject | undefined): string {
   if (!s) return "unknown";
 

--- a/frontend/src/api/useSessionState.ts
+++ b/frontend/src/api/useSessionState.ts
@@ -25,7 +25,6 @@ export interface SessionState {
 // Keep track of the currently logged-in user
 // By initially fetching the user data from the server
 // and then updating it when the user logs in or out
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export default function useSessionState(client: ApiClient, fetchInitialUser: boolean = true): SessionState {
   const [user, setUser] = useState<LoginResponse | null>(null);
   const [expiration, setExpiration] = useState<Date | null>(null);

--- a/frontend/src/app/AuthorizationDialog.tsx
+++ b/frontend/src/app/AuthorizationDialog.tsx
@@ -9,7 +9,6 @@ import { formatTimeToGo } from "@/utils/dateTime";
 
 import { EXPIRATION_DIALOG_SECONDS } from "./authorizationConstants";
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function AuthorizationDialog() {
   const { user, loading, expiration, extendSession, setUser } = useApiState();
   const [sessionValidFor, setSessionValidFor] = useState<number | null>(

--- a/frontend/src/features/data_entry/utils/actions.ts
+++ b/frontend/src/features/data_entry/utils/actions.ts
@@ -49,7 +49,6 @@ export function onSubmitForm(
   dispatch: DataEntryDispatch,
   state: DataEntryState,
 ) {
-  // biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
   return async (
     sectionId: FormSectionId,
     currentValues: SectionValues,

--- a/frontend/src/features/data_entry_detail/hooks/usePollingStationDataEntryErrors.ts
+++ b/frontend/src/features/data_entry_detail/hooks/usePollingStationDataEntryErrors.ts
@@ -28,7 +28,6 @@ interface DataEntryErrors {
   validationError: string | undefined;
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function usePollingStationDataEntryErrors(pollingStationId: number): DataEntryErrors {
   const navigate = useNavigate();
   const client = useApiClient();

--- a/frontend/src/features/election_create/components/AbortModal.tsx
+++ b/frontend/src/features/election_create/components/AbortModal.tsx
@@ -7,7 +7,6 @@ import { t, tx } from "@/i18n/translate";
 
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function AbortModal() {
   const { state } = useElectionCreateContext();
   const user = useUser();

--- a/frontend/src/features/investigations/components/forms/InvestigationFindings.tsx
+++ b/frontend/src/features/investigations/components/forms/InvestigationFindings.tsx
@@ -58,7 +58,6 @@ export function InvestigationFindings({ pollingStationId }: InvestigationFinding
 
   const requiresCorrectedResults = !pollingStation.id_prev_session;
 
-  // biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO function should be refactored
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/frontend/src/features/logs/hooks/useAuditLog.ts
+++ b/frontend/src/features/logs/hooks/useAuditLog.ts
@@ -19,7 +19,6 @@ export interface LogFilterState {
   since?: string;
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function useAuditLog() {
   const path: AUDIT_LOG_LIST_REQUEST_PATH = "/api/log";
   const [searchParams, setSearchParams] = useSearchParams();

--- a/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
+++ b/frontend/src/features/resolve_differences/hooks/usePollingStationDataEntryDifferences.ts
@@ -32,7 +32,6 @@ interface PollingStationDataEntryDifferences {
   validationError: string | undefined;
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function usePollingStationDataEntryDifferences(
   pollingStationId: number,
   afterSave: (status: DataEntryStatusName, firstEntryUserId: number | undefined) => void,

--- a/frontend/src/features/users/components/create/UserCreateRolePage.tsx
+++ b/frontend/src/features/users/components/create/UserCreateRolePage.tsx
@@ -12,7 +12,6 @@ import { StringFormData } from "@/utils/stringFormData";
 
 import { useUserCreateContext } from "../../hooks/useUserCreateContext";
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function UserCreateRolePage() {
   const navigate = useNavigate();
   const [error, setError] = useState<string>("");

--- a/frontend/src/i18n/format.tsx
+++ b/frontend/src/i18n/format.tsx
@@ -19,7 +19,6 @@ const DEFAULT_RENDER_FUNCTIONS: Record<string, RenderFunction> = {
 };
 
 // parse the input string into an AST
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO function should be refactored
 export function parse(input: string, allowed = DEFAULT_ALLOWED_TAGS): AST {
   const ast: AST = [];


### PR DESCRIPTION
Enable [`skipBlankLines`](https://biomejs.dev/linter/rules/no-excessive-lines-per-function/#skipblanklines) in [`noExcessiveLinesPerFunction`](https://biomejs.dev/linter/rules/no-excessive-lines-per-function/) Biome rule.