### PR TITLE
Changed unique highest averages table to show already assigned instead of full seats

### DIFF
--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -213,9 +213,9 @@ describe("ApportionmentResidualSeatsPage", () => {
     const unique_highest_averages_table = await screen.findByTestId("unique-highest-averages-table");
     expect(unique_highest_averages_table).toBeVisible();
     expect(unique_highest_averages_table).toHaveTableContent([
-      ["Lijst", "Lijstnaam", "Aantal volle zetels", "Gemiddelde", "Aantal restzetels"],
-      ["1", "Political Group A", "10", "67", "4/12", "1"],
-      ["2", "Political Group B", "0", "30", "", "0"],
+      ["Lijst", "Lijstnaam", "Reeds toegewezen", "Gemiddelde", "Aantal restzetels"],
+      ["1", "Political Group A", "11", "67", "4/12", "1"],
+      ["2", "Political Group B", "1", "30", "", "0"],
       ["3", "Political Group C", "0", "58", "", "1"],
       ["4", "Political Group D", "0", "57", "", "1"],
       ["5", "Blanco (Smit, G.)", "0", "56", "", "0"],
@@ -300,8 +300,8 @@ describe("ApportionmentResidualSeatsPage", () => {
     const unique_highest_averages_table = await screen.findByTestId("unique-highest-averages-table");
     expect(unique_highest_averages_table).toBeVisible();
     expect(unique_highest_averages_table).toHaveTableContent([
-      ["Lijst", "Lijstnaam", "Aantal volle zetels", "Gemiddelde", "Aantal restzetels"],
-      ["2", "Political Group B", "2", "244", "1/4", "1"],
+      ["Lijst", "Lijstnaam", "Reeds toegewezen", "Gemiddelde", "Aantal restzetels"],
+      ["2", "Political Group B", "3", "244", "1/4", "1"],
     ]);
 
     expect(await screen.findByTestId("footnotes-list")).toHaveTextContent(
@@ -345,7 +345,7 @@ describe("ApportionmentResidualSeatsPage", () => {
     const unique_highest_averages_table = await screen.findByTestId("unique-highest-averages-table");
     expect(unique_highest_averages_table).toBeVisible();
     expect(unique_highest_averages_table).toHaveTableContent([
-      ["Lijst", "Lijstnaam", "Aantal volle zetels", "Gemiddelde", "Aantal restzetels"],
+      ["Lijst", "Lijstnaam", "Reeds toegewezen", "Gemiddelde", "Aantal restzetels"],
       ["1", "Political Group A", "0", "5", "", "1"],
       ["2", "Political Group B", "0", "5", "", "1"],
     ]);

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.tsx
@@ -110,6 +110,7 @@ function LargestRemaindersSection({
 
 interface HighestAveragesSectionProps {
   seatAssignment: SeatAssignment;
+  largestRemainderSteps: LargestRemainderAssignmentStep[];
   uniqueHighestAverageSteps: UniqueHighestAverageAssignmentStep[];
   highestAverageSteps: HighestAverageAssignmentStep[];
   politicalGroups: PoliticalGroup[];
@@ -118,6 +119,7 @@ interface HighestAveragesSectionProps {
 
 function HighestAveragesSection({
   seatAssignment,
+  largestRemainderSteps,
   uniqueHighestAverageSteps,
   highestAverageSteps,
   politicalGroups,
@@ -135,6 +137,7 @@ function HighestAveragesSection({
         </span>
         <UniqueHighestAveragesTable
           steps={uniqueHighestAverageSteps}
+          largestRemainderSteps={largestRemainderSteps}
           finalStanding={seatAssignment.final_standing}
           politicalGroups={politicalGroups}
         />
@@ -193,6 +196,7 @@ function SmallCouncilSection({
       {uniqueHighestAverageSteps.length > 0 && (
         <HighestAveragesSection
           seatAssignment={seatAssignment}
+          largestRemainderSteps={largestRemainderSteps}
           uniqueHighestAverageSteps={uniqueHighestAverageSteps}
           highestAverageSteps={highestAverageSteps}
           politicalGroups={politicalGroups}

--- a/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.stories.tsx
@@ -8,6 +8,7 @@ export const Default: StoryObj = {
     return (
       <UniqueHighestAveragesTable
         steps={lt19Seats.highest_average_steps}
+        largestRemainderSteps={lt19Seats.largest_remainder_steps}
         finalStanding={lt19Seats.seat_assignment.final_standing}
         politicalGroups={lt19Seats.election.political_groups}
       />
@@ -17,9 +18,9 @@ export const Default: StoryObj = {
     const table = canvas.getByRole("table");
     await expect(table).toBeVisible();
     expect(table).toHaveTableContent([
-      ["Lijst", "Lijstnaam", "Aantal volle zetels", "Gemiddelde", "Aantal restzetels"],
-      ["1", "Political Group A", "10", "67", "4/12", "1"],
-      ["2", "Political Group B", "0", "30", "", "0"],
+      ["Lijst", "Lijstnaam", "Reeds toegewezen", "Gemiddelde", "Aantal restzetels"],
+      ["1", "Political Group A", "11", "67", "4/12", "1"],
+      ["2", "Political Group B", "1", "30", "", "0"],
       ["3", "Political Group C", "0", "58", "", "1"],
       ["4", "Political Group D", "0", "57", "", "1"],
       ["5", "Blanco (Smit, G.)", "0", "56", "", "0"],

--- a/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.tsx
@@ -3,22 +3,28 @@ import { t } from "@/i18n/translate";
 import type { ListSeatAssignment, PoliticalGroup } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
 import { formatPoliticalGroupName } from "@/utils/politicalGroup";
-import type { UniqueHighestAverageAssignmentStep } from "../../utils/steps";
+import type { LargestRemainderAssignmentStep, UniqueHighestAverageAssignmentStep } from "../../utils/steps";
 import cls from "../Apportionment.module.css";
 
 interface UniqueHighestAveragesTableProps {
   steps: UniqueHighestAverageAssignmentStep[];
+  largestRemainderSteps: LargestRemainderAssignmentStep[];
   finalStanding: ListSeatAssignment[];
   politicalGroups: PoliticalGroup[];
 }
 
-export function UniqueHighestAveragesTable({ steps, finalStanding, politicalGroups }: UniqueHighestAveragesTableProps) {
+export function UniqueHighestAveragesTable({
+  steps,
+  largestRemainderSteps,
+  finalStanding,
+  politicalGroups,
+}: UniqueHighestAveragesTableProps) {
   return (
     <Table id="unique-highest-averages-table" className={cls.table}>
       <Table.Header>
         <Table.HeaderCell className="text-align-r">{t("list")}</Table.HeaderCell>
         <Table.HeaderCell className="w-full">{t("list_name")}</Table.HeaderCell>
-        <Table.HeaderCell className="text-align-r">{t("apportionment.full_seats_count")}</Table.HeaderCell>
+        <Table.HeaderCell className="text-align-r">{t("apportionment.already_assigned")}</Table.HeaderCell>
         <Table.HeaderCell span={2} className="text-align-r">
           {t("apportionment.average")}
         </Table.HeaderCell>
@@ -29,6 +35,9 @@ export function UniqueHighestAveragesTable({ steps, finalStanding, politicalGrou
           if (steps[0]?.change.list_exhausted.includes(listSeatAssignment.list_number)) {
             return null;
           } else {
+            const residualSeatsAlreadyAssigned = largestRemainderSteps.filter((step) => {
+              return step.change.selected_list_number === listSeatAssignment.list_number;
+            }).length;
             const average = steps[0]?.standings.find(
               (standing) => standing.list_number === listSeatAssignment.list_number,
             )?.next_votes_per_seat;
@@ -46,7 +55,9 @@ export function UniqueHighestAveragesTable({ steps, finalStanding, politicalGrou
                     false,
                   )}
                 </Table.Cell>
-                <Table.NumberCell className="bold">{listSeatAssignment.full_seats}</Table.NumberCell>
+                <Table.NumberCell className="bold">
+                  {listSeatAssignment.full_seats + residualSeatsAlreadyAssigned}
+                </Table.NumberCell>
                 <Table.DisplayFractionCells>{average}</Table.DisplayFractionCells>
                 <Table.NumberCell className="bold">{listSeatAssignmentSteps.length}</Table.NumberCell>
               </Table.Row>

--- a/frontend/src/i18n/locales/nl/apportionment.json
+++ b/frontend/src/i18n/locales/nl/apportionment.json
@@ -1,5 +1,6 @@
 {
   "absolute_majority_reassignment": "Lijst {list_assigned_seat} heeft meer dan de helft van alle uitgebrachte stemmen behaald, maar krijgt op basis van de standaard zetelverdeling niet de meerderheid van de zetels. Volgens de Kieswet (Artikel P 9 Toewijzing zetels bij volstrekte meerderheid) krijgt deze lijst één extra zetel. Deze zetel gaat ten koste van lijst {list_retracted_seat} omdat die de laatste restzetel toegewezen heeft gekregen.",
+  "already_assigned": "Reeds toegewezen",
   "article_p10": "(Kieswet, artikel P 10)",
   "assigned_number_of_seats": "Toegewezen aantal zetels",
   "average": "Gemiddelde",


### PR DESCRIPTION
As discussed with @jorisleker, to match P 22-2

## How to test
Check the `UniqueHighestAveragesTable` in storybook and compare to https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=17533-40230&m=dev

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->