### PR TITLE
Skip cases in differential fuzzer that will need resolving

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
@@ -1,7 +1,9 @@
 #![no_main]
 
 use apportionment::{ApportionmentError, CandidateVotes, process};
-use apportionment_fuzz::{FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log};
+use apportionment_fuzz::{
+    FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log,
+};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -6,8 +6,8 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use apportionment::{ApportionmentError, CandidateVotes, process};
-use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
+use apportionment::{process, ApportionmentError, CandidateVotes};
+use apportionment_fuzz::{get_total_seats, init_tracing, run_with_log, FuzzedApportionmentInput};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
 
@@ -122,6 +122,10 @@ fuzz_target!(
         init_tracing();
     },
     |data: FuzzedApportionmentInput| {
+        // Skip cases with zero total votes cast
+        if data.list_votes.iter().map(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>()).sum::<u32>() == 0 {
+            return
+        }
         // Skip cases where any party has zero total votes
         //if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() == 0) {
         //    return;

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -99,6 +99,8 @@ fn report_mismatch(
     for line in osv2020_log {
         eprintln!("[osv2020] {line}");
     }
+    eprintln!("\n=== Conclusion ===");
+    eprintln!("{message}");
     panic!("{message}");
 }
 

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -85,22 +85,20 @@ fn report_mismatch(
     osv2020_log: &[String],
     message: &str,
 ) -> ! {
-    eprintln!("=== Conclusion ===");
-    eprintln!("{message}");
-    eprintln!("=== Input ===");
-    eprintln!("{:#?}", data);
-    eprintln!("=== Abacus ===");
+    eprintln!("\n=== Abacus ===");
     eprintln!("{abacus}");
     for line in abacus_log.lines() {
         eprintln!("[abacus] {line}");
     }
-    eprintln!("=== OSV2020 ===");
+    eprintln!("\n=== OSV2020 ===");
     eprintln!("{osv2020}");
     for line in osv2020_log {
         eprintln!("[osv2020] {line}");
     }
     eprintln!("\n=== Conclusion ===");
     eprintln!("{message}");
+    eprintln!("=== Input ===");
+    eprintln!("{:#?}", data);
     panic!("{message}");
 }
 

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -148,9 +148,12 @@ fuzz_target!(
         // have the limitation that each list can get only one seat per step. So as long as Abacus assigns seats to
         // lists with zero votes, we need to skip inputs that triggers that behavior in Abacus.
         // related issue: #3212
-        if data.seats < 19 && data.seats > data.list_votes.iter().filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0) ).count() as u32 {
+        let no_of_lists_with_votes = data.list_votes.iter().
+            filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0) ).count() as u32;
+        if data.seats < 19 && data.seats > no_of_lists_with_votes {
             return
         }
+        // }
         // Skip cases where any list has an absolute majority of votes
         // related issue: #3219
         if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() >  (total_votes / 2)) {

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -126,6 +126,11 @@ fuzz_target!(
         if data.list_votes.iter().map(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>()).sum::<u32>() == 0 {
             return
         }
+        // Skip cases where number of seats > number of candidates
+        let no_of_candidates = data.list_votes.iter().map(|x| x.candidate_votes.len() as u32).sum::<u32>();
+        if data.seats > no_of_candidates {
+            return
+        }
         // Skip cases where any party has zero total votes
         //if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() == 0) {
         //    return;

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -135,12 +135,8 @@ fn fuzz(data: FuzzedApportionmentInput) {
     let total_votes = data
         .list_votes
         .iter()
-        .map(|list| {
-            list.candidate_votes
-                .iter()
-                .map(|cv| cv.votes())
-                .sum::<u32>()
-        })
+        .flat_map(|list| list.candidate_votes.iter())
+        .map(|cv| cv.votes())
         .sum::<u32>();
 
     if total_votes == 0 {

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -125,7 +125,8 @@ fuzz_target!(
     },
     |data: FuzzedApportionmentInput| {
         // Skip cases with zero total votes cast
-        if data.list_votes.iter().map(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>()).sum::<u32>() == 0 {
+        let total_votes = data.list_votes.iter().map(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>()).sum::<u32>();
+        if total_votes == 0 {
             return
         }
         // Skip cases where number of seats > number of candidates
@@ -144,6 +145,10 @@ fuzz_target!(
         // have the limitation that each list can get only one seat per step. So as long as Abacus assigns seats to
         // lists with zero votes, we need to skip inputs that triggers that behavior in Abacus.
         if data.seats < 19 && data.seats > data.list_votes.iter().filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0) ).count() as u32 {
+            return
+        }
+        // Skip cases where any list has an absolute majority of votes
+        if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() >  (total_votes / 2)) {
             return
         }
         // Skip cases where any party has zero total votes

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -127,13 +127,13 @@ fuzz_target!(
             return
         }
         // Skip cases where number of seats > number of candidates
-        let no_of_candidates = data.list_votes.iter().map(|x| x.candidate_votes.len() as u32).sum::<u32>();
+        let no_of_candidates = data.list_votes.iter().map(|lv| lv.candidate_votes.len() as u32).sum::<u32>();
         if data.seats > no_of_candidates {
             return
         }
         // Skip cases where number of seats > number of candidates with votes
         let no_of_candidates_with_votes = data.list_votes.iter().
-            map(|x| x.candidate_votes.iter().filter(|y| *y.get_votes() > 0).count() as u32).sum::<u32>();
+            map(|lv| lv.candidate_votes.iter().filter(|cv| *cv.get_votes() > 0).count() as u32).sum::<u32>();
         if data.seats > no_of_candidates_with_votes {
             return
         }

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -137,6 +137,13 @@ fuzz_target!(
         if data.seats > no_of_candidates_with_votes {
             return
         }
+        // Skip cases where seats < 19 and number of seats > number of lists with votes
+        // Reason: when there are fewer than 19 seats, the first two steps in which remaining seats are assigned
+        // have the limitation that each list can get only one seat per step. So as long as Abacus assigns seats to
+        // lists with zero votes, we need to skip inputs that triggers that behavior in Abacus.
+        if data.seats < 19 && data.seats > data.list_votes.iter().filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0) ).count() as u32 {
+            return
+        }
         // Skip cases where any party has zero total votes
         //if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() == 0) {
         //    return;

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -185,11 +185,10 @@ fuzz_target!(
                         // 2. list exhaustion is applied
                         // In most (all?) cases the difference under these circumstances is caused by the fact that OSV and Abacus handle list exhaustion differently.
                         let last_osv2020_log_line = osv2020_log.last().unwrap();
-                        if last_osv2020_log_line.contains(&String::from("Conflict: Auslosung bezüglich P7.")) &&
-                        osv2020_log.iter().any(|line| line.contains("Erschöpfte Listen")) &&
-                        abacus_log.contains("assigned to another list in accordance with Article P 10 Kieswet")
-                        { }
-                        else {
+                        if last_osv2020_log_line.contains(&String::from("Conflict: Auslosung bezüglich P7."))
+                            && osv2020_log.iter().any(|line| line.contains("Erschöpfte Listen"))
+                            && abacus_log.contains("assigned to another list in accordance with Article P 10 Kieswet") {
+                        } else {
                         report_mismatch(
                             &data,
                             &format!("seats: {:?}\n{:#?}", abacus_seats, output.seat_assignment),

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -180,6 +180,16 @@ fuzz_target!(
                         }
                     }
                     Osv2020Result::Conflict => {
+                        // Accept case where OSV does drawing of lots and Abacus has allocation, when
+                        // 1. greatest averages is applied (art. P7)
+                        // 2. list exhaustion is applied
+                        // In most (all?) cases the difference under these circumstances is caused by the fact that OSV and Abacus handle list exhaustion differently.
+                        let last_osv2020_log_line = osv2020_log.last().unwrap();
+                        if last_osv2020_log_line.contains(&String::from("Conflict: Auslosung bezüglich P7.")) &&
+                        osv2020_log.iter().any(|line| line.contains("Erschöpfte Listen")) &&
+                        abacus_log.contains("assigned to another list in accordance with Article P 10 Kieswet")
+                        { }
+                        else {
                         report_mismatch(
                             &data,
                             &format!("seats: {:?}\n{:#?}", abacus_seats, output.seat_assignment),
@@ -188,6 +198,7 @@ fuzz_target!(
                             &osv2020_log,
                             "OSV2020 has conflict where Abacus has allocation",
                         );
+                        }
                     }
                 }
             }

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -6,8 +6,8 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use apportionment::{process, ApportionmentError, CandidateVotes};
-use apportionment_fuzz::{get_total_seats, init_tracing, run_with_log, FuzzedApportionmentInput};
+use apportionment::{ApportionmentError, CandidateVotes, process};
+use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
 
@@ -104,106 +104,160 @@ fn report_mismatch(
     panic!("{message}");
 }
 
-fuzz_target!(
-    init: {
-        let osv2020_wrapper_bin = std::env::var("OSV2020_WRAPPER_BIN")
-            .expect("OSV2020_WRAPPER_BIN environment variable must point to the apportionment-wrapper launcher script");
+fn init() {
+    let osv2020_wrapper_bin = std::env::var("OSV2020_WRAPPER_BIN")
+        .expect("OSV2020_WRAPPER_BIN environment variable must point to the apportionment-wrapper launcher script");
 
-        let mut child = Command::new(&osv2020_wrapper_bin)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .spawn()
-            .unwrap_or_else(|e| panic!("Failed to spawn OSV2020 wrapper process at {osv2020_wrapper_bin}: {e}"));
+    let mut child = Command::new(&osv2020_wrapper_bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap_or_else(|e| {
+            panic!("Failed to spawn OSV2020 wrapper process at {osv2020_wrapper_bin}: {e}")
+        });
 
-        let stdin = child.stdin.take().unwrap();
-        let stdout = BufReader::new(child.stdout.take().unwrap());
+    let stdin = child.stdin.take().unwrap();
+    let stdout = BufReader::new(child.stdout.take().unwrap());
 
-        OSV2020_WRAPPER.set(Mutex::new(Osv2020WrapperProcess { stdin, stdout, _child: child })).ok();
+    OSV2020_WRAPPER
+        .set(Mutex::new(Osv2020WrapperProcess {
+            stdin,
+            stdout,
+            _child: child,
+        }))
+        .ok();
 
-        init_tracing();
-    },
-    |data: FuzzedApportionmentInput| {
-        // Skip cases with zero total votes cast
-        // related issue: #3210
-        let total_votes = data.list_votes.iter().map(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>()).sum::<u32>();
-        if total_votes == 0 {
-            return
-        }
-        // Skip cases where number of seats > number of candidates
-        // related issue: #3211
-        let no_of_candidates = data.list_votes.iter().map(|lv| lv.candidate_votes.len() as u32).sum::<u32>();
-        if data.seats > no_of_candidates {
-            return
-        }
-        // Skip cases where number of seats > number of candidates on lists with votes
-        // related issue: #3212
-        let no_of_candidates_on_lists_with_votes = data.list_votes.iter().
-                    filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0)).
-                    map(|list| list.candidate_votes.len() as u32).sum::<u32>();
-        if data.seats > no_of_candidates_on_lists_with_votes {
-            return
-        }
-        // Skip cases where seats < 19 and number of seats > number of lists with votes
-        // Reason: when there are fewer than 19 seats, the first two steps in which remaining seats are assigned
-        // have the limitation that each list can get only one seat per step. So as long as Abacus assigns seats to
-        // lists with zero votes, we need to skip inputs that triggers that behavior in Abacus.
-        // related issue: #3212
-        let no_of_lists_with_votes = data.list_votes.iter().
-            filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0) ).count() as u32;
-        if data.seats < 19 && data.seats > no_of_lists_with_votes {
-            return
-        }
-        // }
-        // Skip cases where any list has an absolute majority of votes
-        // related issue: #3219
-        if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() >  (total_votes / 2)) {
-            return
-        }
-        // Skip cases where any party has zero total votes
-        //if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() == 0) {
-        //    return;
-        //}
+    init_tracing();
+}
 
-        // Convert current data structure to OSV2020 wrapper format
-        let pg_candidates: Vec<i64> = data.list_votes.iter().map(|x| x.candidate_votes.len() as i64).collect();
-        let votes: Vec<i64> = data.list_votes.iter()
-            .flat_map(|list| list.candidate_votes.iter())
-            .map(|cv| cv.votes() as i64)
-            .collect();
+fn fuzz(data: FuzzedApportionmentInput) {
+    // Skip cases with zero total votes cast
+    // related issue: #3210
+    let total_votes = data
+        .list_votes
+        .iter()
+        .map(|list| {
+            list.candidate_votes
+                .iter()
+                .map(|cv| cv.votes())
+                .sum::<u32>()
+        })
+        .sum::<u32>();
 
-        let (osv2020_result, osv2020_log) = osv2020_apportionment(data.seats.into(), &pg_candidates, &votes);
+    if total_votes == 0 {
+        return;
+    }
+    // Skip cases where number of seats > number of candidates
+    // related issue: #3211
+    let no_of_candidates = data
+        .list_votes
+        .iter()
+        .map(|lv| lv.candidate_votes.len() as u32)
+        .sum::<u32>();
 
-        let (abacus_result, abacus_log) = run_with_log(|| process(&data));
+    if data.seats > no_of_candidates {
+        return;
+    }
+    // Skip cases where number of seats > number of candidates on lists with votes
+    // related issue: #3212
+    let no_of_candidates_on_lists_with_votes = data
+        .list_votes
+        .iter()
+        .filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0))
+        .map(|list| list.candidate_votes.len() as u32)
+        .sum::<u32>();
 
-        match abacus_result {
-            Ok(ref output) => {
-                let abacus_seats = get_total_seats(&output.seat_assignment);
+    if data.seats > no_of_candidates_on_lists_with_votes {
+        return;
+    }
+    // Skip cases where seats < 19 and number of seats > number of lists with votes
+    // Reason: when there are fewer than 19 seats, the first two steps in which remaining seats are assigned
+    // have the limitation that each list can get only one seat per step. So as long as Abacus assigns seats to
+    // lists with zero votes, we need to skip inputs that triggers that behavior in Abacus.
+    // related issue: #3212
+    let no_of_lists_with_votes = data
+        .list_votes
+        .iter()
+        .filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0))
+        .count() as u32;
 
-                match osv2020_result {
-                    Osv2020Result::Allocated(osv2020_seats) => {
-                        if abacus_seats != osv2020_seats {
-                            report_mismatch(
-                                &data,
-                                &format!("seats: {:?}\n{:#?}", abacus_seats, output.seat_assignment),
-                                &abacus_log,
-                                &format!("seats: {:?}", osv2020_seats),
-                                &osv2020_log,
-                                "seat allocation mismatch",
-                            );
-                        }
+    if data.seats < 19 && data.seats > no_of_lists_with_votes {
+        return;
+    }
+
+    // Skip cases where any list has an absolute majority of votes
+    // related issue: #3219
+    if data.list_votes.iter().any(|list| {
+        list.candidate_votes
+            .iter()
+            .map(|cv| cv.votes())
+            .sum::<u32>()
+            > (total_votes / 2)
+    }) {
+        return;
+    }
+
+    // Skip cases where any party has zero total votes
+    //if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() == 0) {
+    //    return;
+    //}
+
+    // Convert current data structure to OSV2020 wrapper format
+    let pg_candidates: Vec<i64> = data
+        .list_votes
+        .iter()
+        .map(|x| x.candidate_votes.len() as i64)
+        .collect();
+
+    let votes: Vec<i64> = data
+        .list_votes
+        .iter()
+        .flat_map(|list| list.candidate_votes.iter())
+        .map(|cv| cv.votes() as i64)
+        .collect();
+
+    let (osv2020_result, osv2020_log) =
+        osv2020_apportionment(data.seats.into(), &pg_candidates, &votes);
+
+    let (abacus_result, abacus_log) = run_with_log(|| process(&data));
+
+    match abacus_result {
+        Ok(ref output) => {
+            let abacus_seats = get_total_seats(&output.seat_assignment);
+
+            match osv2020_result {
+                Osv2020Result::Allocated(osv2020_seats) => {
+                    if abacus_seats != osv2020_seats {
+                        report_mismatch(
+                            &data,
+                            &format!("seats: {:?}\n{:#?}", abacus_seats, output.seat_assignment),
+                            &abacus_log,
+                            &format!("seats: {:?}", osv2020_seats),
+                            &osv2020_log,
+                            "seat allocation mismatch",
+                        );
                     }
-                    Osv2020Result::Conflict => {
-                        // Accept case where OSV does drawing of lots and Abacus has allocation, when
-                        // 1. greatest averages is applied (art. P7)
-                        // 2. list exhaustion is applied
-                        // In most (all?) cases the difference under these circumstances is caused by the fact that OSV and Abacus handle list exhaustion differently.
-                        // related issue: #3214
-                        let last_osv2020_log_line = osv2020_log.last().unwrap();
-                        if last_osv2020_log_line.contains(&String::from("Conflict: Auslosung bezüglich P7."))
-                            && osv2020_log.iter().any(|line| line.contains("Erschöpfte Listen"))
-                            && abacus_log.contains("assigned to another list in accordance with Article P 10 Kieswet") {
-                        } else {
+                }
+                Osv2020Result::Conflict => {
+                    // Accept case where OSV does drawing of lots and Abacus has allocation, when
+                    // 1. greatest averages is applied (art. P7)
+                    // 2. list exhaustion is applied
+                    // In most (all?) cases the difference under these circumstances is caused by the fact that OSV and Abacus handle list exhaustion differently.
+                    // related issue: #3214
+                    if osv2020_log
+                        .last()
+                        .unwrap()
+                        .contains(&String::from("Conflict: Auslosung bezüglich P7."))
+                        && osv2020_log
+                            .iter()
+                            .any(|line| line.contains("Erschöpfte Listen"))
+                        && abacus_log.contains(
+                            "assigned to another list in accordance with Article P 10 Kieswet",
+                        )
+                    {
+                        //do nothing, continue
+                    } else {
                         report_mismatch(
                             &data,
                             &format!("seats: {:?}\n{:#?}", abacus_seats, output.seat_assignment),
@@ -212,26 +266,37 @@ fuzz_target!(
                             &osv2020_log,
                             "OSV2020 has conflict where Abacus has allocation",
                         );
-                        }
                     }
-                }
-            }
-            Err(e @ (ApportionmentError::DrawingOfLotsNotImplemented
-                   | ApportionmentError::AllListsExhausted
-                   | ApportionmentError::ZeroVotesCast)) => {
-                match osv2020_result {
-                    Osv2020Result::Allocated(osv2020_seats) => {
-                        report_mismatch(
-                            &data,
-                            &format!("Err({e:?})"),
-                            &abacus_log,
-                            &format!("seats: {:?}", osv2020_seats),
-                            &osv2020_log,
-                            &format!("OSV2020 has allocation where Abacus has {e:?}"),
-                        );
-                    }
-                    Osv2020Result::Conflict => {} // both agree
                 }
             }
         }
-});
+        Err(
+            e @ (ApportionmentError::DrawingOfLotsNotImplemented
+            | ApportionmentError::AllListsExhausted
+            | ApportionmentError::ZeroVotesCast),
+        ) => {
+            match osv2020_result {
+                Osv2020Result::Allocated(osv2020_seats) => {
+                    report_mismatch(
+                        &data,
+                        &format!("Err({e:?})"),
+                        &abacus_log,
+                        &format!("seats: {:?}", osv2020_seats),
+                        &osv2020_log,
+                        &format!("OSV2020 has allocation where Abacus has {e:?}"),
+                    );
+                }
+                Osv2020Result::Conflict => {} // both agree
+            }
+        }
+    }
+}
+
+fuzz_target!(
+    init: {
+        init()
+    },
+    |data: FuzzedApportionmentInput| {
+        fuzz(data)
+    }
+);

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -125,16 +125,19 @@ fuzz_target!(
     },
     |data: FuzzedApportionmentInput| {
         // Skip cases with zero total votes cast
+        // related issue: #3210
         let total_votes = data.list_votes.iter().map(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>()).sum::<u32>();
         if total_votes == 0 {
             return
         }
         // Skip cases where number of seats > number of candidates
+        // related issue: #3211
         let no_of_candidates = data.list_votes.iter().map(|lv| lv.candidate_votes.len() as u32).sum::<u32>();
         if data.seats > no_of_candidates {
             return
         }
         // Skip cases where number of seats > number of candidates with votes
+        // related issue: #3212
         let no_of_candidates_with_votes = data.list_votes.iter().
             map(|lv| lv.candidate_votes.iter().filter(|cv| *cv.get_votes() > 0).count() as u32).sum::<u32>();
         if data.seats > no_of_candidates_with_votes {
@@ -144,10 +147,12 @@ fuzz_target!(
         // Reason: when there are fewer than 19 seats, the first two steps in which remaining seats are assigned
         // have the limitation that each list can get only one seat per step. So as long as Abacus assigns seats to
         // lists with zero votes, we need to skip inputs that triggers that behavior in Abacus.
+        // related issue: #3212
         if data.seats < 19 && data.seats > data.list_votes.iter().filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0) ).count() as u32 {
             return
         }
         // Skip cases where any list has an absolute majority of votes
+        // related issue: #3219
         if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() >  (total_votes / 2)) {
             return
         }
@@ -189,6 +194,7 @@ fuzz_target!(
                         // 1. greatest averages is applied (art. P7)
                         // 2. list exhaustion is applied
                         // In most (all?) cases the difference under these circumstances is caused by the fact that OSV and Abacus handle list exhaustion differently.
+                        // related issue: #3214
                         let last_osv2020_log_line = osv2020_log.last().unwrap();
                         if last_osv2020_log_line.contains(&String::from("Conflict: Auslosung bezüglich P7."))
                             && osv2020_log.iter().any(|line| line.contains("Erschöpfte Listen"))

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -137,7 +137,7 @@ fuzz_target!(
             return
         }
         // Skip cases where number of seats > number of candidates with votes
-        // related issue: #3212
+        // related issue: #3211
         let no_of_candidates_with_votes = data.list_votes.iter().
             map(|lv| lv.candidate_votes.iter().filter(|cv| *cv.get_votes() > 0).count() as u32).sum::<u32>();
         if data.seats > no_of_candidates_with_votes {

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -131,6 +131,12 @@ fuzz_target!(
         if data.seats > no_of_candidates {
             return
         }
+        // Skip cases where number of seats > number of candidates with votes
+        let no_of_candidates_with_votes = data.list_votes.iter().
+            map(|x| x.candidate_votes.iter().filter(|y| *y.get_votes() > 0).count() as u32).sum::<u32>();
+        if data.seats > no_of_candidates_with_votes {
+            return
+        }
         // Skip cases where any party has zero total votes
         //if data.list_votes.iter().any(|list| list.candidate_votes.iter().map(|cv| cv.votes()).sum::<u32>() == 0) {
         //    return;

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -136,11 +136,12 @@ fuzz_target!(
         if data.seats > no_of_candidates {
             return
         }
-        // Skip cases where number of seats > number of candidates with votes
-        // related issue: #3211
-        let no_of_candidates_with_votes = data.list_votes.iter().
-            map(|lv| lv.candidate_votes.iter().filter(|cv| *cv.get_votes() > 0).count() as u32).sum::<u32>();
-        if data.seats > no_of_candidates_with_votes {
+        // Skip cases where number of seats > number of candidates on lists with votes
+        // related issue: #3212
+        let no_of_candidates_on_lists_with_votes = data.list_votes.iter().
+                    filter(|list| list.candidate_votes.iter().any(|cv| cv.votes() > 0)).
+                    map(|list| list.candidate_votes.len() as u32).sum::<u32>();
+        if data.seats > no_of_candidates_on_lists_with_votes {
             return
         }
         // Skip cases where seats < 19 and number of seats > number of lists with votes

--- a/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
@@ -1,7 +1,9 @@
 #![no_main]
 
 use apportionment::{CandidateVotes, process};
-use apportionment_fuzz::{FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log};
+use apportionment_fuzz::{
+    FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log,
+};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -16,8 +16,6 @@ impl SimpleCandidateVotes {
             votes,
         }
     }
-
-    pub fn get_votes(&self) -> &u32 { &self.votes }
 }
 
 impl apportionment::CandidateVotes for SimpleCandidateVotes {

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -114,9 +114,7 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
     }
 }
 
-pub fn get_total_seats(
-    result: &apportionment::SeatAssignmentResult<SimpleListVotes>,
-) -> Vec<u32> {
+pub fn get_total_seats(result: &apportionment::SeatAssignmentResult<SimpleListVotes>) -> Vec<u32> {
     result
         .final_standing
         .iter()

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -16,6 +16,8 @@ impl SimpleCandidateVotes {
             votes,
         }
     }
+
+    pub fn get_votes(&self) -> &u32 { &self.votes }
 }
 
 impl apportionment::CandidateVotes for SimpleCandidateVotes {

--- a/backend/apportionment/fuzz/src/logging.rs
+++ b/backend/apportionment/fuzz/src/logging.rs
@@ -59,7 +59,6 @@ where
 {
     ABACUS_LOG.with(|b| b.borrow_mut().clear());
     let result = f();
-    let log = ABACUS_LOG
-        .with(|b| String::from_utf8(std::mem::take(&mut *b.borrow_mut())).unwrap());
+    let log = ABACUS_LOG.with(|b| String::from_utf8(std::mem::take(&mut *b.borrow_mut())).unwrap());
     (result, log)
 }


### PR DESCRIPTION
### Scope

Skip certain inputs in our osv2020 differential fuzzer, to uncover as many differences as possible.

PR status will be draft until I've taken this approach as far as I can make it go. Step after that would be to merge the PR. Then whenever we resolve a difference between osv2020 and abacus, the related skips can be removed from the fuzzer.

See sub-issues in epic #3054 for the found differences.

### Testing
Did not find any mismatches after running the fuzzer for 10 hours with 4 jobs, covering over 15.000.000 inputs (unless that number in the output means something different):

```
#15045261: cov: 1927 ft: 8946 corp: 754 exec/s: 144 oom/timeout/crash: 0/0/0 time: 36158s job: 627 dft_time: 0
^C
==59190== libFuzzer: a child was interrupted; exiting
INFO: exiting: 72 time: 36192s
```


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->