### PR TITLE
Added fully qualified path, removed imports

### DIFF
--- a/backend/src/api/authentication.rs
+++ b/backend/src/api/authentication.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     domain::role::Role,
     error::ErrorReference,
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, AuditService, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, AuditService, as_audit_event},
     repository::{
         session_repo::{self, Session},
         user_repo::{self, User, UserId},

--- a/backend/src/api/election.rs
+++ b/backend/src/api/election.rs
@@ -30,7 +30,7 @@ use crate::{
         polling_station::{PollingStation, PollingStationRequest, PollingStationsRequest},
     },
     eml::{EML110, EML230, EMLDocument, EMLImportError, EmlHash, RedactedEmlHash},
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, AuditService, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, AuditService, as_audit_event},
     repository::{
         committee_session_repo, election_repo, investigation_repo, polling_station_repo,
         user_repo::User,

--- a/backend/src/api/investigation.rs
+++ b/backend/src/api/investigation.rs
@@ -30,7 +30,7 @@ use crate::{
         votes_table::VotesTablesWithOnlyPreviousVotes,
     },
     error::ErrorReference,
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, AuditService, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, AuditService, as_audit_event},
     repository::{
         committee_session_repo::get_election_committee_session,
         data_entry_repo::{self, data_entry_exists, previous_results_for_polling_station},

--- a/backend/src/api/middleware/airgap/detect.rs
+++ b/backend/src/api/middleware/airgap/detect.rs
@@ -9,7 +9,7 @@ use sqlx::SqlitePool;
 use tokio::{task::JoinSet, time::timeout};
 use tracing::{debug, error, info, trace, warn};
 
-use crate::infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, as_audit_event};
+use crate::infra::audit_log::{AsAuditEvent, AuditEventType, as_audit_event};
 
 #[derive(Clone)]
 pub struct AirgapDetection {

--- a/backend/src/api/middleware/authentication/middleware.rs
+++ b/backend/src/api/middleware/authentication/middleware.rs
@@ -14,7 +14,7 @@ use super::{SESSION_LIFE_TIME, SESSION_MIN_LIFE_TIME, session::get_expires_at};
 use crate::{
     SqlitePoolExt,
     api::authentication::set_default_cookie_properties,
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, AuditService, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, AuditService, as_audit_event},
     repository::{
         session_repo::{self, Session, SessionIdentifier},
         user_repo::{self, User},

--- a/backend/src/api/polling_station.rs
+++ b/backend/src/api/polling_station.rs
@@ -27,7 +27,7 @@ use crate::{
         },
     },
     eml::{EML110, EMLDocument, EMLImportError, EmlHash},
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, AuditService, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, AuditService, as_audit_event},
     repository::{
         committee_session_repo::get_election_committee_session,
         data_entry_repo, election_repo,

--- a/backend/src/domain/committee_session.rs
+++ b/backend/src/domain/committee_session.rs
@@ -12,7 +12,7 @@ use crate::{
         committee_session_status::CommitteeSessionStatus, election::ElectionId, file::FileId,
         id::id, investigation::PollingStationInvestigation,
     },
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, as_audit_event},
 };
 
 #[derive(Debug, PartialEq, Eq)]

--- a/backend/src/domain/file.rs
+++ b/backend/src/domain/file.rs
@@ -5,7 +5,7 @@ use utoipa::ToSchema;
 
 use crate::{
     domain::id::id,
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, as_audit_event},
 };
 
 id!(FileId);

--- a/backend/src/infra/audit_log/audit_event.rs
+++ b/backend/src/infra/audit_log/audit_event.rs
@@ -27,7 +27,7 @@ macro_rules! as_audit_event {
     ($identifier:ident, $audit_event_type:path) => {
         impl AsAuditEvent for $identifier {
             fn as_audit_event(&self) -> Result<crate::audit_log::AuditEvent, serde_json::Error> {
-                Ok(AuditEvent {
+                Ok(crate::audit_log::AuditEvent {
                     event_type: $audit_event_type,
                     data: serde_json::to_value(self)?,
                 })

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -30,7 +30,7 @@ use utoipa::ToSchema;
 
 use crate::{
     app_error::{DatabaseErrorWithPath, DatabaseMigrationErrorWithPath},
-    infra::audit_log::{AsAuditEvent, AuditEvent, AuditEventType, as_audit_event},
+    infra::audit_log::{AsAuditEvent, AuditEventType, as_audit_event},
 };
 
 /// Maximum size of the request body in megabytes.


### PR DESCRIPTION
Locally ran into an issue where I called macro `as_audit_event` on a struct in `structs.rs` and used that struct in another file. In `structs.rs` I forgot `AuditEvent` and `AsAuditEvent`, resulting into errors on the macro. 

If you forget:
- `AsAuditEvent`, you will get an error that the trait is not implemented for your struct and an error within the macro: cannot find trait `AsAuditEvent`
- `AuditEvent`: you will only get an error within the macro: `cannot find struct AuditEvent`. This is unclear, because my rust-analyzer doen't show where it is missing. 

I've added a fully qualified path to `AuditEvent` in macro `as_audit_event` and removed imports in files where they are not necessary anymore. This prevents the situation with the vague error.

Goal was to also get rid of import `AsAuditEvent` as well, however that one is needed for `as_audit_event`. 