### PR TITLE
Move auth logic from RootLayout to AuthorizationGate

### DIFF
--- a/frontend/src/app/AuthorizationDialog.tsx
+++ b/frontend/src/app/AuthorizationDialog.tsx
@@ -1,91 +1,36 @@
-import { useEffect, useState } from "react";
-import { Navigate, useMatches } from "react-router";
-
-import { useApiState } from "@/api/useApiState";
 import { Button } from "@/components/ui/Button/Button";
 import { Modal } from "@/components/ui/Modal/Modal";
 import { t, tx } from "@/i18n/translate";
 import { formatTimeToGo } from "@/utils/dateTime";
 
-import { EXPIRATION_DIALOG_SECONDS } from "./authorizationConstants";
+interface AuthorizationDialogProps {
+  sessionValidFor: number;
+  extendSession: () => Promise<void>;
+  setHideDialog: (hide: boolean) => void;
+}
 
-export function AuthorizationDialog() {
-  const { user, loading, expiration, extendSession, setUser } = useApiState();
-  const [sessionValidFor, setSessionValidFor] = useState<number | null>(
-    // eslint-disable-next-line react-hooks/purity -- TODO: find pure alternative for Date.now()
-    expiration !== null ? (expiration.getTime() - Date.now()) / 1000 : null,
+export function AuthorizationDialog({ sessionValidFor, extendSession, setHideDialog }: AuthorizationDialogProps) {
+  return (
+    <Modal
+      title={t("users.expiration_warning")}
+      noFlex={true}
+      onClose={() => {
+        setHideDialog(true);
+      }}
+    >
+      <p>{tx("users.expiration_warning_details", {}, { time: formatTimeToGo(sessionValidFor) })}</p>
+      <nav>
+        <Button
+          variant="primary"
+          size="xl"
+          onClick={() => {
+            void extendSession();
+            setHideDialog(true);
+          }}
+        >
+          {t("users.stay_logged_in")}
+        </Button>
+      </nav>
+    </Modal>
   );
-  const [hideDialog, setHideDialog] = useState(false);
-
-  const matches = useMatches();
-  const routeHandle = matches[matches.length - 1]?.handle;
-
-  // update the current time every second when there is a session expiration
-  useEffect(() => {
-    if (expiration !== null) {
-      const update = () => {
-        const now = new Date();
-        const validFor = (expiration.getTime() - now.getTime()) / 1000;
-        setSessionValidFor(validFor);
-
-        // logout after session expiration
-        if (validFor <= 0 && user !== null) {
-          setUser(null);
-        }
-
-        // reset hide dialog state if the session is valid for more than the expiration dialog time
-        if (validFor > EXPIRATION_DIALOG_SECONDS && hideDialog) {
-          setHideDialog(false);
-        }
-      };
-
-      update();
-      const interval = setInterval(update, 1000);
-
-      return () => {
-        clearInterval(interval);
-      };
-    }
-  }, [expiration, user, setUser, hideDialog]);
-
-  // navigate to login page if the session has expired
-  if (sessionValidFor !== null && sessionValidFor <= 0 && !routeHandle?.public) {
-    return <Navigate to="/account/login" state={{ unauthorized: true }} />;
-  }
-
-  // show dialog if the session is about to expire
-  if (
-    !loading &&
-    sessionValidFor !== null &&
-    user !== null &&
-    !hideDialog &&
-    sessionValidFor > 0 &&
-    sessionValidFor < EXPIRATION_DIALOG_SECONDS
-  ) {
-    return (
-      <Modal
-        title={t("users.expiration_warning")}
-        noFlex={true}
-        onClose={() => {
-          setHideDialog(true);
-        }}
-      >
-        <p>{tx("users.expiration_warning_details", {}, { time: formatTimeToGo(sessionValidFor) })}</p>
-        <nav>
-          <Button
-            variant="primary"
-            size="xl"
-            onClick={() => {
-              void extendSession();
-              setHideDialog(true);
-            }}
-          >
-            {t("users.stay_logged_in")}
-          </Button>
-        </nav>
-      </Modal>
-    );
-  }
-
-  return null;
 }

--- a/frontend/src/app/AuthorizationGate.test.tsx
+++ b/frontend/src/app/AuthorizationGate.test.tsx
@@ -7,16 +7,16 @@ import { InitialisedHandler } from "@/testing/api-mocks/RequestHandlers";
 import { server } from "@/testing/server";
 import { TestUserProvider } from "@/testing/TestUserProvider";
 import { render, screen, setupTestRouter, waitFor } from "@/testing/test-utils";
-import { AuthorizationDialog } from "./AuthorizationDialog";
+import { AuthorizationGate } from "./AuthorizationGate";
 import { EXPIRATION_DIALOG_SECONDS } from "./authorizationConstants";
 import { routes } from "./routes";
 
-describe("AuthorizationDialog", () => {
+describe("AuthorizationGate", () => {
   test("Does not show dialog when session is still valid", () => {
     const togo = 1000 * 60 * EXPIRATION_DIALOG_SECONDS;
     render(
       <TestUserProvider userRole="typist_gsb" overrideExpiration={new Date(Date.now() + togo + 1000)}>
-        <AuthorizationDialog />
+        <AuthorizationGate />
       </TestUserProvider>,
     );
     expect(screen.queryByTestId("modal-title")).toBeNull();
@@ -25,7 +25,7 @@ describe("AuthorizationDialog", () => {
   test("Show dialog on short session lifetime", () => {
     render(
       <TestUserProvider userRole="typist_gsb" overrideExpiration={new Date(Date.now() + 1000)}>
-        <AuthorizationDialog />
+        <AuthorizationGate />
       </TestUserProvider>,
     );
 
@@ -35,7 +35,7 @@ describe("AuthorizationDialog", () => {
   test("Does not show dialog when the user is not logged in", () => {
     render(
       <TestUserProvider userRole={null} overrideExpiration={new Date(Date.now() + 1000)}>
-        <AuthorizationDialog />
+        <AuthorizationGate />
       </TestUserProvider>,
     );
 
@@ -45,7 +45,7 @@ describe("AuthorizationDialog", () => {
   test("Dialog can be closed", async () => {
     render(
       <TestUserProvider userRole="typist_gsb" overrideExpiration={new Date(Date.now() + 1000)}>
-        <AuthorizationDialog />
+        <AuthorizationGate />
       </TestUserProvider>,
     );
 
@@ -59,7 +59,7 @@ describe("AuthorizationDialog", () => {
   test("Dialog can be dismissed", async () => {
     render(
       <TestUserProvider userRole="typist_gsb" overrideExpiration={new Date(Date.now() + 1000)}>
-        <AuthorizationDialog />
+        <AuthorizationGate />
       </TestUserProvider>,
     );
 

--- a/frontend/src/app/AuthorizationGate.tsx
+++ b/frontend/src/app/AuthorizationGate.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { Navigate, useMatches } from "react-router";
+
+import { useApiState } from "@/api/useApiState";
+
+import { AuthorizationDialog } from "./AuthorizationDialog";
+import { EXPIRATION_DIALOG_SECONDS } from "./authorizationConstants";
+
+export function AuthorizationGate() {
+  const { user, loading, expiration, extendSession, setUser } = useApiState();
+  const [sessionValidFor, setSessionValidFor] = useState<number | null>(
+    // eslint-disable-next-line react-hooks/purity -- TODO: find pure alternative for Date.now()
+    expiration !== null ? (expiration.getTime() - Date.now()) / 1000 : null,
+  );
+  const [hideDialog, setHideDialog] = useState(false);
+
+  const matches = useMatches();
+  const routeHandle = matches[matches.length - 1]?.handle;
+
+  // check if the route is public or not
+  const isPublic = routeHandle?.public || false;
+
+  // check if the user is authorized for the current route
+  const isAuthorized = user !== null && routeHandle?.roles?.includes(user.role);
+
+  // update the current time every second when there is a session expiration
+  useEffect(() => {
+    if (expiration !== null) {
+      const update = () => {
+        const now = new Date();
+        const validFor = (expiration.getTime() - now.getTime()) / 1000;
+        setSessionValidFor(validFor);
+
+        // logout after session expiration
+        if (validFor <= 0 && user !== null) {
+          setUser(null);
+        }
+
+        // reset hide dialog state if the session is valid for more than the expiration dialog time
+        if (validFor > EXPIRATION_DIALOG_SECONDS && hideDialog) {
+          setHideDialog(false);
+        }
+      };
+
+      update();
+      const interval = setInterval(update, 1000);
+
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [expiration, user, setUser, hideDialog]);
+
+  // navigate to login page if the session has expired
+  if (!isPublic && sessionValidFor !== null && sessionValidFor <= 0) {
+    console.error(`Session expired for ${user ? user.fullname : "unauthenticated user"}`);
+
+    return <Navigate to="/account/login" state={{ unauthorized: true }} />;
+  }
+
+  // navigate to the login page if the user logged-in and does not have the correct role for the route
+  if (!isPublic && !isAuthorized) {
+    const route = matches[matches.length - 1]?.pathname || "unknown";
+    console.error(
+      `Forbidden access to route ${route}  for ${user?.role ? `role ${user.role}` : "unauthenticated user"}`,
+    );
+
+    return <Navigate to="/account/login" state={{ unauthorized: true }} />;
+  }
+
+  // show dialog if the session is about to expire
+  if (
+    !loading &&
+    sessionValidFor !== null &&
+    user !== null &&
+    !hideDialog &&
+    sessionValidFor > 0 &&
+    sessionValidFor < EXPIRATION_DIALOG_SECONDS
+  ) {
+    return (
+      <AuthorizationDialog
+        sessionValidFor={sessionValidFor}
+        extendSession={extendSession}
+        setHideDialog={setHideDialog}
+      />
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/app/RootLayout.tsx
+++ b/frontend/src/app/RootLayout.tsx
@@ -1,40 +1,21 @@
-import { Navigate, Outlet, ScrollRestoration, useMatches } from "react-router";
+import { Outlet, ScrollRestoration } from "react-router";
 
 import { useApiState } from "@/api/useApiState";
 import { AirGapViolationPage } from "@/components/error/AirGapViolationPage";
 import { AppFrame } from "@/components/ui/AppFrame/AppFrame";
-import { useUserRole } from "@/hooks/user/useUserRole";
 
-import { AuthorizationDialog } from "./AuthorizationDialog";
+import { AuthorizationGate } from "./AuthorizationGate";
 
 export function RootLayout() {
   const { airGapError } = useApiState();
-
-  const matches = useMatches();
-  const { role } = useUserRole();
-
-  const handle = matches[matches.length - 1]?.handle;
-  let isAllowed = false;
-  if (handle?.public) {
-    isAllowed = true;
-  } else if (role && handle?.roles.includes(role)) {
-    isAllowed = true;
-  }
 
   if (airGapError) {
     return <AirGapViolationPage />;
   }
 
-  if (!isAllowed) {
-    const route = matches[matches.length - 1]?.pathname || "unknown";
-    console.error(`Forbidden access to route ${route}` + ` for ${role ? `role ${role}` : "unauthenticated user"}`);
-
-    return <Navigate to="/account/login" state={{ unauthorized: true }} />;
-  }
-
   return (
     <AppFrame>
-      <AuthorizationDialog />
+      <AuthorizationGate />
       <ScrollRestoration />
       <Outlet />
     </AppFrame>


### PR DESCRIPTION
The frontend logic to redirect a user to the login page (if a user is unauthorised or their session expired) is currently spread over both the `RootLayout` and the `AuthorizationDialog`, which can be confusing.

This PR moves the authorization logic to from `AuthorizationDialog` and `RootLayout` into `AuthorizationGate`, to improve the readability for a developer or a reviewer. The AuthorizationDialog` only renders the modal/dialog itself.