### PR TITLE
Implement generating results EML for CSB

### DIFF
--- a/backend/apportionment/src/candidate_nomination/structs.rs
+++ b/backend/apportionment/src/candidate_nomination/structs.rs
@@ -17,7 +17,7 @@ pub struct ListCandidateNomination<'a, T: ListVotes> {
 }
 
 /// Contains the preference threshold as a percentage and as a fraction of the number of votes.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct PreferenceThreshold {
     /// Preference threshold as a percentage (0 to 100)
     pub percentage: u64,
@@ -25,8 +25,8 @@ pub struct PreferenceThreshold {
     pub number_of_votes: Fraction,
 }
 
-/// The result of the candidate nomination procedure.  
-/// This contains the preference threshold and percentage that was used.  
+/// The result of the candidate nomination procedure.
+/// This contains the preference threshold and percentage that was used.
 /// It contains a list of all chosen candidates.
 /// It also contains the preferential nomination of candidates, the remaining
 /// nomination of candidates and the final ranking of candidates for each list.

--- a/backend/src/api/apportionment/handlers.rs
+++ b/backend/src/api/apportionment/handlers.rs
@@ -86,9 +86,9 @@ pub async fn election_apportionment(
             .await?;
 
         Ok(Json(ElectionApportionmentResponse {
-            seat_assignment: map_seat_assignment(result.seat_assignment),
+            seat_assignment: map_seat_assignment(&result.seat_assignment),
             candidate_nomination: map_candidate_nomination(
-                result.candidate_nomination,
+                &result.candidate_nomination,
                 election.political_groups,
             ),
             election_summary: summary,

--- a/backend/src/api/apportionment/mapping.rs
+++ b/backend/src/api/apportionment/mapping.rs
@@ -10,17 +10,17 @@ use crate::domain::{
 };
 
 pub fn map_seat_assignment(
-    sa: apportionment::SeatAssignmentResult<PoliticalGroupCandidateVotes>,
+    sa: &apportionment::SeatAssignmentResult<PoliticalGroupCandidateVotes>,
 ) -> SeatAssignment {
     SeatAssignment {
         seats: sa.seats,
         full_seats: sa.full_seats,
         residual_seats: sa.residual_seats,
         quota: DisplayFraction::from(sa.quota),
-        steps: sa.steps.into_iter().map(Into::into).collect(),
+        steps: sa.steps.iter().map(Into::into).collect(),
         final_standing: sa
             .final_standing
-            .into_iter()
+            .iter()
             .map(|standing| ListSeatAssignment {
                 list_number: standing.list_number,
                 votes_cast: standing.votes_cast,
@@ -44,7 +44,7 @@ fn sort_candidates_alphabetically(mut candidates: Vec<ChosenCandidate>) -> Vec<C
 }
 
 pub fn map_candidate_nomination(
-    cn: apportionment::CandidateNominationResult<'_, PoliticalGroupCandidateVotes>,
+    cn: &apportionment::CandidateNominationResult<'_, PoliticalGroupCandidateVotes>,
     political_groups: Vec<PoliticalGroup>,
 ) -> CandidateNomination {
     let mut list_names: HashMap<PGNumber, String> = HashMap::new();
@@ -74,7 +74,7 @@ pub fn map_candidate_nomination(
 
     let list_candidate_nomination = cn
         .list_candidate_nomination
-        .into_iter()
+        .iter()
         .map(|lcn| ListCandidateNomination {
             list_number: lcn.list_number,
             list_name: list_names
@@ -83,13 +83,13 @@ pub fn map_candidate_nomination(
             list_seats: lcn.list_seats,
             preferential_candidate_nomination: lcn
                 .preferential_candidate_nomination
-                .into_iter()
-                .copied()
+                .iter()
+                .map(|&&cv| cv)
                 .collect(),
             other_candidate_nomination: lcn
                 .other_candidate_nomination
-                .into_iter()
-                .copied()
+                .iter()
+                .map(|&&cv| cv)
                 .collect(),
             updated_candidate_ranking: lcn
                 .updated_candidate_ranking

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -1,3 +1,4 @@
+use apportionment::ApportionmentOutput;
 use axum::{
     extract::{Path, State},
     response::IntoResponse,
@@ -34,7 +35,7 @@ use crate::{
             votes_table::{VotesTables, VotesTablesWithPreviousVotes},
         },
         polling_station::PollingStation,
-        results::Results,
+        results::{Results, political_group_candidate_votes::PoliticalGroupCandidateVotes},
         role::Role,
         summary::{ElectionSummary, ElectionSummaryCSB},
     },
@@ -128,10 +129,12 @@ impl ResultsInput {
             None
         };
 
+        let summary = ElectionSummary::from_results(&election, &results)?;
+
         Ok(ResultsInput {
             committee_session,
             previous_summary,
-            summary: ElectionSummary::from_results(&election, &results)?,
+            summary,
             created_at,
             election,
             polling_stations,
@@ -158,6 +161,18 @@ impl ResultsInput {
         slugify_filename(&format!(
             "{} {}{} {}.eml.xml",
             xml_count_base_name(&self.election),
+            self.election.category.to_eml_code(),
+            self.election.election_date.year(),
+            location_without_whitespace
+        ))
+    }
+
+    fn xml_results_filename(&self) -> String {
+        use chrono::Datelike;
+        let location_without_whitespace: String =
+            self.election.location.split_whitespace().collect();
+        slugify_filename(&format!(
+            "Resultaat {}{} {}.eml.xml",
             self.election.category.to_eml_code(),
             self.election.election_date.year(),
             location_without_whitespace
@@ -210,24 +225,21 @@ impl ResultsInput {
 
     fn get_p22_2_pdf_file(
         &self,
+        apportionment_result: &ApportionmentOutput<'_, PoliticalGroupCandidateVotes>,
         hash: String,
         creation_date_time: String,
         filename: String,
     ) -> Result<PdfFileModel, APIError> {
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: self.election.number_of_seats,
-            list_votes: &self.summary.political_group_votes,
-        };
-        let result = apportionment::process(&apportionment_input)?;
         let summary = ElectionSummaryCSB::new(&self.summary, &self.election.political_groups);
-        let seat_assignment = map_seat_assignment(result.seat_assignment);
+        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
         let initial_full_seats_table = InitialFullSeatsTable::new(&summary, &seat_assignment)?;
         let total_seats_table =
             TotalSeatsTable::new(&seat_assignment, &self.election.political_groups)?;
         let candidate_nomination = map_candidate_nomination(
-            result.candidate_nomination,
+            &apportionment_result.candidate_nomination,
             self.election.political_groups.clone(),
         );
+
         let enriched_candidate_nomination =
             EnrichedCandidateNomination::new(&self.election, &candidate_nomination)?;
         let pdf_file: PdfFileModel = ModelP22_2Input {
@@ -275,17 +287,17 @@ impl ResultsInput {
     }
 
     fn get_na31_2_pdf_file(
-        self,
+        &self,
         hash: String,
         creation_date_time: String,
         results_pdf_filename: String,
     ) -> Result<PdfFileModel, APIError> {
         let pdf_file: PdfFileModel = ModelNa31_2Input {
             votes_tables: VotesTables::new(&self.election, &self.summary)?,
-            committee_session: self.committee_session,
-            polling_stations: self.polling_stations,
-            summary: self.summary.into(),
-            election: self.election.into(),
+            committee_session: self.committee_session.clone(),
+            polling_stations: self.polling_stations.clone(),
+            summary: self.summary.clone().into(),
+            election: self.election.clone().into(),
             hash,
             creation_date_time,
         }
@@ -293,8 +305,8 @@ impl ResultsInput {
         Ok(pdf_file)
     }
 
-    fn into_pdf_file_models_gsb(
-        self,
+    fn as_pdf_file_models_gsb(
+        &self,
         xml_hash: impl Into<String>,
     ) -> Result<PdfModelListGSB, APIError> {
         let hash = xml_hash.into();
@@ -337,16 +349,18 @@ impl ResultsInput {
         })
     }
 
-    fn into_pdf_file_models_csb(
-        self,
-        // xml_hash: impl Into<String>,
+    fn as_pdf_file_models_csb(
+        &self,
+        apportionment_result: &ApportionmentOutput<'_, PoliticalGroupCandidateVotes>,
+        xml_hash: impl Into<String>,
     ) -> Result<PdfModelListCSB, APIError> {
         // let hash = xml_hash.into();
         let creation_date_time = self.created_at.format(DEFAULT_DATE_TIME_FORMAT).to_string();
 
         let results_pdf_filename = self.results_pdf_filename();
         let results_pdf = self.get_p22_2_pdf_file(
-            "TODO: hash string".to_string(),
+            apportionment_result,
+            xml_hash.into(),
             creation_date_time,
             results_pdf_filename,
         )?;
@@ -413,6 +427,17 @@ fn xml_zip_filename(election: &ElectionWithPoliticalGroups) -> String {
     ))
 }
 
+fn xml_results_zip_filename(election: &ElectionWithPoliticalGroups) -> String {
+    use chrono::Datelike;
+    let location_without_whitespace: String = election.location.split_whitespace().collect();
+    slugify_filename(&format!(
+        "Resultaat {}{} {}.zip",
+        election.category.to_eml_code(),
+        election.election_date.year(),
+        location_without_whitespace
+    ))
+}
+
 async fn generate_and_save_files_gsb_election(
     conn: &mut SqliteConnection,
     audit_service: &AuditService,
@@ -428,7 +453,7 @@ async fn generate_and_save_files_gsb_election(
 
     let xml_hash = EmlHash::from(xml_string.as_bytes());
     let xml_filename = input.xml_filename();
-    let pdf_files = input.into_pdf_file_models_gsb(xml_hash)?;
+    let pdf_files = input.as_pdf_file_models_gsb(xml_hash)?;
 
     // For the first session, or if there are corrections, we also store the EML and count PDF
     // For next sessions without corrections, we don't store these
@@ -487,20 +512,55 @@ async fn generate_and_save_files_gsb_election(
     Ok((eml_file, pdf_file, overview_pdf_file))
 }
 
+#[expect(clippy::too_many_lines)]
 async fn generate_and_save_files_csb_election(
     conn: &mut SqliteConnection,
     audit_service: &AuditService,
     committee_session: CommitteeSession,
     input: ResultsInput,
 ) -> Result<(Option<File>, Option<File>, Option<File>), APIError> {
-    let eml_file: Option<File> = None;
+    if input.election.committee_category != CommitteeCategory::CSB {
+        return Err(APIError::DataIntegrityError(
+            "Generating CSB files can only be done for CSB elections".to_string(),
+        ));
+    }
+
     let created_at = input.created_at.with_timezone(&Utc);
-    // TODO: Add EML file type to 520 in issue #3110
 
-    let xml_string = input.as_xml()?.write_eml_root_str(true, true)?;
-    let xml_filename = input.xml_filename();
+    let xml_counts_string = input.as_xml()?.write_eml_root_str(true, true)?;
+    let xml_counts_filename = input.xml_filename();
 
-    let pdf_files = input.into_pdf_file_models_csb()?;
+    let apportionment_input = ApportionmentInputData {
+        number_of_seats: input.election.number_of_seats,
+        list_votes: &input.summary.political_group_votes,
+    };
+    let apportionment_result = apportionment::process(&apportionment_input)?;
+
+    let eml_results_data = input.election.as_result_eml(
+        None,
+        created_at,
+        &apportionment_result.candidate_nomination,
+    )?;
+    let xml_results_string = eml_results_data.write_eml_root_str(true, true)?;
+    let xml_results_hash = EmlHash::from(xml_results_string.as_bytes());
+    let xml_results_filename = input.xml_results_filename();
+
+    let pdf_files = input.as_pdf_file_models_csb(&apportionment_result, xml_results_hash)?;
+
+    let eml_results = create_file(
+        conn,
+        audit_service,
+        NewFile {
+            committee_session_id: committee_session.id,
+            file_type: FileType::CsbResultsEml,
+            filename: xml_results_filename,
+            data: xml_results_string.into_bytes(),
+            mime_type: EML_MIME_TYPE.to_string(),
+            created_at,
+        },
+    )
+    .await?;
+
     let pdf = create_file(
         conn,
         audit_service,
@@ -521,8 +581,8 @@ async fn generate_and_save_files_csb_election(
         NewFile {
             committee_session_id: committee_session.id,
             file_type: FileType::CsbTotalCountsEml,
-            filename: xml_filename,
-            data: xml_string.into_bytes(),
+            filename: xml_counts_filename,
+            data: xml_counts_string.into_bytes(),
             mime_type: EML_MIME_TYPE.to_string(),
             created_at,
         },
@@ -530,9 +590,10 @@ async fn generate_and_save_files_csb_election(
     .await?;
 
     let pdf_file: Option<File> = Some(pdf);
-    let total_counts_eml_file: Option<File> = Some(total_counts_eml);
+    let eml_results_file: Option<File> = Some(eml_results);
+    let eml_counts_file = Some(total_counts_eml);
 
-    Ok((eml_file, pdf_file, total_counts_eml_file))
+    Ok((eml_results_file, pdf_file, eml_counts_file))
 }
 
 async fn create_file(
@@ -581,7 +642,9 @@ async fn get_existing_gsb_files(
 async fn get_existing_csb_files(
     conn: &mut SqliteConnection,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, Option<File>, DateTime<Utc>), APIError> {
+) -> Result<(Option<File>, Option<File>, Option<File>, DateTime<Utc>), APIError> {
+    let results_eml_file =
+        file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsEml).await?;
     let results_pdf_file =
         file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsPdf).await?;
     let total_counts_eml_file =
@@ -593,7 +656,12 @@ async fn get_existing_csb_files(
         .map(|f| f.created_at)
         .unwrap_or_else(Utc::now);
 
-    Ok((results_pdf_file, total_counts_eml_file, created_at))
+    Ok((
+        results_eml_file,
+        results_pdf_file,
+        total_counts_eml_file,
+        created_at,
+    ))
 }
 
 async fn get_files_gsb_election(
@@ -660,7 +728,7 @@ async fn get_files_csb_election(
     pool: &SqlitePool,
     audit_service: AuditService,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, Option<File>, DateTime<Utc>), APIError> {
+) -> Result<(Option<File>, Option<File>, Option<File>, DateTime<Utc>), APIError> {
     let mut conn = pool.acquire().await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
 
@@ -675,12 +743,13 @@ async fn get_files_csb_election(
     }
 
     // Check if files exist, if so, get files from database
-    let (mut results_pdf_file, mut total_counts_eml_file, mut created_at) =
+    let (mut results_eml_file, mut results_pdf_file, mut total_counts_eml_file, mut created_at) =
         get_existing_csb_files(&mut conn, committee_session.id).await?;
     drop(conn);
 
     // Determine if we need to generate any of the files
-    let generate_files = results_pdf_file.is_none() || total_counts_eml_file.is_none();
+    let generate_files =
+        results_eml_file.is_none() || results_pdf_file.is_none() || total_counts_eml_file.is_none();
 
     // If one of the files doesn't exist, generate all and save them to the database
     if generate_files {
@@ -692,13 +761,18 @@ async fn get_files_csb_election(
             created_at.with_timezone(&Local),
         )
         .await?;
-        (_, results_pdf_file, total_counts_eml_file) =
+        (results_eml_file, results_pdf_file, total_counts_eml_file) =
             generate_and_save_files_csb_election(&mut tx, &audit_service, committee_session, input)
                 .await?;
         tx.commit().await?;
     }
 
-    Ok((results_pdf_file, total_counts_eml_file, created_at))
+    Ok((
+        results_eml_file,
+        results_pdf_file,
+        total_counts_eml_file,
+        created_at,
+    ))
 }
 
 /// Download a zip containing a PDF for the PV and the EML with GSB election results
@@ -863,7 +937,7 @@ async fn election_download_zip_results_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (pdf_file, _, created_at) =
+    let (eml_results_file, pdf_file, _, created_at) =
         get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -878,6 +952,12 @@ async fn election_download_zip_results_csb(
     tokio::spawn(async move {
         if let Some(pdf_file) = pdf_file {
             zip_writer.add_file(&pdf_file.name, &pdf_file.data).await?;
+        }
+
+        if let Some(eml_results_file) = eml_results_file {
+            let xml_zip_filename = xml_results_zip_filename(&election);
+            let xml_zip = zip_single_file(&eml_results_file.name, &eml_results_file.data).await?;
+            zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
         }
 
         zip_writer.finish().await?;
@@ -926,7 +1006,7 @@ async fn election_download_zip_total_counts_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (_, total_counts_eml_file, created_at) =
+    let (_, _, total_counts_eml_file, created_at) =
         get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -1171,23 +1251,27 @@ mod tests {
 
         // Files should be generated exactly once
         for _ in 1..=2 {
-            let (pdf, eml_total_counts, _) =
+            let (eml_results, pdf, eml_total_counts, _) =
                 get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
                     .await
                     .expect("should return files");
             let pdf = pdf.expect("should have generated pdf");
             let eml_total_counts =
                 eml_total_counts.expect("should have generated total counts eml");
+            let eml_results = eml_results.expect("should have generated eml");
+
+            assert_eq!(eml_results.name, "Resultaat_GR2024_Juinen.eml.xml");
+            assert_eq!(eml_results.id, FileId::from(1));
 
             assert_eq!(pdf.name, "Model_P22-2.pdf");
-            assert_eq!(pdf.id, FileId::from(1));
+            assert_eq!(pdf.id, FileId::from(2));
 
             assert_eq!(eml_total_counts.name, "Totaaltelling_GR2024_Juinen.eml.xml");
-            assert_eq!(eml_total_counts.id, FileId::from(2));
+            assert_eq!(eml_total_counts.id, FileId::from(3));
 
             assert_eq!(
                 list_event_names(&mut conn).await.unwrap(),
-                ["FileCreated", "FileCreated"]
+                ["FileCreated", "FileCreated", "FileCreated"]
             );
         }
     }

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -438,6 +438,7 @@ fn xml_results_zip_filename(election: &ElectionWithPoliticalGroups) -> String {
     ))
 }
 
+#[expect(clippy::too_many_lines)]
 async fn generate_and_save_files_gsb_election(
     conn: &mut SqliteConnection,
     audit_service: &AuditService,
@@ -445,6 +446,12 @@ async fn generate_and_save_files_gsb_election(
     corrections: bool,
     input: ResultsInput,
 ) -> Result<(Option<File>, Option<File>, Option<File>), APIError> {
+    if input.election.committee_category != CommitteeCategory::GSB {
+        return Err(APIError::DataIntegrityError(
+            "Generating GSB files can only be done for GSB elections".to_string(),
+        ));
+    }
+
     let mut eml_file: Option<File> = None;
     let mut pdf_file: Option<File> = None;
     let mut overview_pdf_file: Option<File> = None;
@@ -1258,7 +1265,7 @@ mod tests {
             let pdf = pdf.expect("should have generated pdf");
             let eml_total_counts =
                 eml_total_counts.expect("should have generated total counts eml");
-            let eml_results = eml_results.expect("should have generated eml");
+            let eml_results = eml_results.expect("should have generated results eml");
 
             assert_eq!(eml_results.name, "Resultaat_GR2024_Juinen.eml.xml");
             assert_eq!(eml_results.id, FileId::from(1));

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -354,7 +354,6 @@ impl ResultsInput {
         apportionment_result: &ApportionmentOutput<'_, PoliticalGroupCandidateVotes>,
         xml_hash: impl Into<String>,
     ) -> Result<PdfModelListCSB, APIError> {
-        // let hash = xml_hash.into();
         let creation_date_time = self.created_at.format(DEFAULT_DATE_TIME_FORMAT).to_string();
 
         let results_pdf_filename = self.results_pdf_filename();
@@ -659,6 +658,7 @@ async fn get_existing_csb_files(
 
     let created_at = results_pdf_file
         .as_ref()
+        .or(results_eml_file.as_ref())
         .or(total_counts_eml_file.as_ref())
         .map(|f| f.created_at)
         .unwrap_or_else(Utc::now);

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -109,16 +109,16 @@ pub struct ListCandidateNomination {
     pub updated_candidate_ranking: Vec<Candidate>,
 }
 
-impl From<apportionment::SeatChange<PGNumber>> for SeatChange {
-    fn from(change: apportionment::SeatChange<PGNumber>) -> Self {
+impl From<&apportionment::SeatChange<PGNumber>> for SeatChange {
+    fn from(change: &apportionment::SeatChange<PGNumber>) -> Self {
         use apportionment::SeatChange::*;
 
         let as_highest_avg =
-            |c: apportionment::HighestAverageAssignedSeat<PGNumber>| HighestAverageAssignedSeat {
+            |c: &apportionment::HighestAverageAssignedSeat<PGNumber>| HighestAverageAssignedSeat {
                 selected_list_number: c.selected_list_number,
-                list_options: c.list_options,
-                list_assigned: c.list_assigned,
-                list_exhausted: c.list_exhausted,
+                list_options: c.list_options.clone(),
+                list_assigned: c.list_assigned.clone(),
+                list_exhausted: c.list_exhausted.clone(),
                 votes_per_seat: DisplayFraction::from(c.votes_per_seat),
             };
 
@@ -130,8 +130,8 @@ impl From<apportionment::SeatChange<PGNumber>> for SeatChange {
             LargestRemainderAssignment(c) => {
                 SeatChange::LargestRemainderAssignment(LargestRemainderAssignedSeat {
                     selected_list_number: c.selected_list_number,
-                    list_options: c.list_options,
-                    list_assigned: c.list_assigned,
+                    list_options: c.list_options.clone(),
+                    list_assigned: c.list_assigned.clone(),
                     remainder_votes: DisplayFraction::from(c.remainder_votes),
                 })
             }
@@ -151,14 +151,14 @@ impl From<apportionment::SeatChange<PGNumber>> for SeatChange {
     }
 }
 
-impl From<apportionment::SeatChangeStep<PGNumber>> for SeatChangeStep {
-    fn from(step: apportionment::SeatChangeStep<PGNumber>) -> Self {
+impl From<&apportionment::SeatChangeStep<PGNumber>> for SeatChangeStep {
+    fn from(step: &apportionment::SeatChangeStep<PGNumber>) -> Self {
         SeatChangeStep {
             residual_seat_number: step.residual_seat_number,
-            change: step.change.into(),
+            change: (&step.change).into(),
             standings: step
                 .standings
-                .into_iter()
+                .iter()
                 .map(|standing| ListStanding {
                     list_number: standing.list_number,
                     votes_cast: standing.votes_cast,

--- a/backend/src/domain/file.rs
+++ b/backend/src/domain/file.rs
@@ -22,6 +22,8 @@ pub enum FileType {
     CsbResultsPdf,
     /// CSB total counts EML (510d)
     CsbTotalCountsEml,
+    /// CSB results EML (520)
+    CsbResultsEml,
 }
 
 /// File

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU64;
 mod error;
 pub mod hash;
 
+use apportionment::CandidateNominationResult;
 use chrono::{DateTime, Local, Utc};
 use eml_nl::{
     EMLError,
@@ -21,6 +22,9 @@ use eml_nl::{
             ReportingUnitVotesBuilder, UncountedVotesReason,
         },
         election_definition::{ElectionDefinition, ElectionDefinitionRegisteredParty},
+        election_result::{
+            ElectionResult, ElectionResultContest, ElectionResultSelection, RankingType, YesNoType,
+        },
         polling_stations::{PollingPlace, PollingStations, PollingStationsContest},
     },
     io::{EMLParsingMode, EMLRead as _},
@@ -665,6 +669,118 @@ impl ElectionWithPoliticalGroups {
         builder = add_reporting_unit_investigations(builder, committee_session, results);
         builder.build()
     }
+
+    pub fn as_result_eml(
+        &self,
+        transaction_id: Option<u64>,
+        timestamp: DateTime<Utc>,
+        nominations: &CandidateNominationResult<PoliticalGroupCandidateVotes>,
+    ) -> Result<ElectionResult, EMLError> {
+        ElectionResult::builder()
+            .transaction_id(transaction_id.unwrap_or(1))
+            .managing_authority(ManagingAuthority::new(
+                AuthorityIdentifier::new(AuthorityId::new(&self.domain_id)?)
+                    .with_name(&self.location),
+            ))
+            .creation_date_time(timestamp)
+            .election_identifier(
+                self.get_eml_election_identifier_builder()?
+                    .build_for_result()?,
+            )
+            .contests([self.as_eml_result_contest(nominations)?])
+            .build()
+    }
+
+    fn as_eml_result_contest(
+        &self,
+        nominations: &CandidateNominationResult<PoliticalGroupCandidateVotes>,
+    ) -> Result<ElectionResultContest, EMLError> {
+        let mut selections = vec![];
+        for pg in &self.political_groups {
+            let pg_nominations = nominations
+                .list_candidate_nomination
+                .iter()
+                .find(|lcn| lcn.list_number == pg.number && lcn.list_seats > 0);
+
+            if let Some(pg_nominations) = pg_nominations {
+                selections.push(
+                    ElectionResultSelection::builder()
+                        .affiliation(
+                            eml_nl::documents::election_result::AffiliationSelection::new(
+                                AffiliationId::new(pg.number.as_internal_u32().to_string())?,
+                                &pg.registered_name,
+                            ),
+                        )
+                        .elected(YesNoType::new(true))
+                        .ranking(RankingType::First)
+                        .build()?,
+                );
+
+                for can in &pg.candidates {
+                    let non_preferentially_selected = pg_nominations
+                        .other_candidate_nomination
+                        .iter()
+                        .any(|&cv| cv.number == can.number);
+                    let preferentially_selected = pg_nominations
+                        .preferential_candidate_nomination
+                        .iter()
+                        .any(|&cv| cv.number == can.number);
+                    let can_selected = non_preferentially_selected || preferentially_selected;
+
+                    if can_selected {
+                        selections.push(build_candidate_result(can, preferentially_selected)?);
+                    }
+                }
+            }
+        }
+        Ok(ElectionResultContest::new(
+            ContestIdentifier::geen(),
+            selections,
+        ))
+    }
+}
+
+fn build_candidate_result(
+    can: &Candidate,
+    preferentially_selected: bool,
+) -> Result<ElectionResultSelection, EMLError> {
+    ElectionResultSelection::builder()
+        .candidate({
+            let mut builder = eml_nl::documents::election_result::CandidateSelection::builder()
+                .identifier(CandidateId::new(can.number.as_internal_u32().to_string())?)
+                .name(
+                    PersonName::new(&can.last_name)
+                        .with_first_name_option(can.first_name.clone())
+                        .with_initials_option(if can.initials.is_empty() {
+                            None
+                        } else {
+                            Some(can.initials.clone())
+                        })
+                        .with_name_prefix_option(can.last_name_prefix.clone()),
+                );
+
+            if let Some(gender) = can.gender {
+                builder = builder.gender(match gender {
+                    CandidateGender::Female => Gender::Female,
+                    CandidateGender::Male => Gender::Male,
+                    CandidateGender::X => Gender::Unknown,
+                });
+            }
+
+            builder = builder.locality_name(can.locality.clone());
+            if let Some(country_code) = &can.country_code {
+                builder = builder.country_name_code(country_code.clone());
+            }
+
+            builder.build()?
+        })
+        .elected(YesNoType::new(true))
+        .ranking(if preferentially_selected {
+            RankingType::Second
+        } else {
+            RankingType::First
+        })
+        .build()
 }
 
 fn add_reporting_unit_investigations(

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -776,9 +776,9 @@ fn build_candidate_result(
         })
         .elected(YesNoType::new(true))
         .ranking(if preferentially_selected {
-            RankingType::Second
-        } else {
             RankingType::First
+        } else {
+            RankingType::Second
         })
         .build()
 }


### PR DESCRIPTION
Fixes #3110 

This PR mostly follows the existing structure, a rewrite of the structure to be better abstracted would be better, but that was put in a separate issue to save some time: #3241

I've opted to rework some of the `Into` implementations to work on references instead, because the apportionment keeps references to the results struct at the same time, making it so that consuming functions won't work at the same time. This means some additional clones, but most of the data was `Copy` already, so there isn't that much difference.

Testing:
- When completing an election and downloading the files you should now also get the results EML

