### PR TITLE
Update undici to 7.24.0

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,10 +7,10 @@ settings:
 overrides:
   '@vitest/expect': 4.0.18
   vite: 7.3.1
-  undici@<6.23.0: '>=6.23.0'
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
   rollup@<4.59.0: '>=4.59.0'
   minimatch@<10.2.3: '>=10.2.3'
+  undici@<7.24.0: '>=7.24.0'
 
 importers:
 
@@ -2432,8 +2432,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.0:
+    resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
     engines: {node: '>=20.18.1'}
 
   universal-user-agent@6.0.1:
@@ -2679,12 +2679,12 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
       '@octokit/request': 8.4.1
       '@octokit/request-error': 5.1.1
-      undici: 7.22.0
+      undici: 7.24.0
 
   '@actions/http-client@2.2.3':
     dependencies:
       tunnel: 0.0.6
-      undici: 7.22.0
+      undici: 7.24.0
 
   '@actions/io@1.1.3': {}
 
@@ -4286,7 +4286,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4793,7 +4793,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.22.0: {}
+  undici@7.24.0: {}
 
   universal-user-agent@6.0.1: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -5,8 +5,6 @@ allowBuilds:
   unrs-resolver: true
 blockExoticSubdeps: true
 minimumReleaseAge: 4320
-minimumReleaseAgeExclude:
-  - minimatch@10.2.4
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - semver@6.3.1
@@ -23,11 +21,16 @@ overrides:
   # @codecov/vite-plugin does not have official support for Vite 7, but works:
   # https://github.com/codecov/codecov-javascript-bundler-plugins/issues/264
   "vite": "$vite"
-  # Fix GHSA-g9mf-h72j-4rw9 / CVE-2026-22036
-  "undici@<6.23.0": ">=6.23.0"
   # Fix GHSA-7h2j-956f-4vf2
   "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"
   # Fix GHSA-mw96-cpmx-2vgc / CVE-2026-27606
   "rollup@<4.59.0": ">=4.59.0"
   # Fix GHSA-7r86-cg39-jmmj / CVE-2026-27903
-  minimatch@<10.2.3: '>=10.2.3'
+  minimatch@<10.2.3: ">=10.2.3"
+  # Fix GHSA-2mjp-6q6p-2qxm / CVE-2026-1525
+  # Fix GHSA-vrm6-8vpv-qv8q / CVE-2026-1526
+  # Fix GHSA-4992-7rv2-5pvq / CVE-2026-1527
+  # Fix GHSA-f269-vfmq-vjvj / CVE-2026-1528
+  # Fix GHSA-v9p9-hfj2-hcw8 / CVE-2026-2229
+  # Fix GHSA-phc3-fgpg-7m6h / CVE-2026-2581
+  "undici@<7.24.0": ">=7.24.0"


### PR DESCRIPTION
Fix GHSA-2mjp-6q6p-2qxm / CVE-2026-1525 / https://github.com/kiesraad/abacus/security/dependabot/78
Fix GHSA-vrm6-8vpv-qv8q / CVE-2026-1526 / https://github.com/kiesraad/abacus/security/dependabot/81
Fix GHSA-4992-7rv2-5pvq / CVE-2026-1527 / https://github.com/kiesraad/abacus/security/dependabot/80
Fix GHSA-f269-vfmq-vjvj / CVE-2026-1528 / https://github.com/kiesraad/abacus/security/dependabot/77
Fix GHSA-v9p9-hfj2-hcw8 / CVE-2026-2229 / https://github.com/kiesraad/abacus/security/dependabot/82
Fix GHSA-phc3-fgpg-7m6h / CVE-2026-2581 / https://github.com/kiesraad/abacus/security/dependabot/79