### PR TITLE
Remove documentatie from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,3 @@ CLA.md            @kiesraad/abacus-developers @ring-ring-ring
 contributors.yml  @kiesraad/abacus-developers @ring-ring-ring
 LICENSE           @kiesraad/abacus-developers @ring-ring-ring
 README.md         @kiesraad/abacus-developers @marjoleintamis
-/frontend/        @kiesraad/abacus-developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,4 @@ CLA.md            @kiesraad/abacus-developers @ring-ring-ring
 contributors.yml  @kiesraad/abacus-developers @ring-ring-ring
 LICENSE           @kiesraad/abacus-developers @ring-ring-ring
 README.md         @kiesraad/abacus-developers @marjoleintamis
-/documentatie/    @kiesraad/abacus-developers @marjoleintamis
 /frontend/        @kiesraad/abacus-developers


### PR DESCRIPTION
The `documentatie` folder in this repository contains only developer documentation, so no need for @marjoleintamis to review changes.

Also remove `frontend` from CODEOWNERS because it has the same owner as `*`.