### PR TITLE
Apply Clippy lints to all crates in workspace

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -102,16 +102,19 @@ test-log.workspace = true
 [build-dependencies]
 memory-serve = { version = "2.1.0", optional = true }
 
-[lints.rust]
+[workspace.lints.rust]
 unsafe_code = "forbid"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
-[lints.clippy]
+[workspace.lints.clippy]
 cast_possible_truncation = "deny"
 cognitive_complexity = "warn"
 too_many_lines = "warn"
 unused_async = "warn"
 unwrap_used = "warn"
+
+[lints]
+workspace = true
 
 [profile.release]
 overflow-checks = true

--- a/backend/apportionment/Cargo.toml
+++ b/backend/apportionment/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tracing.workspace = true
 

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -12,6 +12,7 @@ pub use structs::{
 };
 
 /// Candidate nomination
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     input: &CandidateNominationInput<'a, L>,
 ) -> Result<CandidateNominationResult<'a, L>, ApportionmentError> {

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -51,6 +51,7 @@ mod tests {
     };
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_apportionment_process() {
         let input = seat_assignment_fixture_with_default_50_candidates(
             15,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -19,6 +19,7 @@ pub use structs::{
 };
 
 /// Seat assignment
+#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub(crate) fn seat_assignment<T: ApportionmentInput>(
     input: &T,
 ) -> Result<SeatAssignmentResult<T::List>, ApportionmentError> {

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -386,6 +386,7 @@ fn step_assign_remainder_using_highest_averages<'a, LN: Copy + Debug + Eq + 'a>(
 
 /// Assign the next residual seat, and return which group that seat was assigned to.  
 /// This assignment is done according to the rules for elections with less than 19 seats.
+#[allow(clippy::cognitive_complexity)]
 fn step_assign_remainder_using_largest_remainder<LN: Copy + Debug + Eq>(
     standings: &[ListStanding<LN>],
     residual_seats: u32,

--- a/backend/pdf_gen/Cargo.toml
+++ b/backend/pdf_gen/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 embed-typst = ["dep:typst", "dep:typst-pdf"]
 


### PR DESCRIPTION
I noticed that Sigrid found a long function that did not have an Clippy lint allow annotation, and it turns out Clippy lints were not configured for the apportionment and pdf_gen crates. This PR fixes that. 