### PR TITLE
Use fixed seed for P 22-2 smoke test

### DIFF
--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -736,7 +736,9 @@ async fn test_p_2a() {
 
 #[test(tokio::test)]
 async fn test_p_22_2() {
-    let mut rng = rand::rng();
+    use rand::SeedableRng;
+    // Seed determined by a fair dice roll on random.org
+    let mut rng = rand::rngs::StdRng::seed_from_u64(791397299);
 
     // We only test with values that have a possible apportionment outcome
     let (parties, candidates, string_length, none_where_possible) = (10, 10, 10, false);


### PR DESCRIPTION
Unflakes #3277 

Specifically for the P 22-2 smoke test, we use a fixed, predetermined seed, so we're sure the apportionment doesn't result in the need to draw lots.

Not the most ideal solution, but the data used in smoke tests will be revisited in #2899 

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->