### PR TITLE
Data entry roles/committee category check

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -118,7 +118,7 @@
     },
     "/api/data_entries/{data_entry_id}": {
       "delete": {
-        "summary": "Reset the data entry to empty (coordinator_gsb)",
+        "summary": "Reset the data entry to empty (coordinator_csb, coordinator_gsb)",
         "operationId": "data_entry_reset",
         "parameters": [
           {
@@ -189,6 +189,7 @@
         "security": [
           {
             "cookie_auth": [
+              "coordinator_csb",
               "coordinator_gsb"
             ]
           }
@@ -197,7 +198,7 @@
     },
     "/api/data_entries/{data_entry_id}/get": {
       "get": {
-        "summary": "Get data entry with validation results (coordinator_gsb)",
+        "summary": "Get data entry with validation results (coordinator_csb, coordinator_gsb)",
         "operationId": "data_entry_get",
         "parameters": [
           {
@@ -275,6 +276,7 @@
         "security": [
           {
             "cookie_auth": [
+              "coordinator_csb",
               "coordinator_gsb"
             ]
           }
@@ -283,7 +285,7 @@
     },
     "/api/data_entries/{data_entry_id}/resolve_differences": {
       "get": {
-        "summary": "Get data entry differences to be resolved (coordinator_gsb)",
+        "summary": "Get data entry differences to be resolved (coordinator_csb, coordinator_gsb)",
         "operationId": "data_entry_get_differences",
         "parameters": [
           {
@@ -361,13 +363,14 @@
         "security": [
           {
             "cookie_auth": [
+              "coordinator_csb",
               "coordinator_gsb"
             ]
           }
         ]
       },
       "post": {
-        "summary": "Resolve data entry differences by providing a `ResolveDifferencesAction` (coordinator_gsb)",
+        "summary": "Resolve data entry differences by providing a `ResolveDifferencesAction` (coordinator_csb, coordinator_gsb)",
         "operationId": "data_entry_resolve_differences",
         "parameters": [
           {
@@ -465,6 +468,7 @@
         "security": [
           {
             "cookie_auth": [
+              "coordinator_csb",
               "coordinator_gsb"
             ]
           }
@@ -473,7 +477,7 @@
     },
     "/api/data_entries/{data_entry_id}/resolve_errors": {
       "post": {
-        "summary": "Resolve accepted data entry errors by providing a `ResolveErrorsAction` (coordinator_gsb)",
+        "summary": "Resolve accepted data entry errors by providing a `ResolveErrorsAction` (coordinator_csb, coordinator_gsb)",
         "operationId": "data_entry_resolve_errors",
         "parameters": [
           {
@@ -571,6 +575,7 @@
         "security": [
           {
             "cookie_auth": [
+              "coordinator_csb",
               "coordinator_gsb"
             ]
           }
@@ -579,7 +584,7 @@
     },
     "/api/data_entries/{data_entry_id}/{entry_number}": {
       "post": {
-        "summary": "Save a data entry (typist_gsb)",
+        "summary": "Save a data entry (typist_csb, typist_gsb)",
         "operationId": "data_entry_save",
         "parameters": [
           {
@@ -688,13 +693,14 @@
         "security": [
           {
             "cookie_auth": [
+              "typist_csb",
               "typist_gsb"
             ]
           }
         ]
       },
       "delete": {
-        "summary": "Discard an in-progress (not finalised) data entry (typist_gsb)",
+        "summary": "Discard an in-progress (not finalised) data entry (typist_csb, typist_gsb)",
         "operationId": "data_entry_discard",
         "parameters": [
           {
@@ -776,6 +782,7 @@
         "security": [
           {
             "cookie_auth": [
+              "typist_csb",
               "typist_gsb"
             ]
           }
@@ -784,7 +791,7 @@
     },
     "/api/data_entries/{data_entry_id}/{entry_number}/claim": {
       "post": {
-        "summary": "Claim a data entry, returning any existing progress (typist_gsb)",
+        "summary": "Claim a data entry, returning any existing progress (typist_csb, typist_gsb)",
         "operationId": "data_entry_claim",
         "parameters": [
           {
@@ -873,6 +880,7 @@
         "security": [
           {
             "cookie_auth": [
+              "typist_csb",
               "typist_gsb"
             ]
           }
@@ -881,7 +889,7 @@
     },
     "/api/data_entries/{data_entry_id}/{entry_number}/finalise": {
       "post": {
-        "summary": "Finalise the data entry (typist_gsb)",
+        "summary": "Finalise the data entry (typist_csb, typist_gsb)",
         "operationId": "data_entry_finalise",
         "parameters": [
           {
@@ -980,6 +988,7 @@
         "security": [
           {
             "cookie_auth": [
+              "typist_csb",
               "typist_gsb"
             ]
           }

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -147,20 +147,20 @@ pub struct ClaimDataEntryResponse {
 pub fn router() -> OpenApiRouter<AppState> {
     use Role::*;
 
+    const TYPIST: &[Role] = &[TypistCSB, TypistGSB];
+    const COORDINATOR: &[Role] = &[CoordinatorCSB, CoordinatorGSB];
     const ALL_ROLES: &[Role] = Role::VARIANTS;
-    const COORDINATOR_GSB: &[Role] = &[CoordinatorGSB];
-    const TYPIST_GSB: &[Role] = &[TypistGSB];
 
     OpenApiRouter::default()
-        .routes(routes!(data_entry_claim).authorize(TYPIST_GSB))
-        .routes(routes!(data_entry_save).authorize(TYPIST_GSB))
-        .routes(routes!(data_entry_discard).authorize(TYPIST_GSB))
-        .routes(routes!(data_entry_finalise).authorize(TYPIST_GSB))
-        .routes(routes!(data_entry_reset).authorize(COORDINATOR_GSB))
-        .routes(routes!(data_entry_get).authorize(COORDINATOR_GSB))
-        .routes(routes!(data_entry_resolve_errors).authorize(COORDINATOR_GSB))
-        .routes(routes!(data_entry_get_differences).authorize(COORDINATOR_GSB))
-        .routes(routes!(data_entry_resolve_differences).authorize(COORDINATOR_GSB))
+        .routes(routes!(data_entry_claim).authorize(TYPIST))
+        .routes(routes!(data_entry_save).authorize(TYPIST))
+        .routes(routes!(data_entry_discard).authorize(TYPIST))
+        .routes(routes!(data_entry_finalise).authorize(TYPIST))
+        .routes(routes!(data_entry_reset).authorize(COORDINATOR))
+        .routes(routes!(data_entry_get).authorize(COORDINATOR))
+        .routes(routes!(data_entry_resolve_errors).authorize(COORDINATOR))
+        .routes(routes!(data_entry_get_differences).authorize(COORDINATOR))
+        .routes(routes!(data_entry_resolve_differences).authorize(COORDINATOR))
         .routes(routes!(election_status).authorize(ALL_ROLES))
 }
 
@@ -170,6 +170,9 @@ async fn validate_and_get_data(
     user: &User,
 ) -> Result<(DataEntrySourceContext, DataEntryStatus), APIError> {
     let context = data_entry_repo::resolve_source(conn, data_entry_id).await?;
+    user.role()
+        .is_authorized(&context.election.committee_category)?;
+
     let data_entry_status = data_entry_repo::get_status(conn, data_entry_id).await?;
 
     // Investigation check: only for polling stations in next sessions
@@ -596,6 +599,7 @@ impl ResolveErrorsAction {
     ),
 )]
 async fn data_entry_reset(
+    user: User,
     State(pool): State<SqlitePool>,
     Path(data_entry_id): Path<DataEntryId>,
     audit_service: AuditService,
@@ -603,6 +607,9 @@ async fn data_entry_reset(
     let mut tx = pool.begin_immediate().await?;
 
     let context = data_entry_repo::resolve_source(&mut tx, data_entry_id).await?;
+    user.role()
+        .is_authorized(&context.election.committee_category)?;
+
     let data_entry = data_entry_repo::get(&mut tx, data_entry_id).await?;
 
     if data_entry.state.status_name() == DataEntryStatusName::FirstEntryHasErrors
@@ -1111,6 +1118,7 @@ mod tests {
     async fn reset(pool: SqlitePool, data_entry_id: DataEntryId) -> Response {
         let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
         data_entry_reset(
+            user.clone(),
             State(pool),
             Path(data_entry_id),
             AuditService::new(Some(user), None),


### PR DESCRIPTION
Resolves #2836
Changes in addition to https://github.com/kiesraad/abacus/pull/3048

| Method | Path                                                                                        | Allowed roles (before)                                                  | Allowed roles (after) | Election vs Role check | Election == GSB check | Filtered |
| ------ | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------- | :--------------: | :--------: | :--------: |
| GET    | /api/elections/{election_id}/status                                | *ALL ROLES*          |                   🟰              |       ✅         |     ❌     |     ❌     |
| DELETE | /api/data_entries/{data_entry_id}/{entry_number}                   | coordinator_gsb     | coordinator_csb, coordinator_gsb   |       ✅         |     ❌     |     ❌     |
| GET    | /api/data_entries/{data_entry_id}/get                              | coordinator_gsb     | coordinator_csb, coordinator_gsb   |       ✅         |     ❌     |     ❌     |
| GET    | /api/data_entries/{data_entry_id}/resolve_differences              | coordinator_gsb     | coordinator_csb, coordinator_gsb   |       ✅         |     ❌     |     ❌     |
| POST   | /api/data_entries/{data_entry_id}/resolve_differences              | coordinator_gsb     | coordinator_csb, coordinator_gsb   |       ✅         |     ❌     |     ❌     |
| POST   | /api/data_entries/{data_entry_id}/resolve_errors                   | coordinator_gsb     | coordinator_csb, coordinator_gsb   |       ✅         |     ❌     |     ❌     |
| POST   | /api/data_entries/{data_entry_id}/{entry_number}                   | typist_gsb          | typist_csb, typist_gsb             |       ✅         |     ❌     |     ❌     |
| DELETE | /api/data_entries/{data_entry_id}/{entry_number}                   | typist_gsb          | typist_csb, typist_gsb             |       ✅         |     ❌     |     ❌     |
| POST   | /api/data_entries/{data_entry_id}/{entry_number}/claim             | typist_gsb          | typist_csb, typist_gsb             |       ✅         |     ❌     |     ❌     |
| POST   | /api/data_entries/{data_entry_id}/{entry_number}/finalise          | typist_gsb          | typist_csb, typist_gsb             |       ✅         |     ❌     |     ❌     |

- The election status handler is unchanged in this PR
- Roles have been adjusted for each handler
- For `data_entry_reset` the committee category check has been added separately
- All other handlers use `validate_and_get_data`, so the check has been added there