### PR TITLE
Fixed cargo doc warnings

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -847,7 +847,7 @@
     },
     "/api/elections/{election_id}/committee_sessions/{committee_session_id}/investigations": {
       "get": {
-        "summary": "Get a list of all [Investigation]s for a committee session (coordinator)",
+        "summary": "Get a list of all [crate::domain::investigation::PollingStationInvestigation]s for a committee session (coordinator)",
         "operationId": "committee_session_investigations",
         "parameters": [
           {
@@ -6794,7 +6794,7 @@
       },
       "PollingStation": {
         "type": "object",
-        "description": "Polling station of a certain [crate::election::Election]",
+        "description": "Polling station of a certain [crate::domain::election::Election]",
         "required": [
           "id",
           "election_id",
@@ -7025,7 +7025,7 @@
       },
       "PollingStationRequest": {
         "type": "object",
-        "description": "Polling station of a certain [crate::election::Election]",
+        "description": "Polling station of a certain [crate::domain::election::Election]",
         "required": [
           "name",
           "address",

--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -292,7 +292,7 @@ pub async fn committee_session_status_change(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// Get a list of all [Investigation]s for a committee session
+/// Get a list of all [crate::domain::investigation::PollingStationInvestigation]s for a committee session
 #[utoipa::path(
     get,
     path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}/investigations",

--- a/backend/src/api/middleware/authentication/role.rs
+++ b/backend/src/api/middleware/authentication/role.rs
@@ -180,7 +180,7 @@ where
     }
 }
 
-/// Implement the OptionalFromRequestParts trait for User, this allows us to extract an Option<User> from a request
+/// Implement the OptionalFromRequestParts trait for User, this allows us to extract an `Option<User>` from a request
 impl<S> OptionalFromRequestParts<S> for User
 where
     S: Send + Sync,

--- a/backend/src/domain/polling_station.rs
+++ b/backend/src/domain/polling_station.rs
@@ -16,7 +16,7 @@ use crate::{
 pub type PollingStationNumber = u32;
 id!(PollingStationId);
 
-/// Polling station of a certain [crate::election::Election]
+/// Polling station of a certain [crate::domain::election::Election]
 #[derive(Serialize, Deserialize, ToSchema, Debug, FromRow, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PollingStation {
@@ -64,7 +64,7 @@ impl From<PollingStation> for PollingStationDetails {
     }
 }
 
-/// Polling station of a certain [crate::election::Election]
+/// Polling station of a certain [crate::domain::election::Election]
 #[derive(Clone, Serialize, Deserialize, ToSchema, Debug, FromRequest)]
 #[from_request(via(axum::Json), rejection(APIError))]
 #[serde(deny_unknown_fields)]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,7 +35,7 @@ pub const MAX_BODY_SIZE_MB: usize = 12;
 pub trait SqlitePoolExt {
     /// Acquire a connection and start a transaction with "BEGIN IMMEDIATE",
     /// which is needed to prevent database is busy errors.
-    /// See https://sqlite.org/isolation.html for details.
+    /// See <https://sqlite.org/isolation.html> for details.
     fn begin_immediate(
         &self,
     ) -> impl Future<Output = Result<sqlx::Transaction<'_, Sqlite>, sqlx::Error>> + Send;

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1014,7 +1014,7 @@ export interface PoliticalGroupTotalVotes {
 }
 
 /**
- * Polling station of a certain [crate::election::Election]
+ * Polling station of a certain [crate::domain::election::Election]
  */
 export interface PollingStation {
   address: string;
@@ -1087,7 +1087,7 @@ export interface PollingStationListResponse {
 }
 
 /**
- * Polling station of a certain [crate::election::Election]
+ * Polling station of a certain [crate::domain::election::Election]
  */
 export interface PollingStationRequest {
   address: string;


### PR DESCRIPTION
Running `cargo doc --open` now causes no warnings anymore.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->