### PR TITLE
Add HttpOnly and SameSite attributes to session cookie

### DIFF
--- a/backend/src/api/middleware/authentication/session.rs
+++ b/backend/src/api/middleware/authentication/session.rs
@@ -52,6 +52,9 @@ impl Session {
             .max_age(cookie::time::Duration::seconds(
                 SESSION_LIFE_TIME.num_seconds(),
             ))
+            .http_only(true)
+            .same_site(cookie::SameSite::Lax)
+            .path("/")
             .build()
     }
 }


### PR DESCRIPTION
Harden against XSS, CSRF issues. Ip binding (local lan, arp spoofing) and replaying is still wide open.