### PR TITLE
Bugfix data entry scroll

### DIFF
--- a/frontend/e2e-tests/page-objects/data_entry/CandidatesListPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/CandidatesListPgObj.ts
@@ -10,6 +10,7 @@ export class CandidatesListPage extends DataEntryBasePage {
   readonly next: Locator;
   readonly total: Locator;
 
+  readonly missingTotalError: Locator;
   readonly acceptErrorsAndWarnings: Locator;
   readonly acceptErrorsAndWarningsReminder: Locator;
 
@@ -22,6 +23,10 @@ export class CandidatesListPage extends DataEntryBasePage {
     this.total = page.getByRole("textbox", { name: "Totaal" });
     this.next = page.getByRole("button", { name: "Volgende" });
 
+    this.missingTotalError = page.getByRole("alert").filter({
+      hasText:
+        "Controleer het totaal van de lijst. Is dit veld op het papieren proces-verbaal ook leeg? Dan kan je verdergaan. (F.401)",
+    });
     this.acceptErrorsAndWarnings = page.getByRole("checkbox", {
       name: "Ik heb mijn invoer gecontroleerd met het papier en correct overgenomen.",
     });

--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -872,6 +872,85 @@ test.describe("errors and warnings", () => {
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeHidden();
   });
 
+  test("scroll to top when warning/errors, unless accept checkbox or trailing error is visible", async ({
+    page,
+    pollingStation,
+  }) => {
+    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+
+    // Fill sections without errors or warnings
+    const extraInvestigationPage = new ExtraInvestigationPage(page);
+    await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
+
+    const countingDifferencesPollingStationPage = new CountingDifferencesPollingStationPage(page);
+    await countingDifferencesPollingStationPage.fillAndClickNext(noDifferences);
+
+    // Fill form with data that results in errors and a warning
+    const votersAndVotesPage = new VotersAndVotesPage(page);
+    const voters = {
+      poll_card_count: 90,
+      proxy_certificate_count: 0,
+      total_admitted_voters_count: 100,
+    };
+    const votes = {
+      political_group_total_votes: [{ number: 1, total: 100 }],
+      total_votes_candidates_count: 100,
+      blank_votes_count: 0,
+      invalid_votes_count: 0,
+      total_votes_cast_count: 50,
+    };
+    await votersAndVotesPage.fillInPageAndClickNext(voters, votes);
+
+    // Expect errors and a warning, should scroll up
+    await expect(votersAndVotesPage.error).toBeInViewport();
+    await expect(votersAndVotesPage.warning).toBeInViewport();
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeVisible();
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeInViewport();
+
+    // Change input, solving the warning
+    await votersAndVotesPage.totalVotesCastCount.fill("100");
+    // Tab press needed for page to register change after Playwright's fill()
+    await votersAndVotesPage.totalVotesCastCount.press("Tab");
+
+    // Accept errors and warnings checkbox should disappear after input change
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeHidden();
+
+    await votersAndVotesPage.next.click();
+
+    // Expect only errors, should scroll up again
+    await expect(votersAndVotesPage.error).toBeInViewport();
+    await expect(votersAndVotesPage.warning).toBeHidden();
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeVisible();
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeInViewport();
+
+    // When clicking next again without changing input, should scroll to accept errors and warnings checkbox
+    await votersAndVotesPage.next.click();
+    await expect(votersAndVotesPage.error).not.toBeInViewport();
+    await expect(votersAndVotesPage.warning).toBeHidden();
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeInViewport();
+
+    // Solve errors and continue to next page
+    await votersAndVotesPage.pollCardCount.fill("100");
+    // Tab press needed for page to register change after Playwright's fill()
+    await votersAndVotesPage.pollCardCount.press("Tab");
+    await votersAndVotesPage.next.click();
+
+    // Fill without errors
+    const differencesPage = new DifferencesPage(page);
+    await differencesPage.fillInPageAndClickNext(noRecountNoDifferencesDataEntry.differences_counts);
+
+    // Trigger error F401
+    const candidatesListPage_1 = new CandidatesListPage(page, 0, "Partijdige Partij");
+    await expect(candidatesListPage_1.fieldset).toBeVisible();
+
+    // Pressing next without entering total should show error F401
+    // That should be in viewport and browser should not scroll to top
+    await candidatesListPage_1.next.click();
+    await expect(candidatesListPage_1.missingTotalError).toBeInViewport();
+    const scrollPosition = await page.evaluate(() => window.scrollY);
+    expect(scrollPosition).toBeGreaterThan(0);
+  });
+
   test("user can accept errors", async ({ page, pollingStation }) => {
     await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
 

--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -906,6 +906,7 @@ test.describe("errors and warnings", () => {
     await expect(votersAndVotesPage.warning).toBeInViewport();
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeVisible();
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeInViewport();
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
 
     // Change input, solving the warning
     await votersAndVotesPage.totalVotesCastCount.fill("100");
@@ -922,12 +923,14 @@ test.describe("errors and warnings", () => {
     await expect(votersAndVotesPage.warning).toBeHidden();
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeVisible();
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeInViewport();
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
 
     // When clicking next again without changing input, should scroll to accept errors and warnings checkbox
     await votersAndVotesPage.next.click();
     await expect(votersAndVotesPage.error).not.toBeInViewport();
     await expect(votersAndVotesPage.warning).toBeHidden();
     await expect(votersAndVotesPage.acceptErrorsAndWarnings).toBeInViewport();
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
 
     // Solve errors and continue to next page
     await votersAndVotesPage.pollCardCount.fill("100");
@@ -947,8 +950,7 @@ test.describe("errors and warnings", () => {
     // That should be in viewport and browser should not scroll to top
     await candidatesListPage_1.next.click();
     await expect(candidatesListPage_1.missingTotalError).toBeInViewport();
-    const scrollPosition = await page.evaluate(() => window.scrollY);
-    expect(scrollPosition).toBeGreaterThan(0);
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   });
 
   test("user can accept errors", async ({ page, pollingStation }) => {

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -35,13 +35,14 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
     error,
     formRef,
     formSection,
+    isSaving,
     onSubmit,
     previousValues,
     section,
     setAcceptErrorsAndWarnings,
     setValues,
+    trailingError,
     showAcceptErrorsAndWarnings,
-    status,
   } = useDataEntryFormSection();
   const acceptCheckboxRef = useRef<HTMLInputElement>(null);
 
@@ -51,9 +52,6 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
   const bottomBarType = lastSubsection?.type === "inputGrid" ? "inputGrid" : "form";
 
   const keyboardHintText = section.id.startsWith("political_group_votes_") ? t("candidates_votes.goto_totals") : null;
-
-  // Missing totals error for political group votes form
-  const missingTotalError = formSection.errors.find("F401");
 
   // Memoize errors to prevent unnecessary focus triggers in Feedback
   const memoizedErrors = useMemo(
@@ -122,13 +120,13 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
           currentValues={currentValues}
           setValues={setValues}
           defaultProps={defaultProps}
-          missingTotalError={missingTotalError !== undefined}
+          missingTotalError={trailingError !== undefined}
         />
 
-        {missingTotalError && (
+        {trailingError && (
           <div id="missing-total-error" className={cls.missingTotalError}>
             <Alert type="error" small>
-              <p>{getTranslations(election, missingTotalError, "typist").title}</p>
+              <p>{getTranslations(election, trailingError, "typist").title}</p>
             </Alert>
           </div>
         )}
@@ -164,7 +162,7 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
           </BottomBar.Row>
         )}
         <BottomBar.Row>
-          <Button type="submit" disabled={status === "saving"}>
+          <Button type="submit" disabled={isSaving}>
             {t("next")}
           </Button>
           <KeyboardKeys keys={[KeyboardKey.Shift, KeyboardKey.Enter]} />

--- a/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
+++ b/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
@@ -49,12 +49,16 @@ export function useDataEntryFormSection() {
   if (!formSection) {
     throw new Error(`Form section ${sectionId} not found in form state`);
   }
-  const { errors, warnings, isSaved, acceptErrorsAndWarnings, hasChanges } = formSection;
+  const { errors, warnings, isSaved, isSubmitted, acceptErrorsAndWarnings, hasChanges } = formSection;
   const defaultProps = {
     errorsAndWarnings: isSaved ? mapValidationResultSetsToFields(errors, warnings) : undefined,
     errorsAndWarningsAccepted: acceptErrorsAndWarnings,
   };
 
+  // Find error code that is shown on the bottom of the form
+  const trailingError = errors.find("F401");
+
+  // Whether to show the accept errors and warnings checkbox
   const showAcceptErrorsAndWarnings = (!formSection.warnings.isEmpty() || !formSection.errors.isEmpty()) && !hasChanges;
 
   // register changes when fields change
@@ -85,27 +89,28 @@ export function useDataEntryFormSection() {
     return await onSubmitForm(sectionId, currentValues, { ...options, showAcceptErrorsAndWarnings });
   };
 
-  // scroll to top when saved
+  // scroll to top when submitted
   useEffect(() => {
-    if (isSaved || error) {
+    // If isSubmitted=true and hasChanges=false, the form was just submitted successfully
+    const formSubmitted = isSubmitted && !hasChanges;
+
+    if (!trailingError && (formSubmitted || error)) {
       window.scrollTo(0, 0);
     }
-  }, [isSaved, error]);
+  }, [isSubmitted, error, hasChanges, trailingError]);
 
   return {
     error,
     formRef,
     onSubmit,
     previousValues,
-    results,
     currentValues,
-    dataEntryStructure,
     formSection,
     setValues,
-    status,
     setAcceptErrorsAndWarnings,
     defaultProps,
     showAcceptErrorsAndWarnings,
+    trailingError,
     isSaving: status === "saving",
     election,
     section,


### PR DESCRIPTION
Resolves #3224

This PR fixes the scrolling behaviour for the data entry form, specifically when having validation errors again on the second submit. See reproduction steps in linked issue.

Changes:
- Added e2e test which checks the behaviour including what is in the viewport
- Moved check for F401 to `useDataEntryFormSection` as `trailingError`, so it can be used in the hook that scrolls to top
- Removed `dataEntryStructure`/`results`/`status` from  `useDataEntryFormSection` return type since they were not used