### PR TITLE
Move test functions near struct and usage

### DIFF
--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -341,37 +341,4 @@ pub async fn committee_session_investigations(
 }
 
 #[cfg(test)]
-pub mod tests {
-    use chrono::NaiveDate;
-    use sqlx::SqlitePool;
-
-    use super::*;
-    use crate::repository::committee_session_repo::change_status;
-
-    pub async fn change_status_committee_session(
-        pool: SqlitePool,
-        committee_session_id: CommitteeSessionId,
-        status: CommitteeSessionStatus,
-    ) -> CommitteeSession {
-        let mut conn = pool.acquire().await.unwrap();
-        change_status(&mut conn, committee_session_id, status)
-            .await
-            .unwrap()
-    }
-
-    /// Create a test committee session.
-    pub fn committee_session_fixture(election_id: ElectionId) -> CommitteeSession {
-        CommitteeSession {
-            id: CommitteeSessionId::from(1),
-            number: 1,
-            election_id,
-            location: "Test location".to_string(),
-            start_date_time: NaiveDate::from_ymd_opt(2025, 10, 22)
-                .and_then(|d| d.and_hms_opt(9, 15, 0)),
-            status: CommitteeSessionStatus::Completed,
-            results_eml: None,
-            results_pdf: None,
-            overview_pdf: None,
-        }
-    }
-}
+pub mod tests {}

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -1036,14 +1036,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        api::committee_session::tests::change_status_committee_session,
         domain::{
             committee_session::CommitteeSessionId,
-            committee_session_status::CommitteeSessionStatus,
             data_entry::tests::example_polling_station_results,
             validation::{ValidationResult, ValidationResultCode},
         },
         repository::{
+            committee_session_repo::change_status,
             data_entry_repo::{data_entry_exists, result_exists},
             investigation_repo::insert_test_investigation,
             polling_station_repo::insert_test_polling_station,
@@ -1284,6 +1283,17 @@ mod tests {
         let DataEntryStatusResponse { status } = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(status, DataEntryStatusName::FirstEntryHasErrors);
+    }
+
+    pub async fn change_status_committee_session(
+        pool: SqlitePool,
+        committee_session_id: CommitteeSessionId,
+        status: CommitteeSessionStatus,
+    ) -> CommitteeSession {
+        let mut conn = pool.acquire().await.unwrap();
+        change_status(&mut conn, committee_session_id, status)
+            .await
+            .unwrap()
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]

--- a/backend/src/domain/committee_session.rs
+++ b/backend/src/domain/committee_session.rs
@@ -114,3 +114,20 @@ impl IntoResponse for InvestigationListResponse {
         Json(self).into_response()
     }
 }
+
+/// Create a test committee session.
+#[cfg(test)]
+pub fn committee_session_fixture(election_id: ElectionId) -> CommitteeSession {
+    CommitteeSession {
+        id: CommitteeSessionId::from(1),
+        number: 1,
+        election_id,
+        location: "Test location".to_string(),
+        start_date_time: chrono::NaiveDate::from_ymd_opt(2025, 10, 22)
+            .and_then(|d| d.and_hms_opt(9, 15, 0)),
+        status: CommitteeSessionStatus::Completed,
+        results_eml: None,
+        results_pdf: None,
+        overview_pdf: None,
+    }
+}

--- a/backend/src/domain/polling_station.rs
+++ b/backend/src/domain/polling_station.rs
@@ -138,9 +138,8 @@ impl From<String> for PollingStationType {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{
-        api::committee_session::tests::committee_session_fixture,
-        domain::election::tests::election_fixture,
+    use crate::domain::{
+        committee_session::committee_session_fixture, election::tests::election_fixture,
     };
 
     /// Create a test polling station.

--- a/backend/src/domain/summary.rs
+++ b/backend/src/domain/summary.rs
@@ -299,8 +299,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        api::committee_session::tests::committee_session_fixture,
         domain::{
+            committee_session::committee_session_fixture,
             data_entry::{ExtraInvestigation, YesNo, tests::ValidDefault},
             election::{PGNumber, tests::election_fixture},
         },

--- a/backend/src/infra/pdf_gen/mod.rs
+++ b/backend/src/infra/pdf_gen/mod.rs
@@ -22,19 +22,16 @@ pub(crate) mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::{
-        api::committee_session::tests::committee_session_fixture,
-        domain::{
-            committee_session::CommitteeSessionId,
-            election::{
-                ElectionCategory, ElectionId, ElectionWithPoliticalGroups, VoteCountingMethod,
-                tests::election_fixture,
-            },
-            models::{ModelNa31_2Input, PdfFileModel, PdfModel, ToPdfFileModel, filter_input},
-            polling_station::{PollingStation, PollingStationId, PollingStationType},
-            summary::ElectionSummary,
-            votes_table::VotesTables,
+    use crate::domain::{
+        committee_session::{CommitteeSessionId, committee_session_fixture},
+        election::{
+            ElectionCategory, ElectionId, ElectionWithPoliticalGroups, VoteCountingMethod,
+            tests::election_fixture,
         },
+        models::{ModelNa31_2Input, PdfFileModel, PdfModel, ToPdfFileModel, filter_input},
+        polling_station::{PollingStation, PollingStationId, PollingStationType},
+        summary::ElectionSummary,
+        votes_table::VotesTables,
     };
 
     pub fn polling_stations_fixture(


### PR DESCRIPTION
Move two test functions:
- `committee_session_fixture()` to its `struct` and thus to the correct layer (domain)
- `change_status_committee_session()` to the only file where it is used
