### PR TITLE
Use argon2 re-exports

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -18,7 +18,6 @@ dependencies = [
  "http-body-util",
  "hyper",
  "memory-serve",
- "password-hash",
  "pdf_gen",
  "quick-xml 0.39.2",
  "rand 0.10.0",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -86,8 +86,7 @@ tracing.workspace = true
 tower-http = { version = "0.6", features = ["set-header", "trace"] }
 quick-xml = { version = "0.39.2", features = ["serialize"] }
 sha2 = "0.10.9"
-argon2 = "0.5.3"
-password-hash = { version = "0.5.0", features = ["getrandom"] }
+argon2 = { version = "0.5.3", features = ["std"] }
 rand.workspace = true
 cookie = { version = "0.18.1", features = ["percent-encode"] }
 strum.workspace = true

--- a/backend/src/api/middleware/authentication/error.rs
+++ b/backend/src/api/middleware/authentication/error.rs
@@ -1,3 +1,5 @@
+use argon2::password_hash;
+
 #[derive(Debug)]
 pub enum AuthenticationError {
     AlreadyInitialised,


### PR DESCRIPTION
Dependabot wants to update `password-hash` from `0.5.0` to `0.6.0` in [this PR](https://github.com/kiesraad/abacus/pull/3088) and the [previous PR](https://github.com/kiesraad/abacus/pull/3063). `argon2` however, is still using `0.5.0` and this is causing issues.

Instead of adding the dependency ourselves, we can also use the re-export of `argon2` so we are in sync. 