### PR TITLE
Enable `SO_REUSEADDR` on server socket

### DIFF
--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -98,6 +98,7 @@ async fn run() -> Result<(), AppError> {
     let socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
     socket.set_nonblocking(true)?;
     socket.set_only_v6(false)?;
+    socket.set_reuse_address(true)?;
 
     let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, args.port));
     socket.bind(&address.into()).map_err(|e| match e.kind() {


### PR DESCRIPTION
This prevents 'port is in use' errors by allowing the server to bind to the port even if it is in the `TIME_WAIT` state after stopping the server.

#2588 changed the server binding code and omitted `SO_REUSEADDR`, even though the previous code using [`TcpListener::bind`](https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.bind) did implicitly set that option.