### PR TITLE
Refactor API error handling

### DIFF
--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -1,4 +1,6 @@
 use apportionment::ApportionmentError;
+use axum::http::StatusCode;
+use tracing::error;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 mod handlers;
@@ -10,7 +12,10 @@ pub use self::{
     structs::ApportionmentInputData,
 };
 use crate::{
-    APIError, AppState, api::middleware::authentication::RouteAuthorization, domain::role::Role,
+    APIError, AppState,
+    api::middleware::authentication::RouteAuthorization,
+    domain::role::Role,
+    error::{ApiErrorResponse, ErrorReference, ErrorResponse, error_response},
 };
 
 /// Errors that can occur before apportionment
@@ -20,6 +25,49 @@ pub enum ApportionmentApiError {
     CommitteeSessionNotCompleted,
     DrawingOfLotsNotImplemented,
     ZeroVotesCast,
+}
+
+impl ApiErrorResponse for ApportionmentApiError {
+    fn log(&self) {
+        error!("Apportionment error: {:?}", self);
+    }
+
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
+        match self {
+            ApportionmentApiError::AllListsExhausted => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                error_response(
+                    "All lists are exhausted, not enough candidates to fill all seats",
+                    ErrorReference::ApportionmentAllListsExhausted,
+                    false,
+                ),
+            ),
+            ApportionmentApiError::CommitteeSessionNotCompleted => (
+                StatusCode::PRECONDITION_FAILED,
+                error_response(
+                    "Committee session not completed",
+                    ErrorReference::ApportionmentCommitteeSessionNotCompleted,
+                    false,
+                ),
+            ),
+            ApportionmentApiError::DrawingOfLotsNotImplemented => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                error_response(
+                    "Drawing of lots is required",
+                    ErrorReference::ApportionmentDrawingOfLotsRequired,
+                    false,
+                ),
+            ),
+            ApportionmentApiError::ZeroVotesCast => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                error_response(
+                    "No votes on candidates cast",
+                    ErrorReference::ApportionmentZeroVotesCast,
+                    false,
+                ),
+            ),
+        }
+    }
 }
 
 impl From<ApportionmentError> for ApportionmentApiError {
@@ -34,13 +82,13 @@ impl From<ApportionmentError> for ApportionmentApiError {
 
 impl From<ApportionmentError> for APIError {
     fn from(err: ApportionmentError) -> Self {
-        APIError::Apportionment(err.into())
+        ApportionmentApiError::from(err).into()
     }
 }
 
 impl From<ApportionmentApiError> for APIError {
     fn from(err: ApportionmentApiError) -> Self {
-        APIError::Apportionment(err)
+        APIError::Delegated(Box::new(err))
     }
 }
 

--- a/backend/src/api/authentication.rs
+++ b/backend/src/api/authentication.rs
@@ -29,7 +29,7 @@ use crate::{
 
 impl From<AuthenticationError> for APIError {
     fn from(err: AuthenticationError) -> Self {
-        APIError::Authentication(err)
+        APIError::Delegated(Box::new(err))
     }
 }
 #[derive(Serialize)]
@@ -537,12 +537,12 @@ mod tests {
     async fn test_initialised(pool: SqlitePool) {
         let result = initialised(State(pool.clone())).await;
 
-        assert!(matches!(
-            result,
-            Err(APIError::Authentication(
-                AuthenticationError::NotInitialised
-            ))
-        ));
+        let Err(api_error) = result else {
+            panic!("expected NotInitialised error");
+        };
+        let response = api_error.into_response();
+        let error_response = response.extensions().get::<ErrorResponse>().unwrap();
+        assert_eq!(error_response.reference, ErrorReference::NotInitialised);
 
         // Create an admin user to mark the application as initialised
         let mut conn = pool.acquire().await.unwrap();

--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -6,10 +6,11 @@ use axum::{
 use chrono::NaiveDateTime;
 use serde::Serialize;
 use sqlx::{SqliteConnection, SqlitePool};
+use tracing::error;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
-    APIError, AppState, ErrorResponse, SqlitePoolExt,
+    APIError, AppState, SqlitePoolExt,
     api::middleware::authentication::RouteAuthorization,
     domain::{
         committee_session::{
@@ -22,7 +23,7 @@ use crate::{
         role::Role,
         validate::DataError,
     },
-    error::ErrorReference,
+    error::{ApiErrorResponse, ErrorReference, ErrorResponse, error_response},
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
     repository::{
         committee_session_repo::{
@@ -36,6 +37,49 @@ use crate::{
         change_committee_session_status, list_polling_stations_for_session,
     },
 };
+
+impl ApiErrorResponse for CommitteeSessionError {
+    fn log(&self) {
+        error!("Committee session status error: {:?}", self);
+    }
+
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
+        match self {
+            CommitteeSessionError::CommitteeSessionPaused => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Committee session data entry is paused",
+                    ErrorReference::CommitteeSessionPaused,
+                    true,
+                ),
+            ),
+            CommitteeSessionError::InvalidCommitteeSessionStatus => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Invalid committee session status",
+                    ErrorReference::InvalidCommitteeSessionStatus,
+                    true,
+                ),
+            ),
+            CommitteeSessionError::InvalidDetails => (
+                StatusCode::BAD_REQUEST,
+                error_response("Invalid details", ErrorReference::InvalidData, false),
+            ),
+            CommitteeSessionError::InvalidStatusTransition => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Invalid committee session state transition",
+                    ErrorReference::InvalidStateTransition,
+                    true,
+                ),
+            ),
+            CommitteeSessionError::ProviderError => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error_response("Internal server error", ErrorReference::DatabaseError, true),
+            ),
+        }
+    }
+}
 
 #[derive(Serialize)]
 pub struct CommitteeSessionCreatedAuditData(pub CommitteeSessionAuditData);

--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -142,9 +142,7 @@ pub async fn committee_session_create(
         Ok((StatusCode::CREATED, next_committee_session))
     } else {
         tx.rollback().await?;
-        Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidCommitteeSessionStatus,
-        ))
+        Err(CommitteeSessionError::InvalidCommitteeSessionStatus.into())
     }
 }
 
@@ -213,9 +211,7 @@ pub async fn committee_session_delete(
     } else {
         tx.rollback().await?;
 
-        Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidCommitteeSessionStatus,
-        ))
+        Err(CommitteeSessionError::InvalidCommitteeSessionStatus.into())
     }
 }
 
@@ -249,18 +245,14 @@ pub async fn committee_session_update(
         .is_authorized(&get_committee_category(&mut tx, committee_session_id).await?)?;
 
     if request.location.is_empty() {
-        return Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidDetails,
-        ));
+        return Err(CommitteeSessionError::InvalidDetails.into());
     }
 
     let date_time_str = format!("{}T{}", &request.start_date, &request.start_time);
     let date_time = match NaiveDateTime::parse_from_str(&date_time_str, "%Y-%m-%dT%H:%M") {
         Ok(date) => date,
         Err(_) => {
-            return Err(APIError::CommitteeSession(
-                CommitteeSessionError::InvalidDetails,
-            ));
+            return Err(CommitteeSessionError::InvalidDetails.into());
         }
     };
 

--- a/backend/src/api/election.rs
+++ b/backend/src/api/election.rs
@@ -267,9 +267,7 @@ pub async fn election_number_of_voters_change(
     } else {
         tx.rollback().await?;
 
-        Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidCommitteeSessionStatus,
-        ))
+        Err(CommitteeSessionError::InvalidCommitteeSessionStatus.into())
     }
 }
 

--- a/backend/src/api/middleware/authentication/error.rs
+++ b/backend/src/api/middleware/authentication/error.rs
@@ -1,4 +1,8 @@
 use argon2::password_hash;
+use axum::http::StatusCode;
+use tracing::error;
+
+use crate::error::{ApiErrorResponse, ErrorReference, ErrorResponse, error_response};
 
 #[derive(Debug)]
 pub enum AuthenticationError {
@@ -22,6 +26,127 @@ pub enum AuthenticationError {
     UserAlreadySetup,
     UsernameAlreadyExists,
     UserNotFound,
+}
+
+impl ApiErrorResponse for AuthenticationError {
+    fn log(&self) {
+        // note that we don't log the UserNotFound error, as it is triggered for every account call
+        if !matches!(self, Self::UserNotFound) {
+            error!("Authentication error: {:?}", self);
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
+        match self {
+            AuthenticationError::InvalidUsernameOrPassword => (
+                StatusCode::UNAUTHORIZED,
+                error_response(
+                    "Invalid username and/or password",
+                    ErrorReference::InvalidUsernameOrPassword,
+                    false,
+                ),
+            ),
+            AuthenticationError::UsernameAlreadyExists => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Username already exists",
+                    ErrorReference::UsernameNotUnique,
+                    false,
+                ),
+            ),
+            AuthenticationError::NotInitialised => (
+                StatusCode::IM_A_TEAPOT,
+                error_response(
+                    "Application not initialised",
+                    ErrorReference::NotInitialised,
+                    false,
+                ),
+            ),
+            AuthenticationError::AlreadyInitialised => (
+                StatusCode::FORBIDDEN,
+                error_response(
+                    "Application already initialised",
+                    ErrorReference::AlreadyInitialised,
+                    false,
+                ),
+            ),
+            AuthenticationError::UserNotFound => (
+                StatusCode::UNAUTHORIZED,
+                error_response("User not found", ErrorReference::UserNotFound, false),
+            ),
+            AuthenticationError::UserAlreadySetup => (
+                StatusCode::CONFLICT,
+                error_response("Invalid user state", ErrorReference::Forbidden, false),
+            ),
+            AuthenticationError::InvalidPassword => (
+                StatusCode::UNAUTHORIZED,
+                error_response(
+                    "Invalid password provided",
+                    ErrorReference::InvalidPassword,
+                    false,
+                ),
+            ),
+            AuthenticationError::SessionKeyNotFound | AuthenticationError::NoSessionCookie => (
+                StatusCode::UNAUTHORIZED,
+                error_response("Invalid session", ErrorReference::InvalidSession, false),
+            ),
+            AuthenticationError::Unauthorized | AuthenticationError::Unauthenticated => (
+                StatusCode::UNAUTHORIZED,
+                error_response("Unauthorized", ErrorReference::Unauthorized, false),
+            ),
+            AuthenticationError::Forbidden => (
+                StatusCode::FORBIDDEN,
+                error_response("Forbidden", ErrorReference::Forbidden, true),
+            ),
+            AuthenticationError::PasswordRejectionSameAsOld => (
+                StatusCode::BAD_REQUEST,
+                error_response(
+                    "Invalid password",
+                    ErrorReference::PasswordRejectionSameAsOld,
+                    false,
+                ),
+            ),
+            AuthenticationError::PasswordRejectionSameAsUsername => (
+                StatusCode::BAD_REQUEST,
+                error_response(
+                    "Invalid password",
+                    ErrorReference::PasswordRejectionSameAsUsername,
+                    false,
+                ),
+            ),
+            AuthenticationError::PasswordRejectionTooShort => (
+                StatusCode::BAD_REQUEST,
+                error_response(
+                    "Invalid password",
+                    ErrorReference::PasswordRejectionTooShort,
+                    false,
+                ),
+            ),
+            AuthenticationError::RoleNotAuthorizedError => (
+                StatusCode::FORBIDDEN,
+                error_response("Invalid role", ErrorReference::Forbidden, true),
+            ),
+            AuthenticationError::OwnAccountCannotBeDeleted => (
+                StatusCode::FORBIDDEN,
+                error_response(
+                    "Cannot delete your own account",
+                    ErrorReference::OwnAccountCannotBeDeleted,
+                    false,
+                ),
+            ),
+            AuthenticationError::Database(_)
+            | AuthenticationError::HashPassword(_)
+            | AuthenticationError::InvalidSessionDuration => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error_response(
+                    "Internal server error",
+                    ErrorReference::InternalServerError,
+                    false,
+                ),
+            ),
+        }
+    }
 }
 
 impl From<password_hash::Error> for AuthenticationError {

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -682,9 +682,7 @@ async fn get_files_gsb_election(
         || committee_session.start_date_time.is_none()
         || !are_results_complete_for_committee_session(&mut conn, committee_session.id).await?
     {
-        return Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidCommitteeSessionStatus,
-        ));
+        return Err(CommitteeSessionError::InvalidCommitteeSessionStatus.into());
     }
 
     // Check if files exist, if so, get files from database
@@ -740,9 +738,7 @@ async fn get_files_csb_election(
         || committee_session.start_date_time.is_none()
         || !are_results_complete_for_committee_session(&mut conn, committee_session.id).await?
     {
-        return Err(APIError::CommitteeSession(
-            CommitteeSessionError::InvalidCommitteeSessionStatus,
-        ));
+        return Err(CommitteeSessionError::InvalidCommitteeSessionStatus.into());
     }
 
     // Check if files exist, if so, get files from database

--- a/backend/src/domain/committee_session.rs
+++ b/backend/src/domain/committee_session.rs
@@ -1,15 +1,20 @@
 use axum::{
     Json,
+    http::StatusCode,
     response::{IntoResponse, Response},
 };
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Type};
+use tracing::error;
 use utoipa::ToSchema;
 
-use crate::domain::{
-    committee_session_status::CommitteeSessionStatus, election::ElectionId, identifier::id,
-    investigation::PollingStationInvestigation,
+use crate::{
+    domain::{
+        committee_session_status::CommitteeSessionStatus, election::ElectionId, identifier::id,
+        investigation::PollingStationInvestigation,
+    },
+    error::{ApiErrorResponse, ErrorReference, ErrorResponse, error_response},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -19,6 +24,49 @@ pub enum CommitteeSessionError {
     InvalidDetails,
     InvalidStatusTransition,
     ProviderError,
+}
+
+impl ApiErrorResponse for CommitteeSessionError {
+    fn log(&self) {
+        error!("Committee session status error: {:?}", self);
+    }
+
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
+        match self {
+            CommitteeSessionError::CommitteeSessionPaused => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Committee session data entry is paused",
+                    ErrorReference::CommitteeSessionPaused,
+                    true,
+                ),
+            ),
+            CommitteeSessionError::InvalidCommitteeSessionStatus => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Invalid committee session status",
+                    ErrorReference::InvalidCommitteeSessionStatus,
+                    true,
+                ),
+            ),
+            CommitteeSessionError::InvalidDetails => (
+                StatusCode::BAD_REQUEST,
+                error_response("Invalid details", ErrorReference::InvalidData, false),
+            ),
+            CommitteeSessionError::InvalidStatusTransition => (
+                StatusCode::CONFLICT,
+                error_response(
+                    "Invalid committee session state transition",
+                    ErrorReference::InvalidStateTransition,
+                    true,
+                ),
+            ),
+            CommitteeSessionError::ProviderError => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error_response("Internal server error", ErrorReference::DatabaseError, true),
+            ),
+        }
+    }
 }
 
 id!(CommitteeSessionId);

--- a/backend/src/domain/committee_session.rs
+++ b/backend/src/domain/committee_session.rs
@@ -1,20 +1,15 @@
 use axum::{
     Json,
-    http::StatusCode,
     response::{IntoResponse, Response},
 };
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Type};
-use tracing::error;
 use utoipa::ToSchema;
 
-use crate::{
-    domain::{
-        committee_session_status::CommitteeSessionStatus, election::ElectionId, identifier::id,
-        investigation::PollingStationInvestigation,
-    },
-    error::{ApiErrorResponse, ErrorReference, ErrorResponse, error_response},
+use crate::domain::{
+    committee_session_status::CommitteeSessionStatus, election::ElectionId, identifier::id,
+    investigation::PollingStationInvestigation,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -24,49 +19,6 @@ pub enum CommitteeSessionError {
     InvalidDetails,
     InvalidStatusTransition,
     ProviderError,
-}
-
-impl ApiErrorResponse for CommitteeSessionError {
-    fn log(&self) {
-        error!("Committee session status error: {:?}", self);
-    }
-
-    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
-        match self {
-            CommitteeSessionError::CommitteeSessionPaused => (
-                StatusCode::CONFLICT,
-                error_response(
-                    "Committee session data entry is paused",
-                    ErrorReference::CommitteeSessionPaused,
-                    true,
-                ),
-            ),
-            CommitteeSessionError::InvalidCommitteeSessionStatus => (
-                StatusCode::CONFLICT,
-                error_response(
-                    "Invalid committee session status",
-                    ErrorReference::InvalidCommitteeSessionStatus,
-                    true,
-                ),
-            ),
-            CommitteeSessionError::InvalidDetails => (
-                StatusCode::BAD_REQUEST,
-                error_response("Invalid details", ErrorReference::InvalidData, false),
-            ),
-            CommitteeSessionError::InvalidStatusTransition => (
-                StatusCode::CONFLICT,
-                error_response(
-                    "Invalid committee session state transition",
-                    ErrorReference::InvalidStateTransition,
-                    true,
-                ),
-            ),
-            CommitteeSessionError::ProviderError => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                error_response("Internal server error", ErrorReference::DatabaseError, true),
-            ),
-        }
-    }
 }
 
 id!(CommitteeSessionId);

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -16,10 +16,7 @@ use utoipa::ToSchema;
 
 use crate::{
     MAX_BODY_SIZE_MB,
-    api::{
-        apportionment::ApportionmentApiError,
-        middleware::authentication::error::AuthenticationError,
-    },
+    api::middleware::authentication::error::AuthenticationError,
     domain::{
         committee_session::CommitteeSessionError, role::RoleNotAuthorizedError, validate::DataError,
     },
@@ -27,6 +24,15 @@ use crate::{
     repository::polling_station_repo,
     service::{DataEntryServiceError, PollingStationServiceError, SubCommitteeServiceError},
 };
+
+/// Trait for error types that can be converted to HTTP response parts
+pub trait ApiErrorResponse: std::fmt::Debug {
+    /// Returns the HTTP status code and error response body for this error
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse);
+
+    /// Emit tracing logs for this error. Default implementation is a no-op.
+    fn log(&self) {}
+}
 
 /// Error reference used to show the corresponding error message to the end-user
 #[derive(Serialize, Deserialize, Clone, Copy, ToSchema, PartialEq, Eq, Debug)]
@@ -101,11 +107,9 @@ impl IntoResponse for ErrorResponse {
 pub enum APIError {
     AddError(String, ErrorReference),
     AirgapViolation(String),
-    Apportionment(ApportionmentApiError),
-    Authentication(AuthenticationError),
     BadRequest(String, ErrorReference),
-    CommitteeSession(CommitteeSessionError),
     Conflict(String, ErrorReference),
+    Delegated(Box<dyn ApiErrorResponse>),
     ContentTooLarge(String, ErrorReference),
     DataIntegrityError(String),
     EmlImportError(EMLImportError),
@@ -125,75 +129,82 @@ pub enum APIError {
     ZipError(ZipResponseError),
 }
 
-impl IntoResponse for APIError {
+pub(crate) fn error_response(error: &str, reference: ErrorReference, fatal: bool) -> ErrorResponse {
+    ErrorResponse {
+        error: error.to_string(),
+        reference,
+        fatal,
+    }
+}
+
+impl APIError {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::cognitive_complexity)]
-    fn into_response(self) -> Response {
-        fn to_error(error: &str, reference: ErrorReference, fatal: bool) -> ErrorResponse {
-            ErrorResponse {
-                error: error.to_string(),
-                reference,
-                fatal,
+    fn into_response_parts(self) -> (StatusCode, ErrorResponse) {
+        match self {
+            APIError::Delegated(err) => {
+                err.log();
+                err.to_response_parts()
             }
-        }
-
-        let (status, error_response) = match self {
             APIError::AirgapViolation(message) => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                to_error(&message, ErrorReference::AirgapViolation, true),
+                error_response(&message, ErrorReference::AirgapViolation, true),
             ),
-            APIError::BadRequest(message, reference) => {
-                (StatusCode::BAD_REQUEST, to_error(&message, reference, true))
-            }
-            APIError::ContentTooLarge(max_size, reference) => (
+            APIError::BadRequest(message, reference) => (
+                StatusCode::BAD_REQUEST,
+                error_response(&message, reference, true),
+            ),
+            APIError::ContentTooLarge(message, reference) => (
                 StatusCode::PAYLOAD_TOO_LARGE,
-                to_error(&max_size, reference, false),
+                error_response(&message, reference, false),
             ),
-            APIError::NotFound(message, reference) => {
-                (StatusCode::NOT_FOUND, to_error(&message, reference, true))
-            }
-            APIError::Conflict(message, reference) => {
-                (StatusCode::CONFLICT, to_error(&message, reference, false))
-            }
+            APIError::NotFound(message, reference) => (
+                StatusCode::NOT_FOUND,
+                error_response(&message, reference, true),
+            ),
+            APIError::Conflict(message, reference) => (
+                StatusCode::CONFLICT,
+                error_response(&message, reference, false),
+            ),
             APIError::DataIntegrityError(message) => {
                 error!("Data integrity error: {}", message);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error("Internal server error", ErrorReference::DatabaseError, true),
+                    error_response("Internal server error", ErrorReference::DatabaseError, true),
                 )
             }
             APIError::InvalidData(err) => {
                 error!("Invalid data error: {}", err);
                 (
                     StatusCode::UNPROCESSABLE_ENTITY,
-                    to_error("Invalid data", ErrorReference::InvalidData, false),
+                    error_response("Invalid data", ErrorReference::InvalidData, false),
                 )
             }
             APIError::JsonRejection(rejection) => (
                 StatusCode::UNPROCESSABLE_ENTITY,
-                to_error(&rejection.body_text(), ErrorReference::InvalidJson, true),
+                error_response(&rejection.body_text(), ErrorReference::InvalidJson, true),
             ),
             APIError::SerdeJsonError(err) => {
                 error!("Serde JSON error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error("Internal server error", ErrorReference::InvalidJson, true),
+                    error_response("Internal server error", ErrorReference::InvalidJson, true),
                 )
             }
             APIError::SqlxError(sqlx::Error::RowNotFound) => (
                 StatusCode::NOT_FOUND,
-                to_error("Resource not found", ErrorReference::EntryNotFound, true),
+                error_response("Resource not found", ErrorReference::EntryNotFound, true),
             ),
             APIError::SqlxError(err) => {
                 error!("SQLx error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error("Internal server error", ErrorReference::DatabaseError, true),
+                    error_response("Internal server error", ErrorReference::DatabaseError, true),
                 )
             }
             APIError::InvalidHeaderValue => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                to_error(
+                error_response(
                     "Internal server error",
                     ErrorReference::InternalServerError,
                     true,
@@ -203,7 +214,7 @@ impl IntoResponse for APIError {
                 error!("Pdf generation error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error(
+                    error_response(
                         "Internal server error",
                         ErrorReference::PdfGenerationError,
                         false,
@@ -214,7 +225,7 @@ impl IntoResponse for APIError {
                 error!("Error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error(
+                    error_response(
                         "Internal server error",
                         ErrorReference::InternalServerError,
                         true,
@@ -225,21 +236,21 @@ impl IntoResponse for APIError {
                 error!("Error while adding totals: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error("Internal server error", reference, false),
+                    error_response("Internal server error", reference, false),
                 )
             }
             APIError::InvalidHashError => {
                 error!("Invalid hash");
                 (
                     StatusCode::BAD_REQUEST,
-                    to_error("Invalid hash", ErrorReference::InvalidHash, false),
+                    error_response("Invalid hash", ErrorReference::InvalidHash, false),
                 )
             }
             APIError::XmlError(err) => {
                 error!("Could not serialize XML: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error(
+                    error_response(
                         "Internal server error",
                         ErrorReference::InternalServerError,
                         false,
@@ -250,132 +261,14 @@ impl IntoResponse for APIError {
                 error!("Could not deserialize XML: {:?}", err);
                 (
                     StatusCode::BAD_REQUEST,
-                    to_error("Invalid XML", ErrorReference::InvalidXml, false),
+                    error_response("Invalid XML", ErrorReference::InvalidXml, false),
                 )
-            }
-            APIError::Authentication(err) => {
-                // note that we don't log the UserNotFound error, as it is triggered for every account call
-                if !matches!(err, AuthenticationError::UserNotFound) {
-                    error!("Authentication error: {:?}", err);
-                }
-
-                match err {
-                    // client errors
-                    AuthenticationError::InvalidUsernameOrPassword => (
-                        StatusCode::UNAUTHORIZED,
-                        to_error(
-                            "Invalid username and/or password",
-                            ErrorReference::InvalidUsernameOrPassword,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::UsernameAlreadyExists => (
-                        StatusCode::CONFLICT,
-                        to_error(
-                            "Username already exists",
-                            ErrorReference::UsernameNotUnique,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::NotInitialised => (
-                        StatusCode::IM_A_TEAPOT,
-                        to_error(
-                            "Application not initialised",
-                            ErrorReference::NotInitialised,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::AlreadyInitialised => (
-                        StatusCode::FORBIDDEN,
-                        to_error(
-                            "Application already initialised",
-                            ErrorReference::AlreadyInitialised,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::UserNotFound => (
-                        StatusCode::UNAUTHORIZED,
-                        to_error("User not found", ErrorReference::UserNotFound, false),
-                    ),
-                    AuthenticationError::UserAlreadySetup => (
-                        StatusCode::CONFLICT,
-                        to_error("Invalid user state", ErrorReference::Forbidden, false),
-                    ),
-                    AuthenticationError::InvalidPassword => (
-                        StatusCode::UNAUTHORIZED,
-                        to_error(
-                            "Invalid password provided",
-                            ErrorReference::InvalidPassword,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::SessionKeyNotFound
-                    | AuthenticationError::NoSessionCookie => (
-                        StatusCode::UNAUTHORIZED,
-                        to_error("Invalid session", ErrorReference::InvalidSession, false),
-                    ),
-                    AuthenticationError::Unauthorized | AuthenticationError::Unauthenticated => (
-                        StatusCode::UNAUTHORIZED,
-                        to_error("Unauthorized", ErrorReference::Unauthorized, false),
-                    ),
-                    AuthenticationError::Forbidden => (
-                        StatusCode::FORBIDDEN,
-                        to_error("Forbidden", ErrorReference::Forbidden, true),
-                    ),
-                    AuthenticationError::PasswordRejectionSameAsOld => (
-                        StatusCode::BAD_REQUEST,
-                        to_error(
-                            "Invalid password",
-                            ErrorReference::PasswordRejectionSameAsOld,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::PasswordRejectionSameAsUsername => (
-                        StatusCode::BAD_REQUEST,
-                        to_error(
-                            "Invalid password",
-                            ErrorReference::PasswordRejectionSameAsUsername,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::PasswordRejectionTooShort => (
-                        StatusCode::BAD_REQUEST,
-                        to_error(
-                            "Invalid password",
-                            ErrorReference::PasswordRejectionTooShort,
-                            false,
-                        ),
-                    ),
-                    AuthenticationError::RoleNotAuthorizedError => (
-                        StatusCode::FORBIDDEN,
-                        to_error("Invalid role", ErrorReference::Forbidden, true),
-                    ),
-                    AuthenticationError::OwnAccountCannotBeDeleted => (
-                        StatusCode::FORBIDDEN,
-                        to_error(
-                            "Cannot delete your own account",
-                            ErrorReference::OwnAccountCannotBeDeleted,
-                            false,
-                        ),
-                    ),
-                    // server errors
-                    AuthenticationError::Database(_)
-                    | AuthenticationError::HashPassword(_)
-                    | AuthenticationError::InvalidSessionDuration => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        to_error(
-                            "Internal server error",
-                            ErrorReference::InternalServerError,
-                            false,
-                        ),
-                    ),
-                }
             }
             APIError::ZipError(err) => {
                 error!("Error with zip file: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    to_error(
+                    error_response(
                         "Internal server error",
                         ErrorReference::InternalServerError,
                         false,
@@ -386,105 +279,33 @@ impl IntoResponse for APIError {
                 error!("Error importing EML file: {:?}", err);
                 (
                     StatusCode::BAD_REQUEST,
-                    to_error("EML import error", ErrorReference::EmlImportError, false),
+                    error_response("EML import error", ErrorReference::EmlImportError, false),
                 )
             }
             APIError::EmlError(err) => {
                 error!("Error with EML file: {:?}", err);
                 (
                     StatusCode::BAD_REQUEST,
-                    to_error("EML error", ErrorReference::EmlError, false),
+                    error_response("EML error", ErrorReference::EmlError, false),
                 )
-            }
-            APIError::Apportionment(err) => {
-                error!("Apportionment error: {:?}", err);
-
-                match err {
-                    ApportionmentApiError::AllListsExhausted => (
-                        StatusCode::UNPROCESSABLE_ENTITY,
-                        to_error(
-                            "All lists are exhausted, not enough candidates to fill all seats",
-                            ErrorReference::ApportionmentAllListsExhausted,
-                            false,
-                        ),
-                    ),
-                    ApportionmentApiError::CommitteeSessionNotCompleted => (
-                        StatusCode::PRECONDITION_FAILED,
-                        to_error(
-                            "Committee session not completed",
-                            ErrorReference::ApportionmentCommitteeSessionNotCompleted,
-                            false,
-                        ),
-                    ),
-                    ApportionmentApiError::DrawingOfLotsNotImplemented => (
-                        StatusCode::UNPROCESSABLE_ENTITY,
-                        to_error(
-                            "Drawing of lots is required",
-                            ErrorReference::ApportionmentDrawingOfLotsRequired,
-                            false,
-                        ),
-                    ),
-                    ApportionmentApiError::ZeroVotesCast => (
-                        StatusCode::UNPROCESSABLE_ENTITY,
-                        to_error(
-                            "No votes on candidates cast",
-                            ErrorReference::ApportionmentZeroVotesCast,
-                            false,
-                        ),
-                    ),
-                }
-            }
-            APIError::CommitteeSession(err) => {
-                error!("Committee session status error: {:?}", err);
-
-                match err {
-                    CommitteeSessionError::CommitteeSessionPaused => (
-                        StatusCode::CONFLICT,
-                        to_error(
-                            "Committee session data entry is paused",
-                            ErrorReference::CommitteeSessionPaused,
-                            true,
-                        ),
-                    ),
-                    CommitteeSessionError::InvalidCommitteeSessionStatus => (
-                        StatusCode::CONFLICT,
-                        to_error(
-                            "Invalid committee session status",
-                            ErrorReference::InvalidCommitteeSessionStatus,
-                            true,
-                        ),
-                    ),
-                    CommitteeSessionError::InvalidDetails => (
-                        StatusCode::BAD_REQUEST,
-                        to_error("Invalid details", ErrorReference::InvalidData, false),
-                    ),
-                    CommitteeSessionError::InvalidStatusTransition => (
-                        StatusCode::CONFLICT,
-                        to_error(
-                            "Invalid committee session state transition",
-                            ErrorReference::InvalidStateTransition,
-                            true,
-                        ),
-                    ),
-                    CommitteeSessionError::ProviderError => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        to_error("Internal server error", ErrorReference::DatabaseError, true),
-                    ),
-                }
             }
             APIError::InvalidResultsType => (
                 StatusCode::BAD_REQUEST,
-                to_error(
+                error_response(
                     "Internal server error",
                     ErrorReference::InternalServerError,
                     true,
                 ),
             ),
-        };
+        }
+    }
+}
 
-        let mut response = (status, error_response.clone()).into_response();
-        response.extensions_mut().insert(error_response);
-
+impl IntoResponse for APIError {
+    fn into_response(self) -> Response {
+        let (status, body) = self.into_response_parts();
+        let mut response = (status, body.clone()).into_response();
+        response.extensions_mut().insert(body);
         response
     }
 }
@@ -551,7 +372,7 @@ impl From<Box<dyn Error>> for APIError {
 
 impl From<CommitteeSessionError> for APIError {
     fn from(err: CommitteeSessionError) -> Self {
-        APIError::CommitteeSession(err)
+        APIError::Delegated(Box::new(err))
     }
 }
 
@@ -576,7 +397,7 @@ impl From<PollingStationServiceError> for APIError {
 
 impl From<RoleNotAuthorizedError> for APIError {
     fn from(_: RoleNotAuthorizedError) -> Self {
-        APIError::Authentication(AuthenticationError::RoleNotAuthorizedError)
+        AuthenticationError::RoleNotAuthorizedError.into()
     }
 }
 
@@ -598,6 +419,7 @@ impl From<polling_station_repo::CreateDataEntryError> for APIError {
         }
     }
 }
+
 /// Map common internal errors to user-friendly error messages
 pub async fn map_error_response(response: Response) -> Response {
     if response.status() == StatusCode::PAYLOAD_TOO_LARGE {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -117,7 +117,6 @@ pub enum APIError {
     InvalidData(DataError),
     InvalidHeaderValue,
     InvalidHashError,
-    InvalidResultsType,
     JsonRejection(JsonRejection),
     NotFound(String, ErrorReference),
     PdfGenError(PdfGenError),
@@ -289,14 +288,6 @@ impl APIError {
                     error_response("EML error", ErrorReference::EmlError, false),
                 )
             }
-            APIError::InvalidResultsType => (
-                StatusCode::BAD_REQUEST,
-                error_response(
-                    "Internal server error",
-                    ErrorReference::InternalServerError,
-                    true,
-                ),
-            ),
         }
     }
 }


### PR DESCRIPTION
- Refactor API error handling with `ApiErrorResponse` trait and delegate authentication, apportionment and committee session API errors to this trait.
- Remove unused `APIError::InvalidResultsType` enum variant

This resolves a part of the points mentioned in #2884, but not e.g. `APIError` usage in the domain layer.