### PR TITLE
Fix flaky frontend report tests

### DIFF
--- a/frontend/src/features/election_management/components/report/ElectionReportPage.test.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.test.tsx
@@ -341,7 +341,7 @@ describe("ElectionReportPage", () => {
         }),
       ).toBeVisible();
 
-      expect(screen.getByText("In het ZIP-bestand zitten drie documenten:")).toBeInTheDocument();
+      expect(await screen.findByText("In het ZIP-bestand zitten drie documenten:")).toBeInTheDocument();
       expect(await screen.findByRole("link", { name: /Download definitieve documenten tweede zitting/ })).toBeVisible();
     });
 
@@ -379,7 +379,7 @@ describe("ElectionReportPage", () => {
         }),
       ).toBeVisible();
 
-      expect(screen.getByText("In het ZIP-bestand zit één document:")).toBeInTheDocument();
+      expect(await screen.findByText("In het ZIP-bestand zit één document:")).toBeInTheDocument();
       expect(await screen.findByRole("link", { name: /Download definitieve documenten tweede zitting/ })).toBeVisible();
     });
   });


### PR DESCRIPTION
Avoid race condition to fix flaky frontend test, resolves #3127. Thanks to @jschuurk-kr for the suggestion.

I've confirmed the fix with a loop of 200 test runs.