### PR TITLE
Update validation implementation/texts against specs

### DIFF
--- a/backend/src/domain/election.rs
+++ b/backend/src/domain/election.rs
@@ -282,7 +282,8 @@ pub(crate) mod tests {
     /// Create a test election with some political groups and a given number of seats.
     /// The number of political groups is the length of the `political_groups_candidates` slice.
     /// The number of candidates in each political group is equal to the value in the slice at that index.
-    pub fn election_fixture_with_given_number_of_seats(
+    fn election_fixture_with_given_number_of_seats(
+        commitee_category: CommitteeCategory,
         political_groups_candidates: &[u32],
         number_of_seats: u32,
     ) -> ElectionWithPoliticalGroups {
@@ -311,7 +312,7 @@ pub(crate) mod tests {
         ElectionWithPoliticalGroups {
             id: ElectionId::from(1),
             name: "Test".to_string(),
-            committee_category: CommitteeCategory::GSB,
+            committee_category: commitee_category,
             counting_method: Some(VoteCountingMethod::CSO),
             election_id: "Test_2023".to_string(),
             location: "Test".to_string(),
@@ -328,7 +329,14 @@ pub(crate) mod tests {
     /// Create a test election with some political groups.
     /// The number of political groups is the length of the `political_groups_candidates` slice.
     /// The number of candidates in each political group is equal to the value in the slice at that index.
-    pub fn election_fixture(political_groups_candidates: &[u32]) -> ElectionWithPoliticalGroups {
-        election_fixture_with_given_number_of_seats(political_groups_candidates, 29)
+    pub fn election_fixture(
+        commitee_category: CommitteeCategory,
+        political_groups_candidates: &[u32],
+    ) -> ElectionWithPoliticalGroups {
+        election_fixture_with_given_number_of_seats(
+            commitee_category,
+            political_groups_candidates,
+            29,
+        )
     }
 }

--- a/backend/src/domain/election.rs
+++ b/backend/src/domain/election.rs
@@ -283,7 +283,7 @@ pub(crate) mod tests {
     /// The number of political groups is the length of the `political_groups_candidates` slice.
     /// The number of candidates in each political group is equal to the value in the slice at that index.
     fn election_fixture_with_given_number_of_seats(
-        commitee_category: CommitteeCategory,
+        committee_category: CommitteeCategory,
         political_groups_candidates: &[u32],
         number_of_seats: u32,
     ) -> ElectionWithPoliticalGroups {
@@ -312,7 +312,7 @@ pub(crate) mod tests {
         ElectionWithPoliticalGroups {
             id: ElectionId::from(1),
             name: "Test".to_string(),
-            committee_category: commitee_category,
+            committee_category,
             counting_method: Some(VoteCountingMethod::CSO),
             election_id: "Test_2023".to_string(),
             location: "Test".to_string(),
@@ -330,11 +330,11 @@ pub(crate) mod tests {
     /// The number of political groups is the length of the `political_groups_candidates` slice.
     /// The number of candidates in each political group is equal to the value in the slice at that index.
     pub fn election_fixture(
-        commitee_category: CommitteeCategory,
+        committee_category: CommitteeCategory,
         political_groups_candidates: &[u32],
     ) -> ElectionWithPoliticalGroups {
         election_fixture_with_given_number_of_seats(
-            commitee_category,
+            committee_category,
             political_groups_candidates,
             29,
         )

--- a/backend/src/domain/results/common_polling_station_results.rs
+++ b/backend/src/domain/results/common_polling_station_results.rs
@@ -245,7 +245,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO/DSO | W.203: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
+    /// GSB CSO, GSB DSO | W.203: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
     #[test]
     fn test_w203() -> Result<(), DataError> {
         let cases = [
@@ -286,7 +286,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.401 `Er zijn (stemmen op kandidaten of het lijsttotaal van corresponderende E.x is groter dan 0) en het totaal aantal stemmen op een lijst = leeg of 0`
+    /// GSB CSO, GSB DSO, CSB | F.401: 'Kandidaten en lijsttotalen': Er zijn (stemmen op kandidaten of het lijsttotaal van corresponderende E.x is groter dan 0) en het totaal aantal stemmen op een lijst = leeg of 0
     #[test]
     fn test_f401() -> Result<(), DataError> {
         // Only F.401 is triggered.
@@ -417,7 +417,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.402 (Als F.401 niet getoond wordt) `Totaal aantal stemmen op een lijst <> som van aantal stemmen op de kandidaten van die lijst`
+    /// GSB CSO, GSB DSO, CSB | F.402: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst <> som van aantal stemmen op de kandidaten van die lijst
     #[test]
     fn test_f402() -> Result<(), DataError> {
         let mut data = create_test_data();
@@ -455,7 +455,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.403 (Als F.401 niet getoond wordt) `Totaal aantal stemmen op een lijst komt niet overeen met het lijsttotaal van corresponderende E.x`
+    /// GSB CSO, GSB DSO, CSB | F.403: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst komt niet overeen met het lijsttotaal van corresponderende E.x
     #[test]
     fn test_f403() -> Result<(), DataError> {
         let mut data = create_test_data();

--- a/backend/src/domain/results/common_polling_station_results.rs
+++ b/backend/src/domain/results/common_polling_station_results.rs
@@ -182,7 +182,7 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        election::{PGNumber, tests::election_fixture},
+        election::{CommitteeCategory, PGNumber, tests::election_fixture},
         results::political_group_total_votes::PoliticalGroupTotalVotes,
         valid_default::ValidDefault,
     };
@@ -224,6 +224,7 @@ mod tests {
         data.validate(
             // Adjust election political group list to the given test data
             &election_fixture(
+                CommitteeCategory::GSB,
                 &data
                     .political_group_votes
                     .iter()

--- a/backend/src/domain/results/count.rs
+++ b/backend/src/domain/results/count.rs
@@ -37,13 +37,17 @@ impl Validate for Count {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::election::tests::election_fixture;
+    use crate::domain::election::{CommitteeCategory, tests::election_fixture};
     #[test]
     fn test_count_err_out_of_range() {
         let mut validation_results = ValidationResults::default();
         let count: Count = 1_000_000_000;
 
-        let result = count.validate(&election_fixture(&[]), &mut validation_results, &"".into());
+        let result = count.validate(
+            &election_fixture(CommitteeCategory::GSB, &[]),
+            &mut validation_results,
+            &"".into(),
+        );
 
         assert!(result.is_err());
         assert!(result.unwrap_err().message.eq("count out of range"),);

--- a/backend/src/domain/results/counting_differences_polling_station.rs
+++ b/backend/src/domain/results/counting_differences_polling_station.rs
@@ -4,7 +4,7 @@ use utoipa::ToSchema;
 use super::yes_no::YesNo;
 use crate::domain::{
     compare::Compare,
-    election::ElectionWithPoliticalGroups,
+    election::{CommitteeCategory, ElectionWithPoliticalGroups},
     field_path::FieldPath,
     validate::{DataError, Validate, ValidationResult, ValidationResultCode, ValidationResults},
 };
@@ -25,28 +25,30 @@ pub struct CountingDifferencesPollingStation {
 impl Validate for CountingDifferencesPollingStation {
     fn validate(
         &self,
-        _election: &ElectionWithPoliticalGroups,
+        election: &ElectionWithPoliticalGroups,
         validation_results: &mut ValidationResults,
         path: &FieldPath,
     ) -> Result<(), DataError> {
-        if self.unexplained_difference_ballots_voters.is_empty()
-            || self.difference_ballots_per_list.is_empty()
-        {
-            validation_results.errors.push(ValidationResult {
-                fields: vec![path.to_string()],
-                code: ValidationResultCode::F111,
-                context: None,
-            });
-        }
+        if election.committee_category == CommitteeCategory::GSB {
+            if self.unexplained_difference_ballots_voters.is_empty()
+                || self.difference_ballots_per_list.is_empty()
+            {
+                validation_results.errors.push(ValidationResult {
+                    fields: vec![path.to_string()],
+                    code: ValidationResultCode::F111,
+                    context: None,
+                });
+            }
 
-        if self.unexplained_difference_ballots_voters.is_both()
-            || self.difference_ballots_per_list.is_both()
-        {
-            validation_results.errors.push(ValidationResult {
-                fields: vec![path.to_string()],
-                code: ValidationResultCode::F112,
-                context: None,
-            });
+            if self.unexplained_difference_ballots_voters.is_both()
+                || self.difference_ballots_per_list.is_both()
+            {
+                validation_results.errors.push(ValidationResult {
+                    fields: vec![path.to_string()],
+                    code: ValidationResultCode::F112,
+                    context: None,
+                });
+            }
         }
 
         Ok(())
@@ -89,19 +91,18 @@ mod tests {
     }
 
     fn validate(
-        unexplained_yes: bool,
-        unexplained_no: bool,
-        ballots_yes: bool,
-        ballots_no: bool,
+        committee_category: CommitteeCategory,
+        unexplained: YesNo,
+        ballots: YesNo,
     ) -> Result<ValidationResults, DataError> {
         let counting_differences_polling_station = CountingDifferencesPollingStation {
-            unexplained_difference_ballots_voters: YesNo::new(unexplained_yes, unexplained_no),
-            difference_ballots_per_list: YesNo::new(ballots_yes, ballots_no),
+            unexplained_difference_ballots_voters: unexplained,
+            difference_ballots_per_list: ballots,
         };
 
         let mut validation_results = ValidationResults::default();
         counting_differences_polling_station.validate(
-            &election_fixture(CommitteeCategory::GSB, &[]),
+            &election_fixture(committee_category, &[]),
             &mut validation_results,
             &"counting_differences_polling_station".into(),
         )?;
@@ -110,49 +111,34 @@ mod tests {
         Ok(validation_results)
     }
 
-    #[test]
-    fn test_no_validation_errors() -> Result<(), DataError> {
-        let validation_results = validate(false, true, false, true)?;
-        assert_eq!(validation_results.errors, []);
-
-        let validation_results = validate(true, false, true, false)?;
-        assert_eq!(validation_results.errors, []);
-
-        Ok(())
-    }
-
     /// GSB CSO | F.111: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
     #[test]
     fn test_f111() -> Result<(), DataError> {
-        let validation_results = validate(false, true, false, false)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F111,
-                fields: vec!["counting_differences_polling_station".into()],
-                context: None,
-            }]
-        );
+        use CommitteeCategory::*;
 
-        let validation_results = validate(false, false, false, true)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F111,
-                fields: vec!["counting_differences_polling_station".into()],
-                context: None,
-            }]
-        );
+        let f111 = ValidationResult {
+            code: ValidationResultCode::F111,
+            fields: vec!["counting_differences_polling_station".into()],
+            context: None,
+        };
 
-        let validation_results = validate(false, false, false, false)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F111,
-                fields: vec!["counting_differences_polling_station".into()],
-                context: None,
-            }]
-        );
+        let cases = vec![
+            (GSB, YesNo::yes(), YesNo::yes(), false),
+            (GSB, YesNo::yes(), YesNo::no(), false),
+            (GSB, YesNo::default(), YesNo::no(), true),
+            (GSB, YesNo::yes(), YesNo::default(), true),
+            (GSB, YesNo::default(), YesNo::default(), true),
+            (CSB, YesNo::default(), YesNo::no(), false), // Not applicable for CSB
+        ];
+
+        for (committee_category, unexplained, ballots, expect_f111) in cases {
+            let result = validate(committee_category, unexplained.clone(), ballots.clone())?;
+            let has_f111 = result.errors.iter().any(|e| e == &f111);
+            assert_eq!(
+                has_f111, expect_f111,
+                "Failed: {committee_category:?}, unexplained: {unexplained:?}, ballots: {ballots:?}"
+            );
+        }
 
         Ok(())
     }
@@ -160,42 +146,38 @@ mod tests {
     // CSO | F.112: 'Verschillen met telresultaten van het stembureau': meerdere antwoorden per vraag
     #[test]
     fn test_f112() -> Result<(), DataError> {
-        let validation_results = validate(true, true, false, true)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F112,
-                fields: vec!["counting_differences_polling_station".into()],
-                context: None,
-            }]
-        );
+        use CommitteeCategory::*;
 
-        let validation_results = validate(false, true, true, true)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F112,
-                fields: vec!["counting_differences_polling_station".into()],
-                context: None,
-            }]
-        );
+        let f112 = ValidationResult {
+            code: ValidationResultCode::F112,
+            fields: vec!["counting_differences_polling_station".into()],
+            context: None,
+        };
 
-        let validation_results = validate(true, true, true, true)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F112,
-                fields: vec!["counting_differences_polling_station".into()],
-                context: None,
-            }]
-        );
+        let cases = vec![
+            (GSB, YesNo::yes(), YesNo::yes(), false),
+            (GSB, YesNo::yes(), YesNo::no(), false),
+            (GSB, YesNo::both(), YesNo::no(), true),
+            (GSB, YesNo::yes(), YesNo::both(), true),
+            (GSB, YesNo::both(), YesNo::both(), true),
+            (CSB, YesNo::both(), YesNo::no(), false), // Not applicable for CSB
+        ];
+
+        for (committee_category, unexplained, ballots, expect_f112) in cases {
+            let result = validate(committee_category, unexplained.clone(), ballots.clone())?;
+            let has_f112 = result.errors.iter().any(|e| e == &f112);
+            assert_eq!(
+                has_f112, expect_f112,
+                "Failed: {committee_category:?}, unexplained: {unexplained:?}, ballots: {ballots:?}"
+            );
+        }
 
         Ok(())
     }
 
     #[test]
     fn test_multiple_errors() -> Result<(), DataError> {
-        let validation_results = validate(true, true, false, false)?;
+        let validation_results = validate(CommitteeCategory::GSB, YesNo::both(), YesNo::default())?;
         assert_eq!(
             validation_results.errors,
             [
@@ -212,7 +194,7 @@ mod tests {
             ]
         );
 
-        let validation_results = validate(false, false, true, true)?;
+        let validation_results = validate(CommitteeCategory::GSB, YesNo::default(), YesNo::both())?;
         assert_eq!(
             validation_results.errors,
             [

--- a/backend/src/domain/results/counting_differences_polling_station.rs
+++ b/backend/src/domain/results/counting_differences_polling_station.rs
@@ -118,7 +118,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.111: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
+    /// GSB CSO | F.111: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
     #[test]
     fn test_f111() -> Result<(), DataError> {
         let validation_results = validate(false, true, false, false)?;

--- a/backend/src/domain/results/counting_differences_polling_station.rs
+++ b/backend/src/domain/results/counting_differences_polling_station.rs
@@ -74,7 +74,10 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::{election::tests::election_fixture, valid_default::ValidDefault};
+    use crate::domain::{
+        election::{CommitteeCategory, tests::election_fixture},
+        valid_default::ValidDefault,
+    };
 
     impl ValidDefault for CountingDifferencesPollingStation {
         fn valid_default() -> Self {
@@ -98,7 +101,7 @@ mod tests {
 
         let mut validation_results = ValidationResults::default();
         counting_differences_polling_station.validate(
-            &election_fixture(&[]),
+            &election_fixture(CommitteeCategory::GSB, &[]),
             &mut validation_results,
             &"counting_differences_polling_station".into(),
         )?;

--- a/backend/src/domain/results/differences_counts.rs
+++ b/backend/src/domain/results/differences_counts.rs
@@ -805,7 +805,7 @@ mod tests {
         Ok(validation_results)
     }
 
-    /// CSO | F.301: "Vergelijk D&H": (checkbox D=H is aangevinkt, maar D<>H)
+    /// GSB CSO, GSB DSO | F.301: "Vergelijk D&H": (Als checkbox D=H is aangevinkt) D<>H
     #[test]
     fn test_f301() -> Result<(), DataError> {
         // D = H checked & D = H
@@ -846,7 +846,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.302: "Vergelijk D&H": (checkbox H>D is aangevinkt, maar H<=D)
+    /// GSB CSO, GSB DSO | F.302: "Vergelijk D&H": (Als checkbox H>D is aangevinkt) H<=D
     #[test]
     fn test_f302() -> Result<(), DataError> {
         // H > D checked & H > D
@@ -907,7 +907,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.303: "Vergelijk D&H": (checkbox H<D is aangevinkt, maar H>=D)
+    /// GSB CSO, GSB DSO | F.303: "Vergelijk D&H": (Als checkbox H<D is aangevinkt) H>=D
     #[test]
     fn test_f303() -> Result<(), DataError> {
         // H < D checked & H < D
@@ -970,7 +970,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.304 "Vergelijk D&H": Meerdere aangevinkt of geen enkele aangevinkt
+    /// GSB CSO, GSB DSO | F.304: "Vergelijk D&H": Meerdere aangevinkt of geen enkele aangevinkt  
     #[test]
     fn test_f304() -> Result<(), DataError> {
         let f304 = ValidationResult {
@@ -1008,7 +1008,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.305 (Als D = H) I en/of J zijn ingevuld
+    /// GSB CSO, GSB DSO | F.305: (Als D = H) I en/of J zijn ingevuld
     #[test]
     fn test_f305() -> Result<(), DataError> {
         // (description, H=votes, D=voters, I=more_ballots, J=fewer_ballots, expect_f305, expected_fields)
@@ -1053,7 +1053,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.306 (Als H > D) I <> H - D
+    /// GSB CSO, GSB DSO | F.306: (Als H > D) I <> H - D
     #[test]
     fn test_f306() -> Result<(), DataError> {
         let f306 = ValidationResult {
@@ -1084,7 +1084,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.307 (Als H > D) J is ingevuld
+    /// GSB CSO, GSB DSO | F.307: (Als H > D) J is ingevuld
     #[test]
     fn test_f307() -> Result<(), DataError> {
         let f307 = ValidationResult {
@@ -1118,7 +1118,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.308 (Als H < D) J <> D - H
+    /// GSB CSO, GSB DSO | F.308: (Als H < D) J <> D - H
     #[test]
     fn test_f308() -> Result<(), DataError> {
         let f308 = ValidationResult {
@@ -1149,7 +1149,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.309 (Als H < D) I is ingevuld
+    /// GSB CSO, GSB DSO | F.309: (Als H < D) I is ingevuld
     #[test]
     fn test_f309() -> Result<(), DataError> {
         let f309 = ValidationResult {
@@ -1183,7 +1183,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.310 (Als D <> H en verklaring voor verschil niks aangevinkt of 'ja' en 'nee' aangevinkt)
+    /// GSB CSO, GSB DSO | F.310: (Als D <> H) Verklaring voor verschil niks aangevinkt of zowel 'ja' als 'nee' aangevinkt
     #[test]
     fn test_f310() -> Result<(), DataError> {
         let f310 = ValidationResult {

--- a/backend/src/domain/results/extra_investigation.rs
+++ b/backend/src/domain/results/extra_investigation.rs
@@ -117,7 +117,7 @@ pub mod tests {
         Ok(())
     }
 
-    /// CSO | F.101: 'Alleen bij extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
+    /// GSB CSO | F.101: 'Alleen bij extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
     #[test]
     fn test_f101() -> Result<(), DataError> {
         let validation_results = validate(false, true, false, false)?;
@@ -143,7 +143,7 @@ pub mod tests {
         Ok(())
     }
 
-    /// CSO | F.102: 'Alleen bij extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
+    /// GSB CSO | F.102: 'Alleen bij extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
     #[test]
     fn test_f102() -> Result<(), DataError> {
         let validation_results = validate(true, true, true, true)?;

--- a/backend/src/domain/results/extra_investigation.rs
+++ b/backend/src/domain/results/extra_investigation.rs
@@ -73,7 +73,10 @@ pub mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::{election::tests::election_fixture, valid_default::ValidDefault};
+    use crate::domain::{
+        election::{CommitteeCategory, tests::election_fixture},
+        valid_default::ValidDefault,
+    };
 
     impl ValidDefault for ExtraInvestigation {
         fn valid_default() -> Self {
@@ -97,7 +100,7 @@ pub mod tests {
 
         let mut validation_results = ValidationResults::default();
         extra_investigation.validate(
-            &election_fixture(&[]),
+            &election_fixture(CommitteeCategory::GSB, &[]),
             &mut validation_results,
             &"extra_investigation".into(),
         )?;

--- a/backend/src/domain/results/extra_investigation.rs
+++ b/backend/src/domain/results/extra_investigation.rs
@@ -4,7 +4,7 @@ use utoipa::ToSchema;
 use super::yes_no::YesNo;
 use crate::domain::{
     compare::Compare,
-    election::ElectionWithPoliticalGroups,
+    election::{CommitteeCategory, ElectionWithPoliticalGroups},
     field_path::FieldPath,
     validate::{DataError, Validate, ValidationResult, ValidationResultCode, ValidationResults},
 };
@@ -40,28 +40,30 @@ impl Compare for ExtraInvestigation {
 impl Validate for ExtraInvestigation {
     fn validate(
         &self,
-        _election: &ElectionWithPoliticalGroups,
+        election: &ElectionWithPoliticalGroups,
         validation_results: &mut ValidationResults,
         path: &FieldPath,
     ) -> Result<(), DataError> {
-        if self.extra_investigation_other_reason.is_empty()
-            != self.ballots_recounted_extra_investigation.is_empty()
-        {
-            validation_results.errors.push(ValidationResult {
-                fields: vec![path.to_string()],
-                code: ValidationResultCode::F101,
-                context: None,
-            });
-        }
+        if election.committee_category == CommitteeCategory::GSB {
+            if self.extra_investigation_other_reason.is_empty()
+                != self.ballots_recounted_extra_investigation.is_empty()
+            {
+                validation_results.errors.push(ValidationResult {
+                    fields: vec![path.to_string()],
+                    code: ValidationResultCode::F101,
+                    context: None,
+                });
+            }
 
-        if self.extra_investigation_other_reason.is_both()
-            || self.ballots_recounted_extra_investigation.is_both()
-        {
-            validation_results.errors.push(ValidationResult {
-                fields: vec![path.to_string()],
-                code: ValidationResultCode::F102,
-                context: None,
-            });
+            if self.extra_investigation_other_reason.is_both()
+                || self.ballots_recounted_extra_investigation.is_both()
+            {
+                validation_results.errors.push(ValidationResult {
+                    fields: vec![path.to_string()],
+                    code: ValidationResultCode::F102,
+                    context: None,
+                });
+            }
         }
 
         Ok(())
@@ -73,10 +75,7 @@ pub mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::{
-        election::{CommitteeCategory, tests::election_fixture},
-        valid_default::ValidDefault,
-    };
+    use crate::domain::{election::tests::election_fixture, valid_default::ValidDefault};
 
     impl ValidDefault for ExtraInvestigation {
         fn valid_default() -> Self {
@@ -88,19 +87,18 @@ pub mod tests {
     }
 
     fn validate(
-        investigation_yes: bool,
-        investigation_no: bool,
-        recounted_yes: bool,
-        recounted_no: bool,
+        committee_category: CommitteeCategory,
+        investigation: YesNo,
+        recounted: YesNo,
     ) -> Result<ValidationResults, DataError> {
         let extra_investigation = ExtraInvestigation {
-            extra_investigation_other_reason: YesNo::new(investigation_yes, investigation_no),
-            ballots_recounted_extra_investigation: YesNo::new(recounted_yes, recounted_no),
+            extra_investigation_other_reason: investigation,
+            ballots_recounted_extra_investigation: recounted,
         };
 
         let mut validation_results = ValidationResults::default();
         extra_investigation.validate(
-            &election_fixture(CommitteeCategory::GSB, &[]),
+            &election_fixture(committee_category, &[]),
             &mut validation_results,
             &"extra_investigation".into(),
         )?;
@@ -109,39 +107,35 @@ pub mod tests {
         Ok(validation_results)
     }
 
-    #[test]
-    fn test_no_validation_errors() -> Result<(), DataError> {
-        let validation_results = validate(false, false, false, false)?;
-        assert_eq!(validation_results.errors, []);
-
-        let validation_results = validate(true, false, false, true)?;
-        assert_eq!(validation_results.errors, []);
-
-        Ok(())
-    }
-
     /// GSB CSO | F.101: 'Alleen bij extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
     #[test]
     fn test_f101() -> Result<(), DataError> {
-        let validation_results = validate(false, true, false, false)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F101,
-                fields: vec!["extra_investigation".into()],
-                context: None,
-            }]
-        );
+        use CommitteeCategory::*;
 
-        let validation_results = validate(false, false, false, true)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F101,
-                fields: vec!["extra_investigation".into()],
-                context: None,
-            }]
-        );
+        let f101 = ValidationResult {
+            code: ValidationResultCode::F101,
+            fields: vec!["extra_investigation".into()],
+            context: None,
+        };
+
+        let cases = vec![
+            (GSB, YesNo::default(), YesNo::default(), false),
+            (GSB, YesNo::yes(), YesNo::yes(), false),
+            (GSB, YesNo::no(), YesNo::no(), false),
+            (GSB, YesNo::yes(), YesNo::no(), false),
+            (GSB, YesNo::yes(), YesNo::default(), true),
+            (GSB, YesNo::default(), YesNo::no(), true),
+            (CSB, YesNo::default(), YesNo::no(), false), // Not applicable for CSB
+        ];
+
+        for (committee_category, investigation, recounted, expect_f101) in cases {
+            let result = validate(committee_category, investigation.clone(), recounted.clone())?;
+            let has_f101 = result.errors.iter().any(|e| e == &f101);
+            assert_eq!(
+                has_f101, expect_f101,
+                "Failed: {committee_category:?}, investigated: {investigation:?}, recounted: {recounted:?}"
+            );
+        }
 
         Ok(())
     }
@@ -149,22 +143,39 @@ pub mod tests {
     /// GSB CSO | F.102: 'Alleen bij extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
     #[test]
     fn test_f102() -> Result<(), DataError> {
-        let validation_results = validate(true, true, true, true)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F102,
-                fields: vec!["extra_investigation".into()],
-                context: None,
-            }]
-        );
+        use CommitteeCategory::*;
+
+        let f102 = ValidationResult {
+            code: ValidationResultCode::F102,
+            fields: vec!["extra_investigation".into()],
+            context: None,
+        };
+
+        let cases = vec![
+            (GSB, YesNo::default(), YesNo::default(), false),
+            (GSB, YesNo::yes(), YesNo::yes(), false),
+            (GSB, YesNo::yes(), YesNo::no(), false),
+            (GSB, YesNo::both(), YesNo::default(), true),
+            (GSB, YesNo::default(), YesNo::both(), true),
+            (GSB, YesNo::both(), YesNo::both(), true),
+            (CSB, YesNo::default(), YesNo::both(), false), // Not applicable for CSB
+        ];
+
+        for (committee_category, investigation, recounted, expect_f102) in cases {
+            let result = validate(committee_category, investigation.clone(), recounted.clone())?;
+            let has_f102 = result.errors.iter().any(|e| e == &f102);
+            assert_eq!(
+                has_f102, expect_f102,
+                "Failed: {committee_category:?}, investigated: {investigation:?}, recounted: {recounted:?}"
+            );
+        }
 
         Ok(())
     }
 
     #[test]
     fn test_multiple_errors() -> Result<(), DataError> {
-        let validation_results = validate(true, true, false, false)?;
+        let validation_results = validate(CommitteeCategory::GSB, YesNo::both(), YesNo::default())?;
         assert_eq!(
             validation_results.errors,
             [
@@ -181,7 +192,7 @@ pub mod tests {
             ]
         );
 
-        let validation_results = validate(false, false, true, true)?;
+        let validation_results = validate(CommitteeCategory::GSB, YesNo::default(), YesNo::both())?;
         assert_eq!(
             validation_results.errors,
             [

--- a/backend/src/domain/results/gsb_differences_counts.rs
+++ b/backend/src/domain/results/gsb_differences_counts.rs
@@ -476,7 +476,7 @@ mod tests {
         Ok(validation_results)
     }
 
-    /// CSB | F.312: totaal aantal kiezers != totaal aantal uitgebrachte stemmen - meer getelde stemmen + minder getelde stemmen
+    /// CSB | F.312: totaal aantal kiezers <> totaal aantal uitgebrachte stemmen - meer getelde stemmen + minder getelde stemmen
     #[test]
     fn test_f312() -> Result<(), DataError> {
         let validation_error = ValidationResult {

--- a/backend/src/domain/results/gsb_results.rs
+++ b/backend/src/domain/results/gsb_results.rs
@@ -303,7 +303,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO/DSO | W.203: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
+    /// GSB CSO, GSB DSO | W.203: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
     #[test]
     fn test_w203() -> Result<(), DataError> {
         let cases = [
@@ -344,7 +344,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.401 `Er zijn (stemmen op kandidaten of het lijsttotaal van corresponderende E.x is groter dan 0) en het totaal aantal stemmen op een lijst = leeg of 0`
+    /// GSB CSO, GSB DSO, CSB | F.401: 'Kandidaten en lijsttotalen': Er zijn (stemmen op kandidaten of het lijsttotaal van corresponderende E.x is groter dan 0) en het totaal aantal stemmen op een lijst = leeg of 0
     #[test]
     fn test_f401() -> Result<(), DataError> {
         // Only F.401 is triggered.
@@ -475,7 +475,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.402 (Als F.401 niet getoond wordt) `Totaal aantal stemmen op een lijst <> som van aantal stemmen op de kandidaten van die lijst`
+    /// GSB CSO, GSB DSO, CSB | F.402: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst <> som van aantal stemmen op de kandidaten van die lijst
     #[test]
     fn test_f402() -> Result<(), DataError> {
         let mut data = create_test_data();
@@ -513,7 +513,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO | F.403 (Als F.401 niet getoond wordt) `Totaal aantal stemmen op een lijst komt niet overeen met het lijsttotaal van corresponderende E.x`
+    /// GSB CSO, GSB DSO, CSB | F.403: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst komt niet overeen met het lijsttotaal van corresponderende E.x
     #[test]
     fn test_f403() -> Result<(), DataError> {
         let mut data = create_test_data();

--- a/backend/src/domain/results/gsb_results.rs
+++ b/backend/src/domain/results/gsb_results.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::{
-    common_validation::difference_admitted_voters_count_and_votes_cast_count_above_threshold,
     count::Count, gsb_differences_counts::GSBDifferencesCounts,
     political_group_candidate_votes::PoliticalGroupCandidateVotes, voters_counts::VotersCounts,
     votes_counts::VotesCounts,
@@ -39,33 +38,6 @@ pub struct GSBResults {
 }
 
 impl GSBResults {
-    /// W.203 'Aantal kiezers en stemmen':
-    ///   Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen
-    ///   is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
-    fn validate_voters_and_votes_count_difference(
-        &self,
-        validation_results: &mut ValidationResults,
-        path: &FieldPath,
-    ) {
-        if difference_admitted_voters_count_and_votes_cast_count_above_threshold(
-            self.voters_counts.total_admitted_voters_count,
-            self.votes_counts.total_votes_cast_count,
-        ) {
-            validation_results.warnings.push(ValidationResult {
-                fields: vec![
-                    path.field("voters_counts")
-                        .field("total_admitted_voters_count")
-                        .to_string(),
-                    path.field("votes_counts")
-                        .field("total_votes_cast_count")
-                        .to_string(),
-                ],
-                code: ValidationResultCode::W203,
-                context: None,
-            });
-        }
-    }
-
     fn validate_political_group_votes_errors(
         &self,
         political_group_candidate_votes: &PoliticalGroupCandidateVotes,
@@ -191,8 +163,6 @@ impl Validate for GSBResults {
         self.votes_counts
             .validate(election, validation_results, &path.field("votes_counts"))?;
 
-        self.validate_voters_and_votes_count_difference(validation_results, path);
-
         self.differences_counts.validate(
             election,
             validation_results,
@@ -300,47 +270,6 @@ mod tests {
         let result = validate(data);
         assert!(result.is_err());
         assert!(result.unwrap_err().message.eq("count out of range"),);
-
-        Ok(())
-    }
-
-    /// GSB CSO, GSB DSO | W.203: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
-    #[test]
-    fn test_w203() -> Result<(), DataError> {
-        let cases = [
-            (101, 100, false),   // < 2%
-            (102, 100, true),    // == 2%
-            (103, 100, true),    // > 2%
-            (1000, 1014, false), // < 15
-            (1000, 1015, true),  // == 15
-            (1000, 1016, true),  // > 15
-            (1016, 1000, true),  // > 15 (reversed)
-        ];
-
-        for (admitted_voters, votes_cast, expected) in cases {
-            let mut data = create_test_data();
-            data.voters_counts.total_admitted_voters_count = admitted_voters;
-            data.votes_counts.total_votes_cast_count = votes_cast;
-
-            let validation_results = validate(data)?;
-
-            if expected {
-                assert_eq!(
-                    validation_results.warnings,
-                    [ValidationResult {
-                        code: ValidationResultCode::W203,
-                        fields: vec![
-                            "data.voters_counts.total_admitted_voters_count".into(),
-                            "data.votes_counts.total_votes_cast_count".into(),
-                        ],
-                        context: None,
-                    }],
-                    "Warning not found for admitted_voters={admitted_voters}, votes_cast={votes_cast}",
-                );
-            } else {
-                assert!(validation_results.warnings.is_empty());
-            }
-        }
 
         Ok(())
     }

--- a/backend/src/domain/results/gsb_results.rs
+++ b/backend/src/domain/results/gsb_results.rs
@@ -227,7 +227,7 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        election::{PGNumber, tests::election_fixture},
+        election::{CommitteeCategory, PGNumber, tests::election_fixture},
         results::political_group_total_votes::PoliticalGroupTotalVotes,
     };
 
@@ -269,6 +269,7 @@ mod tests {
         data.validate(
             // Adjust election political group list to the given test data
             &election_fixture(
+                CommitteeCategory::GSB,
                 &data
                     .political_group_votes
                     .iter()

--- a/backend/src/domain/results/political_group_total_votes.rs
+++ b/backend/src/domain/results/political_group_total_votes.rs
@@ -69,7 +69,7 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        election::{CandidateNumber, tests::election_fixture},
+        election::{CandidateNumber, CommitteeCategory, tests::election_fixture},
         results::political_group_candidate_votes::{CandidateVotes, PoliticalGroupCandidateVotes},
     };
 
@@ -98,6 +98,7 @@ mod tests {
             .collect();
 
         let election = election_fixture(
+            CommitteeCategory::GSB,
             &candidate_votes_and_totals
                 .iter()
                 .map(|(votes, _)| u32::try_from(votes.len()).unwrap())

--- a/backend/src/domain/results/voters_counts.rs
+++ b/backend/src/domain/results/voters_counts.rs
@@ -99,7 +99,7 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::election::tests::election_fixture;
+    use crate::domain::election::{CommitteeCategory, tests::election_fixture};
 
     #[test]
     fn test_voters_addition() {
@@ -133,7 +133,7 @@ mod tests {
 
         let mut validation_results = ValidationResults::default();
         voters_counts.validate(
-            &election_fixture(&[]),
+            &election_fixture(CommitteeCategory::GSB, &[]),
             &mut validation_results,
             &"voters_counts".into(),
         )?;

--- a/backend/src/domain/results/voters_counts.rs
+++ b/backend/src/domain/results/voters_counts.rs
@@ -99,7 +99,9 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::election::{CommitteeCategory, tests::election_fixture};
+    use crate::domain::election::{
+        CommitteeCategory, CommitteeCategory::*, tests::election_fixture,
+    };
 
     #[test]
     fn test_voters_addition() {
@@ -121,6 +123,7 @@ mod tests {
     }
 
     fn validate(
+        committee_category: CommitteeCategory,
         poll_card_count: u32,
         proxy_certificate_count: u32,
         total_admitted_voters_count: u32,
@@ -133,7 +136,7 @@ mod tests {
 
         let mut validation_results = ValidationResults::default();
         voters_counts.validate(
-            &election_fixture(CommitteeCategory::GSB, &[]),
+            &election_fixture(committee_category, &[]),
             &mut validation_results,
             &"voters_counts".into(),
         )?;
@@ -144,22 +147,25 @@ mod tests {
     /// GSB CSO, GSB DSO, CSB | F.201: 'Aantal kiezers en stemmen': stempassen + volmachten <> totaal toegelaten kiezers
     #[test]
     fn test_f201() -> Result<(), DataError> {
-        let validation_results = validate(100, 50, 150)?;
+        let validation_results = validate(GSB, 100, 50, 150)?;
         assert!(validation_results.errors.is_empty());
 
-        let validation_results = validate(100, 150, 151)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F201,
-                fields: vec![
-                    "voters_counts.poll_card_count".into(),
-                    "voters_counts.proxy_certificate_count".into(),
-                    "voters_counts.total_admitted_voters_count".into()
-                ],
-                context: None,
-            }]
-        );
+        let f201 = vec![ValidationResult {
+            code: ValidationResultCode::F201,
+            fields: vec![
+                "voters_counts.poll_card_count".into(),
+                "voters_counts.proxy_certificate_count".into(),
+                "voters_counts.total_admitted_voters_count".into(),
+            ],
+            context: None,
+        }];
+
+        let validation_results = validate(GSB, 100, 150, 151)?;
+        assert_eq!(validation_results.errors, f201);
+
+        // Also applies for CSB
+        let validation_results = validate(CSB, 100, 150, 151)?;
+        assert_eq!(validation_results.errors, f201);
 
         Ok(())
     }

--- a/backend/src/domain/results/voters_counts.rs
+++ b/backend/src/domain/results/voters_counts.rs
@@ -141,7 +141,7 @@ mod tests {
         Ok(validation_results)
     }
 
-    /// CSO/DSO | F.201: 'Aantal kiezers en stemmen': stempassen + volmachten <> totaal toegelaten kiezers
+    /// GSB CSO, GSB DSO, CSB | F.201: 'Aantal kiezers en stemmen': stempassen + volmachten <> totaal toegelaten kiezers
     #[test]
     fn test_f201() -> Result<(), DataError> {
         let validation_results = validate(100, 50, 150)?;

--- a/backend/src/domain/results/votes_counts.rs
+++ b/backend/src/domain/results/votes_counts.rs
@@ -393,7 +393,7 @@ mod tests {
         Ok(validation_results)
     }
 
-    /// CSO/DSO | F.202: 'Aantal kiezers en stemmen': E.1 t/m E.n tellen niet op naar E
+    /// GSB CSO, GSB DSO, CSB | F.202: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) E.1 t/m E.n tellen niet op naar E
     #[test]
     fn test_f202() -> Result<(), DataError> {
         let validation_results = validate(&[50, 30, 20], 100, 0, 0, 100)?;
@@ -417,7 +417,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO/DSO | F.203: 'Aantal kiezers en stemmen': stemmen op kandidaten + blanco stemmen + ongeldige stemmen <> totaal aantal uitgebrachte stemmen
+    /// GSB CSO, GSB DSO, CSB | F.203: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) stemmen op kandidaten + blanco stemmen + ongeldige stemmen <> totaal aantal uitgebrachte stemmen
     #[test]
     fn test_f203() -> Result<(), DataError> {
         let validation_results = validate(&[50, 30, 20], 100, 1, 2, 103)?;
@@ -441,7 +441,7 @@ mod tests {
         Ok(())
     }
 
-    /// GSB CSO/DSO, CSB | F.204: 'Aantal kiezers en stemmen': De som van lijsttotalen (E.1 t/m E.n) is groter dan 0 en E = leeg of 0
+    /// GSB CSO, GSB DSO, CSB | F.204: 'Aantal kiezers en stemmen': De som van lijsttotalen (E.1 t/m E.n) is groter dan 0 en E = leeg of 0
     #[test]
     fn test_f204() -> Result<(), DataError> {
         // No error
@@ -463,7 +463,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO/DSO | W.201: 'Aantal kiezers en stemmen': Aantal blanco stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
+    /// GSB CSO, GSB DSO | W.201: 'Aantal kiezers en stemmen': Aantal blanco stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
     #[test]
     fn test_w201() -> Result<(), DataError> {
         // < 3% of blank votes
@@ -495,7 +495,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO/DSO | W.202: 'Aantal kiezers en stemmen': Aantal ongeldige stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
+    /// GSB CSO, GSB DSO | W.202: 'Aantal kiezers en stemmen': Aantal ongeldige stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
     #[test]
     fn test_w202() -> Result<(), DataError> {
         // < 3% of invalid votes
@@ -527,7 +527,7 @@ mod tests {
         Ok(())
     }
 
-    /// CSO/DSO | W.204: 'Aantal kiezers en stemmen': Totaal aantal uitgebrachte stemmen leeg of 0
+    /// GSB CSO, GSB DSO, CSB | W.204: 'Aantal kiezers en stemmen': Totaal aantal uitgebrachte stemmen leeg of 0
     #[test]
     fn test_w204() -> Result<(), DataError> {
         let validation_results = validate(&[50, 30, 20], 100, 0, 0, 100)?;

--- a/backend/src/domain/results/votes_counts.rs
+++ b/backend/src/domain/results/votes_counts.rs
@@ -274,7 +274,7 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::election::{PGNumber, tests::election_fixture};
+    use crate::domain::election::{CommitteeCategory, PGNumber, tests::election_fixture};
 
     #[test]
     fn test_votes_addition() {
@@ -385,7 +385,7 @@ mod tests {
 
         let mut validation_results = ValidationResults::default();
         votes_counts.validate(
-            &election_fixture(&[1, 1, 1]),
+            &election_fixture(CommitteeCategory::GSB, &[1, 1, 1]),
             &mut validation_results,
             &"votes_counts".into(),
         )?;

--- a/backend/src/domain/results/votes_counts.rs
+++ b/backend/src/domain/results/votes_counts.rs
@@ -481,11 +481,11 @@ mod tests {
     #[test]
     fn test_w201() -> Result<(), DataError> {
         // < 3% of blank votes
-        let validation_results = validate(GSB, &[40, 20, 11], 71, 29, 0, 100)?;
-        assert!(validation_results.errors.is_empty());
+        let validation_results = validate(GSB, &[40, 20, 11], 98, 2, 0, 100)?;
+        assert!(validation_results.warnings.is_empty());
 
         // == 3% of blank votes
-        let validation_results = validate(GSB, &[40, 20, 10], 70, 30, 0, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 10], 97, 3, 0, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -496,7 +496,7 @@ mod tests {
         );
 
         // > 3% of blank votes
-        let validation_results = validate(GSB, &[40, 20, 9], 69, 31, 0, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 9], 96, 4, 0, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -507,8 +507,8 @@ mod tests {
         );
 
         // Not applicable for CSB
-        let validation_results = validate(CSB, &[40, 20, 9], 69, 31, 0, 100)?;
-        assert!(validation_results.errors.is_empty());
+        let validation_results = validate(CSB, &[40, 20, 9], 96, 4, 0, 100)?;
+        assert!(validation_results.warnings.is_empty());
 
         Ok(())
     }
@@ -517,11 +517,11 @@ mod tests {
     #[test]
     fn test_w202() -> Result<(), DataError> {
         // < 3% of invalid votes
-        let validation_results = validate(GSB, &[40, 20, 11], 71, 0, 29, 100)?;
-        assert!(validation_results.errors.is_empty());
+        let validation_results = validate(GSB, &[40, 20, 11], 98, 0, 2, 100)?;
+        assert!(validation_results.warnings.is_empty());
 
         // == 3% of invalid votes
-        let validation_results = validate(GSB, &[40, 20, 10], 70, 0, 30, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 10], 97, 0, 3, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -532,7 +532,7 @@ mod tests {
         );
 
         // > 3% of invalid votes
-        let validation_results = validate(GSB, &[40, 20, 9], 69, 0, 31, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 9], 96, 0, 4, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -543,8 +543,8 @@ mod tests {
         );
 
         // Not applicable for CSB
-        let validation_results = validate(CSB, &[40, 20, 9], 69, 0, 31, 100)?;
-        assert!(validation_results.errors.is_empty());
+        let validation_results = validate(CSB, &[40, 20, 9], 96, 0, 4, 100)?;
+        assert!(validation_results.warnings.is_empty());
 
         Ok(())
     }
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn test_w204() -> Result<(), DataError> {
         let validation_results = validate(GSB, &[50, 30, 20], 100, 0, 0, 100)?;
-        assert!(validation_results.errors.is_empty());
+        assert!(validation_results.warnings.is_empty());
 
         let w204 = vec![ValidationResult {
             code: ValidationResultCode::W204,

--- a/backend/src/domain/results/votes_counts.rs
+++ b/backend/src/domain/results/votes_counts.rs
@@ -8,7 +8,7 @@ use crate::{
     APIError,
     domain::{
         compare::Compare,
-        election::ElectionWithPoliticalGroups,
+        election::{CommitteeCategory, ElectionWithPoliticalGroups},
         field_path::FieldPath,
         validate::{
             DataError, Validate, ValidationResult, ValidationResultCode, ValidationResults,
@@ -185,23 +185,27 @@ impl VotesCounts {
 
     fn validate_votes_counts_warnings(
         &self,
+        election: &ElectionWithPoliticalGroups,
         validation_results: &mut ValidationResults,
         path: &FieldPath,
     ) {
-        if above_percentage_threshold(self.blank_votes_count, self.total_votes_cast_count, 3) {
-            validation_results.warnings.push(ValidationResult {
-                fields: vec![path.field("blank_votes_count").to_string()],
-                code: ValidationResultCode::W201,
-                context: None,
-            });
-        }
+        if election.committee_category == CommitteeCategory::GSB {
+            if above_percentage_threshold(self.blank_votes_count, self.total_votes_cast_count, 3) {
+                validation_results.warnings.push(ValidationResult {
+                    fields: vec![path.field("blank_votes_count").to_string()],
+                    code: ValidationResultCode::W201,
+                    context: None,
+                });
+            }
 
-        if above_percentage_threshold(self.invalid_votes_count, self.total_votes_cast_count, 3) {
-            validation_results.warnings.push(ValidationResult {
-                fields: vec![path.field("invalid_votes_count").to_string()],
-                code: ValidationResultCode::W202,
-                context: None,
-            });
+            if above_percentage_threshold(self.invalid_votes_count, self.total_votes_cast_count, 3)
+            {
+                validation_results.warnings.push(ValidationResult {
+                    fields: vec![path.field("invalid_votes_count").to_string()],
+                    code: ValidationResultCode::W202,
+                    context: None,
+                });
+            }
         }
 
         if self.total_votes_cast_count == 0 {
@@ -263,7 +267,7 @@ impl Validate for VotesCounts {
 
         self.validate_votes_counts_errors(validation_results, path);
 
-        self.validate_votes_counts_warnings(validation_results, path);
+        self.validate_votes_counts_warnings(election, validation_results, path);
 
         Ok(())
     }
@@ -274,7 +278,7 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::domain::election::{CommitteeCategory, PGNumber, tests::election_fixture};
+    use crate::domain::election::{CommitteeCategory::*, PGNumber, tests::election_fixture};
 
     #[test]
     fn test_votes_addition() {
@@ -362,6 +366,7 @@ mod tests {
     }
 
     fn validate(
+        committee_category: CommitteeCategory,
         political_group_total_votes: &[u32],
         total_votes_candidates_count: u32,
         blank_votes_count: u32,
@@ -385,7 +390,7 @@ mod tests {
 
         let mut validation_results = ValidationResults::default();
         votes_counts.validate(
-            &election_fixture(CommitteeCategory::GSB, &[1, 1, 1]),
+            &election_fixture(committee_category, &[1, 1, 1]),
             &mut validation_results,
             &"votes_counts".into(),
         )?;
@@ -396,23 +401,26 @@ mod tests {
     /// GSB CSO, GSB DSO, CSB | F.202: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) E.1 t/m E.n tellen niet op naar E
     #[test]
     fn test_f202() -> Result<(), DataError> {
-        let validation_results = validate(&[50, 30, 20], 100, 0, 0, 100)?;
+        let validation_results = validate(GSB, &[50, 30, 20], 100, 0, 0, 100)?;
         assert!(validation_results.errors.is_empty());
 
-        let validation_results = validate(&[49, 30, 20], 100, 0, 0, 100)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F202,
-                fields: vec![
-                    "votes_counts.political_group_total_votes.0.total".into(),
-                    "votes_counts.political_group_total_votes.1.total".into(),
-                    "votes_counts.political_group_total_votes.2.total".into(),
-                    "votes_counts.total_votes_candidates_count".into(),
-                ],
-                context: None,
-            }]
-        );
+        let f202 = vec![ValidationResult {
+            code: ValidationResultCode::F202,
+            fields: vec![
+                "votes_counts.political_group_total_votes.0.total".into(),
+                "votes_counts.political_group_total_votes.1.total".into(),
+                "votes_counts.political_group_total_votes.2.total".into(),
+                "votes_counts.total_votes_candidates_count".into(),
+            ],
+            context: None,
+        }];
+
+        let validation_results = validate(GSB, &[49, 30, 20], 100, 0, 0, 100)?;
+        assert_eq!(validation_results.errors, f202);
+
+        // Also applies for CSB
+        let validation_results = validate(CSB, &[49, 30, 20], 100, 0, 0, 100)?;
+        assert_eq!(validation_results.errors, f202);
 
         Ok(())
     }
@@ -420,23 +428,26 @@ mod tests {
     /// GSB CSO, GSB DSO, CSB | F.203: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) stemmen op kandidaten + blanco stemmen + ongeldige stemmen <> totaal aantal uitgebrachte stemmen
     #[test]
     fn test_f203() -> Result<(), DataError> {
-        let validation_results = validate(&[50, 30, 20], 100, 1, 2, 103)?;
+        let validation_results = validate(GSB, &[50, 30, 20], 100, 1, 2, 103)?;
         assert!(validation_results.errors.is_empty());
 
-        let validation_results = validate(&[50, 30, 20], 100, 1, 2, 104)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F203,
-                fields: vec![
-                    "votes_counts.total_votes_candidates_count".into(),
-                    "votes_counts.blank_votes_count".into(),
-                    "votes_counts.invalid_votes_count".into(),
-                    "votes_counts.total_votes_cast_count".into(),
-                ],
-                context: None,
-            }],
-        );
+        let f203 = vec![ValidationResult {
+            code: ValidationResultCode::F203,
+            fields: vec![
+                "votes_counts.total_votes_candidates_count".into(),
+                "votes_counts.blank_votes_count".into(),
+                "votes_counts.invalid_votes_count".into(),
+                "votes_counts.total_votes_cast_count".into(),
+            ],
+            context: None,
+        }];
+
+        let validation_results = validate(GSB, &[50, 30, 20], 100, 1, 2, 104)?;
+        assert_eq!(validation_results.errors, f203);
+
+        // Also applies for CSB
+        let validation_results = validate(CSB, &[50, 30, 20], 100, 1, 2, 104)?;
+        assert_eq!(validation_results.errors, f203);
 
         Ok(())
     }
@@ -445,20 +456,23 @@ mod tests {
     #[test]
     fn test_f204() -> Result<(), DataError> {
         // No error
-        let validation_results = validate(&[50, 30, 20], 100, 1, 2, 103)?;
+        let validation_results = validate(GSB, &[50, 30, 20], 100, 1, 2, 103)?;
         assert!(validation_results.errors.is_empty());
+
+        let f204 = vec![ValidationResult {
+            code: ValidationResultCode::F204,
+            fields: vec!["votes_counts.total_votes_candidates_count".into()],
+            context: None,
+        }];
 
         // Error: sum of political group totals is 100, but total votes on candidates is 0
         // F.202/F.203 errors should not be triggered, since F.204 takes precedence
-        let validation_results = validate(&[50, 30, 20], 0, 1, 2, 103)?;
-        assert_eq!(
-            validation_results.errors,
-            [ValidationResult {
-                code: ValidationResultCode::F204,
-                fields: vec!["votes_counts.total_votes_candidates_count".into()],
-                context: None,
-            }],
-        );
+        let validation_results = validate(GSB, &[50, 30, 20], 0, 1, 2, 103)?;
+        assert_eq!(validation_results.errors, f204);
+
+        // Also applies for CSB
+        let validation_results = validate(CSB, &[50, 30, 20], 0, 1, 2, 103)?;
+        assert_eq!(validation_results.errors, f204);
 
         Ok(())
     }
@@ -467,11 +481,11 @@ mod tests {
     #[test]
     fn test_w201() -> Result<(), DataError> {
         // < 3% of blank votes
-        let validation_results = validate(&[40, 20, 11], 71, 29, 0, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 11], 71, 29, 0, 100)?;
         assert!(validation_results.errors.is_empty());
 
         // == 3% of blank votes
-        let validation_results = validate(&[40, 20, 10], 70, 30, 0, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 10], 70, 30, 0, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -482,7 +496,7 @@ mod tests {
         );
 
         // > 3% of blank votes
-        let validation_results = validate(&[40, 20, 9], 69, 31, 0, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 9], 69, 31, 0, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -492,6 +506,10 @@ mod tests {
             }],
         );
 
+        // Not applicable for CSB
+        let validation_results = validate(CSB, &[40, 20, 9], 69, 31, 0, 100)?;
+        assert!(validation_results.errors.is_empty());
+
         Ok(())
     }
 
@@ -499,11 +517,11 @@ mod tests {
     #[test]
     fn test_w202() -> Result<(), DataError> {
         // < 3% of invalid votes
-        let validation_results = validate(&[40, 20, 11], 71, 0, 29, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 11], 71, 0, 29, 100)?;
         assert!(validation_results.errors.is_empty());
 
         // == 3% of invalid votes
-        let validation_results = validate(&[40, 20, 10], 70, 0, 30, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 10], 70, 0, 30, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -514,7 +532,7 @@ mod tests {
         );
 
         // > 3% of invalid votes
-        let validation_results = validate(&[40, 20, 9], 69, 0, 31, 100)?;
+        let validation_results = validate(GSB, &[40, 20, 9], 69, 0, 31, 100)?;
         assert_eq!(
             validation_results.warnings,
             [ValidationResult {
@@ -524,56 +542,62 @@ mod tests {
             }],
         );
 
+        // Not applicable for CSB
+        let validation_results = validate(CSB, &[40, 20, 9], 69, 0, 31, 100)?;
+        assert!(validation_results.errors.is_empty());
+
         Ok(())
     }
 
     /// GSB CSO, GSB DSO, CSB | W.204: 'Aantal kiezers en stemmen': Totaal aantal uitgebrachte stemmen leeg of 0
     #[test]
     fn test_w204() -> Result<(), DataError> {
-        let validation_results = validate(&[50, 30, 20], 100, 0, 0, 100)?;
+        let validation_results = validate(GSB, &[50, 30, 20], 100, 0, 0, 100)?;
         assert!(validation_results.errors.is_empty());
 
-        let validation_results = validate(&[0, 0, 0], 0, 0, 0, 0)?;
-        assert_eq!(
-            validation_results.warnings,
-            [ValidationResult {
-                code: ValidationResultCode::W204,
-                fields: vec!["votes_counts.total_votes_cast_count".into()],
-                context: None,
-            }],
-        );
+        let w204 = vec![ValidationResult {
+            code: ValidationResultCode::W204,
+            fields: vec!["votes_counts.total_votes_cast_count".into()],
+            context: None,
+        }];
+
+        let validation_results = validate(GSB, &[0, 0, 0], 0, 0, 0, 0)?;
+        assert_eq!(validation_results.warnings, w204);
+
+        // Also applies for CSB
+        let validation_results = validate(CSB, &[0, 0, 0], 0, 0, 0, 0)?;
+        assert_eq!(validation_results.warnings, w204);
 
         Ok(())
     }
 
     #[test]
     fn test_multiple() -> Result<(), DataError> {
-        let validation_results = validate(&[50, 30, 20], 99, 10, 10, 0)?;
-        assert_eq!(
-            validation_results.errors,
-            [
-                ValidationResult {
-                    code: ValidationResultCode::F202,
-                    fields: vec![
-                        "votes_counts.political_group_total_votes.0.total".into(),
-                        "votes_counts.political_group_total_votes.1.total".into(),
-                        "votes_counts.political_group_total_votes.2.total".into(),
-                        "votes_counts.total_votes_candidates_count".into(),
-                    ],
-                    context: None,
-                },
-                ValidationResult {
-                    code: ValidationResultCode::F203,
-                    fields: vec![
-                        "votes_counts.total_votes_candidates_count".into(),
-                        "votes_counts.blank_votes_count".into(),
-                        "votes_counts.invalid_votes_count".into(),
-                        "votes_counts.total_votes_cast_count".into(),
-                    ],
-                    context: None,
-                }
-            ],
-        );
+        let expect_errors = vec![
+            ValidationResult {
+                code: ValidationResultCode::F202,
+                fields: vec![
+                    "votes_counts.political_group_total_votes.0.total".into(),
+                    "votes_counts.political_group_total_votes.1.total".into(),
+                    "votes_counts.political_group_total_votes.2.total".into(),
+                    "votes_counts.total_votes_candidates_count".into(),
+                ],
+                context: None,
+            },
+            ValidationResult {
+                code: ValidationResultCode::F203,
+                fields: vec![
+                    "votes_counts.total_votes_candidates_count".into(),
+                    "votes_counts.blank_votes_count".into(),
+                    "votes_counts.invalid_votes_count".into(),
+                    "votes_counts.total_votes_cast_count".into(),
+                ],
+                context: None,
+            },
+        ];
+
+        let validation_results = validate(GSB, &[50, 30, 20], 99, 10, 10, 0)?;
+        assert_eq!(validation_results.errors, expect_errors);
         assert_eq!(
             validation_results.warnings,
             [
@@ -593,6 +617,18 @@ mod tests {
                     context: None,
                 }
             ],
+        );
+
+        // CSB does not have W.201/W.202 warnings
+        let validation_results = validate(CSB, &[50, 30, 20], 99, 10, 10, 0)?;
+        assert_eq!(validation_results.errors, expect_errors);
+        assert_eq!(
+            validation_results.warnings,
+            [ValidationResult {
+                code: ValidationResultCode::W204,
+                fields: vec!["votes_counts.total_votes_cast_count".into()],
+                context: None,
+            }],
         );
 
         Ok(())

--- a/backend/src/domain/summary.rs
+++ b/backend/src/domain/summary.rs
@@ -328,7 +328,7 @@ mod tests {
     use crate::domain::{
         committee_session::CommitteeSessionId,
         data_entry::DataEntryId,
-        election::{PGNumber, tests::election_fixture},
+        election::{CommitteeCategory, PGNumber, tests::election_fixture},
         polling_station::{
             PollingStation, PollingStationFirstSession, test_helpers::polling_stations_fixture,
         },
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_political_group_counting() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let results = vec![
             (test_ps_to_source(ps[0].clone()), results_fixture_a()),
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_adding_zero_polling_stations() {
-        let election = election_fixture(&[10, 20, 18]);
+        let election = election_fixture(CommitteeCategory::GSB, &[10, 20, 18]);
         let totals = ElectionSummary::from_results(&election, &[]).unwrap();
         assert_eq!(totals.voters_counts.total_admitted_voters_count, 0);
         assert_eq!(totals.votes_counts.total_votes_cast_count, 0);
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_adding_many_polling_stations() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20; 600]);
         let results_ps = results_fixture_a();
         let results = ps
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_too_high_polling_station_numbers() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20; 5]);
         let mut ps_results = results_fixture_a();
         ps_results.political_group_votes_mut()[0].total = 999_999_998;
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn test_invalid_polling_station_data_does_not_add() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps_results = results_fixture_a();
         let mut ps_results2 = ps_results.clone();
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_repeated_polling_stations() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let totals = ElectionSummary::from_results(
             &election,
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_missing_votes_count_political_groups_total() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn test_too_many_votes_count_political_groups_total() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -676,7 +676,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_votes_count_political_groups_total() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_invalid_votes_count_political_group_total() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_missing_political_groups() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn test_too_many_political_groups() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_political_group() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let mut ps1_result = results_fixture_a();
         let ps1_pgvote_copy = ps1_result.political_group_votes()[1].clone();
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_invalid_political_group() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -797,7 +797,7 @@ mod tests {
 
     #[test]
     fn test_invalid_number_of_candidates() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -817,7 +817,7 @@ mod tests {
 
     #[test]
     fn test_investigation() {
-        let election = election_fixture(&[2, 3]);
+        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let ps2_result = results_fixture_b();

--- a/backend/src/domain/summary.rs
+++ b/backend/src/domain/summary.rs
@@ -328,7 +328,7 @@ mod tests {
     use crate::domain::{
         committee_session::CommitteeSessionId,
         data_entry::DataEntryId,
-        election::{CommitteeCategory, PGNumber, tests::election_fixture},
+        election::{CommitteeCategory::*, PGNumber, tests::election_fixture},
         polling_station::{
             PollingStation, PollingStationFirstSession, test_helpers::polling_stations_fixture,
         },
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_political_group_counting() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let results = vec![
             (test_ps_to_source(ps[0].clone()), results_fixture_a()),
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_adding_zero_polling_stations() {
-        let election = election_fixture(CommitteeCategory::GSB, &[10, 20, 18]);
+        let election = election_fixture(GSB, &[10, 20, 18]);
         let totals = ElectionSummary::from_results(&election, &[]).unwrap();
         assert_eq!(totals.voters_counts.total_admitted_voters_count, 0);
         assert_eq!(totals.votes_counts.total_votes_cast_count, 0);
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_adding_many_polling_stations() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20; 600]);
         let results_ps = results_fixture_a();
         let results = ps
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_too_high_polling_station_numbers() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20; 5]);
         let mut ps_results = results_fixture_a();
         ps_results.political_group_votes_mut()[0].total = 999_999_998;
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn test_invalid_polling_station_data_does_not_add() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps_results = results_fixture_a();
         let mut ps_results2 = ps_results.clone();
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_repeated_polling_stations() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let totals = ElectionSummary::from_results(
             &election,
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_missing_votes_count_political_groups_total() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn test_too_many_votes_count_political_groups_total() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -676,7 +676,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_votes_count_political_groups_total() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_invalid_votes_count_political_group_total() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_missing_political_groups() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn test_too_many_political_groups() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_political_group() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let mut ps1_result = results_fixture_a();
         let ps1_pgvote_copy = ps1_result.political_group_votes()[1].clone();
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_invalid_political_group() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -797,7 +797,7 @@ mod tests {
 
     #[test]
     fn test_invalid_number_of_candidates() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
@@ -817,7 +817,7 @@ mod tests {
 
     #[test]
     fn test_investigation() {
-        let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
+        let election = election_fixture(GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let ps2_result = results_fixture_b();

--- a/backend/src/domain/validate.rs
+++ b/backend/src/domain/validate.rs
@@ -51,59 +51,63 @@ pub struct ValidationResultContext {
 #[derive(Serialize, Deserialize, ToSchema, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(deny_unknown_fields)]
 pub enum ValidationResultCode {
-    /// CSO: 'Alleen bij extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
+    /// GSB CSO: 'Alleen bij extra onderzoek B1-1': één van beide vragen is beantwoord, en de andere niet
     F101,
-    /// CSO: 'Alleen bij extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
+    /// GSB CSO: 'Alleen bij extra onderzoek B1-1': meerdere antwoorden op 1 van de vragen
     F102,
-    /// CSO: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
+    /// GSB CSO: 'Verschillen met telresultaten van het stembureau': één of beide vragen zijn niet beantwoord
     F111,
-    /// CSO: 'Verschillen met telresultaten van het stembureau': meerdere antwoorden per vraag
+    /// GSB CSO: 'Verschillen met telresultaten van het stembureau': meerdere antwoorden per vraag
     F112,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': stempassen + volmachten <> totaal toegelaten kiezers
+
+    /// GSB CSO, GSB DSO, CSB: 'Aantal kiezers en stemmen': stempassen + volmachten <> totaal toegelaten kiezers
     F201,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': E.1 t/m E.n tellen niet op naar E
+    /// GSB CSO, GSB DSO, CSB: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) E.1 t/m E.n tellen niet op naar E
     F202,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': stemmen op kandidaten + blanco stemmen + ongeldige stemmen <> totaal aantal uitgebrachte stemmen
+    /// GSB CSO, GSB DSO, CSB: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) stemmen op kandidaten + blanco stemmen + ongeldige stemmen <> totaal aantal uitgebrachte stemmen
     F203,
-    /// GSB CSO/DSO, CSB: 'Aantal kiezers en stemmen': De som van lijsttotalen (E.1 t/m E.n) is groter dan 0 en E = leeg of 0
+    /// GSB CSO, GSB DSO, CSB: 'Aantal kiezers en stemmen': De som van lijsttotalen (E.1 t/m E.n) is groter dan 0 en E = leeg of 0
     F204,
-    /// CSO: "Vergelijk D&H": (checkbox D=H is aangevinkt, maar D<>H)
+
+    /// GSB CSO, GSB DSO: "Vergelijk D&H": (Als checkbox D=H is aangevinkt) D<>H
     F301,
-    /// CSO: "Vergelijk D&H": (checkbox H>D is aangevinkt, maar H<=D)
+    /// GSB CSO, GSB DSO: "Vergelijk D&H": (Als checkbox H>D is aangevinkt) H<=D
     F302,
-    /// CSO: "Vergelijk D&H": (checkbox H<D is aangevinkt, maar H>=D)
+    /// GSB CSO, GSB DSO: "Vergelijk D&H": (Als checkbox H<D is aangevinkt) H>=D
     F303,
-    /// CSO: "Vergelijk D&H": Meerdere aangevinkt of geen enkele aangevinkt
+    /// GSB CSO, GSB DSO: "Vergelijk D&H": Meerdere aangevinkt of geen enkele aangevinkt  
     F304,
-    /// CSO: (Als D = H) I en/of J zijn ingevuld
+    /// GSB CSO, GSB DSO: (Als D = H) I en/of J zijn ingevuld
     F305,
-    /// CSO: (Als H > D) I <> H - D
+    /// GSB CSO, GSB DSO: (Als H > D) I <> H - D
     F306,
-    /// CSO: (Als H > D) J is ingevuld
+    /// GSB CSO, GSB DSO: (Als H > D) J is ingevuld
     F307,
-    /// CSO: (Als H < D) J <> D - H
+    /// GSB CSO, GSB DSO: (Als H < D) J <> D - H
     F308,
-    /// CSO: (Als H < D) I is ingevuld
+    /// GSB CSO, GSB DSO: (Als H < D) I is ingevuld
     F309,
-    /// CSO: (Als D <> H en verklaring voor verschil niks aangevinkt of 'ja' en 'nee' aangevinkt)
+    /// GSB CSO, GSB DSO: (Als D <> H) Verklaring voor verschil niks aangevinkt of zowel 'ja' als 'nee' aangevinkt
     F310,
-    /// CSB: totaal aantal kiezers != totaal aantal uitgebrachte stemmen - meer getelde stemmen + minder getelde stemmen
+    /// CSB: totaal aantal kiezers <> totaal aantal uitgebrachte stemmen - meer getelde stemmen + minder getelde stemmen
     F312,
-    /// CSO: 'Kandidaten en lijsttotalen': Er zijn (stemmen op kandidaten of het lijsttotaal van corresponderende E.x is groter dan 0) en het totaal aantal stemmen op een lijst = leeg of 0
+
+    /// GSB CSO, GSB DSO, CSB: 'Kandidaten en lijsttotalen': Er zijn (stemmen op kandidaten of het lijsttotaal van corresponderende E.x is groter dan 0) en het totaal aantal stemmen op een lijst = leeg of 0
     F401,
-    /// CSO: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst <> som van aantal stemmen op de kandidaten van die lijst
+    /// GSB CSO, GSB DSO, CSB: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst <> som van aantal stemmen op de kandidaten van die lijst
     F402,
-    /// CSO: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst komt niet overeen met het lijsttotaal van corresponderende E.x
+    /// GSB CSO, GSB DSO, CSB: 'Kandidaten en lijsttotalen': (Als F.401 niet getoond wordt) Totaal aantal stemmen op een lijst komt niet overeen met het lijsttotaal van corresponderende E.x
     F403,
 
+    /// GSB CSO, GSB DSO, CSB: (Bij tweede invoer) Niet alle ingevoerde waardes van de tweede invoer zijn gelijk aan die van de eerste invoer
     W001,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': Aantal blanco stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
+    /// GSB CSO, GSB DSO: 'Aantal kiezers en stemmen': Aantal blanco stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
     W201,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': Aantal ongeldige stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
+    /// GSB CSO, GSB DSO: 'Aantal kiezers en stemmen': Aantal ongeldige stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
     W202,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
+    /// GSB CSO, GSB DSO: 'Aantal kiezers en stemmen': Verschil tussen totaal aantal toegelaten kiezers en totaal aantal uitgebrachte stemmen is groter dan of gelijk aan 2% en groter dan of gelijk aan 15
     W203,
-    /// CSO/DSO: 'Aantal kiezers en stemmen': Totaal aantal uitgebrachte stemmen leeg of 0
+    /// GSB CSO, GSB DSO, CSB: 'Aantal kiezers en stemmen': Totaal aantal uitgebrachte stemmen leeg of 0
     W204,
     /// CSB: 'Aantal kiezers en stemmen': Aantal kiesgerechtigden = leeg of 0
     W205,

--- a/backend/src/infra/pdf_gen/typst_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_tests.rs
@@ -95,7 +95,7 @@ async fn it_generates_a_pdf_with_unsupported_chars() {
 
 #[test(tokio::test)]
 async fn it_generates_a_pdf_with_polling_stations() {
-    let election = election_fixture(&[2, 3]);
+    let election = election_fixture(CommitteeCategory::GSB, &[2, 3]);
     let committee_session = committee_session_fixture(election.id);
     let summary = ElectionSummary::from_results(&election, &[]).unwrap();
 

--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -235,7 +235,7 @@ test.describe("full data entry flow", () => {
 
     await expect(votersAndVotesPage.feedbackHeader).toBeFocused();
     await expect(votersAndVotesPage.warning).toContainText("W.203");
-    await expect(votersAndVotesPage.warning).toContainText("Controleer D en H");
+    await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
     await votersAndVotesPage.checkAcceptErrorsAndWarnings();
     await votersAndVotesPage.next.click();
 
@@ -312,7 +312,7 @@ test.describe("full data entry flow", () => {
 
     await expect(votersAndVotesPage.feedbackHeader).toBeFocused();
     await expect(votersAndVotesPage.warning).toContainText("W.203");
-    await expect(votersAndVotesPage.warning).toContainText("Controleer D en H");
+    await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
     await votersAndVotesPage.checkAcceptErrorsAndWarnings();
     await votersAndVotesPage.next.click();
 
@@ -381,7 +381,7 @@ test.describe("full data entry flow", () => {
     await expect(votersAndVotesPage.fieldset).toBeVisible();
     await expect(votersAndVotesPage.feedbackHeader).toBeFocused();
     await expect(votersAndVotesPage.warning).toContainText("W.201");
-    await expect(votersAndVotesPage.warning).toContainText("Controleer F");
+    await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
 
     // accept the warning
     await votersAndVotesPage.checkAcceptErrorsAndWarnings();
@@ -505,7 +505,7 @@ test.describe("full data entry flow", () => {
     await expect(checkAndSavePage.summaryListItemVotersAndVotes).toHaveText([
       "F.202 Controleer je antwoorden",
       "F.203 Controleer je antwoorden",
-      "W.203 Controleer D en H",
+      "W.203 Controleer je antwoorden",
     ]);
     await expect(checkAndSavePage.summaryListItemPoliticalGroupCandidateVotes1).toHaveText([
       "F.402 Controleer ingevoerde aantallen",
@@ -800,7 +800,7 @@ test.describe("errors and warnings", () => {
     await expect(votersAndVotesPage.fieldset).toBeVisible();
     await expect(votersAndVotesPage.feedbackHeader).toBeFocused();
     await expect(votersAndVotesPage.warning).toContainText("W.203");
-    await expect(votersAndVotesPage.warning).toContainText("Controleer D en H");
+    await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
     await expect(votersAndVotesPage.error).toBeHidden();
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeVisible();
 
@@ -857,7 +857,7 @@ test.describe("errors and warnings", () => {
     await expect(votersAndVotesPage.fieldset).toBeVisible();
     await expect(votersAndVotesPage.feedbackHeader).toBeFocused();
     await expect(votersAndVotesPage.warning).toContainText("W.203");
-    await expect(votersAndVotesPage.warning).toContainText("Controleer D en H");
+    await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
 
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeVisible();
 
@@ -867,7 +867,7 @@ test.describe("errors and warnings", () => {
     await votersAndVotesPage.proxyCertificateCount.press("Tab");
     await expect(votersAndVotesPage.fieldset).toBeVisible();
     await expect(votersAndVotesPage.warning).toContainText("W.203");
-    await expect(votersAndVotesPage.warning).toContainText("Controleer D en H");
+    await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
 
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeHidden();
   });

--- a/frontend/e2e-tests/tests/data-entry/data-entry.error.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.error.model.e2e.ts
@@ -347,7 +347,7 @@ test.describe("Data entry model test - errors", () => {
             const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
             expect(votersVotesFields).toStrictEqual({ voters, votes: votesWarning });
             await expect(votersAndVotesPage.warning).toContainText("W.201");
-            await expect(votersAndVotesPage.warning).toContainText("Controleer F");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
           },
           unsavedChangesModalChangedToError: async () => {
             await expect(votersAndVotesPage.unsavedChangesModal.heading).toBeVisible();

--- a/frontend/e2e-tests/tests/data-entry/data-entry.warning.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.warning.model.e2e.ts
@@ -307,33 +307,33 @@ test.describe("Data entry model test - warnings", () => {
           },
           votersVotesPageWarningSubmitted: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeChecked();
           },
           votersVotesPageChangedToWarningSubmitted: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeChecked();
           },
           votersVotesPageWarningAccepted: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeChecked();
           },
           votersVotesPageWarningUnaccepted: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeChecked();
           },
           votersVotesPageWarningReminder: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeChecked();
             await expect(votersAndVotesPage.acceptErrorsAndWarningsReminder).toBeVisible();
           },
           votersVotesPageWarningCorrected: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeHidden();
             const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
             expect(votersVotesFields).toStrictEqual({ voters, votes: votesValid });
@@ -364,7 +364,7 @@ test.describe("Data entry model test - warnings", () => {
           },
           votersVotesPageAfterResumeChangedToWarning: async () => {
             await expect(votersAndVotesPage.fieldset).toBeVisible();
-            await expect(votersAndVotesPage.warning).toContainText("Controleer GW.202");
+            await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoordenW.202");
             await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeChecked();
             const votersVotesFields = await votersAndVotesPage.getVotersAndVotesCounts();
             expect(votersVotesFields).toStrictEqual({ voters, votes: votesWarning });

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -230,7 +230,7 @@ test.describe("resume data entry flow", () => {
       };
       await votersAndVotesPage.fillInPageAndClickNext(voters, votes);
       await expect(votersAndVotesPage.warning).toContainText("W.201");
-      await expect(votersAndVotesPage.warning).toContainText("Controleer F");
+      await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
 
       await votersAndVotesPage.abortInput.click();
 
@@ -520,7 +520,7 @@ test.describe("resume data entry flow", () => {
       };
       await votersAndVotesPage.fillInPageAndClickNext(voters, votes);
       await expect(votersAndVotesPage.warning).toContainText("W.201");
-      await expect(votersAndVotesPage.warning).toContainText("Controleer F");
+      await expect(votersAndVotesPage.warning).toContainText("Controleer je antwoorden");
 
       await votersAndVotesPage.abortInput.click();
 

--- a/frontend/src/components/ui/Feedback/Feedback.stories.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.stories.tsx
@@ -15,13 +15,19 @@ const meta = {
       options: validationResultCodes,
       control: { type: "multi-select" },
     },
+    election: {
+      options: ["GSB", "CSB"],
+      mapping: {
+        GSB: electionMockData,
+        CSB: csbElectionMockData,
+      },
+    },
     type: {
       options: ["error", "warning"],
     },
     userRole: {
       options: roleValues,
     },
-    election: { table: { disable: true } },
   },
 } satisfies Meta<typeof Feedback>;
 

--- a/frontend/src/components/ui/Feedback/Feedback.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.tsx
@@ -4,7 +4,7 @@ import { t, tx } from "@/i18n/translate";
 import type { Election, Role, ValidationResult } from "@/types/generated/openapi";
 import type { AlertType, FeedbackId } from "@/types/ui";
 import { cn } from "@/utils/classnames";
-import { isAdministrator, isCoordinator } from "@/utils/role";
+import { isAdministrator, isCoordinator, isTypist } from "@/utils/role";
 import { getTranslations } from "@/utils/ValidationResults";
 import { AlertIcon } from "../Icon/AlertIcon";
 import cls from "./Feedback.module.css";
@@ -47,7 +47,11 @@ export function Feedback({ id, type, election, validationResults, userRole, shou
   }
 
   const actionsGrouped = role === "typist" && feedbackList.every((item) => item.actions === undefined);
-  const defaultActions = tx(`feedback.${role}_actions`);
+  // Only show default actions for typists (all feedback types, all categories) and coordinators (error, GSB only).
+  const defaultActions =
+    isTypist(userRole) || (role === "coordinator" && type === "error" && election.committee_category === "GSB")
+      ? tx(`feedback.${role}_actions`)
+      : undefined;
 
   useEffect(() => {
     if (shouldFocus) {
@@ -57,20 +61,24 @@ export function Feedback({ id, type, election, validationResults, userRole, shou
 
   return (
     <article id={id} className={cn(cls.feedback, cls[type])}>
-      {feedbackList.map((feedback, index) => (
-        <div key={`feedback-${feedback.codes.join("-")}`} className={cls.item}>
-          <header>
-            <AlertIcon type={type} />
-            <h3 tabIndex={-1} ref={index === 0 ? feedbackHeader : undefined} className="feedback-header">
-              {feedback.title}
-            </h3>
-            <span>{feedback.codes.join(", ")}</span>
-          </header>
-          {feedback.content && <div className={cls.content}>{feedback.content}</div>}
-          {!actionsGrouped && <div className={cls.actions}>{feedback.actions ?? defaultActions}</div>}
-        </div>
-      ))}
-      {actionsGrouped && (
+      {feedbackList.map((feedback, index) => {
+        const actions = feedback.actions ?? defaultActions;
+
+        return (
+          <div key={`feedback-${feedback.codes.join("-")}`} className={cls.item}>
+            <header>
+              <AlertIcon type={type} />
+              <h3 tabIndex={-1} ref={index === 0 ? feedbackHeader : undefined} className="feedback-header">
+                {feedback.title}
+              </h3>
+              <span>{feedback.codes.join(", ")}</span>
+            </header>
+            {feedback.content && <div className={cls.content}>{feedback.content}</div>}
+            {!actionsGrouped && actions !== undefined && <div className={cls.actions}>{actions}</div>}
+          </div>
+        );
+      })}
+      {actionsGrouped && defaultActions && (
         <div className={cls.actions}>
           {feedbackList.length > 1 && (
             <h3>
@@ -79,7 +87,7 @@ export function Feedback({ id, type, election, validationResults, userRole, shou
               })}
             </h3>
           )}
-          {tx(`feedback.${role}_actions`)}
+          {defaultActions}
         </div>
       )}
     </article>

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -216,7 +216,6 @@ describe("Test CheckAndSaveForm", () => {
         },
       },
     };
-
     overrideServerClaimDataEntryResponse({
       formState: mockFormState,
       results: getInitialValues(),
@@ -226,11 +225,9 @@ describe("Test CheckAndSaveForm", () => {
 
     expect(await screen.findByRole("button", { name: "Afronden" })).toBeInTheDocument();
 
-    const summaryList = screen.findByTestId(`save-form-summary-list-voters_votes_counts`);
-
+    const summaryList = screen.findByTestId("save-form-summary-list-voters_votes_counts");
     expect(summaryList).toBeDefined();
-    expect(within(await summaryList).getByText("Controleer je antwoorden")).toBeInTheDocument();
-    expect(within(await summaryList).getByText("Controleer D en H")).toBeInTheDocument();
+    expect(within(await summaryList).getAllByText("Controleer je antwoorden")).toHaveLength(2);
   });
 
   describe("CheckAndSaveForm accept warnings", () => {

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -216,6 +216,7 @@ describe("Test CheckAndSaveForm", () => {
         },
       },
     };
+
     overrideServerClaimDataEntryResponse({
       formState: mockFormState,
       results: getInitialValues(),
@@ -226,6 +227,7 @@ describe("Test CheckAndSaveForm", () => {
     expect(await screen.findByRole("button", { name: "Afronden" })).toBeInTheDocument();
 
     const summaryList = screen.findByTestId("save-form-summary-list-voters_votes_counts");
+
     expect(summaryList).toBeDefined();
     expect(within(await summaryList).getAllByText("Controleer je antwoorden")).toHaveLength(2);
   });

--- a/frontend/src/features/data_entry/components/voters_and_votes/VotersAndVotesForm.test.tsx
+++ b/frontend/src/features/data_entry/components/voters_and_votes/VotersAndVotesForm.test.tsx
@@ -405,7 +405,7 @@ describe("Test VotersAndVotesForm", () => {
       await user.click(submitButton);
 
       const feedbackMessage = [
-        "Controleer F",
+        "Controleer je antwoorden",
         "W.201",
         "Heb je iets niet goed overgenomen? Herstel de fout en ga verder.",
         "Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.",
@@ -496,7 +496,7 @@ describe("Test VotersAndVotesForm", () => {
       await user.click(submitButton);
 
       const feedbackMessage = [
-        "Controleer F",
+        "Controleer je antwoorden",
         "W.201",
         "Heb je iets niet goed overgenomen? Herstel de fout en ga verder.",
         "Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.",
@@ -538,7 +538,7 @@ describe("Test VotersAndVotesForm", () => {
       await user.click(submitButton);
 
       const feedbackMessage = [
-        "Controleer G",
+        "Controleer je antwoorden",
         "W.202",
         "Heb je iets niet goed overgenomen? Herstel de fout en ga verder.",
         "Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.",
@@ -577,7 +577,7 @@ describe("Test VotersAndVotesForm", () => {
       await user.click(submitButton);
 
       const feedbackMessage = [
-        "Controleer D en H",
+        "Controleer je antwoorden",
         "W.203",
         "Heb je iets niet goed overgenomen? Herstel de fout en ga verder.",
         "Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.",
@@ -615,7 +615,7 @@ describe("Test VotersAndVotesForm", () => {
       await user.click(submitButton);
 
       const feedbackMessage = [
-        "Controleer H",
+        "Controleer je antwoorden",
         "W.204",
         "Heb je iets niet goed overgenomen? Herstel de fout en ga verder.",
         "Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.",
@@ -739,7 +739,7 @@ describe("Test VotersAndVotesForm", () => {
       ].join("");
 
       const warningFeedbackMessage = [
-        "Controleer F",
+        "Controleer je antwoorden",
         "W.201",
         "Heb je iets niet goed overgenomen? Herstel de fout en ga verder.",
         "Heb je alles gecontroleerd en komt je invoer overeen met het papier? Ga dan verder.",

--- a/frontend/src/i18n/locales/nl/feedback_CSB.json
+++ b/frontend/src/i18n/locales/nl/feedback_CSB.json
@@ -2,35 +2,31 @@
   "F201": {
     "coordinator": {
       "title": "A en B tellen niet op tot D",
-      "content": "Controleer in rubriek 3.3 (eerste zitting) of 2.3 (volgende zitting) of er een onverklaard verschil opgelost wordt als het juiste getal bij D wordt ingevuld.",
-      "actions": "<ul><li>Zo ja: herstel op papier de optelfout door bij D het juiste getal in te vullen.</li><li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F202": {
     "coordinator": {
       "title": "De stemmen op lijsten tellen niet op tot E",
-      "content": "Controleer in rubriek 3.3 (eerste zitting) of 2.3 (volgende zitting) of er een onverklaard verschil opgelost wordt als de juiste getallen bij E en H worden ingevuld.",
-      "actions": "<ul><li>Zo ja: herstel op papier de optelfout door bij E en H de juiste getallen in te vullen.</li><li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F203": {
     "coordinator": {
       "title": "E, F en G tellen niet op tot H",
-      "content": "Controleer in rubriek 3.3 (eerste zitting) of 2.3 (volgende zitting) of er een onverklaard verschil opgelost wordt als het juiste getal bij H wordt ingevuld.",
-      "actions": "<ul><li>Zo ja: herstel op papier de optelfout door bij H het juiste getal in te vullen.</li><li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F204": {
     "coordinator": {
       "title": "Het totaal aantal stemmen op kandidaten is niet ingevuld",
-      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen.",
-      "actions": ""
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F312": {
     "coordinator": {
       "title": "D is niet gelijk aan H min I plus J",
-      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau."
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F401": {
@@ -39,8 +35,7 @@
     },
     "coordinator": {
       "title": "Het totaal van de lijst is niet ingevuld",
-      "content": "Controleer of het proces-verbaal tijdens het telproces volledig is ingevuld (controleer ook E.{political_group_number} in rubriek 3.2 (eerste zitting) of 2.2 (volgende zitting)).\nKijk of het corrigeren van de fout een onverklaard verschil wegneemt in rubriek 3.3 (eerste zitting) of 2.3 (volgende zitting).",
-      "actions": "<ul><li>Zo ja: corrigeer de optelfout op het papieren proces-verbaal.</li><li>Zo nee: onderzoek wat er fout is gegaan en tel zo nodig de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F402": {
@@ -50,8 +45,7 @@
     },
     "coordinator": {
       "title": "De stemmen op kandidaten tellen niet op tot het lijsttotaal",
-      "content": "Controleer of het proces-verbaal tijdens het telproces volledig is ingevuld.\nReken de optelling in het papieren proces-verbaal na.\nKijk of het corrigeren van de fout een onverklaard verschil wegneemt in rubriek 3.3 (eerste zitting) of 2.3 (volgende zitting).",
-      "actions": "<ul><li>Zo ja: corrigeer de optelfout op het papieren proces-verbaal.</li><li>Zo nee: onderzoek wat er fout is gegaan en tel zo nodig de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "F403": {
@@ -60,8 +54,8 @@
       "content": "Als het totaal overeenkomt met het papieren proces-verbaal, controleer dan ook de waarde bij E.{political_group_number} bij <Link to=\"../voters_votes_counts\">Aantal kiezers en stemmen</Link>."
     },
     "coordinator": {
-      "title": "Controleer het totaal van de lijst en E.{political_group_number} in rubriek 3.2 (eerste zitting) of 2.2 (volgende zitting)",
-      "actions": "<ul><li>Controleer wat er fout is gegaan in rubriek 3.2 (eerste zitting) of 2.2 (volgende zitting) en herstel de fout.</li><li>Pas zo nodig rubriek 3.3.2 (eerste zitting) of 2.3.2 (volgende zitting) aan, en volg de instructies over hertellen die daar staan.</li></ul>"
+      "title": "Controleer het totaal van de lijst en E.{political_group_number} in rubriek 2.2",
+      "content": "Je kan niet verder met dit proces-verbaal. Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "W001": {
@@ -71,33 +65,22 @@
     },
     "coordinator": {
       "title": "W.001 is er alleen voor invoerders",
-      "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'.",
-      "actions": ""
+      "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'."
     }
   },
   "W204": {
-    "typist": {
-      "title": "Controleer H"
-    },
     "coordinator": {
       "title": "Het totaal aantal uitgebrachte stemmen (H) is nul",
-      "content": "Controleer of het stembureau is opgenomen in de vóór de verkiezing gepubliceerde lijst.",
-      "actions": "<ul><li>Zo ja: verklaar in het proces-verbaal van het GSB (rubriek 1.2) waarom in dit stembureau geen stemmen zijn uitgebracht.</li><li>Zo nee: verwijder het stembureau uit Abacus. Het proces-verbaal moet niet ingevoerd worden.</li></ul>"
+      "content": "Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "W205": {
-    "typist": {
-      "title": "Controleer je antwoorden"
-    },
     "coordinator": {
       "title": "Het aantal kiesgerechtigden (Z) is niet ingevuld",
       "content": "Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."
     }
   },
   "W206": {
-    "typist": {
-      "title": "Controleer je antwoorden"
-    },
     "coordinator": {
       "title": "Het aantal kiesgerechtigden (Z) is kleiner dan het aantal stempassen (A)",
       "content": "Controleer of er iets is misgegaan bij het opmaken of overdragen van het proces-verbaal van het onderliggende niveau.\nBlijft de fout? Overleg dan met het CSB over de vervolgstappen."

--- a/frontend/src/i18n/locales/nl/feedback_GSB.json
+++ b/frontend/src/i18n/locales/nl/feedback_GSB.json
@@ -143,8 +143,7 @@
     },
     "coordinator": {
       "title": "W.001 is er alleen voor invoerders",
-      "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'.",
-      "actions": ""
+      "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'."
     }
   },
   "W201": {

--- a/frontend/src/i18n/locales/nl/feedback_GSB.json
+++ b/frontend/src/i18n/locales/nl/feedback_GSB.json
@@ -73,7 +73,7 @@
     "coordinator": {
       "title": "Controleer I en J",
       "content": "De getallen bij D en H zijn gelijk. Er zijn geen stemmen meer of minder geteld.",
-      "actions": "<ul><li>Herstel de fout door op papier I en J leeg te (laten) maken.</li></ul>"
+      "actions": "<ul><li>Herstel de fout door op papier I en/of J leeg te (laten) maken.</li></ul>"
     }
   },
   "F306": {
@@ -148,27 +148,18 @@
     }
   },
   "W201": {
-    "typist": {
-      "title": "Controleer F"
-    },
     "coordinator": {
       "title": "Het aantal blanco stemmen (F) is erg hoog",
       "actions": "<ul><li>Hertel de blanco stemmen of geef een verklaring voor het hoge aantal.</li><li>Geef in elk geval aan wat je hebt gedaan in het proces-verbaal van het GSB (rubriek 1.2).</li></ul>"
     }
   },
   "W202": {
-    "typist": {
-      "title": "Controleer G"
-    },
     "coordinator": {
       "title": "Het aantal ongeldige stemmen (G) is erg hoog",
       "actions": "<ul><li>Hertel de ongeldige stemmen of geef een verklaring voor het hoge aantal.</li><li>Geef in elk geval aan wat je hebt gedaan in het proces-verbaal van het GSB (rubriek 1.2).</li></ul>"
     }
   },
   "W203": {
-    "typist": {
-      "title": "Controleer D en H"
-    },
     "coordinator": {
       "title": "Groot verschil tussen D en H",
       "content": "Er is een groot verschil tussen het aantal toegelaten kiezers (D) en het aantal uitgebrachte stemmen (H).",
@@ -176,9 +167,6 @@
     }
   },
   "W204": {
-    "typist": {
-      "title": "Controleer H"
-    },
     "coordinator": {
       "title": "Het totaal aantal uitgebrachte stemmen (H) is nul",
       "content": "Controleer of het stembureau is opgenomen in de vóór de verkiezing gepubliceerde lijst.",


### PR DESCRIPTION
Resolves #3171

Based on the changes made in https://github.com/kiesraad/abacus-documentatie/pull/54

Changes in this PR:
- Updated docstrings https://github.com/kiesraad/abacus/commit/c162d8d8b3dd0d404a32bb366ac3cf06b8f05387
  - Includes model
  - Some title updates
- Update feedback https://github.com/kiesraad/abacus/commit/d5fdc20f60922d7b9c30737386b5351d12d12f53 / https://github.com/kiesraad/abacus/commit/938ff5953be2ea17d342803759e951ddd08260fd
  - CSB feedback copy updated
  - GSB feedback
    - Title removed for W201 - W204, defaults to "Controleer je antwoorden" so warnings get merged in display
    - Minor action change for F305 to align with documentation
    - Updated tests accordingly
  - Feedback component
    - Only show default actions (=handelingsperspectieven) for typists (all feedback types, all categories) and coordinators (error, GSB only).
    - Story: added election selector so you can see feedback based on GSB or CSB
- Trigger rules for the right model https://github.com/kiesraad/abacus/commit/859076ba077a51babcd0e5e45449308f997e1031
  - `election_fixture` now accept `committee_category` so we can test other election types
  - Rules which are implemented in shared structs, now have explicit tests to check that they trigger in the correct committee category, see changelog below:

Changelog validation rules:
- Removed W203 from `GSBResults`

| Validation code | Model/file                          | Change |
|-----------------|-------------------------------------|--------|
| F101/F102       | ExtraInvestigation                  | Added if-statement to trigger for GSB only<br>Tests converted to matrix, included case to check it doesn't trigger for CSB |
| F111/F112       | CountingDifferencesPollingStation   | Added if-statement to trigger for GSB only<br>Tests converted to matrix, included case to check it doesn't trigger for CSB |
| F201            | VotersCounts                        | Should trigger for all models<br >Added case to check it also triggers for CSB |
| F202/F203/F204  | VotesCounts                         | Should trigger for all models<br>Added case to check it also triggers for CSB |
| F301 - F310     | DifferencesCounts                   | Should only trigger for GSB CSO/DSO. This file is only included in CSO (and later DSO) models, so left as-is. |
| F312            | GSBDifferencesCounts                | Should only trigger for CSB. This file is only included in the GSB model, so left as-is. |
| F401 - F403     | CommonPollingStationResults and GSBResults | Should trigger for all models<br>Each model has their own (identical) implementation, since these rules are placed at the model root. Left as-is |
| W001            | domain/data_entry.rs                | Should trigger for all models, left as-is |
| W201/W202       | VotesCounts                         | Added if-statement to trigger for GSB only<br>Added test case for both rules to check it doesn't trigger for CSB |
| W203            | CommonPollingStationResults         | Should only trigger for CSB. This file is only included in the GSB model, so left as-is. |
| W204            | VotesCounts                         | Should trigger for all models<br>Added case to check it also triggers for CSB |
| W205/W206       | GSBResults                          | Should only trigger for CSB. This file is only included in the GSB model, so left as-is. |