### PR TITLE
Faster CI using build-only job

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -22,6 +22,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      CARGO_TERM_COLOR: always
+      SQLX_OFFLINE: "true"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # Build frontend+Storybook for embedding in the backend binary
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: Install pnpm
+        run: >
+          npm install --global corepack@latest &&
+          corepack enable &&
+          corepack prepare pnpm@latest-10 --activate
+      - name: Install frontend dependencies
+        run: pnpm install
+        working-directory: ./frontend
+      - name: Build frontend
+        run: pnpm build
+        working-directory: ./frontend
+        env:
+          INCLUDE_STORYBOOK_LINK: true
+      - name: Build Storybook
+        run: pnpm build:storybook
+        working-directory: ./frontend
+      # Compile backend with frontend and Storybook embedded
+      - name: Install musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Setup Rust
+        shell: bash
+        run: >
+          rustup update stable &&
+          rustup default stable &&
+          rustup target add x86_64-unknown-linux-musl
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: "backend -> target"
+      - name: Build
+        run: cargo --verbose --locked build --target=x86_64-unknown-linux-musl --features memory-serve,embed-typst,storybook --bin abacus
+      - uses: actions/upload-artifact@v6
+        with:
+          name: abacus
+          path: backend/target/x86_64-unknown-linux-musl/debug/abacus
+
   backend:
     name: Backend
     runs-on: ubuntu-latest
@@ -48,29 +103,7 @@ jobs:
           &&
           df -h
       - uses: actions/checkout@v6
-      # Build frontend so that it can be included in the backend build
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          package-manager-cache: false
-      - name: Install pnpm
-        run: >
-          npm install --global corepack@latest &&
-          corepack enable &&
-          corepack prepare pnpm@latest-10 --activate
-      - name: Install frontend dependencies
-        run: pnpm install
-        working-directory: ./frontend
-      - name: Build frontend
-        run: pnpm build
-        working-directory: ./frontend
-        env:
-          INCLUDE_STORYBOOK_LINK: true
-      - name: Build Storybook
-        run: pnpm build:storybook
-        working-directory: ./frontend
-      # Compile and test backend
+      # Test backend
       - name: Install musl
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Setup Rust
@@ -84,6 +117,9 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           workspaces: "backend -> target"
+      - name: Create empty frontend build dir for memory-serve
+        run: mkdir -p dist dist-storybook
+        working-directory: ./frontend
       - name: Check rustfmt
         run: cargo --verbose --locked fmt --all -- --check
       - name: Check Clippy with all features
@@ -92,12 +128,6 @@ jobs:
         run: cargo --verbose --locked clippy --target=x86_64-unknown-linux-musl --workspace --all-targets --no-default-features -- -D warnings
       - name: Run tests
         run: cargo --verbose --locked test --target=x86_64-unknown-linux-musl --workspace --features embed-typst -- --nocapture
-      - name: Build
-        run: cargo --verbose --locked build --target=x86_64-unknown-linux-musl --features memory-serve,embed-typst,storybook
-      - uses: actions/upload-artifact@v6
-        with:
-          name: abacus
-          path: backend/target/x86_64-unknown-linux-musl/debug/abacus
 
   frontend:
     name: Frontend
@@ -139,7 +169,7 @@ jobs:
   playwright-e2e:
     name: Playwright e2e tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     needs:
-      - backend
+      - build
     strategy:
       matrix:
         shardIndex: [1, 2, 3]
@@ -194,7 +224,7 @@ jobs:
     if: "github.repository == 'kiesraad/abacus' && !github.event.pull_request.head.repo.fork"
     name: Deploy to abacus-test.nl
     needs:
-      - backend
+      - build
     environment:
       name: test
       url: https://${{ github.sha }}.abacus-test.nl


### PR DESCRIPTION
Speed up CI by creating a build-only job (called Build) that builds the backend with frontend and Storybook embedded, so that the Playwright e2e tests can start sooner. The full backend linting and testing is done in parallel in another job (called Backend).

In my testing this speeds up CI by about 5 minutes wall time.