### PR TITLE
Shard Playwright e2e tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           package-manager-cache: false
       - name: Install pnpm
         run: >
-          npm install --global corepack@latest &&
+          npm install --global --force corepack@latest &&
           corepack enable &&
           corepack prepare pnpm@latest-10 --activate
       - name: Install dependencies


### PR DESCRIPTION

Shard Playwright e2e tests in release workflow, changes have been tested in a fork. Resolves #2792.

- **Shard Playwright e2e tests in release workflow**
  

- **Force install Corepack to avoid issues on Windows**
  Without `--force` the install fails on Windows:
  ```
  npm error File exists: C:\npm\prefix\yarn.cmd
  npm error Remove the existing file and try again, or run npm
  npm error with --force to overwrite files recklessly.
  ```
  