### PR TITLE
add page title to logout component

### DIFF
--- a/frontend/src/features/account/components/Logout.tsx
+++ b/frontend/src/features/account/components/Logout.tsx
@@ -3,7 +3,9 @@ import { useNavigate } from "react-router";
 
 import { type AnyApiError, isError } from "@/api/ApiResult";
 import { useApiState } from "@/api/useApiState";
+import { PageTitle } from "@/components/page_title/PageTitle";
 import { Loader } from "@/components/ui/Loader/Loader";
+import { t } from "@/i18n/translate";
 
 export function Logout() {
   const { logout } = useApiState();
@@ -25,5 +27,10 @@ export function Logout() {
     throw error;
   }
 
-  return <Loader />;
+  return (
+    <>
+      <PageTitle title={`${t("account.logout")} - Abacus`} />
+      <Loader />
+    </>
+  );
 }


### PR DESCRIPTION
Our logout component did not set the title of the page. As a result the logout url (`/account/logout`) showed up in the browser history as an entry with the page title of the page you were on, when you logged out. So technically the browser history was incorrect for that entry. Moreover, a user could accidentally log out by opening the logout history entry, assumning it would take them to the page the entry mentions.

Both of those are minor issues, so if the fix is more involved than done in this PR, we should consider closing instead of elaborating on it.

The result of the fix is that history entries now show "Afmelden - Abacus" as name of the history entry:

<img width="889" height="37" alt="image" src="https://github.com/user-attachments/assets/2d03e118-5480-4ce1-8401-443e5a3979fd" />

Note that there is a small difference in how Firefox and Chromium show history entries. If you right-click the back-button, Firefox will not show the "Afmelden - Abacus" entry, but Chromium does. So if your history contains a logout entry, in Firefox you can keep clicking back without being logged out. In Chromium you will be logged out.

### How to test
1. log in, optionally visit some pages
2. log out
3. check browser history
    - right-click the back-button (Firefox and Chromium)
    - in Firefox ctrl+shift+h (auto-refreshes), in Chromium ctrl+h (does not auto-refresh)