### PR TITLE
Sigrid: use component_base_dirs for backend

### DIFF
--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -105,8 +105,8 @@ exclude:
   - ".*/frontend/.*[.]d[.]ts"
   - ".*/frontend/.*[.]config[.]ts"
   - ".*/frontend/package.json"
-  - ".*/frontend/tsconfig[.]ts"
-  - "docker-compose.yml"
+  - ".*/frontend/tsconfig[.]json"
+  - "docker-compose[.]yml"
 
 dependencychecker:
   blocklist:


### PR DESCRIPTION
Currently, for Sigrid the backend is mainly split up into the four layers which is too big to be useful in Sigrid.

<img width="1381" height="1020" alt="image" src="https://github.com/user-attachments/assets/f8dba238-f3bc-46f1-a2ba-b59ac708969d" />

With this PR I want to introduce more fine-grained components, and because all components are new anyway, this is the most opportune moment to try out Sigrid's `component_base_dirs` feature to auto-detect components.

Also, as a first commit, I've used a different syntax in the YAML for list and dict, which I think makes it easier for humans to maintain the list of components. Please comment if this is an improvement or not.
