### PR TITLE
Use the RoleWithoutCommitteeCategory only for user create

### DIFF
--- a/frontend/src/components/ui/Badge/Badge.stories.tsx
+++ b/frontend/src/components/ui/Badge/Badge.stories.tsx
@@ -23,7 +23,7 @@ export const Badges: StoryObj = {
         {badgeTypes.map((type) => (
           <div key={type} className="mb-lg">
             <h2>{type}</h2>
-            <Badge id={type} type={type} showIcon userRole={"coordinator"} />
+            <Badge id={type} type={type} showIcon userRole={"coordinator_gsb"} />
           </div>
         ))}
       </>
@@ -62,7 +62,7 @@ export const CustomizableBadge: StoryObj<BadgeProps> = {
       control: { type: "radio" },
     },
   },
-  render: ({ type, showIcon }) => <Badge type={type} showIcon={showIcon} userRole={"coordinator"} />,
+  render: ({ type, showIcon }) => <Badge type={type} showIcon={showIcon} userRole={"coordinator_gsb"} />,
 };
 
 export default {};

--- a/frontend/src/components/ui/Badge/Badge.tsx
+++ b/frontend/src/components/ui/Badge/Badge.tsx
@@ -2,8 +2,8 @@ import type { ReactElement } from "react";
 
 import { IconEdit } from "@/components/generated/icons";
 import { t } from "@/i18n/translate";
-import type { DataEntryStatusName } from "@/types/generated/openapi";
-import type { RoleWithoutCommitteeCategory } from "@/utils/role";
+import type { DataEntryStatusName, Role } from "@/types/generated/openapi";
+import { isTypist } from "@/utils/role";
 
 import { Icon } from "../Icon/Icon";
 import cls from "./Badge.module.css";
@@ -15,8 +15,8 @@ export interface LabelProps {
   icon?: ReactElement;
 }
 
-function typeToLabel(userRole: RoleWithoutCommitteeCategory, badgeType: BadgeType): LabelProps {
-  if (badgeType === "first_entry_finalised" && userRole === "typist") {
+function typeToLabel(userRole: Role, badgeType: BadgeType): LabelProps {
+  if (badgeType === "first_entry_finalised" && isTypist(userRole)) {
     badgeType = "first_entry_finalised_for_typist";
   }
 
@@ -43,7 +43,7 @@ function typeToLabel(userRole: RoleWithoutCommitteeCategory, badgeType: BadgeTyp
 export interface BadgeProps {
   id?: string;
   type: BadgeType;
-  userRole: RoleWithoutCommitteeCategory;
+  userRole: Role;
   showIcon?: boolean;
 }
 

--- a/frontend/src/components/ui/Feedback/Feedback.stories.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.stories.tsx
@@ -35,7 +35,7 @@ export const Coordinator: Story = {
     id: "feedback-error",
     type: "error",
     data: ["F201", "F202"],
-    userRole: "coordinator",
+    userRole: "coordinator_gsb",
   },
   play: async ({ canvas }) => {
     const titles = await canvas.findAllByRole("heading");
@@ -58,7 +58,7 @@ export const Typist: Story = {
     id: "feedback-error",
     type: "error",
     data: ["F201", "F202"],
-    userRole: "typist",
+    userRole: "typist_gsb",
   },
   play: async ({ canvas }) => {
     const titles = await canvas.findAllByRole("heading");

--- a/frontend/src/components/ui/Feedback/Feedback.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.tsx
@@ -1,10 +1,10 @@
 import { type ReactNode, useEffect, useRef } from "react";
 
 import { hasTranslation, t, tx } from "@/i18n/translate";
-import type { ValidationResult } from "@/types/generated/openapi";
+import type { Role, ValidationResult } from "@/types/generated/openapi";
 import type { AlertType, FeedbackId } from "@/types/ui";
 import { cn } from "@/utils/classnames";
-import type { RoleWithoutCommitteeCategory } from "@/utils/role";
+import { isAdministrator, isCoordinator } from "@/utils/role";
 import { dottedCode } from "@/utils/ValidationResults";
 import { AlertIcon } from "../Icon/AlertIcon";
 import cls from "./Feedback.module.css";
@@ -20,14 +20,14 @@ interface FeedbackProps {
   id: FeedbackId;
   type: AlertType;
   data: ValidationResult[];
-  userRole: RoleWithoutCommitteeCategory;
+  userRole: Role;
   shouldFocus?: boolean;
 }
 
 export function Feedback({ id, type, data, userRole, shouldFocus = true }: FeedbackProps) {
   const feedbackHeader = useRef<HTMLHeadingElement | null>(null);
-  // NOTE: administrator roles are always mapped to coordinator here
-  const role = userRole === "administrator" ? "coordinator" : userRole;
+  // NOTE: Administrators get the same feedback messages as the coordinator
+  const role = isAdministrator(userRole) || isCoordinator(userRole) ? "coordinator" : "typist";
   const feedbackList: FeedbackItem[] = [];
   for (const { code, context } of data) {
     const title = t(`feedback.${code}.${role}.title`, { ...context });

--- a/frontend/src/components/ui/Table/Table.stories.tsx
+++ b/frontend/src/components/ui/Table/Table.stories.tsx
@@ -117,14 +117,14 @@ export const StyledTable: StoryObj = {
             <Table.NumberCell className="bg-gray">33</Table.NumberCell>
             <Table.Cell>
               <span>Op rolletjes</span>
-              <Badge type="first_entry_in_progress" userRole={"coordinator"} />
+              <Badge type="first_entry_in_progress" userRole={"coordinator_gsb"} />
             </Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.NumberCell className="bg-gray">34</Table.NumberCell>
             <Table.Cell>
               <span>Testplek</span>
-              <Badge type="empty" userRole={"coordinator"} />
+              <Badge type="empty" userRole={"coordinator_gsb"} />
             </Table.Cell>
           </Table.Row>
         </Table.Body>
@@ -326,7 +326,7 @@ export const IconBadgeTable: StoryObj = {
               </Table.Cell>
               <Table.Cell>
                 <span>{row[2]}</span>
-                <Badge type="first_entry_in_progress" showIcon userRole={"coordinator"} />
+                <Badge type="first_entry_in_progress" showIcon userRole={"coordinator_gsb"} />
               </Table.Cell>
             </Table.Row>
           ))}

--- a/frontend/src/features/data_entry/components/DataEntryPage.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryPage.tsx
@@ -46,9 +46,7 @@ export function DataEntryPage() {
         <section className="smaller-gap">
           <PollingStationNumber>{pollingStation.number}</PollingStationNumber>
           <h1>{pollingStation.name}</h1>
-          {pollingStationStatus.status && (
-            <Badge type={pollingStationStatus.status} userRole={user.roleWithoutCommitteeCategory} />
-          )}
+          {pollingStationStatus.status && <Badge type={pollingStationStatus.status} userRole={user.role} />}
         </section>
         <section>
           <AbortDataEntryControl />

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -94,20 +94,14 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
         )}
         {error instanceof ApiError && <ErrorModal error={error} />}
         {formSection.isSaved && memoizedErrors.length > 0 && (
-          <Feedback
-            id="feedback-error"
-            type="error"
-            data={memoizedErrors}
-            userRole={user.roleWithoutCommitteeCategory}
-            shouldFocus={true}
-          />
+          <Feedback id="feedback-error" type="error" data={memoizedErrors} userRole={user.role} shouldFocus={true} />
         )}
         {formSection.isSaved && memoizedWarnings.length > 0 && (
           <Feedback
             id="feedback-warning"
             type="warning"
             data={memoizedWarnings}
-            userRole={user.roleWithoutCommitteeCategory}
+            userRole={user.role}
             shouldFocus={formSection.errors.isEmpty()}
           />
         )}

--- a/frontend/src/features/data_entry_detail/components/DetailLayout.tsx
+++ b/frontend/src/features/data_entry_detail/components/DetailLayout.tsx
@@ -69,7 +69,7 @@ export function DetailLayout() {
         <section className="smaller-gap">
           <PollingStationNumber>{pollingStation.number}</PollingStationNumber>
           <h1>{pollingStation.name}</h1>
-          <Badge type={dataEntry.status} userRole={user.roleWithoutCommitteeCategory} />
+          <Badge type={dataEntry.status} userRole={user.role} />
         </section>
         {dataEntry.status !== "first_entry_has_errors" && (
           <section>

--- a/frontend/src/features/data_entry_detail/components/ReadOnlyDataEntrySection.tsx
+++ b/frontend/src/features/data_entry_detail/components/ReadOnlyDataEntrySection.tsx
@@ -20,7 +20,7 @@ export function ReadOnlyDataEntrySection({
   data: pollingStationResults,
   validationResults,
 }: ReadOnlyDataEntrySectionProps) {
-  const userRole = "coordinator";
+  const userRole = "coordinator_gsb";
 
   // Create validation result sets from the validation results
   const errors = getValidationResultSetForSection(validationResults.errors, section);

--- a/frontend/src/features/data_entry_home/components/PollingStationNumberInput.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationNumberInput.tsx
@@ -121,11 +121,7 @@ export function PollingStationNumberInput({
                 content={
                   <>
                     <span className="bold">{currentPollingStation.name}</span>
-                    <Badge
-                      type={currentPollingStation.statusEntry.status}
-                      userRole={user.roleWithoutCommitteeCategory}
-                      showIcon
-                    />
+                    <Badge type={currentPollingStation.statusEntry.status} userRole={user.role} showIcon />
                   </>
                 }
               />

--- a/frontend/src/features/data_entry_home/components/PollingStationsList.tsx
+++ b/frontend/src/features/data_entry_home/components/PollingStationsList.tsx
@@ -37,11 +37,7 @@ export function PollingStationsList({ pollingStations }: PollingStationsListProp
                 <Table.NumberCell>{pollingStation.number}</Table.NumberCell>
                 <Table.Cell>
                   <span>{pollingStation.name}</span>
-                  <Badge
-                    type={pollingStation.statusEntry.status}
-                    userRole={user.roleWithoutCommitteeCategory}
-                    showIcon
-                  />
+                  <Badge type={pollingStation.statusEntry.status} userRole={user.role} showIcon />
                 </Table.Cell>
               </Table.Row>
             ),

--- a/frontend/src/features/election_status/components/CategoryRow.tsx
+++ b/frontend/src/features/election_status/components/CategoryRow.tsx
@@ -75,7 +75,7 @@ function CategoryRowContent({ category, pollingStation, warning }: CategoryRowCo
       <Table.Cell key={`${pollingStation.id}-name`}>
         <span>{pollingStation.name}</span>
         {pollingStation.status && SHOW_BADGE.includes(pollingStation.status) && (
-          <Badge type={pollingStation.status} userRole={user.roleWithoutCommitteeCategory} />
+          <Badge type={pollingStation.status} userRole={user.role} />
         )}
       </Table.Cell>
       {(category === "in_progress" || category === "first_entry_finished") && (

--- a/frontend/src/features/users/components/create/UserCreateContextProvider.tsx
+++ b/frontend/src/features/users/components/create/UserCreateContextProvider.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode, useState } from "react";
 import type { Role } from "@/types/generated/openapi";
-import type { RoleWithoutCommitteeCategory } from "@/utils/role";
 import {
   type CommitteeCategory,
   type IUserCreateContext,
+  type RoleWithoutCommitteeCategory,
   UserCreateContext,
   type UserType,
 } from "../../hooks/UserCreateContext";

--- a/frontend/src/features/users/components/create/UserCreateRolePage.tsx
+++ b/frontend/src/features/users/components/create/UserCreateRolePage.tsx
@@ -8,9 +8,9 @@ import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { useUser } from "@/hooks/user/useUser";
 import { t } from "@/i18n/translate";
-import { isCoordinator, isRoleWithoutCommitteeCategory } from "@/utils/role";
+import { isCoordinator } from "@/utils/role";
 import { StringFormData } from "@/utils/stringFormData";
-import type { CommitteeCategory } from "../../hooks/UserCreateContext";
+import { type CommitteeCategory, isRoleWithoutCommitteeCategory } from "../../hooks/UserCreateContext";
 import { useUserCreateContext } from "../../hooks/useUserCreateContext";
 
 function committeeCategoryFromRole(role: "coordinator_csb" | "coordinator_gsb"): CommitteeCategory {

--- a/frontend/src/features/users/hooks/UserCreateContext.test.tsx
+++ b/frontend/src/features/users/hooks/UserCreateContext.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import {
+  isRoleWithoutCommitteeCategory,
+  type RoleWithoutCommitteeCategory,
+  roleWithoutCommitteeCategoryValues,
+} from "@/features/users/hooks/UserCreateContext";
+
+describe("UserCreateContext", () => {
+  test.each(
+    roleWithoutCommitteeCategoryValues,
+  )("String %j should be a RoleWithoutCommitteeCategory", (role: RoleWithoutCommitteeCategory) => {
+    expect(isRoleWithoutCommitteeCategory(role as string)).toBe(true);
+  });
+
+  test('String "typist_gsb" is not a RoleWithoutCommitteeCategory', () => {
+    expect(isRoleWithoutCommitteeCategory("typist_gsb")).toBe(false);
+  });
+});

--- a/frontend/src/features/users/hooks/UserCreateContext.tsx
+++ b/frontend/src/features/users/hooks/UserCreateContext.tsx
@@ -1,7 +1,13 @@
 import { createContext } from "react";
 
 import type { Role } from "@/types/generated/openapi";
-import type { RoleWithoutCommitteeCategory } from "@/utils/role";
+
+export const roleWithoutCommitteeCategoryValues = ["administrator", "coordinator", "typist"] as const;
+export type RoleWithoutCommitteeCategory = (typeof roleWithoutCommitteeCategoryValues)[number];
+
+export function isRoleWithoutCommitteeCategory(value: string): value is RoleWithoutCommitteeCategory {
+  return (roleWithoutCommitteeCategoryValues as readonly string[]).includes(value);
+}
 
 export type CommitteeCategory = "csb" | "gsb";
 export type UserType = "fullname" | "anonymous";

--- a/frontend/src/hooks/user/useUser.ts
+++ b/frontend/src/hooks/user/useUser.ts
@@ -2,9 +2,8 @@ import { useContext } from "react";
 
 import { ApiProviderContext, type ApiState } from "@/api/ApiProviderContext";
 import type { LoginResponse } from "@/types/generated/openapi";
-import { type RoleWithoutCommitteeCategory, roleWithoutCommitteeCategory } from "@/utils/role";
 
-export type UseUserReturn = (LoginResponse & { roleWithoutCommitteeCategory: RoleWithoutCommitteeCategory }) | null;
+export type UseUserReturn = LoginResponse | null;
 
 export function useUser(): UseUserReturn {
   const apiState = useContext<ApiState | null>(ApiProviderContext);
@@ -13,12 +12,5 @@ export function useUser(): UseUserReturn {
     throw new Error("useUser must be used within an ApiProvider");
   }
 
-  if (apiState.user === null) {
-    return null;
-  }
-
-  return {
-    ...apiState.user,
-    roleWithoutCommitteeCategory: roleWithoutCommitteeCategory(apiState.user.role),
-  };
+  return apiState.user;
 }

--- a/frontend/src/testing/user-mock-data.ts
+++ b/frontend/src/testing/user-mock-data.ts
@@ -4,7 +4,6 @@ export function getTypistUser(): NonNullable<UseUserReturn> {
   return {
     needs_password_change: false,
     role: "typist_gsb",
-    roleWithoutCommitteeCategory: "typist",
     user_id: 1,
     username: "testuser",
   };
@@ -14,7 +13,6 @@ export function getCoordinatorUser(committeeCategory: "csb" | "gsb" = "gsb"): No
   return {
     needs_password_change: false,
     role: `coordinator_${committeeCategory}`,
-    roleWithoutCommitteeCategory: "coordinator",
     user_id: 2,
     username: "testcoordinator",
   };
@@ -24,7 +22,6 @@ export function getAdminUser(): NonNullable<UseUserReturn> {
   return {
     needs_password_change: false,
     role: "administrator",
-    roleWithoutCommitteeCategory: "administrator",
     user_id: 3,
     username: "testadministrator",
   };

--- a/frontend/src/utils/role.test.ts
+++ b/frontend/src/utils/role.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { type Role, roleValues } from "@/types/generated/openapi";
-import {
-  isAdministrator,
-  isCoordinator,
-  isRoleWithoutCommitteeCategory,
-  isTypist,
-  type RoleWithoutCommitteeCategory,
-  roleWithoutCommitteeCategory,
-  roleWithoutCommitteeCategoryValues,
-} from "@/utils/role";
+import { isAdministrator, isCoordinator, isTypist } from "@/utils/role";
 
 describe("Role util", () => {
   test.each(
@@ -27,20 +19,5 @@ describe("Role util", () => {
     role?: Role,
   ) => boolean) => {
     expect(fn(undefined)).toBe(false);
-  });
-
-  test.each(roleValues)("Role %j without committee category should be the first part of role", (role: Role) => {
-    const roleWithout = roleWithoutCommitteeCategory(role);
-    expect(role.startsWith(roleWithout)).toBe(true);
-  });
-
-  test.each(
-    roleWithoutCommitteeCategoryValues,
-  )("String %j should be a RoleWithoutCommitteeCategory", (role: RoleWithoutCommitteeCategory) => {
-    expect(isRoleWithoutCommitteeCategory(role as string)).toBe(true);
-  });
-
-  test('String "typist_gsb" is not a RoleWithoutCommitteeCategory', () => {
-    expect(isRoleWithoutCommitteeCategory("typist_gsb")).toBe(false);
   });
 });

--- a/frontend/src/utils/role.ts
+++ b/frontend/src/utils/role.ts
@@ -11,23 +11,3 @@ export function isCoordinator(role?: Role) {
 export function isTypist(role?: Role) {
   return role === "typist_gsb" || role === "typist_csb";
 }
-
-export const roleWithoutCommitteeCategoryValues = ["administrator", "coordinator", "typist"] as const;
-export type RoleWithoutCommitteeCategory = (typeof roleWithoutCommitteeCategoryValues)[number];
-
-export function isRoleWithoutCommitteeCategory(value: string): value is RoleWithoutCommitteeCategory {
-  return (roleWithoutCommitteeCategoryValues as readonly string[]).includes(value);
-}
-
-export function roleWithoutCommitteeCategory(role: Role): RoleWithoutCommitteeCategory {
-  switch (role) {
-    case "administrator":
-      return "administrator";
-    case "coordinator_gsb":
-    case "coordinator_csb":
-      return "coordinator";
-    case "typist_gsb":
-    case "typist_csb":
-      return "typist";
-  }
-}


### PR DESCRIPTION
Do not use `RoleWithoutCommitteeCategory` outside of the user create, which was introduced in https://github.com/kiesraad/abacus/pull/2930 (as `RoleWithoutElection`) to reduce the number of changes.