### PR TITLE
Allow custom Chrome executable for Playwright

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -211,6 +211,8 @@ jobs:
         run: chmod a+x ../builds/backend/abacus
       - name: Run e2e playwright tests in Chrome
         run: pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --project chrome
+        env:
+          CHROMIUM_CHANNEL: chrome
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -21,13 +21,14 @@ function returnWebserverCommand(): string {
   return `cd ../backend && cargo run --features memory-serve,embed-typst -- --database ../backend/target/debug/playwright.sqlite --port 8081`;
 }
 
-function chromeUseOptions() {
-  const executablePath = process.env.CHROME_BIN;
+function chromiumUseOptions() {
+  const channel = process.env.CHROMIUM_CHANNEL ?? "chromium";
+  const executablePath = process.env.CHROMIUM_BIN;
   return {
     ...devices["Desktop Chrome"],
     userAgent: "Abacus-User-Agent/1",
-    // Use custom Chrome binary (e.g. Chromium) if set or use Playwright's default path
-    ...(executablePath ? { launchOptions: { executablePath } } : { channel: "chrome" }),
+    channel: channel,
+    launchOptions: { executablePath: executablePath },
   };
 }
 
@@ -67,13 +68,13 @@ const config: PlaywrightTestConfig = defineConfig({
       name: "initialisation-test",
       workers: 1,
       testMatch: /initialisation\.e2e\.ts/,
-      use: chromeUseOptions(),
+      use: chromiumUseOptions(),
     },
     {
       name: "setup-test-users",
       workers: 1,
       testMatch: /setup-test-users\.ts/,
-      use: chromeUseOptions(),
+      use: chromiumUseOptions(),
       dependencies: ["initialisation-test"],
     },
     {
@@ -84,7 +85,7 @@ const config: PlaywrightTestConfig = defineConfig({
         contextOptions: {
           permissions: ["clipboard-read", "clipboard-write"],
         },
-        ...chromeUseOptions(),
+        ...chromiumUseOptions(),
       },
       dependencies: ["setup-test-users"],
     },


### PR DESCRIPTION
Use Chromium by default and add the `CHROMIUM_CHANNEL` environment variable to override the [channel](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge) (e.g. `chrome` for locally installed Google Chrome). In addition, the `CHROMIUM_BIN` environment variable can be used if Playwright can't find the Chromium browser on the system by itself.

For other browsers Playwright still requires a patched build, so using a system browser doesn't make sense.