### PR TITLE
Improve testdata generator CSB

### DIFF
--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -312,7 +312,12 @@ fn generate_election(
         location: locality,
         category: ElectionCategory::Municipal,
         number_of_seats: rng.random_range(args.seats.clone()),
-        number_of_voters: rng.random_range(args.voters.clone()),
+        number_of_voters: if args.committee_category == CommitteeCategory::GSB {
+            rng.random_range(args.voters.clone())
+        } else {
+            // only relevant for GSB, so set to default value for MaxVotes in EML_NL
+            1
+        },
         election_date,
         nomination_date,
         political_groups,

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -165,7 +165,7 @@ async fn generate_csb_election_data(
             committee_session.id,
             number,
             &election.location,
-            CommitteeCategory::CSB,
+            CommitteeCategory::GSB,
         )
         .await
         .map_err(|e| format!("{e:?}"))?;

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -302,10 +302,10 @@ fn generate_election(
     NewElection {
         name,
         committee_category: args.committee_category,
-        counting_method: if args.committee_category == CommitteeCategory::CSB {
-            None
-        } else {
+        counting_method: if args.committee_category == CommitteeCategory::GSB {
             Some(VoteCountingMethod::CSO)
+        } else {
+            None
         },
         domain_id: super::data::domain_id(rng),
         election_id,


### PR DESCRIPTION
relates to #3068 Exploratory testing: Election creation CSB

### Scope

Improvements to the test data generator:
- create sub-committee of category GSB instead of CSB for CSB elections
- set number_of_voters to 1 for generated non-GSB elections
- (bonus change) switch condition for counting_method, so it will also work for HSB
