### PR TITLE
Add handler tests for committee category check

### DIFF
--- a/backend/src/api/apportionment/handlers.rs
+++ b/backend/src/api/apportionment/handlers.rs
@@ -108,7 +108,7 @@ mod tests {
     use axum::{
         extract::{Path, State},
         http::StatusCode,
-        response::IntoResponse,
+        response::{IntoResponse, Response},
     };
     use http_body_util::BodyExt;
     use sqlx::SqlitePool;
@@ -172,5 +172,46 @@ mod tests {
             result.reference,
             ErrorReference::ApportionmentCommitteeSessionNotCompleted
         );
+    }
+
+    mod authorization {
+        use super::*;
+        use test_log::test;
+
+        use crate::api::tests::{
+            assert_committee_category_authorization_err, assert_committee_category_authorization_ok,
+        };
+
+        async fn call_handlers(
+            pool: SqlitePool,
+            coordinator_role: Role,
+        ) -> Vec<(&'static str, Response)> {
+            let user = User::test_user(coordinator_role, UserId::from(1));
+            let audit = AuditService::new(Some(user.clone()), None);
+
+            #[rustfmt::skip]
+            let results = vec![
+                ("apportionment", election_apportionment(user.clone(), State(pool.clone()), audit.clone(), Path(ElectionId::from(5))).await.into_response()),
+            ];
+            results
+        }
+
+        #[test(sqlx::test(fixtures(
+            path = "../../../fixtures",
+            scripts("election_5_with_results")
+        )))]
+        async fn test_committee_category_authorization_err(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorCSB).await;
+            assert_committee_category_authorization_err(results).await;
+        }
+
+        #[test(sqlx::test(fixtures(
+            path = "../../../fixtures",
+            scripts("election_5_with_results")
+        )))]
+        async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorGSB).await;
+            assert_committee_category_authorization_ok(results);
+        }
     }
 }

--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -166,11 +166,14 @@ pub async fn committee_session_create(
     ),
 )]
 pub async fn committee_session_delete(
+    user: User,
     State(pool): State<SqlitePool>,
     audit_service: AuditService,
     Path((election_id, committee_session_id)): Path<(ElectionId, CommitteeSessionId)>,
 ) -> Result<StatusCode, APIError> {
     let mut tx = pool.begin_immediate().await?;
+    user.role()
+        .is_authorized(&get_committee_category(&mut tx, committee_session_id).await?)?;
 
     let committee_session = validate_committee_session_is_current_committee_session(
         &mut tx,
@@ -364,4 +367,51 @@ pub async fn committee_session_investigations(
         .investigations();
 
     Ok(Json(InvestigationListResponse { investigations }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::{IntoResponse, Response};
+    use test_log::test;
+
+    use crate::{
+        api::tests::{
+            assert_committee_category_authorization_err, assert_committee_category_authorization_ok,
+        },
+        repository::user_repo::UserId,
+    };
+
+    async fn call_handlers(
+        pool: SqlitePool,
+        coordinator_role: Role,
+    ) -> Vec<(&'static str, Response)> {
+        let user = User::test_user(coordinator_role, UserId::from(1));
+        let audit = AuditService::new(Some(user.clone()), None);
+
+        let election_id = ElectionId::from(2);
+        let committee_session_id = CommitteeSessionId::from(2);
+
+        #[rustfmt::skip]
+        let results = vec![
+            ("create",         committee_session_create(user.clone(), State(pool.clone()), audit.clone(), Path(election_id)).await.into_response()),
+            ("delete",         committee_session_delete(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
+            ("update",         committee_session_update(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id)), Json(CommitteeSessionUpdateRequest { location: "Test".into(), start_date: "2026-04-01".into(), start_time: "09:30".into() })).await.into_response()),
+            ("status_change",  committee_session_status_change(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id)), Json(CommitteeSessionStatusChangeRequest { status: CommitteeSessionStatus::DataEntry })).await.into_response()),
+            ("investigations", committee_session_investigations(user.clone(), State(pool.clone()), Path((election_id, committee_session_id))).await.into_response()),
+        ];
+        results
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_committee_category_authorization_err(pool: SqlitePool) {
+        let results = call_handlers(pool, Role::CoordinatorCSB).await;
+        assert_committee_category_authorization_err(results).await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+        let results = call_handlers(pool, Role::CoordinatorGSB).await;
+        assert_committee_category_authorization_ok(results);
+    }
 }

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -2701,4 +2701,56 @@ mod tests {
             assert!(result.validation_results.has_warnings());
         }
     }
+
+    mod authorization {
+        use super::*;
+        use test_log::test;
+
+        use crate::api::tests::{
+            assert_committee_category_authorization_err, assert_committee_category_authorization_ok,
+        };
+
+        async fn call_handlers(
+            pool: SqlitePool,
+            typist_role: Role,
+            coordinator_role: Role,
+        ) -> Vec<(&'static str, Response)> {
+            let typist_user = User::test_user(typist_role, UserId::from(1));
+            let typist_audit = AuditService::new(Some(typist_user.clone()), None);
+
+            let coordinator_user = User::test_user(coordinator_role, UserId::from(1));
+            let coordinator_audit = AuditService::new(Some(coordinator_user.clone()), None);
+
+            let data_entry_id = DataEntryId::from(201);
+            let election_id = ElectionId::from(2);
+            let entry_number = EntryNumber::FirstEntry;
+
+            #[rustfmt::skip]
+            let results = vec![
+                ("claim",               data_entry_claim(typist_user.clone(), State(pool.clone()), Path((data_entry_id, entry_number)), typist_audit.clone()).await.into_response()),
+                ("save",                data_entry_save(typist_user.clone(), State(pool.clone()), Path((data_entry_id, entry_number)), typist_audit.clone(), example_data_entry()).await.into_response()),
+                ("discard",             data_entry_discard(typist_user.clone(), State(pool.clone()), Path((data_entry_id, entry_number)), typist_audit.clone()).await.into_response()),
+                ("finalise",            data_entry_finalise(typist_user.clone(), State(pool.clone()), Path((data_entry_id, entry_number)), typist_audit.clone()).await.into_response()),
+                ("reset",               data_entry_reset(coordinator_user.clone(), State(pool.clone()), Path(data_entry_id), coordinator_audit.clone()).await.into_response()),
+                ("get",                 data_entry_get(coordinator_user.clone(), State(pool.clone()), Path(data_entry_id)).await.into_response()),
+                ("resolve_errors",      data_entry_resolve_errors(coordinator_user.clone(), State(pool.clone()), Path(data_entry_id), coordinator_audit.clone(), ResolveErrorsAction::DiscardFirstEntry).await.into_response()),
+                ("get_differences",     data_entry_get_differences(coordinator_user.clone(), State(pool.clone()), Path(data_entry_id)).await.into_response()),
+                ("resolve_differences", data_entry_resolve_differences(coordinator_user.clone(), State(pool.clone()), Path(data_entry_id), coordinator_audit.clone(), ResolveDifferencesAction::DiscardBothEntries).await.into_response()),
+                ("election_status",     election_status(coordinator_user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ];
+            results
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_committee_category_authorization_err(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::TypistCSB, Role::CoordinatorCSB).await;
+            assert_committee_category_authorization_err(results).await;
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::TypistGSB, Role::CoordinatorGSB).await;
+            assert_committee_category_authorization_ok(results);
+        }
+    }
 }

--- a/backend/src/api/document.rs
+++ b/backend/src/api/document.rs
@@ -265,3 +265,49 @@ async fn election_download_na_31_2_inlegvel(
         .filename(&name)
         .content_type("application/pdf"))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+    };
+    use test_log::test;
+
+    use super::*;
+    use crate::{
+        api::tests::{
+            assert_committee_category_authorization_err, assert_committee_category_authorization_ok,
+        },
+        domain::role::Role,
+        repository::user_repo::{User, UserId},
+    };
+
+    async fn call_handlers(
+        pool: SqlitePool,
+        coordinator_role: Role,
+    ) -> Vec<(&'static str, Response)> {
+        let user = User::test_user(coordinator_role, UserId::from(1));
+        let election_id = ElectionId::from(2);
+
+        #[rustfmt::skip]
+        let results = vec![
+            ("download_n_10_2", election_download_n_10_2(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ("download_na_31_2_bijlage1", election_download_na_31_2_bijlage1(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ("download_na_31_2_inlegvel", election_download_na_31_2_inlegvel(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+        ];
+        results
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_committee_category_authorization_err(pool: SqlitePool) {
+        let results = call_handlers(pool, Role::CoordinatorCSB).await;
+        assert_committee_category_authorization_err(results).await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+        let results = call_handlers(pool, Role::CoordinatorGSB).await;
+        assert_committee_category_authorization_ok(results);
+    }
+}

--- a/backend/src/api/election.rs
+++ b/backend/src/api/election.rs
@@ -740,3 +740,49 @@ impl From<EMLError> for APIError {
         APIError::EmlError(err)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Json,
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+    };
+    use test_log::test;
+
+    use super::*;
+    use crate::{
+        api::tests::{
+            assert_committee_category_authorization_err, assert_committee_category_authorization_ok,
+        },
+        repository::user_repo::UserId,
+    };
+
+    async fn call_handlers(
+        pool: SqlitePool,
+        coordinator_role: Role,
+    ) -> Vec<(&'static str, Response)> {
+        let user = User::test_user(coordinator_role, UserId::from(1));
+        let audit = AuditService::new(Some(user.clone()), None);
+        let election_id = ElectionId::from(2);
+
+        #[rustfmt::skip]
+        let results = vec![
+            ("details", election_details(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ("voters", election_number_of_voters_change(user.clone(), State(pool.clone()), audit.clone(), Path(election_id), Json(ElectionNumberOfVotersChangeRequest { number_of_voters: 1000 })).await.into_response()),
+        ];
+        results
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_committee_category_authorization_err(pool: SqlitePool) {
+        let results = call_handlers(pool, Role::CoordinatorCSB).await;
+        assert_committee_category_authorization_err(results).await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+        let results = call_handlers(pool, Role::CoordinatorGSB).await;
+        assert_committee_category_authorization_ok(results);
+    }
+}

--- a/backend/src/api/investigation.rs
+++ b/backend/src/api/investigation.rs
@@ -748,6 +748,7 @@ mod tests {
     use sqlx::SqlitePool;
     use test_log::test;
 
+    use super::*;
     use crate::{
         domain::polling_station::PollingStationId, repository::polling_station_repo::exists,
     };
@@ -787,5 +788,60 @@ mod tests {
         let res = super::validate_and_get_committee_session(&mut conn, polling_station_id).await;
 
         assert!(res.is_err());
+    }
+
+    mod authorization {
+        use super::*;
+        use axum::{
+            Json,
+            extract::State,
+            response::{IntoResponse, Response},
+        };
+        use test_log::test;
+
+        use crate::{
+            api::tests::{
+                assert_committee_category_authorization_err,
+                assert_committee_category_authorization_ok,
+            },
+            repository::user_repo::UserId,
+        };
+
+        async fn call_handlers(
+            pool: SqlitePool,
+            coordinator_role: Role,
+        ) -> Vec<(&'static str, Response)> {
+            let user = User::test_user(coordinator_role, UserId::from(1));
+            let audit = AuditService::new(Some(user.clone()), None);
+            let polling_station_id = PollingStationId::from(741);
+
+            #[rustfmt::skip]
+            let results = vec![
+                ("create", polling_station_investigation_create(user.clone(), State(pool.clone()), audit.clone(), CurrentSessionPollingStationId(polling_station_id), Json(PollingStationInvestigationCreateRequest { reason: "reason".into() })).await.into_response()),
+                ("conclude", polling_station_investigation_conclude(user.clone(), State(pool.clone()), audit.clone(), CurrentSessionPollingStationId(polling_station_id), Json(PollingStationInvestigationConcludeRequest { findings: "findings".into(), corrected_results: false })).await.into_response()),
+                ("update", polling_station_investigation_update(user.clone(), State(pool.clone()), audit.clone(), CurrentSessionPollingStationId(polling_station_id), Json(PollingStationInvestigationUpdateRequest { reason: "reason".into(), findings: Some("findings".into()), corrected_results: Some(false), accept_data_entry_deletion: Some(true) })).await.into_response()),
+                ("delete", polling_station_investigation_delete(user.clone(), State(pool.clone()), audit.clone(), CurrentSessionPollingStationId(polling_station_id)).await.into_response()),
+                ("download_corrigendum_pdf", polling_station_investigation_download_corrigendum_pdf(user.clone(), State(pool.clone()), CurrentSessionPollingStationId(polling_station_id)).await.into_response()),
+            ];
+            results
+        }
+
+        #[test(sqlx::test(fixtures(
+            path = "../../fixtures",
+            scripts("election_7_four_sessions")
+        )))]
+        async fn test_committee_category_authorization_err(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorCSB).await;
+            assert_committee_category_authorization_err(results).await;
+        }
+
+        #[test(sqlx::test(fixtures(
+            path = "../../fixtures",
+            scripts("election_7_four_sessions")
+        )))]
+        async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorGSB).await;
+            assert_committee_category_authorization_ok(results);
+        }
     }
 }

--- a/backend/src/api/middleware/authentication/error.rs
+++ b/backend/src/api/middleware/authentication/error.rs
@@ -15,6 +15,7 @@ pub enum AuthenticationError {
     PasswordRejectionSameAsOld,
     PasswordRejectionSameAsUsername,
     PasswordRejectionTooShort,
+    RoleNotAuthorizedError,
     SessionKeyNotFound,
     Unauthenticated,
     Unauthorized,

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -10,4 +10,6 @@ pub mod middleware;
 pub mod polling_station;
 pub mod providers;
 pub mod report;
+#[cfg(test)]
+pub mod tests;
 pub mod user;

--- a/backend/src/api/polling_station.rs
+++ b/backend/src/api/polling_station.rs
@@ -585,7 +585,7 @@ mod tests {
     use sqlx::{SqlitePool, query};
     use test_log::test;
 
-    use super::{PollingStationRequest, create, create_many, update};
+    use super::*;
     use crate::domain::{election::ElectionId, polling_station::PollingStationId};
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2", "election_3"))))]
@@ -724,5 +724,76 @@ VALUES
         data.number = Some(123);
         let result = update(&mut conn, election_id, polling_station_id, data).await;
         assert!(result.is_err());
+    }
+
+    mod authorization {
+        use super::*;
+        use axum::{
+            Json,
+            extract::{Path, State},
+            response::{IntoResponse, Response},
+        };
+        use test_log::test;
+
+        use crate::{
+            api::tests::{
+                assert_committee_category_authorization_err,
+                assert_committee_category_authorization_ok,
+            },
+            domain::role::Role,
+            repository::user_repo::{User, UserId},
+        };
+
+        async fn call_handlers(
+            pool: SqlitePool,
+            coordinator_role: Role,
+        ) -> Vec<(&'static str, Response)> {
+            let user = User::test_user(coordinator_role, UserId::from(1));
+            let audit = AuditService::new(Some(user.clone()), None);
+
+            let election_id = ElectionId::from(2);
+            let import_election_id = ElectionId::from(6);
+            let polling_station_id = PollingStationId::from(211);
+
+            let polling_station_request = PollingStationRequest {
+                name: "Test station".into(),
+                number: Some(42),
+                number_of_voters: Some(123),
+                polling_station_type: None,
+                address: "Teststraat 1".into(),
+                postal_code: "1234 AB".into(),
+                locality: "Testdorp".into(),
+            };
+
+            #[rustfmt::skip]
+            let results = vec![
+                ("list", polling_station_list(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+                ("create", polling_station_create(user.clone(), State(pool.clone()), Path(election_id), audit.clone(), polling_station_request.clone()).await.into_response()),
+                ("import", polling_station_import(user.clone(), State(pool.clone()), Path(import_election_id), audit.clone(), Json(PollingStationsRequest { file_name: "test.xml".into(), polling_stations: "<xml/>".into() })).await.into_response()),
+                ("validate_import", polling_station_validate_import(user.clone(), State(pool.clone()), Path(import_election_id), Json(PollingStationFileRequest { data: "<xml/>".into() })).await.into_response()),
+                ("get", polling_station_get(user.clone(), State(pool.clone()), Path((election_id, polling_station_id))).await.into_response()),
+                ("update", polling_station_update(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, polling_station_id)), polling_station_request.clone()).await.into_response()),
+                ("delete", polling_station_delete(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, polling_station_id))).await.into_response()),
+            ];
+            results
+        }
+
+        #[test(sqlx::test(fixtures(
+            path = "../../fixtures",
+            scripts("election_2", "election_6_no_polling_stations")
+        )))]
+        async fn test_committee_category_authorization_err(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorCSB).await;
+            assert_committee_category_authorization_err(results).await;
+        }
+
+        #[test(sqlx::test(fixtures(
+            path = "../../fixtures",
+            scripts("election_2", "election_6_no_polling_stations")
+        )))]
+        async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorGSB).await;
+            assert_committee_category_authorization_ok(results);
+        }
     }
 }

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -719,4 +719,51 @@ mod tests {
             assert_eq!(list_event_names(&mut conn).await.unwrap(), ["FileCreated"]);
         }
     }
+
+    mod authorization {
+        use super::*;
+        use axum::{
+            extract::{Path, State},
+            response::{IntoResponse, Response},
+        };
+        use test_log::test;
+
+        use crate::{
+            api::tests::{
+                assert_committee_category_authorization_err,
+                assert_committee_category_authorization_ok,
+            },
+            domain::role::Role,
+            repository::user_repo::{User, UserId},
+        };
+
+        async fn call_handlers(
+            pool: SqlitePool,
+            coordinator_role: Role,
+        ) -> Vec<(&'static str, Response)> {
+            let user = User::test_user(coordinator_role, UserId::from(1));
+            let audit = AuditService::new(Some(user.clone()), None);
+            let election_id = ElectionId::from(5);
+            let committee_session_id = CommitteeSessionId::from(5);
+
+            #[rustfmt::skip]
+            let results = vec![
+                ("download_pdf_results", election_download_pdf_results(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
+                ("download_zip_results", election_download_zip_results(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
+            ];
+            results
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+        async fn test_committee_category_authorization_err(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorCSB).await;
+            assert_committee_category_authorization_err(results).await;
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+        async fn test_committee_category_authorization_ok(pool: SqlitePool) {
+            let results = call_handlers(pool, Role::CoordinatorGSB).await;
+            assert_committee_category_authorization_ok(results);
+        }
+    }
 }

--- a/backend/src/api/tests.rs
+++ b/backend/src/api/tests.rs
@@ -1,0 +1,30 @@
+use axum::{http::StatusCode, response::Response};
+use http_body_util::BodyExt;
+
+use crate::{ErrorResponse, error::ErrorReference};
+
+pub async fn assert_committee_category_authorization_err(results: Vec<(&'static str, Response)>) {
+    for (handler, response) in results {
+        let status = response.status();
+        assert_eq!(status, StatusCode::FORBIDDEN, "handler '{handler}'");
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ErrorResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            error.reference,
+            ErrorReference::Forbidden,
+            "handler '{handler}'"
+        );
+        assert_eq!(error.error, "Invalid role", "handler '{handler}'");
+    }
+}
+
+pub fn assert_committee_category_authorization_ok(results: Vec<(&'static str, Response)>) {
+    for (handler, response) in results {
+        assert_ne!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "handler '{handler}'"
+        );
+    }
+}

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -343,6 +343,10 @@ impl IntoResponse for APIError {
                             false,
                         ),
                     ),
+                    AuthenticationError::RoleNotAuthorizedError => (
+                        StatusCode::FORBIDDEN,
+                        to_error("Invalid role", ErrorReference::Forbidden, true),
+                    ),
                     AuthenticationError::OwnAccountCannotBeDeleted => (
                         StatusCode::FORBIDDEN,
                         to_error(
@@ -569,7 +573,7 @@ impl From<PollingStationServiceError> for APIError {
 
 impl From<RoleNotAuthorizedError> for APIError {
     fn from(_: RoleNotAuthorizedError) -> Self {
-        APIError::Authentication(AuthenticationError::Forbidden)
+        APIError::Authentication(AuthenticationError::RoleNotAuthorizedError)
     }
 }
 


### PR DESCRIPTION
Resolves #3108 

The endpoints listed below (derived from https://github.com/kiesraad/abacus/pull/3048) are using `user.role().is_authorized(committee_category)?;` to check if the user is authorized to do something with the relevant entity, based on the `election.committee_category` that is related to that entity. We did not have tests in place that check if `is_authorized(...)` was actually implemented for those handlers.

This PR adds tests for each endpoint by calling them with a user that shouldn't be authorized for the related election and one that is. It checks the returned status code and error message.

These tests found that `committee_session_delete` was missing the check. 

Changes:
- The `RoleNotAuthorizedError` now turns into `APIError::Authentication(AuthenticationError::RoleNotAuthorizedError)` (instead of `Forbidden`), which then gets returned as a 403 Forbidden with text `Invalid role`
- Added committee category check for `committee_session_delete`
- Added tests for every endpoint listed below

### api/apportionment/handlers.rs

| Method | Path                                                                                        | 
| ------ | ------------------------------------------------------------------------------------------- | 
| POST   | /api/elections/{election_id}/apportionment                                               |  

### api/committee_session.rs

Delete endpoint was missing the check

| Method | Path                                                                                        | 
| ------ | ------------------------------------------------------------------------------------------- | 
| POST   | /api/elections/{election_id}/committee_sessions                                             | 
| PUT    | /api/elections/{election_id}/committee_sessions/{committee_session_id}                      | 
| DELETE | /api/elections/{election_id}/committee_sessions/{committee_session_id}                      | 
| GET    | /api/elections/{election_id}/committee_sessions/{committee_session_id}/investigations       | 
| PUT    | /api/elections/{election_id}/committee_sessions/{committee_session_id}/status               | 

### api/data_entry.rs

| Method | Path                                                                                        | 
| ------ | ------------------------------------------------------------------------------------------- | 
| GET    | /api/elections/{election_id}/status                                |
| DELETE | /api/data_entries/{data_entry_id}/{entry_number}                   |
| GET    | /api/data_entries/{data_entry_id}/get                              |
| GET    | /api/data_entries/{data_entry_id}/resolve_differences              |
| POST   | /api/data_entries/{data_entry_id}/resolve_differences              |
| POST   | /api/data_entries/{data_entry_id}/resolve_errors                   |
| POST   | /api/data_entries/{data_entry_id}/{entry_number}                   |
| DELETE | /api/data_entries/{data_entry_id}/{entry_number}                   |
| POST   | /api/data_entries/{data_entry_id}/{entry_number}/claim             |
| POST   | /api/data_entries/{data_entry_id}/{entry_number}/finalise          |

### api/document.rs

| Method | Path                                                                                        |
| ------ | ------------------------------------------------------------------------------------------- |
| GET    | /api/elections/{election_id}/download_n_10_2                                                |
| GET    | /api/elections/{election_id}/download_na_31_2_bijlage1                                      |
| GET    | /api/elections/{election_id}/download_na_31_2_inlegvel                                      |

### api/election.rs

| Method | Path                                                                                        | 
| ------ | ------------------------------------------------------------------------------------------- | 
| GET    | /api/elections/{election_id}                                                                | 
| PUT    | /api/elections/{election_id}/voters                                                         | 

### api/investigations.rs

| Method | Path                                                                                        |
| ------ | ------------------------------------------------------------------------------------------- |
| PUT    | /api/polling_stations/{polling_station_id}/investigation                                    |
| POST   | /api/polling_stations/{polling_station_id}/investigation                                    |
| DELETE | /api/polling_stations/{polling_station_id}/investigation                                    |
| POST   | /api/polling_stations/{polling_station_id}/investigation/conclude                           |
| GET    | /api/polling_stations/{polling_station_id}/investigation/download_corrigendum_pdf           |

### api/polling_station.rs

| Method | Path                                                                                        |
| ------ | ------------------------------------------------------------------------------------------- |
| GET    | /api/elections/{election_id}/polling_stations                                               |
| POST   | /api/elections/{election_id}/polling_stations                                               |
| POST   | /api/elections/{election_id}/polling_stations/import                                        |
| POST   | /api/elections/{election_id}/polling_stations/validate-import                               |
| GET    | /api/elections/{election_id}/polling_stations/{polling_station_id}                          |
| PUT    | /api/elections/{election_id}/polling_stations/{polling_station_id}                          |
| DELETE | /api/elections/{election_id}/polling_stations/{polling_station_id}                          |

### api/report.rs

| Method | Path                                                                                        |
| ------ | ------------------------------------------------------------------------------------------- |
| GET    | /api/elections/{election_id}/committee_sessions/{committee_session_id}/download_pdf_results |
| GET    | /api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_results |