### PR TITLE
impl ToString for Error::new

### DIFF
--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -37,9 +37,7 @@ impl ApiErrorResponse for ApportionmentApiError {
             ApportionmentApiError::AllListsExhausted => (
                 StatusCode::UNPROCESSABLE_ENTITY,
                 ErrorResponse::new(
-                    String::from(
-                        "All lists are exhausted, not enough candidates to fill all seats",
-                    ),
+                    "All lists are exhausted, not enough candidates to fill all seats",
                     ErrorReference::ApportionmentAllListsExhausted,
                     false,
                 ),
@@ -47,7 +45,7 @@ impl ApiErrorResponse for ApportionmentApiError {
             ApportionmentApiError::CommitteeSessionNotCompleted => (
                 StatusCode::PRECONDITION_FAILED,
                 ErrorResponse::new(
-                    String::from("Committee session not completed"),
+                    "Committee session not completed",
                     ErrorReference::ApportionmentCommitteeSessionNotCompleted,
                     false,
                 ),
@@ -55,7 +53,7 @@ impl ApiErrorResponse for ApportionmentApiError {
             ApportionmentApiError::DrawingOfLotsNotImplemented => (
                 StatusCode::UNPROCESSABLE_ENTITY,
                 ErrorResponse::new(
-                    String::from("Drawing of lots is required"),
+                    "Drawing of lots is required",
                     ErrorReference::ApportionmentDrawingOfLotsRequired,
                     false,
                 ),
@@ -63,7 +61,7 @@ impl ApiErrorResponse for ApportionmentApiError {
             ApportionmentApiError::ZeroVotesCast => (
                 StatusCode::UNPROCESSABLE_ENTITY,
                 ErrorResponse::new(
-                    String::from("No votes on candidates cast"),
+                    "No votes on candidates cast",
                     ErrorReference::ApportionmentZeroVotesCast,
                     false,
                 ),

--- a/backend/src/api/committee_session.rs
+++ b/backend/src/api/committee_session.rs
@@ -48,7 +48,7 @@ impl ApiErrorResponse for CommitteeSessionError {
             CommitteeSessionError::CommitteeSessionPaused => (
                 StatusCode::CONFLICT,
                 ErrorResponse::new(
-                    String::from("Committee session data entry is paused"),
+                    "Committee session data entry is paused",
                     ErrorReference::CommitteeSessionPaused,
                     true,
                 ),
@@ -56,34 +56,26 @@ impl ApiErrorResponse for CommitteeSessionError {
             CommitteeSessionError::InvalidCommitteeSessionStatus => (
                 StatusCode::CONFLICT,
                 ErrorResponse::new(
-                    String::from("Invalid committee session status"),
+                    "Invalid committee session status",
                     ErrorReference::InvalidCommitteeSessionStatus,
                     true,
                 ),
             ),
             CommitteeSessionError::InvalidDetails => (
                 StatusCode::BAD_REQUEST,
-                ErrorResponse::new(
-                    String::from("Invalid details"),
-                    ErrorReference::InvalidData,
-                    false,
-                ),
+                ErrorResponse::new("Invalid details", ErrorReference::InvalidData, false),
             ),
             CommitteeSessionError::InvalidStatusTransition => (
                 StatusCode::CONFLICT,
                 ErrorResponse::new(
-                    String::from("Invalid committee session state transition"),
+                    "Invalid committee session state transition",
                     ErrorReference::InvalidStateTransition,
                     true,
                 ),
             ),
             CommitteeSessionError::ProviderError => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                ErrorResponse::new(
-                    String::from("Internal server error"),
-                    ErrorReference::DatabaseError,
-                    true,
-                ),
+                ErrorResponse::new("Internal server error", ErrorReference::DatabaseError, true),
             ),
         }
     }

--- a/backend/src/api/middleware/authentication/error.rs
+++ b/backend/src/api/middleware/authentication/error.rs
@@ -42,7 +42,7 @@ impl ApiErrorResponse for AuthenticationError {
             AuthenticationError::InvalidUsernameOrPassword => (
                 StatusCode::UNAUTHORIZED,
                 ErrorResponse::new(
-                    String::from("Invalid username and/or password"),
+                    "Invalid username and/or password",
                     ErrorReference::InvalidUsernameOrPassword,
                     false,
                 ),
@@ -50,7 +50,7 @@ impl ApiErrorResponse for AuthenticationError {
             AuthenticationError::UsernameAlreadyExists => (
                 StatusCode::CONFLICT,
                 ErrorResponse::new(
-                    String::from("Username already exists"),
+                    "Username already exists",
                     ErrorReference::UsernameNotUnique,
                     false,
                 ),
@@ -58,7 +58,7 @@ impl ApiErrorResponse for AuthenticationError {
             AuthenticationError::NotInitialised => (
                 StatusCode::IM_A_TEAPOT,
                 ErrorResponse::new(
-                    String::from("Application not initialised"),
+                    "Application not initialised",
                     ErrorReference::NotInitialised,
                     false,
                 ),
@@ -66,59 +66,43 @@ impl ApiErrorResponse for AuthenticationError {
             AuthenticationError::AlreadyInitialised => (
                 StatusCode::FORBIDDEN,
                 ErrorResponse::new(
-                    String::from("Application already initialised"),
+                    "Application already initialised",
                     ErrorReference::AlreadyInitialised,
                     false,
                 ),
             ),
             AuthenticationError::UserNotFound => (
                 StatusCode::UNAUTHORIZED,
-                ErrorResponse::new(
-                    String::from("User not found"),
-                    ErrorReference::UserNotFound,
-                    false,
-                ),
+                ErrorResponse::new("User not found", ErrorReference::UserNotFound, false),
             ),
             AuthenticationError::UserAlreadySetup => (
                 StatusCode::CONFLICT,
-                ErrorResponse::new(
-                    String::from("Invalid user state"),
-                    ErrorReference::Forbidden,
-                    false,
-                ),
+                ErrorResponse::new("Invalid user state", ErrorReference::Forbidden, false),
             ),
             AuthenticationError::InvalidPassword => (
                 StatusCode::UNAUTHORIZED,
                 ErrorResponse::new(
-                    String::from("Invalid password provided"),
+                    "Invalid password provided",
                     ErrorReference::InvalidPassword,
                     false,
                 ),
             ),
             AuthenticationError::SessionKeyNotFound | AuthenticationError::NoSessionCookie => (
                 StatusCode::UNAUTHORIZED,
-                ErrorResponse::new(
-                    String::from("Invalid session"),
-                    ErrorReference::InvalidSession,
-                    false,
-                ),
+                ErrorResponse::new("Invalid session", ErrorReference::InvalidSession, false),
             ),
             AuthenticationError::Unauthorized | AuthenticationError::Unauthenticated => (
                 StatusCode::UNAUTHORIZED,
-                ErrorResponse::new(
-                    String::from("Unauthorized"),
-                    ErrorReference::Unauthorized,
-                    false,
-                ),
+                ErrorResponse::new("Unauthorized", ErrorReference::Unauthorized, false),
             ),
             AuthenticationError::Forbidden => (
                 StatusCode::FORBIDDEN,
-                ErrorResponse::new(String::from("Forbidden"), ErrorReference::Forbidden, true),
+                ErrorResponse::new("Forbidden", ErrorReference::Forbidden, true),
             ),
             AuthenticationError::PasswordRejectionSameAsOld => (
                 StatusCode::BAD_REQUEST,
                 ErrorResponse::new(
-                    String::from("Invalid password"),
+                    "Invalid password",
                     ErrorReference::PasswordRejectionSameAsOld,
                     false,
                 ),
@@ -126,7 +110,7 @@ impl ApiErrorResponse for AuthenticationError {
             AuthenticationError::PasswordRejectionSameAsUsername => (
                 StatusCode::BAD_REQUEST,
                 ErrorResponse::new(
-                    String::from("Invalid password"),
+                    "Invalid password",
                     ErrorReference::PasswordRejectionSameAsUsername,
                     false,
                 ),
@@ -134,23 +118,19 @@ impl ApiErrorResponse for AuthenticationError {
             AuthenticationError::PasswordRejectionTooShort => (
                 StatusCode::BAD_REQUEST,
                 ErrorResponse::new(
-                    String::from("Invalid password"),
+                    "Invalid password",
                     ErrorReference::PasswordRejectionTooShort,
                     false,
                 ),
             ),
             AuthenticationError::RoleNotAuthorizedError => (
                 StatusCode::FORBIDDEN,
-                ErrorResponse::new(
-                    String::from("Invalid role"),
-                    ErrorReference::Forbidden,
-                    true,
-                ),
+                ErrorResponse::new("Invalid role", ErrorReference::Forbidden, true),
             ),
             AuthenticationError::OwnAccountCannotBeDeleted => (
                 StatusCode::FORBIDDEN,
                 ErrorResponse::new(
-                    String::from("Cannot delete your own account"),
+                    "Cannot delete your own account",
                     ErrorReference::OwnAccountCannotBeDeleted,
                     false,
                 ),
@@ -160,7 +140,7 @@ impl ApiErrorResponse for AuthenticationError {
             | AuthenticationError::InvalidSessionDuration => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ErrorResponse::new(
-                    String::from("Internal server error"),
+                    "Internal server error",
                     ErrorReference::InternalServerError,
                     false,
                 ),

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -96,9 +96,9 @@ pub struct ErrorResponse {
 }
 
 impl ErrorResponse {
-    pub fn new(error: String, reference: ErrorReference, fatal: bool) -> Self {
+    pub fn new(error: impl ToString, reference: ErrorReference, fatal: bool) -> Self {
         Self {
-            error,
+            error: error.to_string(),
             reference,
             fatal,
         }
@@ -149,30 +149,30 @@ impl APIError {
             }
             APIError::AirgapViolation(message) => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                ErrorResponse::new(message.to_string(), ErrorReference::AirgapViolation, true),
+                ErrorResponse::new(message, ErrorReference::AirgapViolation, true),
             ),
             APIError::BadRequest(message, reference) => (
                 StatusCode::BAD_REQUEST,
-                ErrorResponse::new(message.to_string(), reference, true),
+                ErrorResponse::new(message, reference, true),
             ),
             APIError::ContentTooLarge(message, reference) => (
                 StatusCode::PAYLOAD_TOO_LARGE,
-                ErrorResponse::new(message.to_string(), reference, false),
+                ErrorResponse::new(message, reference, false),
             ),
             APIError::NotFound(message, reference) => (
                 StatusCode::NOT_FOUND,
-                ErrorResponse::new(message.to_string(), reference, true),
+                ErrorResponse::new(message, reference, true),
             ),
             APIError::Conflict(message, reference) => (
                 StatusCode::CONFLICT,
-                ErrorResponse::new(message.to_string(), reference, false),
+                ErrorResponse::new(message, reference, false),
             ),
             APIError::DataIntegrityError(message) => {
                 error!("Data integrity error: {}", message);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::new(
-                        String::from("Internal server error"),
+                        "Internal server error",
                         ErrorReference::DatabaseError,
                         true,
                     ),
@@ -182,46 +182,30 @@ impl APIError {
                 error!("Invalid data error: {}", err);
                 (
                     StatusCode::UNPROCESSABLE_ENTITY,
-                    ErrorResponse::new(
-                        String::from("Invalid data"),
-                        ErrorReference::InvalidData,
-                        false,
-                    ),
+                    ErrorResponse::new("Invalid data", ErrorReference::InvalidData, false),
                 )
             }
             APIError::JsonRejection(rejection) => (
                 StatusCode::UNPROCESSABLE_ENTITY,
-                ErrorResponse::new(
-                    rejection.body_text().to_string(),
-                    ErrorReference::InvalidJson,
-                    true,
-                ),
+                ErrorResponse::new(rejection.body_text(), ErrorReference::InvalidJson, true),
             ),
             APIError::SerdeJsonError(err) => {
                 error!("Serde JSON error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    ErrorResponse::new(
-                        String::from("Internal server error"),
-                        ErrorReference::InvalidJson,
-                        true,
-                    ),
+                    ErrorResponse::new("Internal server error", ErrorReference::InvalidJson, true),
                 )
             }
             APIError::SqlxError(sqlx::Error::RowNotFound) => (
                 StatusCode::NOT_FOUND,
-                ErrorResponse::new(
-                    String::from("Resource not found"),
-                    ErrorReference::EntryNotFound,
-                    true,
-                ),
+                ErrorResponse::new("Resource not found", ErrorReference::EntryNotFound, true),
             ),
             APIError::SqlxError(err) => {
                 error!("SQLx error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::new(
-                        String::from("Internal server error"),
+                        "Internal server error",
                         ErrorReference::DatabaseError,
                         true,
                     ),
@@ -230,7 +214,7 @@ impl APIError {
             APIError::InvalidHeaderValue => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ErrorResponse::new(
-                    String::from("Internal server error"),
+                    "Internal server error",
                     ErrorReference::InternalServerError,
                     true,
                 ),
@@ -240,7 +224,7 @@ impl APIError {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::new(
-                        String::from("Internal server error"),
+                        "Internal server error",
                         ErrorReference::PdfGenerationError,
                         false,
                     ),
@@ -251,7 +235,7 @@ impl APIError {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::new(
-                        String::from("Internal server error"),
+                        "Internal server error",
                         ErrorReference::InternalServerError,
                         true,
                     ),
@@ -261,18 +245,14 @@ impl APIError {
                 error!("Error while adding totals: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    ErrorResponse::new(String::from("Internal server error"), reference, false),
+                    ErrorResponse::new("Internal server error", reference, false),
                 )
             }
             APIError::InvalidHashError => {
                 error!("Invalid hash");
                 (
                     StatusCode::BAD_REQUEST,
-                    ErrorResponse::new(
-                        String::from("Invalid hash"),
-                        ErrorReference::InvalidHash,
-                        false,
-                    ),
+                    ErrorResponse::new("Invalid hash", ErrorReference::InvalidHash, false),
                 )
             }
             APIError::XmlError(err) => {
@@ -280,7 +260,7 @@ impl APIError {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::new(
-                        String::from("Internal server error"),
+                        "Internal server error",
                         ErrorReference::InternalServerError,
                         false,
                     ),
@@ -290,11 +270,7 @@ impl APIError {
                 error!("Could not deserialize XML: {:?}", err);
                 (
                     StatusCode::BAD_REQUEST,
-                    ErrorResponse::new(
-                        String::from("Invalid XML"),
-                        ErrorReference::InvalidXml,
-                        false,
-                    ),
+                    ErrorResponse::new("Invalid XML", ErrorReference::InvalidXml, false),
                 )
             }
             APIError::ZipError(err) => {
@@ -302,7 +278,7 @@ impl APIError {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ErrorResponse::new(
-                        String::from("Internal server error"),
+                        "Internal server error",
                         ErrorReference::InternalServerError,
                         false,
                     ),
@@ -312,18 +288,14 @@ impl APIError {
                 error!("Error importing EML file: {:?}", err);
                 (
                     StatusCode::BAD_REQUEST,
-                    ErrorResponse::new(
-                        String::from("EML import error"),
-                        ErrorReference::EmlImportError,
-                        false,
-                    ),
+                    ErrorResponse::new("EML import error", ErrorReference::EmlImportError, false),
                 )
             }
             APIError::EmlError(err) => {
                 error!("Error with EML file: {:?}", err);
                 (
                     StatusCode::BAD_REQUEST,
-                    ErrorResponse::new(String::from("EML error"), ErrorReference::EmlError, false),
+                    ErrorResponse::new("EML error", ErrorReference::EmlError, false),
                 )
             }
         }


### PR DESCRIPTION
- Changes `ErrorResponse::new` signature to accept `impl ToString` messages
- Removes now unnecessary `String::from` and `.to_string()` calls

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->