### PR TITLE
Fix second entry badge color on data entry home page

### DIFF
--- a/frontend/src/components/ui/Badge/Badge.tsx
+++ b/frontend/src/components/ui/Badge/Badge.tsx
@@ -15,11 +15,7 @@ export interface LabelProps {
   icon?: ReactElement;
 }
 
-function typeToLabel(userRole: Role, badgeType: BadgeType): LabelProps {
-  if (badgeType === "first_entry_finalised" && isTypist(userRole)) {
-    badgeType = "first_entry_finalised_for_typist";
-  }
-
+function typeToLabel(badgeType: BadgeType): LabelProps {
   switch (badgeType) {
     case "empty":
       return { label: t("data_entry.first_entry") };
@@ -48,7 +44,10 @@ export interface BadgeProps {
 }
 
 export function Badge({ id, type, userRole, showIcon = false }: BadgeProps) {
-  const { label, icon } = typeToLabel(userRole, type);
+  if (type === "first_entry_finalised" && isTypist(userRole)) {
+    type = "first_entry_finalised_for_typist";
+  }
+  const { label, icon } = typeToLabel(type);
   return (
     <div id={id} className={`${cls[type]} ${cls.badge}`}>
       {label}


### PR DESCRIPTION
Before:
<img width="628" height="683" alt="image" src="https://github.com/user-attachments/assets/7b3284b4-a7c9-40c5-bf12-fcdf1ed2424e" />

After:
<img width="628" height="683" alt="Screenshot from 2026-03-10 16-24-03" src="https://github.com/user-attachments/assets/cd104a7e-ea37-403b-89b6-f6b29cb6893d" />

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->