### PR TITLE
Use Rust Nightly 2026-02-21 for code coverage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   backend:
-    name: Backend
+    name: Backend coverage
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -95,7 +95,7 @@ jobs:
         run: df -h
 
   frontend:
-    name: Frontend
+    name: Frontend coverage
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
- Pin Rust nightly to 2026-02-21 version, workaround for https://github.com/rust-lang/rust/issues/152961
- Add 'coverage' to Codecov job names to differentiate them from the jobs in the 'Build, lint & test' workflow