### PR TITLE
Improve backend CSB fixtures

### DIFF
--- a/backend/fixtures/election_10_csb.sql
+++ b/backend/fixtures/election_10_csb.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- copy of election_3 with committee_category changed to 'CSB' and subcommittee instead of polling station
-VALUES (10, 'Municipal Re-election', 'CSB', NULL, 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 29, 1, '2024-12-31', '2024-12-01',
+VALUES (10, 'Municipal Re-election', 'CSB', NULL, 'GR2024_Heemdamseburg', 'Heemdamseburg', '9102', 'Municipal', 29, 1, '2024-12-31', '2024-12-01',
         '[
           {
             "number": 1,
@@ -54,4 +54,4 @@ INSERT INTO data_entries (id, state, updated_at)
 VALUES (1001, '{"status":"Empty"}', '2024-12-05 09:15:00');
 
 INSERT INTO sub_committees (id, committee_session_id, data_entry_id, name, number, category)
-VALUES (1011, 1001, 1001, 'Juinen', 1, 'GSB');
+VALUES (1011, 1001, 1001, 'Juinen', 9102, 'GSB');

--- a/backend/fixtures/election_10_csb.sql
+++ b/backend/fixtures/election_10_csb.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- copy of election_3 with committee_category changed to 'CSB' and subcommittee instead of polling station
-VALUES (10, 'Municipal Re-election', 'CSB', NULL, 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 29, 2000, '2024-12-31', '2024-12-01',
+VALUES (10, 'Municipal Re-election', 'CSB', NULL, 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 29, 1, '2024-12-31', '2024-12-01',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_8_csb_with_results.sql
+++ b/backend/fixtures/election_8_csb_with_results.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- CSB election for GSB election_5_with_results
-VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', '0000', 'Municipal', 23, 15000, '2024-11-30', '2024-11-01', '[
+VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', '0000', 'Municipal', 23, 1, '2024-11-30', '2024-11-01', '[
          {
            "number": 1,
            "registered_name": "Political Group A",

--- a/backend/fixtures/election_8_csb_with_results.sql
+++ b/backend/fixtures/election_8_csb_with_results.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- CSB election for GSB election_5_with_results
-VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', '0000', 'Municipal', 23, 1, '2024-11-30', '2024-11-01', '[
+VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', '9100', 'Municipal', 23, 1, '2024-11-30', '2024-11-01', '[
          {
            "number": 1,
            "registered_name": "Political Group A",
@@ -462,4 +462,4 @@ VALUES (801,
         '2026-03-20 17:07:31');
 
 INSERT INTO sub_committees (id, committee_session_id, data_entry_id, name, number, category)
-VALUES (811, 801, 801, 'Juinen', 1, 'GSB');
+VALUES (811, 801, 801, 'Juinen', 9100, 'GSB');

--- a/backend/fixtures/election_9_csb.sql
+++ b/backend/fixtures/election_9_csb.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- copy of election_4 with committee_category changed to 'CSB' and subcommittee instead of polling station
-VALUES (9, 'Test Election < 19 seats', 'CSB', NULL, 'GR2026_TestLocation', 'Test Location', '0000', 'Municipal', 15, 3000, '2026-03-18', '2026-02-02', '[
+VALUES (9, 'Test Election < 19 seats', 'CSB', NULL, 'GR2026_TestLocation', 'Test Location', '0000', 'Municipal', 15, 1, '2026-03-18', '2026-02-02', '[
          {
            "number": 1,
            "registered_name": "Political Group A",

--- a/backend/fixtures/election_9_csb.sql
+++ b/backend/fixtures/election_9_csb.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- copy of election_4 with committee_category changed to 'CSB' and subcommittee instead of polling station
-VALUES (9, 'Test Election < 19 seats', 'CSB', NULL, 'GR2026_TestLocation', 'Test Location', '0000', 'Municipal', 15, 1, '2026-03-18', '2026-02-02', '[
+VALUES (9, 'Test Election < 19 seats', 'CSB', NULL, 'GR2026_TestLocation', 'Test Location', '9101', 'Municipal', 15, 1, '2026-03-18', '2026-02-02', '[
          {
            "number": 1,
            "registered_name": "Political Group A",
@@ -418,4 +418,4 @@ INSERT INTO data_entries (id, state, updated_at)
 VALUES (901, '{"status":"Empty"}', '2024-12-05 09:15:00');
 
 INSERT INTO sub_committees (id, committee_session_id, data_entry_id, name, number, category)
-VALUES (911, 901, 901, 'Juinen', 1, 'GSB');
+VALUES (911, 901, 901, 'Juinen', 9101, 'GSB');

--- a/backend/src/service/sub_committee.rs
+++ b/backend/src/service/sub_committee.rs
@@ -83,9 +83,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(list.len(), 2);
-        assert_eq!(list[1].sub_committee.id, created.sub_committee.id);
-        assert_eq!(list[1].sub_committee.name, "Test GSB");
-        assert_eq!(list[1].sub_committee.category, CommitteeCategory::GSB);
-        assert_eq!(list[1].data_entry_id, created.data_entry_id);
+        assert_eq!(list[0].sub_committee.id, created.sub_committee.id);
+        assert_eq!(list[0].sub_committee.name, "Test GSB");
+        assert_eq!(list[0].sub_committee.category, CommitteeCategory::GSB);
+        assert_eq!(list[0].data_entry_id, created.data_entry_id);
     }
 }


### PR DESCRIPTION
relates to #3068 Exploratory testing: Election creation CSB

### Scope

Two improvements to our backend CSB fixtures:

1) Set `number_of_voters` for CSB elections to `1`. Because `MaxVotes` is empty in the EML file, so [it defaults to 1](https://schemas.liquid-technologies.com/EML/5.0/maxvotes.html).

2) Make `number` in `sub_committees` match the `domain_id` in `elections` for CSB elections, because the domain id ("gemeentecode") functions here similarly as a polling station id for a GSB election. Since that `number` can't be `0`, I had to update the domain ids. I updated them to be in the 9000-range, because [according to the CBS](https://www.cbs.nl/nl-nl/dossier/nederland-regionaal/informatie-voor-gemeenten/niet-gemeentelijke-indelingen) they already contain the "fictitious" codes for the Caribian Netherlands:

> Bonaire, Sint-Eustatius en Saba, ofwel Caribisch Nederland, horen voortaan als bijzondere gemeenten bij Nederland. Zij krijgen voor statistische doeleinden fictieve gemeentecodes, respectievelijk 9001, 9002 en 9003, maar worden niet standaard als gemeente in alle statistieken meegenomen.


<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->