### PR TITLE
Preload error image

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Abacus</title>
     <link rel="icon" href="./src/assets/favicon.svg" />
+    <link rel="preload" href="./src/assets/images/error.webp" as="image" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>


### PR DESCRIPTION
Preload error image so that it can still be shown when the client loses its connection and a `NetworkError` is thrown. Can be reproduced by starting the Abacus server, loading it in the browser, stopping the server, and then navigating to another page in the browser.

Before:
<img width="1880" height="1729" alt="before" src="https://github.com/user-attachments/assets/ba27b3e9-a3f9-4730-8e70-08275f27a8ad" />

After:
<img width="1880" height="1729" alt="after" src="https://github.com/user-attachments/assets/563a36ed-2e95-49c5-9d31-cc3298fbda1a" />
