### PR TITLE
Add endpoint and download link for EML_NL CSB count (510d)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1922,6 +1922,105 @@
         ]
       }
     },
+    "/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_total_counts_csb": {
+      "get": {
+        "summary": "Download a zip containing a zip with the EML with CSB total counts (coordinator_csb)",
+        "operationId": "election_download_zip_total_counts_csb",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          },
+          {
+            "name": "committee_session_id",
+            "in": "path",
+            "description": "Committee session database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CommitteeSessionId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "attachment; filename=\"filename.zip\""
+              }
+            },
+            "content": {
+              "application/zip": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request cannot be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "coordinator_csb"
+            ]
+          }
+        ]
+      }
+    },
     "/api/elections/{election_id}/committee_sessions/{committee_session_id}/investigations": {
       "get": {
         "summary": "Get a list of all [crate::domain::investigation::PollingStationInvestigation]s for a committee session (coordinator_gsb)",

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -80,6 +80,7 @@ pub fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(election_download_zip_results_gsb).authorize(&[CoordinatorGSB]))
         .routes(routes!(election_download_pdf_results_gsb).authorize(&[CoordinatorGSB]))
         .routes(routes!(election_download_zip_results_csb).authorize(&[CoordinatorCSB]))
+        .routes(routes!(election_download_zip_total_counts_csb).authorize(&[CoordinatorCSB]))
 }
 
 #[derive(Debug)]
@@ -510,6 +511,38 @@ async fn generate_and_save_files_csb_election(
     Ok((eml_file, pdf_file))
 }
 
+async fn generate_and_save_files_csb_total_counts_election(
+    conn: &mut SqliteConnection,
+    audit_service: &AuditService,
+    committee_session: CommitteeSession,
+    input: ResultsInput,
+) -> Result<(Option<File>, Option<File>), APIError> {
+    // TODO: Add CSV file in epic #3053
+    let csv_file: Option<File> = None;
+    let created_at = input.created_at.with_timezone(&Utc);
+
+    let xml_string = input.as_xml()?.write_eml_root_str(true, true)?;
+    let xml_filename = input.xml_filename();
+
+    let eml = create_file(
+        conn,
+        audit_service,
+        NewFile {
+            committee_session_id: committee_session.id,
+            file_type: FileType::CsbTotalCountsEml,
+            filename: xml_filename,
+            data: xml_string.into_bytes(),
+            mime_type: EML_MIME_TYPE.to_string(),
+            created_at,
+        },
+    )
+    .await?;
+
+    let eml_file = Some(eml);
+
+    Ok((eml_file, csv_file))
+}
+
 async fn create_file(
     conn: &mut SqliteConnection,
     audit_service: &AuditService,
@@ -566,6 +599,21 @@ async fn get_existing_csb_files(
         .unwrap_or_else(Utc::now);
 
     Ok((results_pdf_file, created_at))
+}
+
+async fn get_existing_csb_total_counts_files(
+    conn: &mut SqliteConnection,
+    committee_session_id: CommitteeSessionId,
+) -> Result<(Option<File>, DateTime<Utc>), APIError> {
+    let total_counts_eml_file =
+        file_repo::get_for_session(conn, committee_session_id, FileType::CsbTotalCountsEml).await?;
+
+    let created_at = total_counts_eml_file
+        .as_ref()
+        .map(|f| f.created_at)
+        .unwrap_or_else(Utc::now);
+
+    Ok((total_counts_eml_file, created_at))
 }
 
 async fn get_files_gsb_election(
@@ -671,6 +719,55 @@ async fn get_files_csb_election(
     }
 
     Ok((results_pdf_file, created_at))
+}
+
+async fn get_files_csb_election_total_counts(
+    pool: &SqlitePool,
+    audit_service: AuditService,
+    committee_session_id: CommitteeSessionId,
+) -> Result<(Option<File>, DateTime<Utc>), APIError> {
+    let mut conn = pool.acquire().await?;
+    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+
+    // Only generate files if the committee session is completed and has all the data needed
+    if committee_session.status != CommitteeSessionStatus::Completed
+        || committee_session.start_date_time.is_none()
+        || !are_results_complete_for_committee_session(&mut conn, committee_session.id).await?
+    {
+        return Err(APIError::CommitteeSession(
+            CommitteeSessionError::InvalidCommitteeSessionStatus,
+        ));
+    }
+
+    // Check if files exist, if so, get files from database
+    let (mut eml_file, mut created_at) =
+        get_existing_csb_total_counts_files(&mut conn, committee_session.id).await?;
+    drop(conn);
+
+    // Determine if we need to generate any of the files
+    let generate_files = eml_file.is_none();
+
+    // If one of the files doesn't exist, generate all and save them to the database
+    if generate_files {
+        created_at = Utc::now();
+        let mut tx = pool.begin_immediate().await?;
+        let input = ResultsInput::new(
+            &mut tx,
+            committee_session.id,
+            created_at.with_timezone(&Local),
+        )
+        .await?;
+        (eml_file, _) = generate_and_save_files_csb_total_counts_election(
+            &mut tx,
+            &audit_service,
+            committee_session,
+            input,
+        )
+        .await?;
+        tx.commit().await?;
+    }
+
+    Ok((eml_file, created_at))
 }
 
 /// Download a zip containing a PDF for the PV and the EML with GSB election results
@@ -850,6 +947,71 @@ async fn election_download_zip_results_csb(
     tokio::spawn(async move {
         if let Some(pdf_file) = pdf_file {
             zip_writer.add_file(&pdf_file.name, &pdf_file.data).await?;
+        }
+
+        zip_writer.finish().await?;
+
+        Ok::<(), ZipResponseError>(())
+    });
+
+    Ok(zip_response)
+}
+
+/// Download a zip containing a zip with the EML with CSB total counts
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_total_counts_csb",
+    responses(
+        (
+            status = 200,
+            description = "ZIP",
+            content_type = "application/zip",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.zip\"")
+            )
+        ),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+        ("committee_session_id" = CommitteeSessionId, description = "Committee session database id"),
+    ),
+)]
+async fn election_download_zip_total_counts_csb(
+    user: User,
+    State(pool): State<SqlitePool>,
+    audit_service: AuditService,
+    Path((election_id, committee_session_id)): Path<(ElectionId, CommitteeSessionId)>,
+) -> Result<impl IntoResponse, APIError> {
+    let mut conn = pool.acquire().await?;
+
+    let committee_category =
+        committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
+    user.role().is_authorized(&committee_category)?;
+
+    let election = election_repo::get(&mut conn, election_id).await?;
+    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+    let (eml_file, created_at) =
+        get_files_csb_election_total_counts(&pool, audit_service, committee_session.id).await?;
+    drop(conn);
+
+    let download_zip_filename = download_zip_filename(
+        &election,
+        created_at.with_timezone(&Local),
+        "definitieve-documenten",
+    );
+
+    let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
+
+    tokio::spawn(async move {
+        if let Some(eml_file) = eml_file {
+            let xml_zip_filename = xml_zip_filename(&election);
+            let xml_zip = zip_single_file(&eml_file.name, &eml_file.data).await?;
+            zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
         }
 
         zip_writer.finish().await?;
@@ -1156,6 +1318,7 @@ mod tests {
             #[rustfmt::skip]
             let results = vec![
                 ("download_zip_results_csb", election_download_zip_results_csb(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
+                ("download_zip_total_counts_csb", election_download_zip_total_counts_csb(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
             ];
             results
         }

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -485,13 +485,15 @@ async fn generate_and_save_files_csb_election(
     audit_service: &AuditService,
     committee_session: CommitteeSession,
     input: ResultsInput,
-) -> Result<(Option<File>, Option<File>), APIError> {
+) -> Result<(Option<File>, Option<File>, Option<File>), APIError> {
     let eml_file: Option<File> = None;
     let created_at = input.created_at.with_timezone(&Utc);
     // TODO: Add EML file type to 520 in issue #3110
 
-    let pdf_files = input.into_pdf_file_models_csb()?;
+    let xml_string = input.as_xml()?.write_eml_root_str(true, true)?;
+    let xml_filename = input.xml_filename();
 
+    let pdf_files = input.into_pdf_file_models_csb()?;
     let pdf = create_file(
         conn,
         audit_service,
@@ -506,25 +508,7 @@ async fn generate_and_save_files_csb_election(
     )
     .await?;
 
-    let pdf_file: Option<File> = Some(pdf);
-
-    Ok((eml_file, pdf_file))
-}
-
-async fn generate_and_save_files_csb_total_counts_election(
-    conn: &mut SqliteConnection,
-    audit_service: &AuditService,
-    committee_session: CommitteeSession,
-    input: ResultsInput,
-) -> Result<(Option<File>, Option<File>), APIError> {
-    // TODO: Add CSV file in epic #3053
-    let csv_file: Option<File> = None;
-    let created_at = input.created_at.with_timezone(&Utc);
-
-    let xml_string = input.as_xml()?.write_eml_root_str(true, true)?;
-    let xml_filename = input.xml_filename();
-
-    let eml = create_file(
+    let total_counts_eml = create_file(
         conn,
         audit_service,
         NewFile {
@@ -538,9 +522,10 @@ async fn generate_and_save_files_csb_total_counts_election(
     )
     .await?;
 
-    let eml_file = Some(eml);
+    let pdf_file: Option<File> = Some(pdf);
+    let total_counts_eml_file: Option<File> = Some(total_counts_eml);
 
-    Ok((eml_file, csv_file))
+    Ok((eml_file, pdf_file, total_counts_eml_file))
 }
 
 async fn create_file(
@@ -589,31 +574,19 @@ async fn get_existing_gsb_files(
 async fn get_existing_csb_files(
     conn: &mut SqliteConnection,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, DateTime<Utc>), APIError> {
+) -> Result<(Option<File>, Option<File>, DateTime<Utc>), APIError> {
     let results_pdf_file =
         file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsPdf).await?;
-
-    let created_at = results_pdf_file
-        .as_ref()
-        .map(|f| f.created_at)
-        .unwrap_or_else(Utc::now);
-
-    Ok((results_pdf_file, created_at))
-}
-
-async fn get_existing_csb_total_counts_files(
-    conn: &mut SqliteConnection,
-    committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, DateTime<Utc>), APIError> {
     let total_counts_eml_file =
         file_repo::get_for_session(conn, committee_session_id, FileType::CsbTotalCountsEml).await?;
 
-    let created_at = total_counts_eml_file
+    let created_at = results_pdf_file
         .as_ref()
+        .or(total_counts_eml_file.as_ref())
         .map(|f| f.created_at)
         .unwrap_or_else(Utc::now);
 
-    Ok((total_counts_eml_file, created_at))
+    Ok((results_pdf_file, total_counts_eml_file, created_at))
 }
 
 async fn get_files_gsb_election(
@@ -680,7 +653,7 @@ async fn get_files_csb_election(
     pool: &SqlitePool,
     audit_service: AuditService,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, DateTime<Utc>), APIError> {
+) -> Result<(Option<File>, Option<File>, DateTime<Utc>), APIError> {
     let mut conn = pool.acquire().await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
 
@@ -695,12 +668,12 @@ async fn get_files_csb_election(
     }
 
     // Check if files exist, if so, get files from database
-    let (mut results_pdf_file, mut created_at) =
+    let (mut results_pdf_file, mut total_counts_eml_file, mut created_at) =
         get_existing_csb_files(&mut conn, committee_session.id).await?;
     drop(conn);
 
     // Determine if we need to generate any of the files
-    let generate_files = results_pdf_file.is_none();
+    let generate_files = results_pdf_file.is_none() || total_counts_eml_file.is_none();
 
     // If one of the files doesn't exist, generate all and save them to the database
     if generate_files {
@@ -712,62 +685,13 @@ async fn get_files_csb_election(
             created_at.with_timezone(&Local),
         )
         .await?;
-        (_, results_pdf_file) =
+        (_, results_pdf_file, total_counts_eml_file) =
             generate_and_save_files_csb_election(&mut tx, &audit_service, committee_session, input)
                 .await?;
         tx.commit().await?;
     }
 
-    Ok((results_pdf_file, created_at))
-}
-
-async fn get_files_csb_election_total_counts(
-    pool: &SqlitePool,
-    audit_service: AuditService,
-    committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, DateTime<Utc>), APIError> {
-    let mut conn = pool.acquire().await?;
-    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-
-    // Only generate files if the committee session is completed and has all the data needed
-    if committee_session.status != CommitteeSessionStatus::Completed
-        || committee_session.start_date_time.is_none()
-        || !are_results_complete_for_committee_session(&mut conn, committee_session.id).await?
-    {
-        return Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidCommitteeSessionStatus,
-        ));
-    }
-
-    // Check if files exist, if so, get files from database
-    let (mut eml_file, mut created_at) =
-        get_existing_csb_total_counts_files(&mut conn, committee_session.id).await?;
-    drop(conn);
-
-    // Determine if we need to generate any of the files
-    let generate_files = eml_file.is_none();
-
-    // If one of the files doesn't exist, generate all and save them to the database
-    if generate_files {
-        created_at = Utc::now();
-        let mut tx = pool.begin_immediate().await?;
-        let input = ResultsInput::new(
-            &mut tx,
-            committee_session.id,
-            created_at.with_timezone(&Local),
-        )
-        .await?;
-        (eml_file, _) = generate_and_save_files_csb_total_counts_election(
-            &mut tx,
-            &audit_service,
-            committee_session,
-            input,
-        )
-        .await?;
-        tx.commit().await?;
-    }
-
-    Ok((eml_file, created_at))
+    Ok((results_pdf_file, total_counts_eml_file, created_at))
 }
 
 /// Download a zip containing a PDF for the PV and the EML with GSB election results
@@ -932,7 +856,7 @@ async fn election_download_zip_results_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (pdf_file, created_at) =
+    let (pdf_file, _, created_at) =
         get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -995,8 +919,8 @@ async fn election_download_zip_total_counts_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (eml_file, created_at) =
-        get_files_csb_election_total_counts(&pool, audit_service, committee_session.id).await?;
+    let (_, total_counts_eml_file, created_at) =
+        get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
     let download_zip_filename = download_zip_filename(
@@ -1008,9 +932,10 @@ async fn election_download_zip_total_counts_csb(
     let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
 
     tokio::spawn(async move {
-        if let Some(eml_file) = eml_file {
+        if let Some(total_counts_eml_file) = total_counts_eml_file {
             let xml_zip_filename = xml_zip_filename(&election);
-            let xml_zip = zip_single_file(&eml_file.name, &eml_file.data).await?;
+            let xml_zip =
+                zip_single_file(&total_counts_eml_file.name, &total_counts_eml_file.data).await?;
             zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
         }
 
@@ -1239,16 +1164,24 @@ mod tests {
 
         // Files should be generated exactly once
         for _ in 1..=2 {
-            let (pdf, _) =
+            let (pdf, eml_total_counts, _) =
                 get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
                     .await
                     .expect("should return files");
             let pdf = pdf.expect("should have generated pdf");
+            let eml_total_counts =
+                eml_total_counts.expect("should have generated total counts eml");
 
             assert_eq!(pdf.name, "Model_P22-2.pdf");
             assert_eq!(pdf.id, FileId::from(1));
 
-            assert_eq!(list_event_names(&mut conn).await.unwrap(), ["FileCreated"]);
+            assert_eq!(eml_total_counts.name, "Totaaltelling_GR2024_Juinen.eml.xml");
+            assert_eq!(eml_total_counts.id, FileId::from(2));
+
+            assert_eq!(
+                list_event_names(&mut conn).await.unwrap(),
+                ["FileCreated", "FileCreated"]
+            );
         }
     }
 

--- a/backend/src/domain/file.rs
+++ b/backend/src/domain/file.rs
@@ -20,6 +20,8 @@ pub enum FileType {
     GsbOverviewPdf,
     /// CSB results PDF (Model P 22-2)
     CsbResultsPdf,
+    /// CSB total counts EML (510d)
+    CsbTotalCountsEml,
 }
 
 /// File

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -789,6 +789,160 @@ async fn test_csb_election_zip_download_results_invalid_committee_session_state(
     assert_eq!(response.status(), StatusCode::CONFLICT);
 }
 
+#[test(sqlx::test(fixtures(
+    path = "../fixtures",
+    scripts("election_8_csb_with_results", "users")
+)))]
+async fn test_csb_election_zip_download_total_counts_works(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorCSB).await;
+    let election_id = 8;
+    let committee_session_id = 801;
+
+    change_status_committee_session(
+        &addr,
+        &coordinator_cookie,
+        election_id,
+        committee_session_id,
+        "completed",
+    )
+    .await;
+    let committee_session =
+        get_election_committee_session(&addr, &coordinator_cookie, election_id).await;
+    assert_eq!(committee_session["status"], "completed");
+
+    // Update committee session details
+    let url = format!(
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}"
+    );
+    let response = reqwest::Client::new()
+        .put(&url)
+        .header("cookie", &coordinator_cookie)
+        .json(&serde_json::json!({
+            "location": "Juinen".to_string(),
+            "start_date": "2026-03-18".to_string(),
+            "start_time": "10:45".to_string(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "Unexpected response status"
+    );
+
+    let url = format!(
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_total_counts_csb"
+    );
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", &coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/zip");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    println!("{:?}", content_disposition_string);
+    // Full filename contains created date and time, so checking if the name is correct up to the date
+    // File name: definitieve-documenten_gr2024_juinen_gemeente_juinen-Ymd-HMS.zip
+    assert!(
+        &content_disposition_string[21..]
+            .starts_with("\"definitieve-documenten_gr2024_juinen_gemeente_juinen"),
+    );
+
+    let bytes = response.bytes().await.unwrap();
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
+
+    // Extract the XML archive
+    let mut reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Totaaltelling_GR2024_Juinen.zip"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+    let mut xml_zip_file = Vec::new();
+    reader.read_to_end_checked(&mut xml_zip_file).await.unwrap();
+
+    // Extract and hash the XML file
+    let xml_archive = ZipFileReader::new(xml_zip_file).await.unwrap();
+    let mut xml_reader = xml_archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        xml_reader.entry().filename().as_str().unwrap(),
+        "Totaaltelling_GR2024_Juinen.eml.xml"
+    );
+    assert!(xml_reader.entry().uncompressed_size() > 1024);
+    let mut eml_content = Vec::new();
+    xml_reader
+        .read_to_end_checked(&mut eml_content)
+        .await
+        .unwrap();
+    let eml_hash1 = sha2::Sha256::digest(&eml_content);
+
+    // Extract the XML archive from second download
+    let mut reader2 = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader2.entry().filename().as_str().unwrap(),
+        "Totaaltelling_GR2024_Juinen.zip"
+    );
+    assert!(reader2.entry().uncompressed_size() > 1024);
+    let mut xml_zip_file2 = Vec::new();
+    reader2
+        .read_to_end_checked(&mut xml_zip_file2)
+        .await
+        .unwrap();
+
+    // Extract and hash the XML file from second download
+    let xml_archive2 = ZipFileReader::new(xml_zip_file2).await.unwrap();
+    let mut xml_reader2 = xml_archive2.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        xml_reader2.entry().filename().as_str().unwrap(),
+        "Totaaltelling_GR2024_Juinen.eml.xml"
+    );
+    assert!(xml_reader2.entry().uncompressed_size() > 1024);
+    let mut eml_content2 = Vec::new();
+    xml_reader2
+        .read_to_end_checked(&mut eml_content2)
+        .await
+        .unwrap();
+    let eml_hash2 = sha2::Sha256::digest(&eml_content2);
+
+    // Check that the files inside the zip are the same
+    assert_eq!(eml_hash1, eml_hash2, "EML files should have the same hash");
+}
+
+#[test(sqlx::test(fixtures(
+    path = "../fixtures",
+    scripts("election_8_csb_with_results", "users")
+)))]
+async fn test_csb_election_zip_download_total_counts_invalid_committee_session_state(
+    pool: SqlitePool,
+) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorCSB).await;
+    let election_id = 8;
+
+    let url = format!(
+        "http://{addr}/api/elections/{election_id}/committee_sessions/801/download_zip_total_counts_csb"
+    );
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_2", "users"))))]
 async fn test_election_n_10_2_download(pool: SqlitePool) {
     let addr = serve_api(pool).await;

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
@@ -95,17 +95,28 @@ export function ElectionReportPage() {
                   : "",
               })}
               .
-              {election.committee_category === "GSB" && election.counting_method && (
+              {election.committee_category === "GSB" && (
                 <>
-                  <br />
-                  {t("election_report.there_was_counting_method", {
-                    method: t(election.counting_method).toLowerCase(),
-                  })}
-                  .
+                  {election.counting_method && (
+                    <>
+                      <br />
+                      {t("election_report.there_was_counting_method", {
+                        method: t(election.counting_method).toLowerCase(),
+                      })}
+                      .
+                    </>
+                  )}
+                  <DownloadButton
+                    icon="download"
+                    href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_results`}
+                    title={t(`election_management.${election.committee_category}.download_definitive_documents`, {
+                      sessionLabel: sessionLabel.toLowerCase(),
+                    })}
+                    subtitle={t("election_management.zip_file")}
+                  />
                 </>
               )}
               {election.committee_category === "CSB" && (
-                // TODO #2972: update hrefs for both download buttons once backend is updated
                 <>
                   <DownloadButton
                     icon="download"
@@ -120,16 +131,16 @@ export function ElectionReportPage() {
                   {/*  title={t("election_management.CSB.p_22_2_attachment.download")}*/}
                   {/*  subtitle={t("election_management.zip_file")}*/}
                   {/*/>*/}
+                  <DownloadButton
+                    icon="download"
+                    href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_total_counts_csb`}
+                    title={t(`election_management.${election.committee_category}.download_definitive_documents`, {
+                      sessionLabel: sessionLabel.toLowerCase(),
+                    })}
+                    subtitle={t("election_management.zip_file")}
+                  />
                 </>
               )}
-              <DownloadButton
-                icon="download"
-                href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_results`}
-                title={t(`election_management.${election.committee_category}.download_definitive_documents`, {
-                  sessionLabel: sessionLabel.toLowerCase(),
-                })}
-                subtitle={t("election_management.zip_file")}
-              />
             </div>
             <section className={cn(cls.reportInfoSection, "sm")}>
               <h3>{t("election_management.what_now")}?</h3>

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -137,6 +137,14 @@ export interface ELECTION_DOWNLOAD_ZIP_RESULTS_CSB_REQUEST_PARAMS {
 export type ELECTION_DOWNLOAD_ZIP_RESULTS_CSB_REQUEST_PATH =
   `/api/elections/${ElectionId}/committee_sessions/${CommitteeSessionId}/download_zip_results_csb`;
 
+// /api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_total_counts_csb
+export interface ELECTION_DOWNLOAD_ZIP_TOTAL_COUNTS_CSB_REQUEST_PARAMS {
+  election_id: ElectionId;
+  committee_session_id: CommitteeSessionId;
+}
+export type ELECTION_DOWNLOAD_ZIP_TOTAL_COUNTS_CSB_REQUEST_PATH =
+  `/api/elections/${ElectionId}/committee_sessions/${CommitteeSessionId}/download_zip_total_counts_csb`;
+
 // /api/elections/{election_id}/committee_sessions/{committee_session_id}/investigations
 export interface COMMITTEE_SESSION_INVESTIGATIONS_REQUEST_PARAMS {
   election_id: ElectionId;


### PR DESCRIPTION
Resolves #3109

- Added report endpoint `election_download_zip_total_counts_csb`
  - Added tests, including endpoint committee category test
  - Saving eml with type `CsbCountTotalsEml` 
- Added download link

File tree is:
```
definitieve-documenten_gr2024_juinen_gemeente_juinen-20260423-140029.zip
├─ Totaaltelling_GR2024_Juinen.zip
│  └─ Totaaltelling_GR2024_Juinen.eml.xml
```

<img width="568" height="307" alt="image" src="https://github.com/user-attachments/assets/3d2f2152-0953-45c9-8b78-571e0ba55ba2" />


Note: `report.rs` could be refactored in the future into a folder like apportionment and repetition could be reduced. 