### PR TITLE
Add more apportionment fuzz targets

### DIFF
--- a/backend/apportionment/fuzz/Cargo.toml
+++ b/backend/apportionment/fuzz/Cargo.toml
@@ -32,3 +32,38 @@ path = "fuzz_targets/differential_osv2020.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "apportionment"
+path = "fuzz_targets/apportionment.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "anonymity"
+path = "fuzz_targets/anonymity.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fractions"
+path = "fuzz_targets/fractions.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "house_monotonicity"
+path = "fuzz_targets/house_monotonicity.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "population_monotonicity"
+path = "fuzz_targets/population_monotonicity.rs"
+test = false
+doc = false
+bench = false

--- a/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
@@ -1,0 +1,68 @@
+#![no_main]
+
+use apportionment::{CandidateVotes, process};
+use apportionment_fuzz::{FuzzedApportionmentInput, SimpleListVotes, init_tracing, run_with_log};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(
+    init: {
+        init_tracing();
+    },
+    |data: (FuzzedApportionmentInput, Vec::<usize>)| {
+    let (data, mut random_order) = data;
+    let (alloc, log1) = run_with_log(|| process(&data));
+
+    if random_order.is_empty() {
+        random_order.push(42);
+    }
+
+    // Randomly shuffle the party list based on random_order
+    let mut reorder: Vec<(usize, &SimpleListVotes)> =
+        data.list_votes.iter().enumerate().collect();
+    reorder.sort_by_key(|(i, _)| random_order[*i % random_order.len()]);
+
+    // Build a new input with reordered lists, renumbered sequentially
+    let reordered_input = FuzzedApportionmentInput {
+        seats: data.seats,
+        list_votes: reorder
+            .iter()
+            .enumerate()
+            .map(|(new_idx, (_, list))| {
+                SimpleListVotes::new(
+                    (new_idx + 1) as u32,
+                    list.candidate_votes.iter().map(|cv| cv.votes()).collect(),
+                )
+            })
+            .collect(),
+    };
+
+    let (new_alloc, log2) = run_with_log(|| process(&reordered_input));
+
+    if let (Ok(alloc), Ok(new_alloc)) = (alloc, new_alloc) {
+        let seats_per_party: Vec<u32> = alloc
+            .seat_assignment
+            .final_standing
+            .iter()
+            .map(|p| p.total_seats)
+            .collect();
+
+        // Reorder seat allocation to match the reordered parties
+        let reordered: Vec<u32> = reorder
+            .iter()
+            .map(|(i, _)| seats_per_party[*i])
+            .collect();
+
+        let new_seats_per_party: Vec<u32> = new_alloc
+            .seat_assignment
+            .final_standing
+            .iter()
+            .map(|p| p.total_seats)
+            .collect();
+
+        // The allocation should be the same, but in the new order
+        assert!(
+            reordered.iter().eq(new_seats_per_party.iter()),
+            "{reordered:?} (was {seats_per_party:?}) is not equal to {new_seats_per_party:?}\n{reorder:?}\n[original]\n{log1}\n[reordered]\n{log2}",
+        );
+    }
+});

--- a/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
@@ -1,0 +1,144 @@
+#![no_main]
+
+use apportionment::{ApportionmentError, CandidateVotes, process};
+use apportionment_fuzz::{FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(
+    init: {
+        init_tracing();
+    },
+    |data: FuzzedApportionmentInput| {
+    // Calculate total votes for validation
+    let total_votes: u32 = data
+        .list_votes
+        .iter()
+        .map(|list: &SimpleListVotes| {
+            list.candidate_votes
+                .iter()
+                .map(|cv: &SimpleCandidateVotes| cv.votes())
+                .sum::<u32>()
+        })
+        .sum();
+
+    let votes_per_party: Vec<u32> = data
+        .list_votes
+        .iter()
+        .map(|list: &SimpleListVotes| {
+            list.candidate_votes
+                .iter()
+                .map(|cv: &SimpleCandidateVotes| cv.votes())
+                .sum::<u32>()
+        })
+        .collect();
+
+    let (result, log) = run_with_log(|| process(&data));
+
+    match result {
+        Ok(result) => {
+            let total_seats = data.seats;
+
+            // Validate total votes calculation
+            assert_eq!(total_votes, votes_per_party.iter().sum::<u32>());
+
+            // Validate total seats assigned
+            let seats_per_party: Vec<u32> = result
+                .seat_assignment
+                .final_standing
+                .iter()
+                .map(|standing| standing.total_seats)
+                .collect();
+
+            assert_eq!(
+                total_seats,
+                seats_per_party.iter().sum::<u32>(),
+                "Total seats mismatch: expected {}, got {}\n{log}",
+                total_seats,
+                seats_per_party.iter().sum::<u32>()
+            );
+
+            // Lower bound: every party deserves at least the percentage of seats relative to votes (rounded down)
+            if total_votes > 0 {
+                let seats_lower_bound: Vec<u32> = votes_per_party
+                    .iter()
+                    .map(|v: &u32| u64::from(total_seats) * u64::from(*v) / u64::from(total_votes))
+                    .map(|x: u64| x.try_into().unwrap())
+                    .collect();
+
+                assert!(
+                    seats_per_party
+                        .iter()
+                        .zip(seats_lower_bound.iter())
+                        .all(|(s, lb)| s >= lb),
+                    "{:?} is not element-wise greater or equal than {:?}\n{log}",
+                    seats_per_party,
+                    seats_lower_bound,
+                );
+            }
+
+            // Upper bound: proportional share rounded up, plus at most all residual seats
+            if total_votes > 0 {
+                let extra = u64::from(result.seat_assignment.residual_seats);
+                let seats_upper_bound: Vec<u32> = votes_per_party
+                    .iter()
+                    .map(|v: &u32| {
+                        ((u64::from(total_seats) * u64::from(*v)) as f64 / (total_votes as f64))
+                            .ceil() as u64
+                            + extra
+                    })
+                    .map(|x: u64| x.try_into().unwrap())
+                    .collect();
+
+                assert!(
+                    seats_per_party
+                        .iter()
+                        .zip(seats_upper_bound.iter())
+                        .all(|(s, ub)| s <= ub),
+                    "{:?} is not element-wise less or equal than {:?}\nextra (residual seats): {}\n{log}",
+                    seats_per_party,
+                    seats_upper_bound,
+                    extra,
+                );
+            }
+
+            // Concordance: parties with more votes should have at least as many seats
+            for (i, (votes, seats)) in votes_per_party
+                .iter()
+                .zip(seats_per_party.iter())
+                .enumerate()
+            {
+                for (j, (other_votes, other_seats)) in votes_per_party
+                    .iter()
+                    .zip(seats_per_party.iter())
+                    .enumerate()
+                {
+                    if i != j && votes > other_votes {
+                        assert!(
+                            seats >= other_seats,
+                            "Party {} with more votes ({}) should have at least as many seats as party {} ({} votes), but got {} vs {} seats\n{votes_per_party:?}\n{seats_per_party:?}\n{log}",
+                            i,
+                            votes,
+                            j,
+                            other_votes,
+                            seats,
+                            other_seats
+                        );
+                    }
+                }
+            }
+        }
+        Err(
+            ApportionmentError::DrawingOfLotsNotImplemented | ApportionmentError::AllListsExhausted,
+        ) => {
+            // These are expected errors that we ignore
+        }
+        Err(ApportionmentError::ZeroVotesCast) => {
+            // This is expected when no votes are cast
+            assert_eq!(
+                total_votes, 0,
+                "ZeroVotesCast error but total_votes was {}\n{log}",
+                total_votes
+            );
+        }
+    }
+});

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -1,48 +1,15 @@
 #![no_main]
 
 use std::{
-    cell::RefCell,
     io::{BufRead, BufReader, Write},
     process::{Command, Stdio},
     sync::{Mutex, OnceLock},
 };
 
 use apportionment::{ApportionmentError, CandidateVotes, process};
-use apportionment_fuzz::{FuzzedApportionmentInput, SimpleListVotes};
+use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
-use tracing::level_filters::LevelFilter;
-use tracing_subscriber::{
-    Layer,
-    filter::Targets,
-    fmt::{self, MakeWriter},
-    layer::SubscriberExt,
-    util::SubscriberInitExt,
-};
-
-// Per-iteration buffer for Abacus tracing events.
-thread_local! {
-    static ABACUS_LOG: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-}
-
-struct ThreadLocalWriter;
-
-impl Write for ThreadLocalWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        ABACUS_LOG.with(|b| b.borrow_mut().extend_from_slice(buf));
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a> MakeWriter<'a> for ThreadLocalWriter {
-    type Writer = Self;
-    fn make_writer(&'a self) -> Self::Writer {
-        ThreadLocalWriter
-    }
-}
 
 #[derive(Serialize)]
 struct ApportionmentRequest {
@@ -109,14 +76,6 @@ fn osv2020_apportionment(
     }
 }
 
-fn get_total_seats(result: &apportionment::SeatAssignmentResult<SimpleListVotes>) -> Vec<u32> {
-    result
-        .final_standing
-        .iter()
-        .map(|p| p.total_seats)
-        .collect::<Vec<_>>()
-}
-
 /// Print diagnostic output for a mismatch between Abacus and OSV2020, then panic.
 fn report_mismatch(
     data: &FuzzedApportionmentInput,
@@ -160,14 +119,7 @@ fuzz_target!(
 
         OSV2020_WRAPPER.set(Mutex::new(Osv2020WrapperProcess { stdin, stdout, _child: child })).ok();
 
-        let layer = fmt::layer()
-            .with_writer(ThreadLocalWriter)
-            .without_time()
-            .with_ansi(false)
-            .with_target(true)
-            .with_level(true)
-            .with_filter(Targets::new().with_target("apportionment::seat_assignment", LevelFilter::TRACE));
-        tracing_subscriber::registry().with(layer).init();
+        init_tracing();
     },
     |data: FuzzedApportionmentInput| {
         // Skip cases where any party has zero total votes
@@ -184,11 +136,7 @@ fuzz_target!(
 
         let (osv2020_result, osv2020_log) = osv2020_apportionment(data.seats.into(), &pg_candidates, &votes);
 
-        ABACUS_LOG.with(|b| b.borrow_mut().clear());
-        let abacus_result = process(&data);
-        let abacus_log = ABACUS_LOG.with(|b| {
-            String::from_utf8(std::mem::take(&mut *b.borrow_mut())).unwrap()
-        });
+        let (abacus_result, abacus_log) = run_with_log(|| process(&data));
 
         match abacus_result {
             Ok(ref output) => {

--- a/backend/apportionment/fuzz/fuzz_targets/fractions.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/fractions.rs
@@ -1,0 +1,47 @@
+#![no_main]
+
+use apportionment::Fraction;
+use libfuzzer_sys::{
+    arbitrary::{Arbitrary, Error, Result, Unstructured},
+    fuzz_target,
+};
+
+/// Fuzzed Fractions with a numerator and denominator of any size (e.g. u16, u32, etc.)
+#[derive(Debug)]
+pub struct FuzzedFraction<T: Into<u64>> {
+    pub numerator: T,
+    pub denominator: T,
+    pub fraction: Fraction,
+}
+
+impl<'a, T: Arbitrary<'a> + Into<u64> + Copy> Arbitrary<'a> for FuzzedFraction<T> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let numerator = T::arbitrary(u)?;
+        let denominator = T::arbitrary(u)?;
+
+        // prevent denominators from being 0
+        if denominator.into() == 0u64 {
+            return Err(Error::IncorrectFormat);
+        }
+
+        Ok(FuzzedFraction {
+            numerator,
+            denominator,
+            fraction: Fraction::new(numerator.into(), denominator.into()),
+        })
+    }
+}
+
+fuzz_target!(|inputs: [FuzzedFraction<u32>; 3]| {
+    let [a, b, c] = inputs;
+
+    // if a == b, then whatever b is to c (less, equal, or greater), a must be to c
+    if a.fraction == b.fraction {
+        assert!(b.fraction.cmp(&c.fraction) == a.fraction.cmp(&c.fraction));
+    }
+
+    // if a < b and b <= c, then a < c
+    if a.fraction < b.fraction && b.fraction <= c.fraction {
+        assert!(a.fraction < c.fraction);
+    }
+});

--- a/backend/apportionment/fuzz/fuzz_targets/house_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/house_monotonicity.rs
@@ -1,0 +1,32 @@
+#![no_main]
+
+use apportionment::process;
+use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(
+    init: {
+        init_tracing();
+    },
+    |data: (FuzzedApportionmentInput, u16)| {
+    let (mut data, added_seats) = data;
+    let seats = data.seats.max(19); // apportionment for < 19 seats is not monotonic
+    let new_seats = seats + u32::from(added_seats);
+
+    data.seats = seats;
+    let (alloc, log1) = run_with_log(|| process(&data));
+    let alloc = alloc.map(|r| get_total_seats(&r.seat_assignment));
+
+    data.seats = new_seats;
+    let (new_alloc, log2) = run_with_log(|| process(&data));
+    let new_alloc = new_alloc.map(|r| get_total_seats(&r.seat_assignment));
+
+    if let (Ok(seats_per_party), Ok(new_seats_per_party)) = (alloc, new_alloc) {
+        // House monotonicity:
+        // The number of seats given to any party will not decrease if the number of seats increases (when votes stay the same)
+        assert!(
+            new_seats_per_party.iter().ge(seats_per_party.iter()),
+            "{new_seats_per_party:?} ({new_seats} seats) is not greater or equal than {seats_per_party:?} ({seats} seats)\n[{seats} seats]\n{log1}\n[{new_seats} seats]\n{log2}",
+        );
+    }
+});

--- a/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
@@ -1,0 +1,63 @@
+#![no_main]
+
+use apportionment::{CandidateVotes, process};
+use apportionment_fuzz::{FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(
+    init: {
+        init_tracing();
+    },
+    |data: (FuzzedApportionmentInput, u16)| {
+    let (data, added_votes) = data;
+    let (alloc, log1) = run_with_log(|| process(&data));
+
+    // Add some votes to the first candidate of the first party
+    let mut new_data = FuzzedApportionmentInput {
+        seats: data.seats,
+        list_votes: data
+            .list_votes
+            .iter()
+            .map(|list| {
+                SimpleListVotes::new(
+                    list.number,
+                    list.candidate_votes
+                        .iter()
+                        .map(|cv| cv.votes())
+                        .collect(),
+                )
+            })
+            .collect(),
+    };
+
+    if let Some(first_list) = new_data.list_votes.first_mut()
+        && let Some(first_candidate) = first_list.candidate_votes.first_mut() {
+            *first_candidate =
+                SimpleCandidateVotes::new(first_candidate.number(), first_candidate.votes() + u32::from(added_votes));
+        }
+
+    let (new_alloc, log2) = run_with_log(|| process(&new_data));
+
+    if let (Ok(alloc), Ok(new_alloc)) = (alloc, new_alloc) {
+        let seats_per_party: Vec<u32> = alloc
+            .seat_assignment
+            .final_standing
+            .iter()
+            .map(|p| p.total_seats)
+            .collect();
+        let new_seats_per_party: Vec<u32> = new_alloc
+            .seat_assignment
+            .final_standing
+            .iter()
+            .map(|p| p.total_seats)
+            .collect();
+
+        // The party with the extra votes should have at least as many seats as before
+        let my_party_seats = seats_per_party[0];
+        let new_my_party_seats = new_seats_per_party[0];
+        assert!(
+            new_my_party_seats >= my_party_seats,
+            "{new_my_party_seats} is not greater or equal than {my_party_seats}\n{seats_per_party:?} -> {new_seats_per_party:?}\n[before]\n{log1}\n[after +{added_votes} votes]\n{log2}",
+        );
+    }
+});

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -114,6 +114,16 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
     }
 }
 
+pub fn get_total_seats(
+    result: &apportionment::SeatAssignmentResult<SimpleListVotes>,
+) -> Vec<u32> {
+    result
+        .final_standing
+        .iter()
+        .map(|p| p.total_seats)
+        .collect()
+}
+
 impl fmt::Debug for FuzzedApportionmentInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let total_votes: u64 = self

--- a/backend/apportionment/fuzz/src/lib.rs
+++ b/backend/apportionment/fuzz/src/lib.rs
@@ -1,3 +1,5 @@
 mod apportionment_input;
+mod logging;
 
 pub use apportionment_input::*;
+pub use logging::{init_tracing, run_with_log};

--- a/backend/apportionment/fuzz/src/logging.rs
+++ b/backend/apportionment/fuzz/src/logging.rs
@@ -1,0 +1,65 @@
+use std::{cell::RefCell, io::Write};
+
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+    Layer,
+    filter::Targets,
+    fmt::{self, MakeWriter},
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
+};
+
+// Per-iteration buffer for Abacus tracing events.
+thread_local! {
+    static ABACUS_LOG: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+struct ThreadLocalWriter;
+
+impl Write for ThreadLocalWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        ABACUS_LOG.with(|b| b.borrow_mut().extend_from_slice(buf));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for ThreadLocalWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        ThreadLocalWriter
+    }
+}
+
+/// Initialise the tracing subscriber that captures apportionment traces into a
+/// per-iteration thread-local buffer.  Call once from the `init:` block of a
+/// fuzz target.
+pub fn init_tracing() {
+    let layer = fmt::layer()
+        .with_writer(ThreadLocalWriter)
+        .without_time()
+        .with_ansi(false)
+        .with_target(true)
+        .with_level(true)
+        .with_filter(
+            Targets::new().with_target("apportionment::seat_assignment", LevelFilter::TRACE),
+        );
+    tracing_subscriber::registry().with(layer).init();
+}
+
+/// Run `f`, capture all apportionment tracing output, and return both the
+/// return value and the captured log as a UTF-8 string.
+pub fn run_with_log<F, R>(f: F) -> (R, String)
+where
+    F: FnOnce() -> R,
+{
+    ABACUS_LOG.with(|b| b.borrow_mut().clear());
+    let result = f();
+    let log = ABACUS_LOG
+        .with(|b| String::from_utf8(std::mem::take(&mut *b.borrow_mut())).unwrap());
+    (result, log)
+}


### PR DESCRIPTION
Add apportionment fuzz targets from https://github.com/squell/abacus-fuzz/tree/fuzzer/backend/fuzz, resolves #2875. These have been adjusted for the current apportionment API and logging has been added (extracted from the differential OSV2020 fuzz target).

These fuzz targets run and find error cases very quickly, I have not checked whether these are valid issues with the Abacus apportionment code or with the assumptions in the fuzz targets themselves.