### PR TITLE
Set report type for Codecov test result uploads

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -227,6 +227,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: "Playwright e2e"
           files: frontend/playwright.e2e.junit.xml
+          report-type: test_results
           disable_search: true
           fail_ci_if_error: true
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -81,6 +81,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Backend Nextest Results
           files: backend/target/nextest/ci/junit.xml
+          report-type: test_results
           disable_search: true
           fail_ci_if_error: true
       - name: Upload coverage to Codecov
@@ -132,6 +133,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Frontend Vitest Results
           files: frontend/test-report.junit.xml
+          report-type: test_results
           disable_search: true
           fail_ci_if_error: true
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Codecov uploads broken since 7f929bb08a0f9c2606e17e7616202f24f797645c:

<img width="1050" height="193" alt="Screenshot 2026-02-23 at 15 01 36" src="https://github.com/user-attachments/assets/869d5b66-214d-436f-9075-acfd9393aec0" />

Apparently we should have added the `report-type: test_results` option, see https://github.com/codecov/test-results-action.

**Draft until fix is verified.**