### PR TITLE
Increase Playwright webServer timeout to 5 minutes

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -61,6 +61,7 @@ const config: PlaywrightTestConfig = defineConfig({
           command: returnWebserverCommand(),
           url: "http://127.0.0.1:8081",
           stdout: process.env.LOCAL_CI ? "pipe" : "ignore",
+          timeout: 300_000,
         },
       ],
   projects: [


### PR DESCRIPTION
For me locally a full Abacus build can take more than one minute, so I had to restart the Playwright tests often more than once to give it enough time to build and start the tests.

This PR is to set the [timeout for the Playwright `webServer`](https://playwright.dev/docs/test-webserver#adding-a-server-timeout) to 5 minutes.

