### PR TITLE
adds CSB election to feedback story

### DIFF
--- a/frontend/src/components/ui/Feedback/Feedback.stories.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
 import { expect } from "storybook/test";
-import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { csbElectionMockData, electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
-import type { ValidationResultCode } from "@/types/generated/openapi";
+import { roleValues, type ValidationResultCode } from "@/types/generated/openapi";
 import { Feedback } from "./Feedback";
 
 const validationResultCodes = Object.keys(validationResultMockData) as ValidationResultCode[];
@@ -18,6 +18,10 @@ const meta = {
     type: {
       options: ["error", "warning"],
     },
+    userRole: {
+      options: roleValues,
+    },
+    election: { table: { disable: true } },
   },
 } satisfies Meta<typeof Feedback>;
 
@@ -28,7 +32,7 @@ type StoryArgs = Omit<ComponentProps<typeof Feedback>, "validationResults"> & {
 };
 type Story = StoryObj<StoryArgs>;
 
-export const Coordinator: Story = {
+export const GSBCoordinator: Story = {
   render: (args) => (
     <Feedback {...args} validationResults={args.validationResults.map((code) => validationResultMockData[code])} />
   ),
@@ -54,16 +58,16 @@ export const Coordinator: Story = {
   },
 };
 
-export const Typist: Story = {
+export const CSBTypist: Story = {
   render: (args) => (
     <Feedback {...args} validationResults={args.validationResults.map((c) => validationResultMockData[c])} />
   ),
   args: {
     id: "feedback-error",
     type: "error",
-    election: electionMockData,
+    election: csbElectionMockData,
     validationResults: ["F201", "F202"],
-    userRole: "typist_gsb",
+    userRole: "typist_csb",
   },
   play: async ({ canvas }) => {
     const titles = await canvas.findAllByRole("heading");


### PR DESCRIPTION
closes #3192: Update Feedback story for CSB validations

### Scope
- change `Coordinator` story to `GSBCoordinator`
- change `Typist` story to `CSBTypist`
- do not allow selecting a different election
- do allow selecting any role

Note that for some combinations no heading is rendered. This is because the key for that combination is not present in our i18n files.

I decided to implement the simplest solution. I don't think it's worth the effort to split out all combinations (error vs warning, GSB vs CSB, typist vs coordinator/admin).

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->