### PR TITLE
Use new error type in `domain/models`

### DIFF
--- a/backend/src/domain/models/enriched_candidate_nomination.rs
+++ b/backend/src/domain/models/enriched_candidate_nomination.rs
@@ -1,12 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    APIError,
-    domain::{
-        apportionment::{CandidateNomination, ChosenCandidate, ListCandidateNomination},
-        election::{Candidate, ElectionWithPoliticalGroups, PGNumber, PoliticalGroup},
-        results::{count::Count, political_group_candidate_votes::CandidateVotes},
-    },
+use crate::domain::{
+    apportionment::{CandidateNomination, ChosenCandidate, ListCandidateNomination},
+    election::{Candidate, ElectionWithPoliticalGroups, PGNumber, PoliticalGroup},
+    models::error::ModelsError,
+    results::{count::Count, political_group_candidate_votes::CandidateVotes},
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,7 +17,7 @@ impl EnrichedCandidateNomination {
     pub fn new(
         election: &ElectionWithPoliticalGroups,
         candidate_nomination: &CandidateNomination,
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         Ok(EnrichedCandidateNomination {
             chosen_candidates: candidate_nomination.chosen_candidates.clone(),
             list_candidate_nomination: election
@@ -28,7 +26,7 @@ impl EnrichedCandidateNomination {
               .map(|pg| {
                   EnrichedListCandidateNomination::new(
                       pg.clone(),
-                      candidate_nomination.list_candidate_nomination.iter().find(|cn| cn.list_number == pg.number).ok_or(APIError::DataIntegrityError(format!(
+                      candidate_nomination.list_candidate_nomination.iter().find(|cn| cn.list_number == pg.number).ok_or(ModelsError::DataIntegrityError(format!(
                           "No list candidate nomination found for political group number {} in candidate nomination", pg.number
                       )))?,
                   )
@@ -59,14 +57,14 @@ impl EnrichedListCandidateNomination {
         list_candidates: &[Candidate],
         candidate_votes: &[CandidateVotes],
         start_seat_number: usize,
-    ) -> Result<Vec<CandidateWithSeatTableColumn>, APIError> {
+    ) -> Result<Vec<CandidateWithSeatTableColumn>, ModelsError> {
         let mut columns = Vec::new();
 
         for (idx, chosen_candidate) in candidate_votes.iter().enumerate() {
             let candidate = list_candidates
                 .iter()
                 .find(|candidate| candidate.number == chosen_candidate.number)
-                .ok_or(APIError::DataIntegrityError(format!(
+                .ok_or(ModelsError::DataIntegrityError(format!(
                     "No candidate found for candidate number {} in political group candidates",
                     chosen_candidate.number
                 )))?;
@@ -82,7 +80,7 @@ impl EnrichedListCandidateNomination {
     pub fn new(
         group: PoliticalGroup,
         list_candidate_nomination: &ListCandidateNomination,
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         let preferential_nomination_columns = Self::get_candidate_with_seat_table_columns(
             &group.candidates,
             &list_candidate_nomination.preferential_candidate_nomination,

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -1,12 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    APIError,
-    domain::{
-        apportionment::{DisplayFraction, ListSeatAssignment, SeatAssignment, SeatChangeStep},
-        election::PGNumber,
-        summary::ElectionSummaryCSB,
-    },
+use crate::domain::{
+    apportionment::{DisplayFraction, ListSeatAssignment, SeatAssignment, SeatChangeStep},
+    election::PGNumber,
+    models::error::ModelsError,
+    summary::ElectionSummaryCSB,
 };
 
 struct InitialSteps<'a> {
@@ -147,7 +145,7 @@ impl EnrichedSeatAssignment {
     fn get_list_seat_assignments(
         summary: &ElectionSummaryCSB,
         seat_assignment: &SeatAssignment,
-    ) -> Result<ListSeatAssignments, APIError> {
+    ) -> Result<ListSeatAssignments, ModelsError> {
         let mut enriched_list_seat_assignments = Vec::new();
         let mut initial_total_full_seats = 0;
 
@@ -191,7 +189,7 @@ impl EnrichedSeatAssignment {
         number_of_seats: u32,
         summary: &ElectionSummaryCSB,
         seat_assignment: &SeatAssignment,
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         let list_seat_assignments = Self::get_list_seat_assignments(summary, seat_assignment)?;
         Ok(EnrichedSeatAssignment {
             quota: seat_assignment.quota.clone(),

--- a/backend/src/domain/models/error.rs
+++ b/backend/src/domain/models/error.rs
@@ -1,0 +1,34 @@
+use axum::http::StatusCode;
+use tracing::error;
+
+use crate::error::{ApiErrorResponse, ErrorReference, ErrorResponse};
+
+/// Error type for models
+#[derive(Debug)]
+pub enum ModelsError {
+    /// Data integrity violation in models
+    DataIntegrityError(String),
+}
+
+impl ApiErrorResponse for ModelsError {
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
+        match self {
+            ModelsError::DataIntegrityError(_message) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::new(
+                    "Internal server error",
+                    ErrorReference::InternalServerError,
+                    true,
+                ),
+            ),
+        }
+    }
+
+    fn log(&self) {
+        match self {
+            ModelsError::DataIntegrityError(message) => {
+                error!("Models data integrity error: {}", message);
+            }
+        }
+    }
+}

--- a/backend/src/domain/models/mod.rs
+++ b/backend/src/domain/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod apportionment_footnotes;
 pub mod enriched_candidate_nomination;
 pub mod enriched_seat_assignment;
+pub mod error;
 pub mod filter_input;
 mod model_n_10_2;
 mod model_na_14_2;

--- a/backend/src/domain/models/votes_table.rs
+++ b/backend/src/domain/models/votes_table.rs
@@ -2,18 +2,14 @@ use std::slice::Iter;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    APIError,
-    domain::{
-        election::{
-            Candidate, CandidateNumber, ElectionWithPoliticalGroups, PGNumber, PoliticalGroup,
-        },
-        results::{
-            common_polling_station_results::CommonPollingStationResults, count::Count,
-            political_group_candidate_votes::PoliticalGroupCandidateVotes,
-        },
-        summary::ElectionSummary,
+use crate::domain::{
+    election::{Candidate, CandidateNumber, ElectionWithPoliticalGroups, PGNumber, PoliticalGroup},
+    models::error::ModelsError,
+    results::{
+        common_polling_station_results::CommonPollingStationResults, count::Count,
+        political_group_candidate_votes::PoliticalGroupCandidateVotes,
     },
+    summary::ElectionSummary,
 };
 
 const DEFAULT_CANDIDATES_PER_COLUMN: [usize; 4] = [25, 25, 15, 15];
@@ -23,7 +19,7 @@ const JUSTIFIED_CANDIDATES_PER_COLUMN: [usize; 4] = [20, 20, 20, 20];
 pub struct CandidatesTables(Vec<VotesTable>);
 
 impl CandidatesTables {
-    pub fn new(election: &ElectionWithPoliticalGroups) -> Result<Self, APIError> {
+    pub fn new(election: &ElectionWithPoliticalGroups) -> Result<Self, ModelsError> {
         Ok(CandidatesTables(
             election
                 .political_groups
@@ -41,7 +37,7 @@ impl VotesTables {
     pub fn new(
         election: &ElectionWithPoliticalGroups,
         summary: &ElectionSummary,
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         Ok(VotesTables(
             election
                 .political_groups
@@ -71,7 +67,7 @@ impl VotesTablesWithPreviousVotes {
         election: &ElectionWithPoliticalGroups,
         summary: &ElectionSummary,
         previous_summary: &ElectionSummary,
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         Ok(VotesTablesWithPreviousVotes(
             election
                 .political_groups
@@ -104,7 +100,7 @@ impl VotesTablesWithOnlyPreviousVotes {
     pub fn new(
         election: &ElectionWithPoliticalGroups,
         previous: &CommonPollingStationResults,
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         Ok(VotesTablesWithOnlyPreviousVotes(
             election
                 .political_groups
@@ -129,11 +125,11 @@ impl VotesTablesWithOnlyPreviousVotes {
 fn get_votes_for_political_party(
     political_group_number: PGNumber,
     political_group_votes: &[PoliticalGroupCandidateVotes],
-) -> Result<&PoliticalGroupCandidateVotes, APIError> {
+) -> Result<&PoliticalGroupCandidateVotes, ModelsError> {
     political_group_votes
         .iter()
         .find(|pg_votes| pg_votes.number == political_group_number)
-        .ok_or(APIError::DataIntegrityError(format!(
+        .ok_or(ModelsError::DataIntegrityError(format!(
             "No votes found for political group number {political_group_number} in summary",
         )))
 }
@@ -141,7 +137,7 @@ fn get_votes_for_political_party(
 fn get_votes_for_candidate(
     candidate_number: CandidateNumber,
     candidate_votes: Option<&PoliticalGroupCandidateVotes>,
-) -> Result<Option<Count>, APIError> {
+) -> Result<Option<Count>, ModelsError> {
     let Some(candidate_votes) = candidate_votes else {
         return Ok(None);
     };
@@ -151,7 +147,7 @@ fn get_votes_for_candidate(
         .iter()
         .find(|cv| cv.number == candidate_number)
     else {
-        return Err(APIError::DataIntegrityError(format!(
+        return Err(ModelsError::DataIntegrityError(format!(
             "No votes found for candidate number {candidate_number} in political group {}",
             candidate_votes.number,
         )));
@@ -180,7 +176,7 @@ impl VotesTable {
         candidate_votes: Option<&PoliticalGroupCandidateVotes>,
         previous_candidate_votes: Option<&PoliticalGroupCandidateVotes>,
         column_sizes: [usize; 4],
-    ) -> Result<Vec<VotesTableColumn>, APIError> {
+    ) -> Result<Vec<VotesTableColumn>, ModelsError> {
         let mut columns = Vec::new();
 
         for max_per_column in &column_sizes {
@@ -232,7 +228,7 @@ impl VotesTable {
         candidate_votes: Option<&PoliticalGroupCandidateVotes>,
         previous_candidate_votes: Option<&PoliticalGroupCandidateVotes>,
         column_sizes: [usize; 4],
-    ) -> Result<Self, APIError> {
+    ) -> Result<Self, ModelsError> {
         let mut candidate_iterator = group.candidates.iter();
         let columns = Self::get_votes_table_columns(
             &mut candidate_iterator,
@@ -243,7 +239,7 @@ impl VotesTable {
 
         // sanity check: there should not be more candidates than expected in political group
         if candidate_iterator.next().is_some() {
-            return Err(APIError::DataIntegrityError(format!(
+            return Err(ModelsError::DataIntegrityError(format!(
                 "More candidates than expected in political group {}",
                 group.number
             )));
@@ -256,7 +252,7 @@ impl VotesTable {
                 .map(|col| col.column_total.unwrap_or_default())
                 .sum();
             if pg_votes.total < columns_total {
-                return Err(APIError::DataIntegrityError(format!(
+                return Err(ModelsError::DataIntegrityError(format!(
                     "Sum of column totals ({columns_total}) exceeds total votes ({}) for political group {}",
                     pg_votes.total, pg_votes.number,
                 )));
@@ -270,7 +266,7 @@ impl VotesTable {
                 .map(|col| col.previous_column_total.unwrap_or_default())
                 .sum();
             if prev_pg_votes.total < previous_columns_total {
-                return Err(APIError::DataIntegrityError(format!(
+                return Err(ModelsError::DataIntegrityError(format!(
                     "Sum of previous column totals ({previous_columns_total}) exceeds previous total votes ({}) for political group {}",
                     prev_pg_votes.total, prev_pg_votes.number,
                 )));
@@ -388,13 +384,12 @@ mod tests {
         let err = VotesTables::new(&election, &summary).unwrap_err();
 
         match err {
-            APIError::DataIntegrityError(message) => {
+            ModelsError::DataIntegrityError(message) => {
                 assert_eq!(
                     message,
                     "No votes found for political group number 1 in summary"
                 );
             }
-            other => panic!("expected DataIntegrityError, got {other:?}"),
         }
     }
 
@@ -412,13 +407,12 @@ mod tests {
         .unwrap_err();
 
         match err {
-            APIError::DataIntegrityError(message) => {
+            ModelsError::DataIntegrityError(message) => {
                 assert_eq!(
                     message,
                     "No votes found for candidate number 1 in political group 1"
                 );
             }
-            other => panic!("expected DataIntegrityError, got {other:?}"),
         }
     }
 
@@ -463,13 +457,12 @@ mod tests {
         let err = VotesTable::new(&group, None, None, [1, 0, 0, 0]).unwrap_err();
 
         match err {
-            APIError::DataIntegrityError(message) => {
+            ModelsError::DataIntegrityError(message) => {
                 assert_eq!(
                     message,
                     "More candidates than expected in political group 1"
                 );
             }
-            other => panic!("expected DataIntegrityError, got {other:?}"),
         }
     }
 
@@ -487,13 +480,12 @@ mod tests {
         .unwrap_err();
 
         match err {
-            APIError::DataIntegrityError(message) => {
+            ModelsError::DataIntegrityError(message) => {
                 assert_eq!(
                     message,
                     "Sum of column totals (27) exceeds total votes (20) for political group 1"
                 );
             }
-            other => panic!("expected DataIntegrityError, got {other:?}"),
         }
     }
 
@@ -511,13 +503,12 @@ mod tests {
         .unwrap_err();
 
         match err {
-            APIError::DataIntegrityError(message) => {
+            ModelsError::DataIntegrityError(message) => {
                 assert_eq!(
                     message,
                     "Sum of previous column totals (27) exceeds previous total votes (20) for political group 1"
                 );
             }
-            other => panic!("expected DataIntegrityError, got {other:?}"),
         }
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -18,7 +18,8 @@ use crate::{
     MAX_BODY_SIZE_MB,
     api::middleware::authentication::error::AuthenticationError,
     domain::{
-        committee_session::CommitteeSessionError, role::RoleNotAuthorizedError, validate::DataError,
+        committee_session::CommitteeSessionError, models::error::ModelsError,
+        role::RoleNotAuthorizedError, validate::DataError,
     },
     eml::EMLImportError,
     repository::polling_station_repo,
@@ -385,6 +386,11 @@ impl From<DataEntryServiceError> for APIError {
                 APIError::DataIntegrityError(String::from("Data entry is already linked"))
             }
         }
+    }
+}
+impl From<ModelsError> for APIError {
+    fn from(err: ModelsError) -> Self {
+        APIError::Delegated(Box::new(err))
     }
 }
 


### PR DESCRIPTION
Use new error type in `domain/models` to replace `APIError` usage. Resolves #3254.