### PR TITLE
Add note to GSB DataEntryStructure

### DIFF
--- a/frontend/src/components/data_entry/subsections/MessageSubsection.module.css
+++ b/frontend/src/components/data_entry/subsections/MessageSubsection.module.css
@@ -1,4 +1,8 @@
 .message {
   color: var(--gray-900);
   width: 37.5rem;
+
+  &.dimmed {
+    color: var(--gray-400);
+  }
 }

--- a/frontend/src/components/data_entry/subsections/MessageSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/MessageSubsection.tsx
@@ -7,5 +7,5 @@ export interface MessageSubsectionProps {
 }
 
 export function MessageSubsectionComponent({ subsection }: MessageSubsectionProps) {
-  return <p className={cls.message}>{subsection.message}</p>;
+  return <p className={`${cls.message} ${subsection.variant ? cls[subsection.variant] : ""}`}>{subsection.message}</p>;
 }

--- a/frontend/src/i18n/locales/nl/differences_counts.json
+++ b/frontend/src/i18n/locales/nl/differences_counts.json
@@ -1,6 +1,7 @@
 {
   "form_title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
   "short_title": "Verschillen D & H",
+  "checkbox_message": "De vinkvraag op deze pagina in het proces-verbaal vul je niet in Abacus in.",
   "validation_error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
   "section_number": {
     "CSOFirstSession": "B1-3.3",

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -15,6 +15,7 @@ export interface HeadingSubsection {
 
 export interface MessageSubsection {
   type: "message";
+  variant?: "dimmed";
   message: string;
 }
 

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.GSB.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.GSB.snap
@@ -96,6 +96,11 @@
     "short_title": "Verschillen D & H",
     "subsections": [
       {
+        "message": "De vinkvraag op deze pagina in het proces-verbaal vul je niet in Abacus in.",
+        "type": "message",
+        "variant": "dimmed",
+      },
+      {
         "headers": [
           "Veld",
           "Geteld aantal",

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -179,7 +179,14 @@ export const createDifferencesSection = (model: DataEntryModel): DataEntrySectio
       id: "differences_counts",
       title: t("differences_counts.form_title"),
       short_title: t("differences_counts.short_title"),
-      subsections: [differencesInputGrid],
+      subsections: [
+        {
+          type: "message",
+          variant: "dimmed",
+          message: t("differences_counts.checkbox_message"),
+        },
+        differencesInputGrid,
+      ],
     };
   }
 


### PR DESCRIPTION
Based on this [Figma comment](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp?node-id=17951-11681&m=dev#1685694167)

Added [this note](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=20473-15524&m=dev) to the GSB DataEntryStructure. 

The snapshot file indicates the changes to the form. Since no other snapshot files have changes, only GSB is adjusted. 

Screenshot:
<img width="1094" height="598" alt="image" src="https://github.com/user-attachments/assets/d87b5ce2-7457-4cbc-8501-96827afacee4" />
