### PR TITLE
Allow coordinator csb to update committee session

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1442,7 +1442,7 @@
     },
     "/api/elections/{election_id}/committee_sessions/{committee_session_id}": {
       "put": {
-        "summary": "Update a [CommitteeSession]. (coordinator_gsb)",
+        "summary": "Update a [CommitteeSession]. (coordinator_csb, coordinator_gsb)",
         "operationId": "committee_session_update",
         "parameters": [
           {
@@ -1532,6 +1532,7 @@
         "security": [
           {
             "cookie_auth": [
+              "coordinator_csb",
               "coordinator_gsb"
             ]
           }

--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -60,7 +60,7 @@ pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(committee_session_create).authorize(COORDINATOR_GSB))
         .routes(routes!(committee_session_delete).authorize(COORDINATOR_GSB))
-        .routes(routes!(committee_session_update).authorize(COORDINATOR_GSB))
+        .routes(routes!(committee_session_update).authorize(COORDINATOR))
         .routes(routes!(committee_session_status_change).authorize(COORDINATOR))
         .routes(routes!(committee_session_investigations).authorize(COORDINATOR_GSB))
 }


### PR DESCRIPTION
### Scope

The PUT on a committee session was only allowed for GSB coordinators. CSB coordinators should be allowed to do this as well, so they can fill in the session details and generate the official results.

I noticed we don't have any tests for this. I think that's (probably) ok. A backend test does not add that much value over reviewing either the API code or the API specs. And this issue would also have been found by the full flow e2e test we still need to build for CSB.
