### PR TITLE
Add endpoint and download link for CSB P 22-2 Bijlage 1

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1724,6 +1724,105 @@
         ]
       }
     },
+    "/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_attachment_csb": {
+      "get": {
+        "summary": "Download a zip containing a PDF with model P 22-2 Bijlage 1 for CSB (coordinator_csb)",
+        "operationId": "election_download_zip_attachment_csb",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          },
+          {
+            "name": "committee_session_id",
+            "in": "path",
+            "description": "Committee session database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CommitteeSessionId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "attachment; filename=\"filename.zip\""
+              }
+            },
+            "content": {
+              "application/zip": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request cannot be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "coordinator_csb"
+            ]
+          }
+        ]
+      }
+    },
     "/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_results": {
       "get": {
         "summary": "Download a zip containing a PDF for the PV and the EML with GSB election results (coordinator_gsb)",

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -68,6 +68,67 @@ struct NewFile {
     created_at: DateTime<Utc>,
 }
 
+pub struct GsbFiles {
+    pub results_eml: Option<File>,
+    pub results_pdf: Option<File>,
+    pub overview_pdf: Option<File>,
+}
+
+impl GsbFiles {
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.results_eml
+            .as_ref()
+            .or(self.results_pdf.as_ref())
+            .or(self.overview_pdf.as_ref())
+            .map(|f| f.created_at)
+            .expect("At least one file should be present")
+    }
+
+    pub fn needs_generation(
+        &self,
+        committee_session: &CommitteeSession,
+        corrections: bool,
+    ) -> bool {
+        if committee_session.is_next_session() {
+            if corrections {
+                self.results_eml.is_none()
+                    || self.results_pdf.is_none()
+                    || self.overview_pdf.is_none()
+            } else {
+                self.overview_pdf.is_none()
+            }
+        } else {
+            self.results_eml.is_none() || self.results_pdf.is_none()
+        }
+    }
+}
+
+pub struct CsbFiles {
+    pub results_eml: Option<File>,
+    pub results_pdf: Option<File>,
+    pub attachment_pdf: Option<File>,
+    pub total_counts_eml: Option<File>,
+}
+
+impl CsbFiles {
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.results_eml
+            .as_ref()
+            .or(self.results_pdf.as_ref())
+            .or(self.attachment_pdf.as_ref())
+            .or(self.total_counts_eml.as_ref())
+            .map(|f| f.created_at)
+            .expect("At least one file should be present")
+    }
+
+    pub fn needs_generation(&self) -> bool {
+        self.results_eml.is_none()
+            || self.results_pdf.is_none()
+            || self.attachment_pdf.is_none()
+            || self.total_counts_eml.is_none()
+    }
+}
+
 #[derive(Serialize)]
 pub struct FileCreatedAuditData(pub FileAuditData);
 impl AsAuditEvent for FileCreatedAuditData {
@@ -468,16 +529,19 @@ async fn generate_and_save_files_gsb_election(
     committee_session: CommitteeSession,
     corrections: bool,
     input: ResultsInput,
-) -> Result<(Option<File>, Option<File>, Option<File>), APIError> {
+) -> Result<GsbFiles, APIError> {
     if input.election.committee_category != CommitteeCategory::GSB {
         return Err(APIError::DataIntegrityError(
             "Generating GSB files can only be done for GSB elections".to_string(),
         ));
     }
 
-    let mut eml_file: Option<File> = None;
-    let mut pdf_file: Option<File> = None;
-    let mut overview_pdf_file: Option<File> = None;
+    let mut files = GsbFiles {
+        results_eml: None,
+        results_pdf: None,
+        overview_pdf: None,
+    };
+
     let created_at = input.created_at.with_timezone(&Utc);
     let xml_string = input.as_xml()?.write_eml_root_str(true, true)?;
 
@@ -488,58 +552,59 @@ async fn generate_and_save_files_gsb_election(
     // For the first session, or if there are corrections, we also store the EML and count PDF
     // For next sessions without corrections, we don't store these
     if !committee_session.is_next_session() || corrections {
-        let eml = create_file(
-            conn,
-            audit_service,
-            NewFile {
-                committee_session_id: committee_session.id,
-                file_type: FileType::GsbResultsEml,
-                filename: xml_filename,
-                data: xml_string.into_bytes(),
-                mime_type: EML_MIME_TYPE.to_string(),
-                created_at,
-            },
-        )
-        .await?;
+        files.results_eml = Some(
+            create_file(
+                conn,
+                audit_service,
+                NewFile {
+                    committee_session_id: committee_session.id,
+                    file_type: FileType::GsbResultsEml,
+                    filename: xml_filename,
+                    data: xml_string.into_bytes(),
+                    mime_type: EML_MIME_TYPE.to_string(),
+                    created_at,
+                },
+            )
+            .await?,
+        );
 
-        let pdf = create_file(
-            conn,
-            audit_service,
-            NewFile {
-                committee_session_id: committee_session.id,
-                file_type: FileType::GsbResultsPdf,
-                filename: pdf_files.results.file_name.clone(),
-                data: generate_pdf(&pdf_files.results).await?.buffer,
-                mime_type: PDF_MIME_TYPE.to_string(),
-                created_at,
-            },
-        )
-        .await?;
-
-        eml_file = Some(eml);
-        pdf_file = Some(pdf);
+        files.results_pdf = Some(
+            create_file(
+                conn,
+                audit_service,
+                NewFile {
+                    committee_session_id: committee_session.id,
+                    file_type: FileType::GsbResultsPdf,
+                    filename: pdf_files.results.file_name.clone(),
+                    data: generate_pdf(&pdf_files.results).await?.buffer,
+                    mime_type: PDF_MIME_TYPE.to_string(),
+                    created_at,
+                },
+            )
+            .await?,
+        );
     }
 
     // Store the overview PDF for next sessions
     if let Some(overview_pdf) = pdf_files.overview {
-        let overview_pdf = create_file(
-            conn,
-            audit_service,
-            NewFile {
-                committee_session_id: committee_session.id,
-                file_type: FileType::GsbOverviewPdf,
-                filename: overview_pdf.file_name.clone(),
-                data: generate_pdf(&overview_pdf).await?.buffer,
-                mime_type: PDF_MIME_TYPE.to_string(),
-                created_at,
-            },
-        )
-        .await?;
-
-        overview_pdf_file = Some(overview_pdf);
+        files.overview_pdf = Some(
+            create_file(
+                conn,
+                audit_service,
+                NewFile {
+                    committee_session_id: committee_session.id,
+                    file_type: FileType::GsbOverviewPdf,
+                    filename: overview_pdf.file_name.clone(),
+                    data: generate_pdf(&overview_pdf).await?.buffer,
+                    mime_type: PDF_MIME_TYPE.to_string(),
+                    created_at,
+                },
+            )
+            .await?,
+        );
     }
 
-    Ok((eml_file, pdf_file, overview_pdf_file))
+    Ok(files)
 }
 
 #[expect(clippy::too_many_lines)]
@@ -548,7 +613,7 @@ async fn generate_and_save_files_csb_election(
     audit_service: &AuditService,
     committee_session: CommitteeSession,
     input: ResultsInput,
-) -> Result<(Option<File>, Option<File>, Option<File>, Option<File>), APIError> {
+) -> Result<CsbFiles, APIError> {
     if input.election.committee_category != CommitteeCategory::CSB {
         return Err(APIError::DataIntegrityError(
             "Generating CSB files can only be done for CSB elections".to_string(),
@@ -577,7 +642,7 @@ async fn generate_and_save_files_csb_election(
 
     let pdf_files = input.as_pdf_file_models_csb(&apportionment_result, xml_results_hash)?;
 
-    let eml_results = create_file(
+    let results_eml = create_file(
         conn,
         audit_service,
         NewFile {
@@ -591,7 +656,7 @@ async fn generate_and_save_files_csb_election(
     )
     .await?;
 
-    let pdf = create_file(
+    let results_pdf = create_file(
         conn,
         audit_service,
         NewFile {
@@ -633,17 +698,12 @@ async fn generate_and_save_files_csb_election(
     )
     .await?;
 
-    let pdf_file = Some(pdf);
-    let attachment_pdf_file = Some(attachment_pdf);
-    let eml_results_file = Some(eml_results);
-    let eml_counts_file = Some(total_counts_eml);
-
-    Ok((
-        eml_results_file,
-        pdf_file,
-        attachment_pdf_file,
-        eml_counts_file,
-    ))
+    Ok(CsbFiles {
+        results_eml: Some(results_eml),
+        results_pdf: Some(results_pdf),
+        attachment_pdf: Some(attachment_pdf),
+        total_counts_eml: Some(total_counts_eml),
+    })
 }
 
 async fn create_file(
@@ -671,68 +731,36 @@ async fn create_file(
 async fn get_existing_gsb_files(
     conn: &mut SqliteConnection,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, Option<File>, Option<File>, DateTime<Utc>), APIError> {
-    let eml_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::GsbResultsEml).await?;
-    let pdf_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::GsbResultsPdf).await?;
-    let overview_pdf_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::GsbOverviewPdf).await?;
-
-    let created_at = eml_file
-        .as_ref()
-        .or(pdf_file.as_ref())
-        .or(overview_pdf_file.as_ref())
-        .map(|f| f.created_at)
-        .unwrap_or_else(Utc::now);
-
-    Ok((eml_file, pdf_file, overview_pdf_file, created_at))
+) -> Result<GsbFiles, APIError> {
+    use FileType::*;
+    Ok(GsbFiles {
+        results_eml: file_repo::get_for_session(conn, committee_session_id, GsbResultsEml).await?,
+        results_pdf: file_repo::get_for_session(conn, committee_session_id, GsbResultsPdf).await?,
+        overview_pdf: file_repo::get_for_session(conn, committee_session_id, GsbOverviewPdf)
+            .await?,
+    })
 }
 
 async fn get_existing_csb_files(
     conn: &mut SqliteConnection,
     committee_session_id: CommitteeSessionId,
-) -> Result<
-    (
-        Option<File>,
-        Option<File>,
-        Option<File>,
-        Option<File>,
-        DateTime<Utc>,
-    ),
-    APIError,
-> {
-    let results_eml_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsEml).await?;
-    let results_pdf_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsPdf).await?;
-    let attachment_pdf_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::CsbAttachmentPdf).await?;
-    let total_counts_eml_file =
-        file_repo::get_for_session(conn, committee_session_id, FileType::CsbTotalCountsEml).await?;
-
-    let created_at = results_eml_file
-        .as_ref()
-        .or(results_pdf_file.as_ref())
-        .or(attachment_pdf_file.as_ref())
-        .or(total_counts_eml_file.as_ref())
-        .map(|f| f.created_at)
-        .unwrap_or_else(Utc::now);
-
-    Ok((
-        results_eml_file,
-        results_pdf_file,
-        attachment_pdf_file,
-        total_counts_eml_file,
-        created_at,
-    ))
+) -> Result<CsbFiles, APIError> {
+    use FileType::*;
+    Ok(CsbFiles {
+        results_eml: file_repo::get_for_session(conn, committee_session_id, CsbResultsEml).await?,
+        results_pdf: file_repo::get_for_session(conn, committee_session_id, CsbResultsPdf).await?,
+        attachment_pdf: file_repo::get_for_session(conn, committee_session_id, CsbAttachmentPdf)
+            .await?,
+        total_counts_eml: file_repo::get_for_session(conn, committee_session_id, CsbTotalCountsEml)
+            .await?,
+    })
 }
 
 async fn get_files_gsb_election(
     pool: &SqlitePool,
     audit_service: AuditService,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, Option<File>, Option<File>, DateTime<Utc>), APIError> {
+) -> Result<GsbFiles, APIError> {
     let mut conn = pool.acquire().await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
     let session_pss = list_polling_stations_for_session(&mut conn, &committee_session).await?;
@@ -749,32 +777,14 @@ async fn get_files_gsb_election(
     }
 
     // Check if files exist, if so, get files from database
-    let (mut eml_file, mut pdf_file, mut overview_pdf_file, mut created_at) =
-        get_existing_gsb_files(&mut conn, committee_session.id).await?;
+    let mut files = get_existing_gsb_files(&mut conn, committee_session.id).await?;
     drop(conn);
 
-    // Determine if we need to generate any of the files
-    let generate_files = if committee_session.is_next_session() {
-        if corrections {
-            eml_file.is_none() || pdf_file.is_none() || overview_pdf_file.is_none()
-        } else {
-            overview_pdf_file.is_none()
-        }
-    } else {
-        eml_file.is_none() || pdf_file.is_none()
-    };
-
     // If one of the files doesn't exist, generate all and save them to the database
-    if generate_files {
-        created_at = Utc::now();
+    if files.needs_generation(&committee_session, corrections) {
         let mut tx = pool.begin_immediate().await?;
-        let input = ResultsInput::new(
-            &mut tx,
-            committee_session.id,
-            created_at.with_timezone(&Local),
-        )
-        .await?;
-        (eml_file, pdf_file, overview_pdf_file) = generate_and_save_files_gsb_election(
+        let input = ResultsInput::new(&mut tx, committee_session.id, Local::now()).await?;
+        files = generate_and_save_files_gsb_election(
             &mut tx,
             &audit_service,
             committee_session,
@@ -785,23 +795,14 @@ async fn get_files_gsb_election(
         tx.commit().await?;
     }
 
-    Ok((eml_file, pdf_file, overview_pdf_file, created_at))
+    Ok(files)
 }
 
 async fn get_files_csb_election(
     pool: &SqlitePool,
     audit_service: AuditService,
     committee_session_id: CommitteeSessionId,
-) -> Result<
-    (
-        Option<File>,
-        Option<File>,
-        Option<File>,
-        Option<File>,
-        DateTime<Utc>,
-    ),
-    APIError,
-> {
+) -> Result<CsbFiles, APIError> {
     let mut conn = pool.acquire().await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
 
@@ -816,48 +817,20 @@ async fn get_files_csb_election(
     }
 
     // Check if files exist, if so, get files from database
-    let (
-        mut results_eml_file,
-        mut results_pdf_file,
-        mut attachment_pdf_file,
-        mut total_counts_eml_file,
-        mut created_at,
-    ) = get_existing_csb_files(&mut conn, committee_session.id).await?;
+    let mut files = get_existing_csb_files(&mut conn, committee_session.id).await?;
     drop(conn);
 
-    // Determine if we need to generate any of the files
-    let generate_files = results_eml_file.is_none()
-        || results_pdf_file.is_none()
-        || attachment_pdf_file.is_none()
-        || total_counts_eml_file.is_none();
-
     // If one of the files doesn't exist, generate all and save them to the database
-    if generate_files {
-        created_at = Utc::now();
+    if files.needs_generation() {
         let mut tx = pool.begin_immediate().await?;
-        let input = ResultsInput::new(
-            &mut tx,
-            committee_session.id,
-            created_at.with_timezone(&Local),
-        )
-        .await?;
-        (
-            results_eml_file,
-            results_pdf_file,
-            attachment_pdf_file,
-            total_counts_eml_file,
-        ) = generate_and_save_files_csb_election(&mut tx, &audit_service, committee_session, input)
-            .await?;
+        let input = ResultsInput::new(&mut tx, committee_session.id, Local::now()).await?;
+        files =
+            generate_and_save_files_csb_election(&mut tx, &audit_service, committee_session, input)
+                .await?;
         tx.commit().await?;
     }
 
-    Ok((
-        results_eml_file,
-        results_pdf_file,
-        attachment_pdf_file,
-        total_counts_eml_file,
-        created_at,
-    ))
+    Ok(files)
 }
 
 /// Download a zip containing a PDF for the PV and the EML with GSB election results
@@ -898,30 +871,29 @@ async fn election_download_zip_results_gsb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (eml_file, pdf_file, overview_file, created_at) =
-        get_files_gsb_election(&pool, audit_service, committee_session.id).await?;
+    let files = get_files_gsb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
     let download_zip_filename = download_zip_filename(
         &election,
-        created_at.with_timezone(&Local),
+        files.created_at().with_timezone(&Local),
         zip_file_base_name_gsb(&committee_session),
     );
 
     let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
 
     tokio::spawn(async move {
-        if let Some(pdf_file) = pdf_file {
+        if let Some(pdf_file) = files.results_pdf {
             zip_writer.add_file(&pdf_file.name, &pdf_file.data).await?;
         }
 
-        if let Some(eml_file) = eml_file {
+        if let Some(eml_file) = files.results_eml {
             let xml_zip_filename = xml_zip_filename(&election);
             let xml_zip = zip_single_file(&eml_file.name, &eml_file.data).await?;
             zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
         }
 
-        if let Some(overview_file) = overview_file {
+        if let Some(overview_file) = files.overview_pdf {
             zip_writer
                 .add_file(&overview_file.name, &overview_file.data)
                 .await?;
@@ -971,10 +943,9 @@ async fn election_download_pdf_results_gsb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(&committee_category)?;
 
-    let (_, pdf_file, _, _) =
-        get_files_gsb_election(&pool, audit_service, committee_session_id).await?;
+    let files = get_files_gsb_election(&pool, audit_service, committee_session_id).await?;
 
-    let pdf_file = pdf_file.ok_or(APIError::BadRequest(
+    let pdf_file = files.results_pdf.ok_or(APIError::BadRequest(
         "PDF results are not generated".to_string(),
         ErrorReference::PdfGenerationError,
     ))?;
@@ -1022,24 +993,23 @@ async fn election_download_zip_results_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (eml_results_file, pdf_file, _, _, created_at) =
-        get_files_csb_election(&pool, audit_service, committee_session.id).await?;
+    let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
     let download_zip_filename = download_zip_filename(
         &election,
-        created_at.with_timezone(&Local),
+        files.created_at().with_timezone(&Local),
         "vaststelling-uitslag",
     );
 
     let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
 
     tokio::spawn(async move {
-        if let Some(pdf_file) = pdf_file {
+        if let Some(pdf_file) = files.results_pdf {
             zip_writer.add_file(&pdf_file.name, &pdf_file.data).await?;
         }
 
-        if let Some(eml_results_file) = eml_results_file {
+        if let Some(eml_results_file) = files.results_eml {
             let xml_zip_filename = xml_results_zip_filename(&election);
             let xml_zip = zip_single_file(&eml_results_file.name, &eml_results_file.data).await?;
             zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
@@ -1091,20 +1061,19 @@ async fn election_download_zip_attachment_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (_, _, attachment_pdf_file, _, created_at) =
-        get_files_csb_election(&pool, audit_service, committee_session.id).await?;
+    let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
     let download_zip_filename = download_zip_filename(
         &election,
-        created_at.with_timezone(&Local),
+        files.created_at().with_timezone(&Local),
         "model-p22-2-bijlage",
     );
 
     let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
 
     tokio::spawn(async move {
-        if let Some(attachment_pdf_file) = attachment_pdf_file {
+        if let Some(attachment_pdf_file) = files.attachment_pdf {
             zip_writer
                 .add_file(&attachment_pdf_file.name, &attachment_pdf_file.data)
                 .await?;
@@ -1156,20 +1125,19 @@ async fn election_download_zip_total_counts_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (_, _, _, total_counts_eml_file, created_at) =
-        get_files_csb_election(&pool, audit_service, committee_session.id).await?;
+    let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
     let download_zip_filename = download_zip_filename(
         &election,
-        created_at.with_timezone(&Local),
+        files.created_at().with_timezone(&Local),
         "definitieve-documenten",
     );
 
     let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
 
     tokio::spawn(async move {
-        if let Some(total_counts_eml_file) = total_counts_eml_file {
+        if let Some(total_counts_eml_file) = files.total_counts_eml {
             let xml_zip_filename = xml_zip_filename(&election);
             let xml_zip =
                 zip_single_file(&total_counts_eml_file.name, &total_counts_eml_file.data).await?;
@@ -1247,18 +1215,18 @@ mod tests {
 
         // Files should be generated exactly once
         for _ in 1..=2 {
-            let (eml, pdf, overview, _) =
+            let files =
                 get_files_gsb_election(&pool, audit_service.clone(), CommitteeSessionId::from(5))
                     .await
                     .expect("should return files");
-            let eml = eml.expect("should have generated eml");
-            let pdf = pdf.expect("should have generated pdf");
+            let eml = files.results_eml.expect("should have generated eml");
+            let pdf = files.results_pdf.expect("should have generated pdf");
 
             assert_eq!(eml.name, "Telling_GR2026_GroteStad.eml.xml");
             assert_eq!(eml.id, FileId::from(1));
             assert_eq!(pdf.name, "Model_Na31-2.pdf");
             assert_eq!(pdf.id, FileId::from(2));
-            assert!(overview.is_none());
+            assert!(files.overview_pdf.is_none());
 
             assert_eq!(
                 list_event_names(&mut conn).await.unwrap(),
@@ -1274,14 +1242,14 @@ mod tests {
 
         // Files should be generated exactly once
         for _ in 1..=2 {
-            let (eml, pdf, overview, _) =
+            let files =
                 get_files_gsb_election(&pool, audit_service.clone(), CommitteeSessionId::from(703))
                     .await
                     .expect("should return files");
 
-            let eml = eml.expect("should have generated eml");
-            let pdf = pdf.expect("should have generated pdf");
-            let overview = overview.expect("should have generated overview");
+            let eml = files.results_eml.expect("should have generated eml");
+            let pdf = files.results_pdf.expect("should have generated pdf");
+            let overview = files.overview_pdf.expect("should have generated overview");
 
             assert_eq!(eml.name, "Telling_GR2026_GroteStad.eml.xml");
             assert_eq!(eml.id, FileId::from(1));
@@ -1318,15 +1286,15 @@ mod tests {
 
         // File should be generated exactly once
         for _ in 1..=2 {
-            let (eml, pdf, overview, _) =
+            let files =
                 get_files_gsb_election(&pool, audit_service.clone(), CommitteeSessionId::from(703))
                     .await
                     .expect("should return files");
 
             // No EML and no model PDF should be generated at all
-            assert_eq!(eml, None);
-            assert_eq!(pdf, None);
-            let overview = overview.expect("should have generated overview");
+            assert_eq!(files.results_eml, None);
+            assert_eq!(files.results_pdf, None);
+            let overview = files.overview_pdf.expect("should have generated overview");
 
             assert_eq!(overview.name, "Leeg_Model_P2a.pdf");
             assert_eq!(overview.id, FileId::from(1));
@@ -1401,15 +1369,20 @@ mod tests {
 
         // Files should be generated exactly once
         for _ in 1..=2 {
-            let (eml_results, pdf, attachment_pdf, eml_total_counts, _) =
+            let files =
                 get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
                     .await
                     .expect("should return files");
-            let pdf = pdf.expect("should have generated pdf");
-            let attachment_pdf = attachment_pdf.expect("should have generated attachment pdf");
-            let eml_total_counts =
-                eml_total_counts.expect("should have generated total counts eml");
-            let eml_results = eml_results.expect("should have generated results eml");
+            let pdf = files.results_pdf.expect("should have generated pdf");
+            let attachment_pdf = files
+                .attachment_pdf
+                .expect("should have generated attachment pdf");
+            let eml_total_counts = files
+                .total_counts_eml
+                .expect("should have generated total counts eml");
+            let eml_results = files
+                .results_eml
+                .expect("should have generated results eml");
 
             assert_eq!(eml_results.name, "Resultaat_GR2024_Juinen.eml.xml");
             assert_eq!(eml_results.id, FileId::from(1));

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -28,8 +28,8 @@ use crate::{
         file::{File, FileType},
         investigation::PollingStationInvestigation,
         models::{
-            ModelNa14_2Input, ModelNa31_2Input, ModelP2aInput, ModelP22_2Input, PdfFileModel,
-            ToPdfFileModel,
+            ModelNa14_2Input, ModelNa31_2Input, ModelP2aInput, ModelP22_2Bijlage1Input,
+            ModelP22_2Input, PdfFileModel, ToPdfFileModel,
             enriched_candidate_nomination::EnrichedCandidateNomination,
             enriched_seat_assignment::EnrichedSeatAssignment,
             votes_table::{VotesTables, VotesTablesWithPreviousVotes},
@@ -82,6 +82,7 @@ pub fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(election_download_zip_results_gsb).authorize(&[CoordinatorGSB]))
         .routes(routes!(election_download_pdf_results_gsb).authorize(&[CoordinatorGSB]))
         .routes(routes!(election_download_zip_results_csb).authorize(&[CoordinatorCSB]))
+        .routes(routes!(election_download_zip_attachment_csb).authorize(&[CoordinatorCSB]))
         .routes(routes!(election_download_zip_total_counts_csb).authorize(&[CoordinatorCSB]))
 }
 
@@ -256,6 +257,23 @@ impl ResultsInput {
         Ok(pdf_file)
     }
 
+    fn get_p22_2_attachment_1_pdf_file(
+        &self,
+        hash: String,
+        creation_date_time: String,
+        filename: String,
+    ) -> Result<PdfFileModel, APIError> {
+        let votes_tables = VotesTables::new(&self.election, &self.summary)?;
+        let pdf_file: PdfFileModel = ModelP22_2Bijlage1Input {
+            election: self.election.clone().into(),
+            votes_tables,
+            hash,
+            creation_date_time,
+        }
+        .to_pdf_file_model(filename);
+        Ok(pdf_file)
+    }
+
     fn get_na14_2_pdf_file(
         &self,
         previous_summary: &ElectionSummary,
@@ -350,18 +368,27 @@ impl ResultsInput {
         apportionment_result: &ApportionmentOutput<'_, PoliticalGroupCandidateVotes>,
         xml_hash: impl Into<String>,
     ) -> Result<PdfModelListCSB, APIError> {
+        let hash = xml_hash.into();
         let creation_date_time = self.created_at.format(DEFAULT_DATE_TIME_FORMAT).to_string();
 
         let results_pdf_filename = self.results_pdf_filename();
         let results_pdf = self.get_p22_2_pdf_file(
             apportionment_result,
-            xml_hash.into(),
-            creation_date_time,
+            hash.clone(),
+            creation_date_time.clone(),
             results_pdf_filename,
+        )?;
+
+        let attachment_pdf_filename = "Model_P22-2_bijlage.pdf".to_string();
+        let attachment_pdf = self.get_p22_2_attachment_1_pdf_file(
+            hash,
+            creation_date_time,
+            attachment_pdf_filename,
         )?;
 
         Ok(PdfModelListCSB {
             results: results_pdf,
+            attachment: attachment_pdf,
         })
     }
 }
@@ -380,6 +407,7 @@ struct PdfModelListGSB {
 
 struct PdfModelListCSB {
     results: PdfFileModel,
+    attachment: PdfFileModel,
 }
 
 fn download_zip_filename(
@@ -520,7 +548,7 @@ async fn generate_and_save_files_csb_election(
     audit_service: &AuditService,
     committee_session: CommitteeSession,
     input: ResultsInput,
-) -> Result<(Option<File>, Option<File>, Option<File>), APIError> {
+) -> Result<(Option<File>, Option<File>, Option<File>, Option<File>), APIError> {
     if input.election.committee_category != CommitteeCategory::CSB {
         return Err(APIError::DataIntegrityError(
             "Generating CSB files can only be done for CSB elections".to_string(),
@@ -577,6 +605,20 @@ async fn generate_and_save_files_csb_election(
     )
     .await?;
 
+    let attachment_pdf = create_file(
+        conn,
+        audit_service,
+        NewFile {
+            committee_session_id: committee_session.id,
+            file_type: FileType::CsbAttachmentPdf,
+            filename: pdf_files.attachment.file_name.clone(),
+            data: generate_pdf(&pdf_files.attachment).await?.buffer,
+            mime_type: PDF_MIME_TYPE.to_string(),
+            created_at,
+        },
+    )
+    .await?;
+
     let total_counts_eml = create_file(
         conn,
         audit_service,
@@ -591,11 +633,17 @@ async fn generate_and_save_files_csb_election(
     )
     .await?;
 
-    let pdf_file: Option<File> = Some(pdf);
-    let eml_results_file: Option<File> = Some(eml_results);
+    let pdf_file = Some(pdf);
+    let attachment_pdf_file = Some(attachment_pdf);
+    let eml_results_file = Some(eml_results);
     let eml_counts_file = Some(total_counts_eml);
 
-    Ok((eml_results_file, pdf_file, eml_counts_file))
+    Ok((
+        eml_results_file,
+        pdf_file,
+        attachment_pdf_file,
+        eml_counts_file,
+    ))
 }
 
 async fn create_file(
@@ -644,17 +692,29 @@ async fn get_existing_gsb_files(
 async fn get_existing_csb_files(
     conn: &mut SqliteConnection,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, Option<File>, Option<File>, DateTime<Utc>), APIError> {
+) -> Result<
+    (
+        Option<File>,
+        Option<File>,
+        Option<File>,
+        Option<File>,
+        DateTime<Utc>,
+    ),
+    APIError,
+> {
     let results_eml_file =
         file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsEml).await?;
     let results_pdf_file =
         file_repo::get_for_session(conn, committee_session_id, FileType::CsbResultsPdf).await?;
+    let attachment_pdf_file =
+        file_repo::get_for_session(conn, committee_session_id, FileType::CsbAttachmentPdf).await?;
     let total_counts_eml_file =
         file_repo::get_for_session(conn, committee_session_id, FileType::CsbTotalCountsEml).await?;
 
-    let created_at = results_pdf_file
+    let created_at = results_eml_file
         .as_ref()
-        .or(results_eml_file.as_ref())
+        .or(results_pdf_file.as_ref())
+        .or(attachment_pdf_file.as_ref())
         .or(total_counts_eml_file.as_ref())
         .map(|f| f.created_at)
         .unwrap_or_else(Utc::now);
@@ -662,6 +722,7 @@ async fn get_existing_csb_files(
     Ok((
         results_eml_file,
         results_pdf_file,
+        attachment_pdf_file,
         total_counts_eml_file,
         created_at,
     ))
@@ -731,7 +792,16 @@ async fn get_files_csb_election(
     pool: &SqlitePool,
     audit_service: AuditService,
     committee_session_id: CommitteeSessionId,
-) -> Result<(Option<File>, Option<File>, Option<File>, DateTime<Utc>), APIError> {
+) -> Result<
+    (
+        Option<File>,
+        Option<File>,
+        Option<File>,
+        Option<File>,
+        DateTime<Utc>,
+    ),
+    APIError,
+> {
     let mut conn = pool.acquire().await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
 
@@ -746,13 +816,20 @@ async fn get_files_csb_election(
     }
 
     // Check if files exist, if so, get files from database
-    let (mut results_eml_file, mut results_pdf_file, mut total_counts_eml_file, mut created_at) =
-        get_existing_csb_files(&mut conn, committee_session.id).await?;
+    let (
+        mut results_eml_file,
+        mut results_pdf_file,
+        mut attachment_pdf_file,
+        mut total_counts_eml_file,
+        mut created_at,
+    ) = get_existing_csb_files(&mut conn, committee_session.id).await?;
     drop(conn);
 
     // Determine if we need to generate any of the files
-    let generate_files =
-        results_eml_file.is_none() || results_pdf_file.is_none() || total_counts_eml_file.is_none();
+    let generate_files = results_eml_file.is_none()
+        || results_pdf_file.is_none()
+        || attachment_pdf_file.is_none()
+        || total_counts_eml_file.is_none();
 
     // If one of the files doesn't exist, generate all and save them to the database
     if generate_files {
@@ -764,15 +841,20 @@ async fn get_files_csb_election(
             created_at.with_timezone(&Local),
         )
         .await?;
-        (results_eml_file, results_pdf_file, total_counts_eml_file) =
-            generate_and_save_files_csb_election(&mut tx, &audit_service, committee_session, input)
-                .await?;
+        (
+            results_eml_file,
+            results_pdf_file,
+            attachment_pdf_file,
+            total_counts_eml_file,
+        ) = generate_and_save_files_csb_election(&mut tx, &audit_service, committee_session, input)
+            .await?;
         tx.commit().await?;
     }
 
     Ok((
         results_eml_file,
         results_pdf_file,
+        attachment_pdf_file,
         total_counts_eml_file,
         created_at,
     ))
@@ -940,7 +1022,7 @@ async fn election_download_zip_results_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (eml_results_file, pdf_file, _, created_at) =
+    let (eml_results_file, pdf_file, _, _, created_at) =
         get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -961,6 +1043,71 @@ async fn election_download_zip_results_csb(
             let xml_zip_filename = xml_results_zip_filename(&election);
             let xml_zip = zip_single_file(&eml_results_file.name, &eml_results_file.data).await?;
             zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
+        }
+
+        zip_writer.finish().await?;
+
+        Ok::<(), ZipResponseError>(())
+    });
+
+    Ok(zip_response)
+}
+
+/// Download a zip containing a PDF with model P 22-2 Bijlage 1 for CSB
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_attachment_csb",
+    responses(
+        (
+            status = 200,
+            description = "ZIP",
+            content_type = "application/zip",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.zip\"")
+            )
+        ),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+        ("committee_session_id" = CommitteeSessionId, description = "Committee session database id"),
+    ),
+)]
+async fn election_download_zip_attachment_csb(
+    user: User,
+    State(pool): State<SqlitePool>,
+    audit_service: AuditService,
+    Path((election_id, committee_session_id)): Path<(ElectionId, CommitteeSessionId)>,
+) -> Result<impl IntoResponse, APIError> {
+    let mut conn = pool.acquire().await?;
+
+    let committee_category =
+        committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
+    user.role().is_authorized(&committee_category)?;
+
+    let election = election_repo::get(&mut conn, election_id).await?;
+    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+    let (_, _, attachment_pdf_file, _, created_at) =
+        get_files_csb_election(&pool, audit_service, committee_session.id).await?;
+    drop(conn);
+
+    let download_zip_filename = download_zip_filename(
+        &election,
+        created_at.with_timezone(&Local),
+        "model-p22-2-bijlage",
+    );
+
+    let (zip_response, mut zip_writer) = ZipResponse::new(&download_zip_filename);
+
+    tokio::spawn(async move {
+        if let Some(attachment_pdf_file) = attachment_pdf_file {
+            zip_writer
+                .add_file(&attachment_pdf_file.name, &attachment_pdf_file.data)
+                .await?;
         }
 
         zip_writer.finish().await?;
@@ -1009,7 +1156,7 @@ async fn election_download_zip_total_counts_csb(
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
-    let (_, _, total_counts_eml_file, created_at) =
+    let (_, _, _, total_counts_eml_file, created_at) =
         get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -1254,11 +1401,12 @@ mod tests {
 
         // Files should be generated exactly once
         for _ in 1..=2 {
-            let (eml_results, pdf, eml_total_counts, _) =
+            let (eml_results, pdf, attachment_pdf, eml_total_counts, _) =
                 get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
                     .await
                     .expect("should return files");
             let pdf = pdf.expect("should have generated pdf");
+            let attachment_pdf = attachment_pdf.expect("should have generated attachment pdf");
             let eml_total_counts =
                 eml_total_counts.expect("should have generated total counts eml");
             let eml_results = eml_results.expect("should have generated results eml");
@@ -1269,12 +1417,15 @@ mod tests {
             assert_eq!(pdf.name, "Model_P22-2.pdf");
             assert_eq!(pdf.id, FileId::from(2));
 
+            assert_eq!(attachment_pdf.name, "Model_P22-2_bijlage.pdf");
+            assert_eq!(attachment_pdf.id, FileId::from(3));
+
             assert_eq!(eml_total_counts.name, "Totaaltelling_GR2024_Juinen.eml.xml");
-            assert_eq!(eml_total_counts.id, FileId::from(3));
+            assert_eq!(eml_total_counts.id, FileId::from(4));
 
             assert_eq!(
                 list_event_names(&mut conn).await.unwrap(),
-                ["FileCreated", "FileCreated", "FileCreated"]
+                ["FileCreated", "FileCreated", "FileCreated", "FileCreated"]
             );
         }
     }
@@ -1345,6 +1496,7 @@ mod tests {
             #[rustfmt::skip]
             let results = vec![
                 ("download_zip_results_csb", election_download_zip_results_csb(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
+                ("download_zip_attachment_csb", election_download_zip_attachment_csb(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
                 ("download_zip_total_counts_csb", election_download_zip_total_counts_csb(user.clone(), State(pool.clone()), audit.clone(), Path((election_id, committee_session_id))).await.into_response()),
             ];
             results

--- a/backend/src/domain/file.rs
+++ b/backend/src/domain/file.rs
@@ -20,6 +20,8 @@ pub enum FileType {
     GsbOverviewPdf,
     /// CSB results PDF (Model P 22-2)
     CsbResultsPdf,
+    /// CSB attachment PDF (Model P 22-2 Bijlage 1)
+    CsbAttachmentPdf,
     /// CSB total counts EML (510d)
     CsbTotalCountsEml,
     /// CSB results EML (520)

--- a/backend/tests/election_integration_test.rs
+++ b/backend/tests/election_integration_test.rs
@@ -793,6 +793,138 @@ async fn test_csb_election_zip_download_results_invalid_committee_session_state(
     path = "../fixtures",
     scripts("election_8_csb_with_results", "users")
 )))]
+async fn test_csb_election_zip_download_attachment_works(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorCSB).await;
+    let election_id = 8;
+    let committee_session_id = 801;
+
+    change_status_committee_session(
+        &addr,
+        &coordinator_cookie,
+        election_id,
+        committee_session_id,
+        "completed",
+    )
+    .await;
+    let committee_session =
+        get_election_committee_session(&addr, &coordinator_cookie, election_id).await;
+    assert_eq!(committee_session["status"], "completed");
+
+    // Update committee session details
+    let url = format!(
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}"
+    );
+    let response = reqwest::Client::new()
+        .put(&url)
+        .header("cookie", &coordinator_cookie)
+        .json(&serde_json::json!({
+            "location": "Juinen".to_string(),
+            "start_date": "2026-03-18".to_string(),
+            "start_time": "10:45".to_string(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "Unexpected response status"
+    );
+
+    let url = format!(
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_attachment_csb"
+    );
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", &coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/zip");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    println!("{:?}", content_disposition_string);
+    // Full filename contains created date and time, so checking if the name is correct up to the date
+    // File name: model-p22-2-bijlage_gr2024_juinen_gemeente_juinen-Ymd-HMS.zip
+    assert!(
+        &content_disposition_string[21..]
+            .starts_with("\"model-p22-2-bijlage_gr2024_juinen_gemeente_juinen"),
+    );
+
+    let bytes = response.bytes().await.unwrap();
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
+
+    // Extract and hash the PDF file
+    let mut reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_P22-2_bijlage.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+    let mut pdf_content = Vec::new();
+    reader.read_to_end_checked(&mut pdf_content).await.unwrap();
+    let pdf_hash1 = sha2::Sha256::digest(&pdf_content);
+
+    // Request the file again
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", &coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+
+    let bytes2 = response.bytes().await.unwrap();
+    let archive2 = ZipFileReader::new(bytes2.to_vec()).await.unwrap();
+
+    // Extract and hash the PDF file from second download
+    let mut reader2 = archive2.reader_with_entry(0).await.unwrap();
+    let mut pdf_content2 = Vec::new();
+    reader2
+        .read_to_end_checked(&mut pdf_content2)
+        .await
+        .unwrap();
+    let pdf_hash2 = sha2::Sha256::digest(&pdf_content2);
+
+    // Check that the files inside the zip are the same
+    assert_eq!(pdf_hash1, pdf_hash2, "PDF files should have the same hash");
+}
+
+#[test(sqlx::test(fixtures(
+    path = "../fixtures",
+    scripts("election_8_csb_with_results", "users")
+)))]
+async fn test_csb_election_zip_download_attachment_invalid_committee_session_state(
+    pool: SqlitePool,
+) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorCSB).await;
+    let election_id = 8;
+
+    let url = format!(
+        "http://{addr}/api/elections/{election_id}/committee_sessions/801/download_zip_attachment_csb"
+    );
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[test(sqlx::test(fixtures(
+    path = "../fixtures",
+    scripts("election_8_csb_with_results", "users")
+)))]
 async fn test_csb_election_zip_download_total_counts_works(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let coordinator_cookie = login(&addr, CoordinatorCSB).await;

--- a/frontend/src/features/election_management/components/report/CSBElectionReportSection.tsx
+++ b/frontend/src/features/election_management/components/report/CSBElectionReportSection.tsx
@@ -22,7 +22,6 @@ export function CSBElectionReportSection({ election }: CSBElectionReportSectionP
           {t("election_management.CSB.p_22_2_attachment.download", {
             electionName: election.name,
           })}
-          :
         </strong>
       </p>
       <ul>{tx("election_management.CSB.p_22_2_attachment.explanation_text")}</ul>

--- a/frontend/src/features/election_management/components/report/CSBElectionReportSection.tsx
+++ b/frontend/src/features/election_management/components/report/CSBElectionReportSection.tsx
@@ -17,15 +17,15 @@ export function CSBElectionReportSection({ election }: CSBElectionReportSectionP
         </strong>
       </p>
       <ul>{tx("election_management.CSB.determination_election_results.explanation_text")}</ul>
-      {/* Disabled for now: https://github.com/kiesraad/abacus/issues/2967 */}
-      {/*<p>*/}
-      {/*  <strong>*/}
-      {/*    {t("election_management.CSB.p_22_2_attachment.download", {*/}
-      {/*      electionName: election.name,*/}
-      {/*    })}:*/}
-      {/*  </strong>*/}
-      {/*</p>*/}
-      {/*<ul>{tx("election_management.CSB.p_22_2_attachment.explanation_text")}</ul>*/}
+      <p>
+        <strong>
+          {t("election_management.CSB.p_22_2_attachment.download", {
+            electionName: election.name,
+          })}
+          :
+        </strong>
+      </p>
+      <ul>{tx("election_management.CSB.p_22_2_attachment.explanation_text")}</ul>
       <p>
         <strong>{t("election_management.CSB.definitive_documents.download", { electionName: election.name })}</strong>
       </p>

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.test.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.test.tsx
@@ -427,8 +427,7 @@ describe("ElectionReportPage", () => {
         }),
       ).toBeVisible();
       expect(await screen.findByRole("link", { name: /Vaststelling uitslag/ })).toBeVisible();
-      // Disabled for now: https://github.com/kiesraad/abacus/issues/2967
-      // expect(await screen.findByRole("link", { name: /Model-p22-2-bijlage/ })).toBeVisible();
+      expect(await screen.findByRole("link", { name: /Model P 22-2 Bijlage 1/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: /Definitieve documenten/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: "Terug naar overzicht" })).toBeVisible();
       expect(await screen.findByRole("button", { name: "Invoer hervatten" })).toBeVisible();
@@ -462,8 +461,7 @@ describe("ElectionReportPage", () => {
         }),
       ).toBeVisible();
       expect(await screen.findByRole("link", { name: /Vaststelling uitslag/ })).toBeVisible();
-      // Disabled for now: https://github.com/kiesraad/abacus/issues/2967
-      //expect(await screen.findByRole("link", { name: /Model-p22-2-bijlage/ })).toBeVisible();
+      expect(await screen.findByRole("link", { name: /Model P 22-2 Bijlage 1/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: /Definitieve documenten/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: "Terug naar overzicht" })).toBeVisible();
 
@@ -509,8 +507,7 @@ describe("ElectionReportPage", () => {
         }),
       ).toBeVisible();
       expect(await screen.findByRole("link", { name: /Vaststelling uitslag/ })).toBeVisible();
-      // Disabled for now: https://github.com/kiesraad/abacus/issues/2967
-      // expect(await screen.findByRole("link", { name: /Model-p22-2-bijlage/ })).toBeVisible();
+      expect(await screen.findByRole("link", { name: /Model P 22-2 Bijlage 1/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: /Definitieve documenten/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: "Terug naar overzicht" })).toBeVisible();
       expect(screen.queryByRole("button", { name: "Invoer hervatten" })).not.toBeInTheDocument();
@@ -561,8 +558,7 @@ describe("ElectionReportPage", () => {
         }),
       ).toBeVisible();
       expect(await screen.findByRole("link", { name: /Vaststelling uitslag/ })).toBeVisible();
-      // Disabled for now: https://github.com/kiesraad/abacus/issues/2967
-      // expect(await screen.findByRole("link", { name: /Model-p22-2-bijlage/ })).toBeVisible();
+      expect(await screen.findByRole("link", { name: /Model P 22-2 Bijlage 1/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: /Definitieve documenten/ })).toBeVisible();
       expect(await screen.findByRole("link", { name: "Terug naar overzicht" })).toBeVisible();
 

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
@@ -109,7 +109,7 @@ export function ElectionReportPage() {
                   <DownloadButton
                     icon="download"
                     href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_results`}
-                    title={t(`election_management.${election.committee_category}.download_definitive_documents`, {
+                    title={t(`election_management.GSB.download_definitive_documents`, {
                       sessionLabel: sessionLabel.toLowerCase(),
                     })}
                     subtitle={t("election_management.zip_file")}
@@ -124,17 +124,16 @@ export function ElectionReportPage() {
                     title={t("election_management.CSB.determination_election_results.download")}
                     subtitle={t("election_management.zip_file")}
                   />
-                  {/* Disabled for now: https://github.com/kiesraad/abacus/issues/2967 */}
-                  {/*<DownloadButton*/}
-                  {/*  icon="download"*/}
-                  {/*  href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_results`}*/}
-                  {/*  title={t("election_management.CSB.p_22_2_attachment.download")}*/}
-                  {/*  subtitle={t("election_management.zip_file")}*/}
-                  {/*/>*/}
+                  <DownloadButton
+                    icon="download"
+                    href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_attachment_csb`}
+                    title={t("election_management.CSB.p_22_2_attachment.download")}
+                    subtitle={t("election_management.zip_file")}
+                  />
                   <DownloadButton
                     icon="download"
                     href={`/api/elections/${election.id}/committee_sessions/${committeeSession.id}/download_zip_total_counts_csb`}
-                    title={t(`election_management.${election.committee_category}.download_definitive_documents`, {
+                    title={t(`election_management.CSB.download_definitive_documents`, {
                       sessionLabel: sessionLabel.toLowerCase(),
                     })}
                     subtitle={t("election_management.zip_file")}

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -121,6 +121,14 @@ export interface ELECTION_DOWNLOAD_PDF_RESULTS_GSB_REQUEST_PARAMS {
 export type ELECTION_DOWNLOAD_PDF_RESULTS_GSB_REQUEST_PATH =
   `/api/elections/${ElectionId}/committee_sessions/${CommitteeSessionId}/download_pdf_results`;
 
+// /api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_attachment_csb
+export interface ELECTION_DOWNLOAD_ZIP_ATTACHMENT_CSB_REQUEST_PARAMS {
+  election_id: ElectionId;
+  committee_session_id: CommitteeSessionId;
+}
+export type ELECTION_DOWNLOAD_ZIP_ATTACHMENT_CSB_REQUEST_PATH =
+  `/api/elections/${ElectionId}/committee_sessions/${CommitteeSessionId}/download_zip_attachment_csb`;
+
 // /api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_results
 export interface ELECTION_DOWNLOAD_ZIP_RESULTS_GSB_REQUEST_PARAMS {
   election_id: ElectionId;


### PR DESCRIPTION
Resolves #3104

- Added report endpoint `download_zip_attachment_csb`
  - Added tests, including endpoint committee category test
  - Saving pdf with type `CsbAttachmentPdf` 
- Added download link and text
- Small refactor, now using structs instead of tuples https://github.com/kiesraad/abacus/pull/3246/commits/71b3ebe278ca79f03723c9ffa126583e6b3d5d09

File tree is:
```
model-p22-2-bijlage_gr2024_juinen_gemeente_juinen-20260430-141029.zip
├─ Model_P22-2_bijlage.pdf
```

<img width="589" height="977" alt="image" src="https://github.com/user-attachments/assets/2e57126c-c6d7-453b-9a0f-378323e9fbdc" />
