### PR TITLE
Temporarily disable checks on apportionment state

### DIFF
--- a/backend/src/api/report/handlers.rs
+++ b/backend/src/api/report/handlers.rs
@@ -158,6 +158,8 @@ pub async fn election_download_zip_results_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(&committee_category)?;
 
+    // TODO: #3160 check if apportionment state is finalised
+
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
@@ -224,6 +226,8 @@ pub async fn election_download_zip_attachment_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(&committee_category)?;
 
+    // TODO: #3160 check if apportionment state is finalised
+
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
@@ -284,6 +288,8 @@ pub async fn election_download_zip_total_counts_csb(
     let committee_category =
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(&committee_category)?;
+
+    // TODO: #3160 check if apportionment state is finalised
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;

--- a/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
@@ -1,3 +1,4 @@
+import { stat } from "node:fs/promises";
 import { expect, request } from "@playwright/test";
 import { test } from "e2e-tests/fixtures";
 import { apiLogout, createUser, firstLogin, getTestPassword } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
@@ -17,6 +18,7 @@ import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckA
 import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj.ts";
 import { ElectionDetailsPgObj } from "e2e-tests/page-objects/election/ElectionDetailsPgObj";
 import { ElectionHome } from "e2e-tests/page-objects/election/ElectionHomePgObj";
+import { ElectionReport } from "e2e-tests/page-objects/election/ElectionReportPgObj";
 import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
 import { ElectionsOverviewPgObj } from "e2e-tests/page-objects/election/ElectionsOverviewPgObj";
 import { FinishDataEntry } from "e2e-tests/page-objects/election/FinishDataEntryPgObj";
@@ -293,7 +295,9 @@ test.describe("full flow CSB", () => {
     await logout(page);
   });
 
-  test("finish session, check apportionment and download results", async ({ page }) => {
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip("finish session, check apportionment and download results", async ({ page }) => {
+    // TODO: #3160 unskip test when apportionment deceased candidate flow is implemented
     await page.goto("/account/login");
 
     const loginPage = new LoginPgObj(page);
@@ -330,36 +334,36 @@ test.describe("full flow CSB", () => {
     await expect(apportionmentResidualSeatsPage.header).toBeVisible();
 
     await page.goBack();
-    // TODO: #3160 adjust when apportionment deceased candidate flow is implemented
-    // await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
-    // await apportionmentPage.toReport.click();
 
-    // const electionReportPage = new ElectionReport(page);
+    await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
+    await apportionmentPage.toReport.click();
 
-    // const resultsDownloadPromise = page.waitForEvent("download");
-    // await electionReportPage.downloadCSBResultsZip.click();
-    // const resultsDownload = await resultsDownloadPromise;
-    // expect(resultsDownload.suggestedFilename()).toMatch(
-    //   /vaststelling-uitslag_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/,
-    // );
-    // expect((await stat(await resultsDownload.path())).size).toBeGreaterThan(1024);
+    const electionReportPage = new ElectionReport(page);
 
-    // const attachmentDownloadPromise = page.waitForEvent("download");
-    // await electionReportPage.downloadCSBAttachmentZip.click();
-    // const attachmentDownload = await attachmentDownloadPromise;
-    // expect(attachmentDownload.suggestedFilename()).toMatch(
-    //   /model-p22-2-bijlage_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/,
-    // );
-    // expect((await stat(await attachmentDownload.path())).size).toBeGreaterThan(1024);
+    const resultsDownloadPromise = page.waitForEvent("download");
+    await electionReportPage.downloadCSBResultsZip.click();
+    const resultsDownload = await resultsDownloadPromise;
+    expect(resultsDownload.suggestedFilename()).toMatch(
+      /vaststelling-uitslag_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/,
+    );
+    expect((await stat(await resultsDownload.path())).size).toBeGreaterThan(1024);
 
-    // const countsDownloadPromise = page.waitForEvent("download");
-    // await electionReportPage.downloadCSBCountsZip.click();
-    // const countsDownload = await countsDownloadPromise;
-    // expect(countsDownload.suggestedFilename()).toMatch(
-    //   /definitieve-documenten_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/,
-    // );
-    // expect((await stat(await countsDownload.path())).size).toBeGreaterThan(1024);
+    const attachmentDownloadPromise = page.waitForEvent("download");
+    await electionReportPage.downloadCSBAttachmentZip.click();
+    const attachmentDownload = await attachmentDownloadPromise;
+    expect(attachmentDownload.suggestedFilename()).toMatch(
+      /model-p22-2-bijlage_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/,
+    );
+    expect((await stat(await attachmentDownload.path())).size).toBeGreaterThan(1024);
 
-    // await logout(page);
+    const countsDownloadPromise = page.waitForEvent("download");
+    await electionReportPage.downloadCSBCountsZip.click();
+    const countsDownload = await countsDownloadPromise;
+    expect(countsDownload.suggestedFilename()).toMatch(
+      /definitieve-documenten_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/,
+    );
+    expect((await stat(await countsDownload.path())).size).toBeGreaterThan(1024);
+
+    await logout(page);
   });
 });

--- a/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
@@ -295,9 +295,7 @@ test.describe("full flow CSB", () => {
     await logout(page);
   });
 
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip("finish session, check apportionment and download results", async ({ page }) => {
-    // TODO: #3160 unskip test when apportionment deceased candidate flow is implemented
+  test("finish session, check apportionment and download results", async ({ page }) => {
     await page.goto("/account/login");
 
     const loginPage = new LoginPgObj(page);

--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -38,7 +38,8 @@ const renderApportionmentPage = (withRouter: boolean) => {
 };
 
 describe("ApportionmentPage", () => {
-  test.each(
+  // TODO: #3160 enable this test when alert check is enabled again
+  test.skip.each(
     Object.values({
       Uninitialised: {
         state: { type: "Uninitialised" },

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -22,7 +22,7 @@ function getNumberOfSeatsAssignedSentence(seats: number, type: "residual_seat" |
 
 export function ApportionmentPage() {
   const { currentCommitteeSession, election } = useElection();
-  const { seatAssignment, candidateNomination, electionSummary, state, error } = useApportionmentContext();
+  const { seatAssignment, candidateNomination, electionSummary, error } = useApportionmentContext();
 
   return (
     <>
@@ -36,8 +36,9 @@ export function ApportionmentPage() {
             candidateNomination &&
             electionSummary && (
               <>
-                {state?.type === "Finalised" && (
-                  <FormLayout.Alert>
+                {
+                  // TODO: #3160 enable this check when apportionment deceased candidate flow is implemented
+                  /* state?.type === "Finalised" && */ <FormLayout.Alert>
                     <Alert type="success">
                       <strong className="heading-md">{t("apportionment.all_seats_assigned")}</strong>
                       <p>{t("apportionment.make_apportionment_definitive")}</p>
@@ -46,7 +47,7 @@ export function ApportionmentPage() {
                       </Button.Link>
                     </Alert>
                   </FormLayout.Alert>
-                )}
+                }
                 <div className={cn(cls.tableDiv, "mb-lg")}>
                   <div>
                     <h2 className={cls.tableTitle}>{t("apportionment.election_summary")}</h2>

--- a/frontend/src/features/election_management/components/report/CSBElectionReportSection.test.tsx
+++ b/frontend/src/features/election_management/components/report/CSBElectionReportSection.test.tsx
@@ -51,7 +51,8 @@ describe("CSBElectionReportSection", () => {
     vi.spyOn(ReactRouter, "useParams").mockReturnValue({ committeeSessionId: "2" });
   });
 
-  test("Error when apportionment state is not Finalised", async () => {
+  // TODO: #3160 enable this test when check is enabled again
+  test.skip("Error when apportionment state is not Finalised", async () => {
     // error is expected
     vi.spyOn(console, "error").mockImplementation(() => {});
     const router = setupTestRouter([

--- a/frontend/src/features/election_management/components/report/CSBElectionReportSection.tsx
+++ b/frontend/src/features/election_management/components/report/CSBElectionReportSection.tsx
@@ -1,4 +1,3 @@
-import { ApplicationError } from "@/api/ApiResult";
 import { DownloadButton } from "@/components/ui/DownloadButton/DownloadButton";
 import { Loader } from "@/components/ui/Loader/Loader";
 import { useApportionmentStateRequest } from "@/hooks/apportionment/useApportionmentStateRequest";
@@ -24,9 +23,10 @@ export function CSBElectionReportSection({ election, committeeSession, sessionLa
   if (!apportionmentState) {
     return <Loader />;
   }
-  if (apportionmentState.type !== "Finalised") {
-    throw new ApplicationError(t("error.forbidden_message"), "InvalidCommitteeSessionStatus");
-  }
+  // TODO: #3160 enable this check when apportionment deceased candidate flow is implemented
+  // if (apportionmentState.type !== "Finalised") {
+  //   throw new ApplicationError(t("error.forbidden_message"), "InvalidCommitteeSessionStatus");
+  // }
 
   return (
     <>


### PR DESCRIPTION
~~Skips last test of the CSB full flow test instead of commenting it out. Also had to re-introduce two imports that were removed as a result of the commenting out.~~

Disable checks on apportionment. Will be enabled again as part of #3160.