### PR TITLE
Remove Codecov test result uploads

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -220,15 +220,6 @@ jobs:
           name: playwright-report-ubuntu-latest-${{ matrix.shardIndex }}
           path: frontend/playwright-report/
           retention-days: 30
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: "Playwright e2e"
-          files: frontend/playwright.e2e.junit.xml
-          disable_search: true
-          fail_ci_if_error: true
 
   deploy:
     if: "github.repository == 'kiesraad/abacus' && !github.event.pull_request.head.repo.fork"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -74,15 +74,6 @@ jobs:
         run: cargo binstall cargo-nextest
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --workspace --branch --profile ci --features embed-typst,airgap-detection --cobertura --output-path ./target/llvm-cov-target/codecov.json
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: Backend Nextest Results
-          files: backend/target/nextest/ci/junit.xml
-          disable_search: true
-          fail_ci_if_error: true
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
@@ -124,16 +115,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Run tests with coverage
-        run: pnpm vitest run --coverage --reporter=junit --outputFile=test-report.junit.xml
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: Frontend Vitest Results
-          files: frontend/test-report.junit.xml
-          disable_search: true
-          fail_ci_if_error: true
+        run: pnpm vitest run --coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:


### PR DESCRIPTION
Test result uploads to Codecov are broken and I can't figure out why. Since test results failures are reported by CI as well, we can just remove the test result uploads. Code coverage uploads are unchanged.

Related issue: https://github.com/codecov/feedback/issues/843