### PR TITLE
Rename `data_entry_delete` to `data_entry_discard`

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3183,8 +3183,8 @@
         ]
       },
       "delete": {
-        "summary": "Delete an in-progress (not finalised) data entry for a polling station (typist_gsb)",
-        "operationId": "data_entry_delete",
+        "summary": "Discard an in-progress (not finalised) data entry for a polling station (typist_gsb)",
+        "operationId": "data_entry_discard",
         "parameters": [
           {
             "name": "polling_station_id",
@@ -3209,7 +3209,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Data entry deleted successfully"
+            "description": "Data entry discarded successfully"
           },
           "401": {
             "description": "Unauthorized",

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -156,7 +156,7 @@ pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(data_entry_claim).authorize(TYPIST_GSB))
         .routes(routes!(data_entry_save).authorize(TYPIST_GSB))
-        .routes(routes!(data_entry_delete).authorize(TYPIST_GSB))
+        .routes(routes!(data_entry_discard).authorize(TYPIST_GSB))
         .routes(routes!(data_entry_finalise).authorize(TYPIST_GSB))
         .routes(routes!(data_entry_reset).authorize(COORDINATOR_GSB))
         .routes(routes!(data_entry_get).authorize(COORDINATOR_GSB))
@@ -470,12 +470,12 @@ async fn data_entry_save(
     Ok(SaveDataEntryResponse { validation_results })
 }
 
-/// Delete an in-progress (not finalised) data entry for a polling station
+/// Discard an in-progress (not finalised) data entry for a polling station
 #[utoipa::path(
     delete,
     path = "/api/polling_stations/{polling_station_id}/data_entries/{entry_number}",
     responses(
-        (status = 204, description = "Data entry deleted successfully"),
+        (status = 204, description = "Data entry discarded successfully"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),
@@ -487,7 +487,7 @@ async fn data_entry_save(
         ("entry_number" = u8, description = "Data entry number (first or second data entry)"),
     ),
 )]
-async fn data_entry_delete(
+async fn data_entry_discard(
     user: User,
     State(pool): State<SqlitePool>,
     Path((polling_station_id, entry_number)): Path<(PollingStationId, EntryNumber)>,
@@ -1083,7 +1083,7 @@ mod tests {
             EntryNumber::FirstEntry => User::test_user(Role::TypistGSB, UserId::from(1)),
             EntryNumber::SecondEntry => User::test_user(Role::TypistGSB, UserId::from(2)),
         };
-        data_entry_delete(
+        data_entry_discard(
             user.clone(),
             State(pool),
             Path((polling_station_id, entry_number)),
@@ -1771,7 +1771,7 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_data_entry_delete_first_entry(pool: SqlitePool) {
+    async fn test_data_entry_discard_first_entry(pool: SqlitePool) {
         // create data entry
         let request_body = example_data_entry();
         let polling_station_id = PollingStationId::from(1);
@@ -1804,7 +1804,7 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_data_entry_delete_second_entry(pool: SqlitePool) {
+    async fn test_data_entry_discard_second_entry(pool: SqlitePool) {
         // create data entry with warning
         let request_body = example_data_entry_with_warning();
         let polling_station_id = PollingStationId::from(1);
@@ -1876,7 +1876,7 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_data_entry_delete_committee_session_status_is_paused(pool: SqlitePool) {
+    async fn test_data_entry_discard_committee_session_status_is_paused(pool: SqlitePool) {
         // create data entry
         let request_body = example_data_entry();
         let polling_station_id = PollingStationId::from(1);
@@ -1914,7 +1914,7 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_data_entry_delete_committee_session_status_not_paused_or_data_entry(
+    async fn test_data_entry_discard_committee_session_status_not_paused_or_data_entry(
         pool: SqlitePool,
     ) {
         // create data entry
@@ -1957,10 +1957,10 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_data_entry_delete_nonexistent(pool: SqlitePool) {
+    async fn test_data_entry_discard_nonexistent(pool: SqlitePool) {
         let user = User::test_user(Role::TypistGSB, UserId::from(1));
-        // check that deleting a non-existing data entry returns 404
-        let response = data_entry_delete(
+        // check that discarding a non-existing data entry returns 404
+        let response = data_entry_discard(
             User::test_user(Role::TypistGSB, UserId::from(1)),
             State(pool.clone()),
             Path((PollingStationId::from(1), EntryNumber::FirstEntry)),
@@ -1973,7 +1973,7 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_data_entry_delete_finalised_not_possible(pool: SqlitePool) {
+    async fn test_data_entry_discard_finalised_not_possible(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
         let polling_station_id = PollingStationId::from(1);
 

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.test.tsx
@@ -40,7 +40,7 @@ function renderComponent(onSubmit: (options?: SubmitCurrentFormOptions) => Promi
 describe("DataEntryNavigation", () => {
   describe("Blocker behaviour", () => {
     test.each<Status>([
-      "deleted",
+      "discarded",
       "finalised",
       "finalising",
       "aborted",
@@ -63,7 +63,7 @@ describe("DataEntryNavigation", () => {
     test.each<Status>([
       "idle",
       "saving",
-      "deleting",
+      "discarding",
     ])("Does not block navigation without changes for status: %s", async (status) => {
       const state: DataEntryStateAndActionsLoaded = {
         ...getDefaultDataEntryStateAndActionsLoaded(),
@@ -83,7 +83,7 @@ describe("DataEntryNavigation", () => {
     test.each<Status>([
       "idle",
       "saving",
-      "deleting",
+      "discarding",
     ])("Blocks navigation when form has changes for status: %s", async (status) => {
       const state: DataEntryStateAndActionsLoaded = {
         ...getDefaultDataEntryStateAndActionsLoaded(),
@@ -182,12 +182,12 @@ describe("DataEntryNavigation", () => {
 
   describe("Abort modal actions", () => {
     test("Abort modal delete", async () => {
-      const onDeleteDataEntry = vi.fn(async () => {
+      const onDiscardDataEntry = vi.fn(async () => {
         return Promise.resolve(true);
       });
       const state: DataEntryStateAndActionsLoaded = {
         ...getDefaultDataEntryStateAndActionsLoaded(),
-        onDeleteDataEntry,
+        onDiscardDataEntry,
         status: "idle",
       };
 
@@ -208,7 +208,7 @@ describe("DataEntryNavigation", () => {
       expect(deleteButton).toBeVisible();
       deleteButton.click();
 
-      expect(onDeleteDataEntry).toHaveBeenCalled();
+      expect(onDiscardDataEntry).toHaveBeenCalled();
       await waitFor(() => {
         expect(router.state.location.pathname).toBe("/test");
       });

--- a/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryNavigation.tsx
@@ -28,7 +28,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
     formState,
     setCache,
     entryNumber,
-    onDeleteDataEntry,
+    onDiscardDataEntry,
     updateFormSection,
   } = useDataEntryContext();
   const params = useParams<{ sectionId: FormSectionId }>();
@@ -52,7 +52,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
     }
 
     if (
-      status === "deleted" ||
+      status === "discarded" ||
       status === "finalising" ||
       status === "finalised" ||
       status === "aborted" ||
@@ -149,7 +149,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
 
   // when discard is chosen in the abort dialog
   const onAbortModalDelete = async () => {
-    if (await onDeleteDataEntry()) {
+    if (await onDiscardDataEntry()) {
       blocker.proceed();
     } else {
       blocker.reset();
@@ -182,7 +182,7 @@ export function DataEntryNavigation({ onSubmit, currentValues = {} }: DataEntryN
           onClick={() => {
             void onAbortModalDelete();
           }}
-          disabled={status === "deleting"}
+          disabled={status === "discarding"}
         >
           {t("data_entry.abort.discard_input")}
         </Button>

--- a/frontend/src/features/data_entry/hooks/useDataEntry.ts
+++ b/frontend/src/features/data_entry/hooks/useDataEntry.ts
@@ -3,7 +3,7 @@ import { useReducer } from "react";
 import { useApiClient } from "@/api/useApiClient";
 import type {
   DATA_ENTRY_CLAIM_REQUEST_PATH,
-  DATA_ENTRY_DELETE_REQUEST_PATH,
+  DATA_ENTRY_DISCARD_REQUEST_PATH,
   DATA_ENTRY_FINALISE_REQUEST_PATH,
   DATA_ENTRY_SAVE_REQUEST_PATH,
   ElectionWithPoliticalGroups,
@@ -11,7 +11,7 @@ import type {
 import type { FormSectionId } from "@/types/types";
 
 import type { DataEntryStateAndActions } from "../types/types";
-import { onDeleteDataEntry, onFinaliseDataEntry, onSubmitForm, setCache, updateFormSection } from "../utils/actions";
+import { onDiscardDataEntry, onFinaliseDataEntry, onSubmitForm, setCache, updateFormSection } from "../utils/actions";
 import dataEntryReducer, { getInitialState } from "../utils/reducer";
 import useDataEntryNavigation from "./useDataEntryNavigation";
 import { useInitialDataEntryState } from "./useInitialDataEntryState";
@@ -27,7 +27,7 @@ export default function useDataEntry(
 
   // initial request to get the current data entry from the backend
   const saveRequestPath: DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
-  const deleteRequestPath: DATA_ENTRY_DELETE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
+  const discardRequestPath: DATA_ENTRY_DISCARD_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}`;
   const finaliseRequestPath: DATA_ENTRY_FINALISE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/data_entries/${entryNumber}/finalise`;
   const claimRequestPath: DATA_ENTRY_CLAIM_REQUEST_PATH = `${saveRequestPath}/claim`;
   useInitialDataEntryState(client, dispatch, claimRequestPath);
@@ -39,7 +39,7 @@ export default function useDataEntry(
     ...state,
     dispatch,
     onSubmitForm: onSubmitForm(client, saveRequestPath, dispatch, state),
-    onDeleteDataEntry: onDeleteDataEntry(client, deleteRequestPath, dispatch),
+    onDiscardDataEntry: onDiscardDataEntry(client, discardRequestPath, dispatch),
     onFinaliseDataEntry: onFinaliseDataEntry(client, finaliseRequestPath, dispatch),
     setCache: setCache(dispatch),
     updateFormSection: updateFormSection(dispatch),

--- a/frontend/src/features/data_entry/testing/mock-data.ts
+++ b/frontend/src/features/data_entry/testing/mock-data.ts
@@ -119,7 +119,7 @@ export function getDefaultDataEntryStateAndActionsLoaded(): DataEntryStateAndAct
     ...getDefaultDataEntryState(),
     dispatch: () => null,
     onSubmitForm: () => Promise.resolve(true),
-    onDeleteDataEntry: () => Promise.resolve(true),
+    onDiscardDataEntry: () => Promise.resolve(true),
     onFinaliseDataEntry: () => Promise.resolve(undefined),
     setCache: () => null,
     updateFormSection: () => null,

--- a/frontend/src/features/data_entry/types/types.ts
+++ b/frontend/src/features/data_entry/types/types.ts
@@ -51,7 +51,7 @@ export interface DataEntryStateAndActions extends DataEntryState {
     currentValues: SectionValues,
     options?: SubmitCurrentFormOptions,
   ) => Promise<boolean>;
-  onDeleteDataEntry: () => Promise<boolean>;
+  onDiscardDataEntry: () => Promise<boolean>;
   onFinaliseDataEntry: () => Promise<DataEntryStatusResponse | undefined>;
   setCache: (cache: TemporaryCache) => void;
   updateFormSection: (sectionId: FormSectionId, partialFormSection: Partial<FormSection>) => void;
@@ -123,7 +123,7 @@ export type TemporaryCache = {
 
 // Status of the form controller
 // This is a type instead of an enum because of https://github.com/ArnaudBarre/eslint-plugin-react-refresh/issues/36
-export type Status = "idle" | "saving" | "deleting" | "deleted" | "finalising" | "finalised" | "aborted";
+export type Status = "idle" | "saving" | "discarding" | "discarded" | "finalising" | "finalised" | "aborted";
 
 export interface ClientState {
   furthest: FormSectionId;

--- a/frontend/src/features/data_entry/utils/actions.ts
+++ b/frontend/src/features/data_entry/utils/actions.ts
@@ -137,9 +137,9 @@ export function onSubmitForm(
   };
 }
 
-export function onDeleteDataEntry(client: ApiClient, requestPath: string, dispatch: DataEntryDispatch) {
+export function onDiscardDataEntry(client: ApiClient, requestPath: string, dispatch: DataEntryDispatch) {
   return async (): Promise<boolean> => {
-    dispatch({ type: "SET_STATUS", status: "deleting" });
+    dispatch({ type: "SET_STATUS", status: "discarding" });
 
     const response = await client.deleteRequest(requestPath);
 
@@ -149,7 +149,7 @@ export function onDeleteDataEntry(client: ApiClient, requestPath: string, dispat
       return false;
     }
 
-    dispatch({ type: "SET_STATUS", status: "deleted" });
+    dispatch({ type: "SET_STATUS", status: "discarded" });
     return true;
   };
 }

--- a/frontend/src/features/data_entry/utils/reducer.test.ts
+++ b/frontend/src/features/data_entry/utils/reducer.test.ts
@@ -5,7 +5,7 @@ import { ApiResponseStatus } from "@/api/ApiResult";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { pollingStationMockData } from "@/testing/api-mocks/PollingStationMockData";
 import {
-  PollingStationDataEntryDeleteHandler,
+  PollingStationDataEntryDiscardHandler,
   PollingStationDataEntryFinaliseHandler,
 } from "@/testing/api-mocks/RequestHandlers";
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
@@ -18,7 +18,7 @@ import type {
 import { ValidationResultSet } from "@/utils/ValidationResults";
 import { getDefaultDataEntryState, getInitialValues } from "../testing/mock-data";
 import type { DataEntryAction, DataEntryState } from "../types/types";
-import { onDeleteDataEntry, onFinaliseDataEntry, onSubmitForm } from "./actions";
+import { onDiscardDataEntry, onFinaliseDataEntry, onSubmitForm } from "./actions";
 import dataEntryReducer, { getInitialState as _getInitialState } from "./reducer";
 
 function getInitialState(): DataEntryState {
@@ -345,23 +345,25 @@ describe("onSubmitForm", () => {
   });
 });
 
-describe("onDeleteDataEntry", () => {
-  test("should handle delete data entry", async () => {
-    server.use(PollingStationDataEntryDeleteHandler);
+describe("onDiscardDataEntry", () => {
+  test("should handle discard data entry", async () => {
+    server.use(PollingStationDataEntryDiscardHandler);
 
     const dispatch = vi.fn();
     const client = new ApiClient();
 
     const requestPath = "/api/polling_stations/1/data_entries/1";
-    const onDelete = onDeleteDataEntry(client, requestPath, dispatch);
+    const onDiscard = onDiscardDataEntry(client, requestPath, dispatch);
 
-    const result = await onDelete();
+    const result = await onDiscard();
 
     expect(dispatch).toHaveBeenCalledTimes(2);
     expect(dispatch.mock.calls[0]).toStrictEqual([
-      { type: "SET_STATUS", status: "deleting" } satisfies DataEntryAction,
+      { type: "SET_STATUS", status: "discarding" } satisfies DataEntryAction,
     ]);
-    expect(dispatch.mock.calls[1]).toStrictEqual([{ type: "SET_STATUS", status: "deleted" } satisfies DataEntryAction]);
+    expect(dispatch.mock.calls[1]).toStrictEqual([
+      { type: "SET_STATUS", status: "discarded" } satisfies DataEntryAction,
+    ]);
 
     expect(result).toBe(true);
   });

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -32,8 +32,8 @@ import type {
   CREATE_FIRST_ADMIN_REQUEST_PATH,
   DATA_ENTRY_CLAIM_REQUEST_PARAMS,
   DATA_ENTRY_CLAIM_REQUEST_PATH,
-  DATA_ENTRY_DELETE_REQUEST_PARAMS,
-  DATA_ENTRY_DELETE_REQUEST_PATH,
+  DATA_ENTRY_DISCARD_REQUEST_PARAMS,
+  DATA_ENTRY_DISCARD_REQUEST_PATH,
   DATA_ENTRY_FINALISE_REQUEST_PARAMS,
   DATA_ENTRY_FINALISE_REQUEST_PATH,
   DATA_ENTRY_GET_DIFFERENCES_REQUEST_PARAMS,
@@ -414,9 +414,9 @@ export const PollingStationDataEntryClaimHandler = http.post<
   HttpResponse.json(claimDataEntryResponse, { status: 200 }),
 );
 
-// delete data entry handler
-export const PollingStationDataEntryDeleteHandler = http.delete<ParamsToString<DATA_ENTRY_DELETE_REQUEST_PARAMS>>(
-  "/api/polling_stations/1/data_entries/1" satisfies DATA_ENTRY_DELETE_REQUEST_PATH,
+// discard data entry handler
+export const PollingStationDataEntryDiscardHandler = http.delete<ParamsToString<DATA_ENTRY_DISCARD_REQUEST_PARAMS>>(
+  "/api/polling_stations/1/data_entries/1" satisfies DATA_ENTRY_DISCARD_REQUEST_PATH,
   () => new HttpResponse(null, { status: 204 }),
 );
 
@@ -534,7 +534,7 @@ export const handlers: HttpHandler[] = [
   PollingStationListRequestHandler,
   PollingStationDataEntrySaveHandler,
   PollingStationDataEntryClaimHandler,
-  PollingStationDataEntryDeleteHandler,
+  PollingStationDataEntryDiscardHandler,
   PollingStationDataEntryFinaliseHandler,
   PollingStationDataEntryResetHandler,
   PollingStationCreateHandler,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -246,11 +246,11 @@ export interface DATA_ENTRY_SAVE_REQUEST_PARAMS {
 }
 export type DATA_ENTRY_SAVE_REQUEST_PATH = `/api/polling_stations/${PollingStationId}/data_entries/${number}`;
 export type DATA_ENTRY_SAVE_REQUEST_BODY = DataEntry;
-export interface DATA_ENTRY_DELETE_REQUEST_PARAMS {
+export interface DATA_ENTRY_DISCARD_REQUEST_PARAMS {
   polling_station_id: PollingStationId;
   entry_number: number;
 }
-export type DATA_ENTRY_DELETE_REQUEST_PATH = `/api/polling_stations/${PollingStationId}/data_entries/${number}`;
+export type DATA_ENTRY_DISCARD_REQUEST_PATH = `/api/polling_stations/${PollingStationId}/data_entries/${number}`;
 
 // /api/polling_stations/{polling_station_id}/data_entries/{entry_number}/claim
 export interface DATA_ENTRY_CLAIM_REQUEST_PARAMS {


### PR DESCRIPTION
Rename data entry endpoint `data_entry_delete` to `data_entry_discard`, resolves #2936.