### PR TITLE
make dependabot ignore all biome updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,8 @@ updates:
       # ESLint major upgrades usually have breaking changes
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+      # @biomejs/biome updates should be done manually, if only for updating $schema in biome.jsonc
+      - dependency-name: "@biomejs/biome"
       # React Router major upgrades usually have breaking changes
       - dependency-name: "react-router"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Updating biome should be done manually, because:
- `biome.jsonc` contains the full biome version number in `$schema`;
- even patch updates may contain changes to the linting rules.

So this PR makes dependabot ignore all biome updates.

See dependabot PR https://github.com/kiesraad/abacus/pull/3018 for examples of these issues: https://github.com/kiesraad/abacus/actions/runs/22842898958/job/66252610005?pr=3018

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->