### PR TITLE
Backend: exclude saved deceased candidates

### DIFF
--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -1,4 +1,7 @@
-use std::fmt;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 use apportionment::CandidateVotes;
 use libfuzzer_sys::arbitrary::{Arbitrary, Result, Unstructured};
@@ -66,6 +69,7 @@ impl apportionment::ListVotes for SimpleListVotes {
 pub struct FuzzedApportionmentInput {
     pub seats: u32,
     pub list_votes: Vec<SimpleListVotes>,
+    pub deceased_candidates: HashMap<u32, HashSet<u32>>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzedApportionmentInput {
@@ -98,7 +102,11 @@ impl<'a> Arbitrary<'a> for FuzzedApportionmentInput {
             list_votes.push(SimpleListVotes::new((list_idx + 1) as u32, candidate_votes));
         }
 
-        Ok(FuzzedApportionmentInput { seats, list_votes })
+        Ok(FuzzedApportionmentInput {
+            seats,
+            list_votes,
+            deceased_candidates: HashMap::new(),
+        })
     }
 }
 
@@ -111,6 +119,10 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
 
     fn list_votes(&self) -> &[Self::List] {
         &self.list_votes
+    }
+
+    fn deceased_candidates(&self) -> &HashMap<u32, HashSet<u32>> {
+        &self.deceased_candidates
     }
 }
 

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -139,8 +139,9 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
         );
 
         // [Artikel P 19 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19)
-        let updated_candidate_ranking = if candidate_votes_meeting_preference_threshold.is_empty()
-            || (input.number_of_seats >= LARGE_COUNCIL_THRESHOLD && list_seats == 0)
+        let updated_candidate_ranking = if input.deceased_candidates.get(&list.number()).is_none()
+            && (candidate_votes_meeting_preference_threshold.is_empty()
+                || (input.number_of_seats >= LARGE_COUNCIL_THRESHOLD && list_seats == 0))
         {
             vec![]
         } else {
@@ -152,7 +153,7 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
 
             // If the updated candidate ranking is the same as the original candidate list,
             // return an empty list, otherwise return the updated list
-            // TODO: Should we take this from list.candidate_votes()? It will always result into updated ranking if deceased candidates
+            // Note: we base this on the original list, so if there are deceased candidates, the ranking is always updated
             let original_ranking = list
                 .candidate_votes()
                 .iter()
@@ -513,6 +514,101 @@ mod tests {
         );
     }
 
+    /// Candidate nomination with ranking change due to preferential candidate nomination and deceased candidates
+    ///
+    /// Actual case from GR2022  
+    /// List seats: [8, 3, 2, 1, 1]  
+    /// List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8  
+    /// List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3  
+    /// List 3: Preferential candidate nomination of candidate 1 and other candidate nomination of candidate 2  
+    /// List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations  
+    /// List 5: Preferential candidate nomination of candidate 1 and no other candidate nominations
+    #[test]
+    fn test_with_lt_19_seats_and_preferential_candidate_nomination_and_deceased_candidates() {
+        let quota = Fraction::new(5104, 15);
+        let mut seat_assignment_input = seat_assignment_fixture_with_given_candidate_votes(
+            15,
+            vec![
+                vec![1069, 303, 321, 210, 36, 101, 79, 121, 150, 149, 15, 17],
+                vec![
+                    452, 39, 81, 76, 35, 109, 29, 25, 17, 6, 18, 9, 25, 30, 5, 18, 3,
+                ],
+                vec![229, 63, 65, 9, 10, 58, 29, 50, 6, 11, 37],
+                vec![347, 33, 14, 82, 30, 30],
+                vec![266, 36, 39, 36, 38, 38],
+            ],
+        );
+        seat_assignment_input
+            .deceased_candidates
+            .insert(2, HashSet::from([3]));
+        let input = candidate_nomination_fixture_with_given_number_of_seats(
+            quota,
+            &seat_assignment_input,
+            vec![8, 3, 2, 1, 1],
+        );
+        let result = candidate_nomination(&input).unwrap();
+
+        assert_eq!(result.preference_threshold.percentage, 50);
+        assert_eq!(
+            result.preference_threshold.number_of_votes,
+            quota * Fraction::new(result.preference_threshold.percentage, 100)
+        );
+        check_list_candidate_nomination(
+            &result.list_candidate_nomination[0],
+            &[1, 3, 2, 4],
+            &[5, 6, 7, 8],
+            &[1, 3, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        );
+        check_list_candidate_nomination(
+            &result.list_candidate_nomination[1],
+            &[1],
+            &[2, 4], // Instead of [2, 3]
+            &[1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
+        );
+        check_list_candidate_nomination(&result.list_candidate_nomination[2], &[1], &[2], &[]);
+        check_list_candidate_nomination(&result.list_candidate_nomination[3], &[1], &[], &[]);
+        check_list_candidate_nomination(&result.list_candidate_nomination[4], &[1], &[], &[]);
+
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[0].number,
+            &input.list_votes[0].candidate_votes[..8],
+            &input.list_votes[0].candidate_votes[9..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[1].number,
+            &[
+                &input.list_votes[1].candidate_votes[..2],
+                &input.list_votes[1].candidate_votes[3..4],
+            ]
+            .concat(),
+            &[
+                &input.list_votes[1].candidate_votes[2..3],
+                &input.list_votes[1].candidate_votes[4..],
+            ]
+            .concat(),
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[2].number,
+            &input.list_votes[2].candidate_votes[..2],
+            &input.list_votes[2].candidate_votes[3..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[3].number,
+            &input.list_votes[3].candidate_votes[..1],
+            &input.list_votes[3].candidate_votes[2..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[4].number,
+            &input.list_votes[4].candidate_votes[..1],
+            &input.list_votes[4].candidate_votes[2..],
+        );
+    }
+
     /// Candidate nomination with no preferential candidate nomination
     ///
     /// List seats: [1, 1, 1, 1, 1]  
@@ -557,6 +653,90 @@ mod tests {
             input.list_votes[0].number,
             &input.list_votes[0].candidate_votes[..1],
             &input.list_votes[0].candidate_votes[2..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[1].number,
+            &input.list_votes[1].candidate_votes[..1],
+            &input.list_votes[1].candidate_votes[2..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[2].number,
+            &input.list_votes[2].candidate_votes[..1],
+            &input.list_votes[2].candidate_votes[2..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[3].number,
+            &input.list_votes[3].candidate_votes[..1],
+            &input.list_votes[3].candidate_votes[2..],
+        );
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[4].number,
+            &input.list_votes[4].candidate_votes[..1],
+            &input.list_votes[4].candidate_votes[2..],
+        );
+    }
+
+    /// Candidate nomination with no preferential candidate nomination and deceased candidates
+    ///
+    /// List seats: [1, 1, 1, 1, 1]  
+    /// List 1: No preferential candidate nominations and other candidate nomination of candidate 1  
+    /// List 2: No preferential candidate nominations and other candidate nomination of candidate 1  
+    /// List 3: No preferential candidate nominations and other candidate nomination of candidate 1  
+    /// List 4: No preferential candidate nominations and other candidate nomination of candidate 1  
+    /// List 5: No preferential candidate nominations and other candidate nomination of candidate 1
+    #[test]
+    fn test_with_lt_19_seats_and_no_preferential_candidate_nomination_and_deceased_candidates() {
+        let quota = Fraction::new(105, 5);
+        let mut seat_assignment_input = seat_assignment_fixture_with_given_candidate_votes(
+            5,
+            vec![
+                vec![5, 4, 4, 4, 4],
+                vec![4, 5, 4, 4, 4],
+                vec![4, 4, 5, 4, 4],
+                vec![4, 4, 4, 5, 4],
+                vec![4, 4, 4, 4, 5],
+            ],
+        );
+        seat_assignment_input
+            .deceased_candidates
+            .insert(1, HashSet::from([1]));
+
+        let input = candidate_nomination_fixture_with_given_number_of_seats(
+            quota,
+            &seat_assignment_input,
+            vec![1, 1, 1, 1, 1],
+        );
+        let result = candidate_nomination(&input).unwrap();
+
+        assert_eq!(result.preference_threshold.percentage, 50);
+        assert_eq!(
+            result.preference_threshold.number_of_votes,
+            quota * Fraction::new(result.preference_threshold.percentage, 100)
+        );
+        check_list_candidate_nomination(
+            &result.list_candidate_nomination[0],
+            &[],
+            &[2],
+            &[2, 3, 4, 5],
+        );
+        check_list_candidate_nomination(&result.list_candidate_nomination[1], &[], &[1], &[]);
+        check_list_candidate_nomination(&result.list_candidate_nomination[2], &[], &[1], &[]);
+        check_list_candidate_nomination(&result.list_candidate_nomination[3], &[], &[1], &[]);
+        check_list_candidate_nomination(&result.list_candidate_nomination[4], &[], &[1], &[]);
+
+        check_chosen_candidates(
+            &result.chosen_candidates,
+            input.list_votes[0].number,
+            &input.list_votes[0].candidate_votes[1..2],
+            &[
+                &input.list_votes[0].candidate_votes[0..1],
+                &input.list_votes[0].candidate_votes[2..],
+            ]
+            .concat(),
         );
         check_chosen_candidates(
             &result.chosen_candidates,

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -1,14 +1,14 @@
 mod structs;
 
+pub use structs::{
+    Candidate, CandidateNominationResult, ListCandidateNomination, PreferenceThreshold,
+};
 use tracing::{debug, info};
 
 use super::{
     ApportionmentError, CandidateVotes, ListVotes,
     fraction::Fraction,
-    structs::{CandidateNominationInput, LARGE_COUNCIL_THRESHOLD},
-};
-pub use structs::{
-    Candidate, CandidateNominationResult, ListCandidateNomination, PreferenceThreshold,
+    structs::{CandidateNominationInput, DeceasedCandidates, LARGE_COUNCIL_THRESHOLD},
 };
 
 /// Candidate nomination
@@ -32,12 +32,7 @@ pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     );
     info!("Preference threshold: {}", preference_threshold);
 
-    let list_candidate_nomination = candidate_nomination_per_list(
-        input.number_of_seats,
-        input.list_votes,
-        preference_threshold,
-        &input.total_seats_per_list,
-    )?;
+    let list_candidate_nomination = candidate_nomination_per_list(input, preference_threshold)?;
     debug!(
         "List candidate nomination: {:#?}",
         list_candidate_nomination
@@ -90,23 +85,44 @@ fn all_chosen_candidates<T: ListVotes>(
         .collect()
 }
 
+fn filter_out_deceased_candidates<'a, T: ListVotes>(
+    list: &'a T,
+    deceased_candidates: &'a DeceasedCandidates<T>,
+) -> Vec<&'a T::Cv> {
+    list.candidate_votes()
+        .iter()
+        .filter(|cv| {
+            !deceased_candidates
+                .get(&list.number())
+                .is_some_and(|candidates| candidates.contains(&cv.number()))
+        })
+        .collect()
+}
+
 /// This function nominates candidates for the seats each list has been assigned.  
 /// The candidate nomination is first done based on preferential votes and then the other
 /// candidates are nominated.
 fn candidate_nomination_per_list<'a, T: ListVotes>(
-    seats: u32,
-    list_votes: &'a [T],
+    input: &CandidateNominationInput<'a, T>,
     preference_threshold: Fraction,
-    total_seats: &[(T::ListNumber, u32)],
 ) -> Result<Vec<ListCandidateNomination<'a, T>>, ApportionmentError> {
     let mut list_candidate_nomination: Vec<ListCandidateNomination<T>> = vec![];
-    for list in list_votes {
-        let (list_number, list_seats) = total_seats
+    for list in input.list_votes {
+        let (list_number, list_seats) = input
+            .total_seats_per_list
             .iter()
             .find(|(number, _)| *number == list.number())
             .expect("Total seats exists")
             .to_owned();
-        let candidate_votes = &list.candidate_votes();
+
+        info!(
+            "Deceased candidates {:?} will be filtered out for list {:?}",
+            input.deceased_candidates.get(&list.number()),
+            list.number()
+        );
+
+        let candidate_votes = &filter_out_deceased_candidates(list, input.deceased_candidates);
+
         let candidate_votes_meeting_preference_threshold =
             candidate_votes_meeting_preference_threshold(preference_threshold, candidate_votes);
         let preferential_candidate_nomination = preferential_candidate_nomination::<T::Cv>(
@@ -124,7 +140,7 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
 
         // [Artikel P 19 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19)
         let updated_candidate_ranking = if candidate_votes_meeting_preference_threshold.is_empty()
-            || (seats >= LARGE_COUNCIL_THRESHOLD && list_seats == 0)
+            || (input.number_of_seats >= LARGE_COUNCIL_THRESHOLD && list_seats == 0)
         {
             vec![]
         } else {
@@ -136,7 +152,9 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
 
             // If the updated candidate ranking is the same as the original candidate list,
             // return an empty list, otherwise return the updated list
-            let original_ranking = candidate_votes
+            // TODO: Should we take this from list.candidate_votes()? It will always result into updated ranking if deceased candidates
+            let original_ranking = list
+                .candidate_votes()
                 .iter()
                 .map(|cv| cv.number())
                 .collect::<Vec<_>>();
@@ -184,7 +202,7 @@ pub fn candidate_votes_numbers<T: CandidateVotes>(
 /// List the other candidates nominated
 fn other_candidate_nomination<'a, T: CandidateVotes>(
     preferential_candidate_nomination: &[&T],
-    candidate_votes: &'a [T],
+    candidate_votes: &[&'a T],
     non_assigned_seats: usize,
 ) -> Vec<&'a T> {
     if non_assigned_seats == 0 {
@@ -193,7 +211,7 @@ fn other_candidate_nomination<'a, T: CandidateVotes>(
 
     candidate_votes
         .iter()
-        .filter(|candidate_votes| !preferential_candidate_nomination.contains(candidate_votes))
+        .filter_map(|&cv| (!preferential_candidate_nomination.contains(&cv)).then_some(cv))
         .take(non_assigned_seats)
         .collect()
 }
@@ -242,7 +260,7 @@ fn preferential_candidate_nomination<'a, T: CandidateVotes>(
 fn update_candidate_ranking<T: CandidateVotes>(
     preference_threshold: Fraction,
     candidate_votes_meeting_preference_threshold: &[&T],
-    candidate_votes: &[T],
+    candidate_votes: &[&T],
 ) -> Vec<T::CandidateNumber> {
     let mut updated_candidate_ranking: Vec<T::CandidateNumber> = vec![];
     // Add candidates meeting preference threshold to the top of the ranking
@@ -263,13 +281,17 @@ fn update_candidate_ranking<T: CandidateVotes>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+
     use test_log::test;
 
     use crate::{
-        ApportionmentError,
+        ApportionmentError, ListVotes,
         candidate_nomination::candidate_nomination,
         fraction::Fraction,
+        structs::DeceasedCandidates,
         test_helpers::{
+            ListVotesMock,
             candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats,
             candidate_nomination_fixture_with_given_number_of_seats, check_chosen_candidates,
             check_list_candidate_nomination, get_chosen_and_not_chosen_candidates_for_a_list,
@@ -277,6 +299,23 @@ mod tests {
             seat_assignment_fixture_with_given_list_numbers_candidate_numbers_and_votes,
         },
     };
+
+    #[test]
+    fn test_filter_out_deceased_candidates() {
+        let deceased_candidates: DeceasedCandidates<ListVotesMock> =
+            HashMap::from([(1, HashSet::from([1, 3])), (2, HashSet::from([2]))]);
+        let list = ListVotesMock::from_test_data_auto(1, vec![100, 80, 60, 40, 20]);
+        let filtered_candidate_votes =
+            super::filter_out_deceased_candidates(&list, &deceased_candidates);
+        assert_eq!(
+            filtered_candidate_votes,
+            vec![
+                &list.candidate_votes()[1],
+                &list.candidate_votes()[3],
+                &list.candidate_votes()[4]
+            ]
+        );
+    }
 
     /// Candidate nomination with non-consecutive list and candidate numbers
     ///

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -518,7 +518,7 @@ mod tests {
 
     /// Candidate nomination with ranking change due to preferential candidate nomination and deceased candidates
     ///
-    /// Actual case from GR2022 (excluding the deceased candidates)
+    /// Actual case from GR2022 (excluding the deceased candidates)  
     /// List seats: [8, 3, 2, 1, 1]  
     /// List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8  
     /// List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3  

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -178,13 +178,14 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
 }
 
 /// List and sort the candidate votes whose votes meet the preference threshold
-fn candidate_votes_meeting_preference_threshold<T: CandidateVotes>(
+fn candidate_votes_meeting_preference_threshold<'a, T: CandidateVotes>(
     preference_threshold: Fraction,
-    candidate_votes: &[T],
-) -> Vec<&T> {
-    let mut candidates_meeting_preference_threshold: Vec<&T> = candidate_votes
+    candidate_votes: &[&'a T],
+) -> Vec<&'a T> {
+    let mut candidates_meeting_preference_threshold: Vec<&'a T> = candidate_votes
         .iter()
         .filter(|candidate_votes| Fraction::from(candidate_votes.votes()) > preference_threshold)
+        .copied()
         .collect();
     candidates_meeting_preference_threshold.sort_by_key(|b| std::cmp::Reverse(b.votes()));
     candidates_meeting_preference_threshold
@@ -212,7 +213,8 @@ fn other_candidate_nomination<'a, T: CandidateVotes>(
 
     candidate_votes
         .iter()
-        .filter_map(|&cv| (!preferential_candidate_nomination.contains(&cv)).then_some(cv))
+        .filter(|candidate_votes| !preferential_candidate_nomination.contains(candidate_votes))
+        .copied()
         .take(non_assigned_seats)
         .collect()
 }
@@ -516,7 +518,7 @@ mod tests {
 
     /// Candidate nomination with ranking change due to preferential candidate nomination and deceased candidates
     ///
-    /// Actual case from GR2022  
+    /// Actual case from GR2022 (excluding the deceased candidates)
     /// List seats: [8, 3, 2, 1, 1]  
     /// List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8  
     /// List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3  

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -40,13 +40,16 @@ pub fn process<T: ApportionmentInput>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+
     use super::process;
-    use crate::test_helpers::{check_chosen_candidates, check_list_candidate_nomination};
     use crate::{
         Fraction,
         test_helpers::{
+            check_chosen_candidates, check_list_candidate_nomination,
             get_total_seats_from_apportionment_result,
             seat_assignment_fixture_with_default_50_candidates,
+            seat_assignment_fixture_with_given_candidate_votes,
         },
     };
 
@@ -183,5 +186,176 @@ mod tests {
             &[],
             &input.list_votes[7].candidate_votes[1..],
         );
+    }
+
+    /// Same as `test_apportionment_process`, but on list 1 we mark two candidates as deceased:
+    /// - candidate 1, who originally received the only preferential seat on list 1
+    /// - candidate 50, who had 0 votes and never received a seat (control case)
+    ///
+    /// Seat assignment must be unchanged (votes of deceased candidates still count toward
+    /// the list total). Only the candidate nomination changes for list 1.
+    #[test]
+    fn test_apportionment_process_with_deceased_candidates() {
+        let mut input = seat_assignment_fixture_with_default_50_candidates(
+            15,
+            vec![540, 160, 160, 80, 80, 80, 60, 40],
+        );
+        input.deceased_candidates = HashMap::from([(1, HashSet::from([1, 50]))]);
+
+        let result = process(&input).unwrap();
+
+        // Seat assignment is identical to the `test_apportionment_process` test.
+        assert_eq!(result.seat_assignment.full_seats, 13);
+        assert_eq!(result.seat_assignment.residual_seats, 2);
+        let total_seats = get_total_seats_from_apportionment_result(&result.seat_assignment);
+        assert_eq!(total_seats, vec![7, 2, 2, 1, 1, 1, 1, 0]);
+
+        // List 1: candidate 1 is deceased, so nobody meets the preference threshold.
+        // The 7 nominated "other" candidates are the next 7 alive candidates by number.
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[0],
+            &[],
+            &[2, 3, 4, 5, 6, 7, 8],
+            &[],
+        );
+        // Lists 2–8 unchanged.
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[1],
+            &[1],
+            &[2],
+            &[],
+        );
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[2],
+            &[1],
+            &[2],
+            &[],
+        );
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[3],
+            &[1],
+            &[],
+            &[],
+        );
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[4],
+            &[1],
+            &[],
+            &[],
+        );
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[5],
+            &[1],
+            &[],
+            &[],
+        );
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[6],
+            &[1],
+            &[],
+            &[],
+        );
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[7],
+            &[],
+            &[],
+            &[],
+        );
+
+        // List 1 chosen: candidates 2..=8 (indices 1..8)
+        // Not chosen: candidate 1 (deceased, index 0) and candidates 9..=50 (indices 8..)
+        let list1 = &input.list_votes[0];
+        check_chosen_candidates(
+            &result.candidate_nomination.chosen_candidates,
+            list1.number,
+            &list1.candidate_votes[1..8],
+            &[&list1.candidate_votes[..1], &list1.candidate_votes[8..]].concat(),
+        );
+    }
+
+    /// Scenarios testing deceased candidates and seat assignment.
+    ///
+    /// All cases share the same small fixture:
+    /// 5 seats, quota = 480 / 5 = 96.
+    /// List 1: 300 votes -> 3 full seats.
+    /// List 2: 100 -> 1 full seat.
+    /// List 3: 80 -> 0 full seats, 1 residual (largest remainder = 80, threshold 72)
+    /// Initial distribution: [3, 1, 1].
+    #[test]
+    fn test_apportionment_process_with_deceased_scenarios() {
+        struct Case {
+            name: &'static str,
+            deceased: HashMap<u32, HashSet<u32>>,
+            expected_seats: Vec<u32>,
+            expects_exhaustion_step: bool,
+        }
+
+        let cases = vec![
+            Case {
+                name: "no deceased -> initial distribution",
+                deceased: HashMap::new(),
+                expected_seats: vec![3, 1, 1],
+                expects_exhaustion_step: false,
+            },
+            Case {
+                name: "deceased on a list whose alive count still covers its seats",
+                // List 2, # alive = 1, list 2 seats = 1 -> not exhausted
+                deceased: HashMap::from([(2, HashSet::from([2]))]),
+                expected_seats: vec![3, 1, 1],
+                expects_exhaustion_step: false,
+            },
+            Case {
+                name: "single-seat exhaustion on list 1 -> reassigns to list 2",
+                // List 1, # alive = 2, list 1 seats = 3 -> exhausted by 1.
+                // List 3 already got a largest remainder seat, so only list 2 qualifies.
+                deceased: HashMap::from([(1, HashSet::from([3]))]),
+                expected_seats: vec![2, 2, 1],
+                expects_exhaustion_step: true,
+            },
+            Case {
+                name: "two-seat exhaustion on list 1 -> list 2 gets LR, list 3 gets UHA",
+                // List 1, # alive = 1, list 1 seats = 3 -> exhausted by 2.
+                // First retraction reassigns via largest remainder to list 2; after that
+                // both list 2 and list 3 have gotten their LR seat, so the second seat
+                // is assigned through unique-highest-average and goes to list 3.
+                deceased: HashMap::from([(1, HashSet::from([2, 3]))]),
+                expected_seats: vec![1, 2, 2],
+                expects_exhaustion_step: true,
+            },
+            Case {
+                name: "all of list 3 deceased -> list 2 absorbs the retracted seat",
+                // List 3, # alive = 0, list 3 seats = 1 -> exhausted by 1.
+                // The retracted seat goes to list 2 via LR assignment
+                // list 1 already has 3 full seats from full-quota assignment.
+                deceased: HashMap::from([(3, HashSet::from([1, 2]))]),
+                expected_seats: vec![3, 2, 0],
+                expects_exhaustion_step: true,
+            },
+        ];
+
+        for case in cases {
+            let mut input = seat_assignment_fixture_with_given_candidate_votes(
+                5,
+                vec![vec![300, 0, 0], vec![100, 0], vec![80, 0]],
+            );
+            input.deceased_candidates = case.deceased;
+
+            let result =
+                process(&input).unwrap_or_else(|e| panic!("case `{}` failed: {e:?}", case.name));
+
+            let total_seats = get_total_seats_from_apportionment_result(&result.seat_assignment);
+            assert_eq!(total_seats, case.expected_seats, "case: {}", case.name);
+
+            let has_exhaustion_step = result
+                .seat_assignment
+                .steps
+                .iter()
+                .any(|s| s.change.is_changed_by_list_exhaustion_removal());
+            assert_eq!(
+                has_exhaustion_step, case.expects_exhaustion_step,
+                "case: {} (steps: {:#?})",
+                case.name, result.seat_assignment.steps,
+            );
+        }
     }
 }

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -212,11 +212,12 @@ mod tests {
 
         // List 1: candidate 1 is deceased, so nobody meets the preference threshold.
         // The 7 nominated "other" candidates are the next 7 alive candidates by number.
+        // Expect updated ranking
         check_list_candidate_nomination(
             &result.candidate_nomination.list_candidate_nomination[0],
             &[],
             &[2, 3, 4, 5, 6, 7, 8],
-            &[],
+            &(2..=49).collect::<Vec<_>>(),
         );
         // Lists 2–8 unchanged.
         check_list_candidate_nomination(

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -195,6 +195,7 @@ mod tests {
     /// Seat assignment must be unchanged (votes of deceased candidates still count toward
     /// the list total). Only the candidate nomination changes for list 1.
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_apportionment_process_with_deceased_candidates() {
         let mut input = seat_assignment_fixture_with_default_50_candidates(
             15,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -647,10 +647,10 @@ pub(crate) mod tests {
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
-            /// Apportionment with no residual seats
+            /// Apportionment with no residual seats  
             /// This test triggers Kieswet Article P 10
             ///
-            /// Full seats: [5, 4, 3, 2, 1] - Remainder seats: 0
+            /// Full seats: [5, 4, 3, 2, 1] - Remainder seats: 0  
             /// 1 - Seat first assigned to list 1 has been removed and
             ///     will be assigned to another list in accordance with Article P 10 Kieswet  
             /// Remainders: [0/15, 0/15, 0/15, 0/15, 0/15]  
@@ -694,7 +694,7 @@ pub(crate) mod tests {
             /// 5 - largest remainder: seat assigned to list 1  
             /// 6 - largest remainder: seat assigned to list 4  
             /// 7 - Seat first assigned to list 10 has been removed and
-            ///     will be assigned to another list in accordance with Article P 10 Kieswet    
+            ///     will be assigned to another list in accordance with Article P 10 Kieswet  
             /// 8 - largest remainder: seat assigned to list 6
             #[test]
             fn test_with_list_exhaustion_during_residual_seats_assignment_with_largest_remainders_method()
@@ -960,7 +960,7 @@ pub(crate) mod tests {
             /// Full seats: [3, 4, 0] - Remainder seats: 1  
             /// Remainders: [2, 1, 7], only votes of lists [1, 2] meet the threshold of 75% of the quota  
             /// 1 - largest remainder: seat assigned to list 1  
-            /// 2 - Seat first assigned to list 1 has been re-assigned to list 2 in accordance with Article P 9 Kieswet    
+            /// 2 - Seat first assigned to list 1 has been re-assigned to list 2 in accordance with Article P 9 Kieswet  
             /// 3 - Seat first assigned to list 2 has been removed and
             ///     will be assigned to another list in accordance with Article P 10 Kieswet  
             /// 4 - Seat first assigned to list 2 has been removed and
@@ -1011,7 +1011,7 @@ pub(crate) mod tests {
             /// Full seats: [2, 1, 5] - Remainder seats: 1  
             /// Remainders: [50 4/8, 10, 61 1/8], only votes of lists [1, 3] meet the threshold of 75% of the quota  
             /// 1 - largest remainder: seat assigned to list 3  
-            /// 2 - Seat first assigned to list 3 has been re-assigned to list 1 in accordance with Article P 9 Kieswet    
+            /// 2 - Seat first assigned to list 3 has been re-assigned to list 1 in accordance with Article P 9 Kieswet  
             /// 3 - Seat first assigned to list 1 has been removed and
             ///     will be assigned to another list in accordance with Article P 10 Kieswet  
             /// 4 - Seat first assigned to list 1 has been removed and
@@ -1119,18 +1119,18 @@ pub(crate) mod tests {
 
             /// Apportionment where deceased candidates cause a list to be exhausted.
             ///
-            /// 15 seats, quota = 1500 / 15 = 100.
-            /// Votes: list 1 = 610, list 2 = 520, list 3 = 370.
-            /// Full seats: [6, 5, 3] - Remainder seats: 1
+            /// 15 seats, quota = 1500 / 15 = 100.  
+            /// Votes: list 1 = 610, list 2 = 520, list 3 = 370.  
+            /// Full seats: [6, 5, 3] - Remainder seats: 1  
             /// Remainders: [10, 20, 70], all lists meet the 3/4 quota threshold.
             ///
-            /// 1 - largest remainder: seat assigned to list 3 (remainder 70).
+            /// 1 - largest remainder: seat assigned to list 3 (remainder 70).  
             /// Initial distribution: [6, 5, 4].
             ///
             /// Marking candidate 6 of list 1 as deceased leaves 5 alive for 6 assigned
-            /// seats, triggering article P 10:
+            /// seats, triggering article P 10:  
             /// 2 - list 1 has one seat retracted (was a full seat, since list 1 has no
-            ///     residual seats).
+            ///     residual seats).  
             /// 3 - largest remainder reassigns to list 2 (list 3 already got a LR
             ///     seat in step 1, so it no longer qualifies).
             ///
@@ -1390,7 +1390,7 @@ pub(crate) mod tests {
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
-            /// Apportionment with no residual seats
+            /// Apportionment with no residual seats  
             /// This test triggers Kieswet Article P 10
             ///
             /// Full seats: [5, 5, 4, 4, 2] - Remainder seats: 0  
@@ -1569,19 +1569,19 @@ pub(crate) mod tests {
             /// Apportionment where deceased candidates cause a list to be exhausted
             /// in a council with >=19 seats (residual assignment via highest averages).
             ///
-            /// 20 seats, quota = 2000 / 20 = 100.
-            /// Votes: list 1 = 810, list 2 = 620, list 3 = 570.
-            /// Full seats: [8, 6, 5] - Remainder seats: 1
+            /// 20 seats, quota = 2000 / 20 = 100.  
+            /// Votes: list 1 = 810, list 2 = 620, list 3 = 570.  
+            /// Full seats: [8, 6, 5] - Remainder seats: 1  
             /// Next averages: list 1 = 810/9 = 90, list 2 = 620/7 ≈ 88.57,
             /// list 3 = 570/6 = 95.
             ///
-            /// 1 - highest average: seat assigned to list 3 (95).
+            /// 1 - highest average: seat assigned to list 3 (95).  
             /// Initial distribution: [8, 6, 6].
             ///
             /// Marking candidate 8 of list 1 as deceased leaves 7 alive for 8 assigned
-            /// seats, triggering article P 10:
+            /// seats, triggering article P 10:  
             /// 2 - list 1 has one seat retracted (was a full seat, since list 1 has no
-            ///     residual seats).
+            ///     residual seats).  
             /// 3 - highest average reassigns to list 2 (list 1 is exhausted; list 3's
             ///     next average is now 570/7 ≈ 81.43, list 2's is 620/7 ≈ 88.57).
             ///

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -94,7 +94,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(
     }
 
     // [Artikel P 19a Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19a)
-    for (list_number, list_deceased) in input.deceased_candidates().iter() {
+    for (list_number, list_deceased) in input.deceased_candidates() {
         info!(
             "Following deceased candidates will be taken into account for list {:?}: {}",
             list_number,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -2,6 +2,10 @@ use std::cmp::Ordering;
 
 mod residual_seat_assignment;
 mod structs;
+pub use structs::{
+    AbsoluteMajorityReassignedSeat, HighestAverageAssignedSeat, ListExhaustionRemovedSeat,
+    ListStanding, SeatAssignmentResult, SeatChange, SeatChangeStep,
+};
 use tracing::info;
 
 use self::{
@@ -11,11 +15,10 @@ use self::{
 use super::{
     ApportionmentInput, ListVotes,
     fraction::Fraction,
-    structs::{ApportionmentError, CandidateNominationInput, CandidateNominationInputType},
-};
-pub use structs::{
-    AbsoluteMajorityReassignedSeat, HighestAverageAssignedSeat, ListExhaustionRemovedSeat,
-    ListStanding, SeatAssignmentResult, SeatChange, SeatChangeStep,
+    structs::{
+        ApportionmentError, CandidateNominationInput, CandidateNominationInputType,
+        DeceasedCandidates,
+    },
 };
 
 /// Seat assignment
@@ -90,14 +93,25 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(
         });
     }
 
-    // TODO: #797 [Artikel P 19a Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19a)
-    //  Mark deceased candidates
+    // [Artikel P 19a Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19a)
+    for (list_number, list_deceased) in input.deceased_candidates().iter() {
+        info!(
+            "Following deceased candidates will be taken into account for list {:?}: {}",
+            list_number,
+            list_deceased
+                .iter()
+                .map(|c| format!("{:?}", c))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
 
     // [Artikel P 10 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP10)
     let (final_steps, final_standing) = reassign_residual_seats_for_exhausted_lists(
         cumulative_standings,
         input.number_of_seats(),
         input.list_votes(),
+        input.deceased_candidates(),
         residual_seats,
         steps,
     )?;
@@ -138,6 +152,7 @@ pub fn as_candidate_nomination_input<'a, T: ApportionmentInput>(
     CandidateNominationInput {
         number_of_seats: input.number_of_seats(),
         list_votes: input.list_votes(),
+        deceased_candidates: input.deceased_candidates(),
         quota: seat_assignment.quota,
         total_seats_per_list: get_total_seats_per_list_number_from_apportionment_result(
             seat_assignment,
@@ -154,12 +169,16 @@ fn list_numbers<LN: Copy>(standing: &[&ListStanding<LN>]) -> Vec<LN> {
 fn get_number_of_candidates<T: ListVotes>(
     input_list_votes: &[T],
     list_number: T::ListNumber,
+    deceased_candidates: &DeceasedCandidates<T>,
 ) -> u32 {
     let list_votes = input_list_votes
         .iter()
         .find(|list_votes| list_votes.number() == list_number)
         .expect("List votes exists");
-    u32::try_from(list_votes.candidate_votes().len()).expect("Number of candidates fits in u32")
+
+    let deceased_count = deceased_candidates.get(&list_number).map_or(0, |v| v.len());
+    u32::try_from(list_votes.candidate_votes().len() - deceased_count)
+        .expect("Number of candidates fits in u32")
 }
 
 /// Returns a vector with tuples of list numbers and how many more seats it was assigned
@@ -167,11 +186,13 @@ fn get_number_of_candidates<T: ListVotes>(
 fn list_numbers_with_exhausted_seats<T: ListVotes>(
     standings: &[ListStanding<T::ListNumber>],
     input_list_votes: &[T],
+    deceased_candidates: &DeceasedCandidates<T>,
 ) -> Vec<(T::ListNumber, u32)> {
     standings
         .iter()
         .fold(vec![], |mut exhausted_list_numbers_and_seats, s| {
-            let number_of_candidates = get_number_of_candidates(input_list_votes, s.list_number);
+            let number_of_candidates =
+                get_number_of_candidates(input_list_votes, s.list_number, deceased_candidates);
             if number_of_candidates.cmp(&s.total_seats()) == Ordering::Less {
                 exhausted_list_numbers_and_seats.push((
                     s.list_number,
@@ -256,10 +277,12 @@ fn reassign_residual_seats_for_exhausted_lists<T: ListVotes>(
     previous_standings: Vec<ListStanding<T::ListNumber>>,
     seats: u32,
     list_votes: &[T],
+    deceased_candidates: &DeceasedCandidates<T>,
     assigned_residual_seats: u32,
     previous_steps: Vec<SeatChangeStep<T::ListNumber>>,
 ) -> RemainderAssignmentResult<T::ListNumber> {
-    let exhausted_lists = list_numbers_with_exhausted_seats(&previous_standings, list_votes);
+    let exhausted_lists =
+        list_numbers_with_exhausted_seats(&previous_standings, list_votes, deceased_candidates);
     if !exhausted_lists.is_empty() {
         let mut current_standings = previous_standings.clone();
         let mut seats_to_reassign = 0;
@@ -304,7 +327,7 @@ fn reassign_residual_seats_for_exhausted_lists<T: ListVotes>(
             assigned_residual_seats + seats_to_reassign,
             assigned_residual_seats,
             &current_steps,
-            Some(list_votes),
+            Some((list_votes, deceased_candidates)),
         )?;
         Ok((current_steps, current_standings))
     } else {
@@ -314,6 +337,8 @@ fn reassign_residual_seats_for_exhausted_lists<T: ListVotes>(
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use test_log::test;
+
     use crate::{
         ListVotes, SeatAssignmentResult,
         fraction::Fraction,
@@ -322,7 +347,6 @@ pub(crate) mod tests {
             list_numbers,
         },
     };
-    use test_log::test;
 
     impl SeatChange<u32> {
         /// Returns true if the seat was changed through the list exhaustion removal
@@ -613,6 +637,8 @@ pub(crate) mod tests {
         }
 
         mod list_exhaustion {
+            use std::collections::{HashMap, HashSet};
+
             use test_log::test;
 
             use super::get_total_seats_from_apportionment_result;
@@ -621,10 +647,10 @@ pub(crate) mod tests {
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
-            /// Apportionment with no residual seats  
+            /// Apportionment with no residual seats
             /// This test triggers Kieswet Article P 10
             ///
-            /// Full seats: [5, 4, 3, 2, 1] - Remainder seats: 0  
+            /// Full seats: [5, 4, 3, 2, 1] - Remainder seats: 0
             /// 1 - Seat first assigned to list 1 has been removed and
             ///     will be assigned to another list in accordance with Article P 10 Kieswet  
             /// Remainders: [0/15, 0/15, 0/15, 0/15, 0/15]  
@@ -1090,6 +1116,57 @@ pub(crate) mod tests {
                 let result = seat_assignment(&input);
                 assert_eq!(result, Err(ApportionmentError::AllListsExhausted));
             }
+
+            /// Apportionment where deceased candidates cause a list to be exhausted.
+            ///
+            /// 15 seats, quota = 1500 / 15 = 100.
+            /// Votes: list 1 = 610, list 2 = 520, list 3 = 370.
+            /// Full seats: [6, 5, 3] - Remainder seats: 1
+            /// Remainders: [10, 20, 70], all lists meet the 3/4 quota threshold.
+            ///
+            /// 1 - largest remainder: seat assigned to list 3 (remainder 70).
+            /// Initial distribution: [6, 5, 4].
+            ///
+            /// Marking candidate 6 of list 1 as deceased leaves 5 alive for 6 assigned
+            /// seats, triggering article P 10:
+            /// 2 - list 1 has one seat retracted (was a full seat, since list 1 has no
+            ///     residual seats).
+            /// 3 - largest remainder reassigns to list 2 (list 3 already got a LR
+            ///     seat in step 1, so it no longer qualifies).
+            ///
+            /// Final distribution: [5, 6, 4].
+            #[test]
+            fn test_with_list_exhaustion_due_to_deceased_candidates() {
+                let mut input = seat_assignment_fixture_with_given_candidate_votes(
+                    15,
+                    vec![
+                        vec![610, 0, 0, 0, 0, 0],
+                        vec![520, 0, 0, 0, 0, 0, 0],
+                        vec![370, 0, 0, 0, 0],
+                    ],
+                );
+                input.deceased_candidates = HashMap::from([(1, HashSet::from([6]))]);
+
+                let result = seat_assignment(&input).unwrap();
+                assert_eq!(result.full_seats, 13);
+                assert_eq!(result.residual_seats, 2);
+                assert_eq!(result.steps.len(), 3);
+                assert_eq!(result.steps[0].change.list_number_assigned(), 3);
+                assert!(
+                    result.steps[1]
+                        .change
+                        .is_changed_by_list_exhaustion_removal()
+                );
+                assert_eq!(result.steps[1].change.list_number_retracted(), 1);
+                assert!(
+                    result.steps[2]
+                        .change
+                        .is_changed_by_largest_remainder_assignment()
+                );
+                assert_eq!(result.steps[2].change.list_number_assigned(), 2);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, vec![5, 6, 4]);
+            }
         }
     }
 
@@ -1303,6 +1380,8 @@ pub(crate) mod tests {
         }
 
         mod list_exhaustion {
+            use std::collections::{HashMap, HashSet};
+
             use test_log::test;
 
             use super::get_total_seats_from_apportionment_result;
@@ -1311,7 +1390,7 @@ pub(crate) mod tests {
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
-            /// Apportionment with no residual seats  
+            /// Apportionment with no residual seats
             /// This test triggers Kieswet Article P 10
             ///
             /// Full seats: [5, 5, 4, 4, 2] - Remainder seats: 0  
@@ -1485,6 +1564,62 @@ pub(crate) mod tests {
                 );
                 let result = seat_assignment(&input);
                 assert_eq!(result, Err(ApportionmentError::AllListsExhausted));
+            }
+
+            /// Apportionment where deceased candidates cause a list to be exhausted
+            /// in a council with >=19 seats (residual assignment via highest averages).
+            ///
+            /// 20 seats, quota = 2000 / 20 = 100.
+            /// Votes: list 1 = 810, list 2 = 620, list 3 = 570.
+            /// Full seats: [8, 6, 5] - Remainder seats: 1
+            /// Next averages: list 1 = 810/9 = 90, list 2 = 620/7 ≈ 88.57,
+            /// list 3 = 570/6 = 95.
+            ///
+            /// 1 - highest average: seat assigned to list 3 (95).
+            /// Initial distribution: [8, 6, 6].
+            ///
+            /// Marking candidate 8 of list 1 as deceased leaves 7 alive for 8 assigned
+            /// seats, triggering article P 10:
+            /// 2 - list 1 has one seat retracted (was a full seat, since list 1 has no
+            ///     residual seats).
+            /// 3 - highest average reassigns to list 2 (list 1 is exhausted; list 3's
+            ///     next average is now 570/7 ≈ 81.43, list 2's is 620/7 ≈ 88.57).
+            ///
+            /// Final distribution: [7, 7, 6].
+            #[test]
+            fn test_with_list_exhaustion_due_to_deceased_candidates() {
+                let mut input = seat_assignment_fixture_with_given_candidate_votes(
+                    20,
+                    vec![
+                        vec![810, 0, 0, 0, 0, 0, 0, 0],
+                        vec![620, 0, 0, 0, 0, 0, 0],
+                        vec![570, 0, 0, 0, 0, 0, 0],
+                    ],
+                );
+                input.deceased_candidates = HashMap::from([(1, HashSet::from([8]))]);
+
+                let result = seat_assignment(&input).unwrap();
+                assert_eq!(result.steps.len(), 3);
+                assert!(
+                    result.steps[0]
+                        .change
+                        .is_changed_by_highest_average_assignment()
+                );
+                assert_eq!(result.steps[0].change.list_number_assigned(), 3);
+                assert!(
+                    result.steps[1]
+                        .change
+                        .is_changed_by_list_exhaustion_removal()
+                );
+                assert_eq!(result.steps[1].change.list_number_retracted(), 1);
+                assert!(
+                    result.steps[2]
+                        .change
+                        .is_changed_by_highest_average_assignment()
+                );
+                assert_eq!(result.steps[2].change.list_number_assigned(), 2);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, vec![7, 7, 6]);
             }
         }
     }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -1,7 +1,11 @@
+use std::{cmp::Ordering, fmt::Debug};
+
+use tracing::{debug, info};
+
 use super::{
     super::{
         fraction::Fraction,
-        structs::{LARGE_COUNCIL_THRESHOLD, ListVotes},
+        structs::{DeceasedCandidates, LARGE_COUNCIL_THRESHOLD, ListVotes},
     },
     ApportionmentError, get_number_of_candidates, list_numbers,
     structs::{
@@ -9,8 +13,6 @@ use super::{
         RemainderAssignmentResult, SeatChange, SeatChangeStep,
     },
 };
-use std::{cmp::Ordering, fmt::Debug};
-use tracing::{debug, info};
 
 /// This function assigns the residual seats that remain after full seat assignment is finished.
 /// These residual seats are assigned through two different procedures,
@@ -21,7 +23,7 @@ pub fn assign_remainder<T: ListVotes>(
     total_residual_seats: u32,
     current_residual_seat_number: u32,
     previous_steps: &[SeatChangeStep<T::ListNumber>],
-    exclude_exhausted_lists: Option<&[T]>,
+    exclude_exhausted_lists: Option<(&[T], &DeceasedCandidates<T>)>,
 ) -> RemainderAssignmentResult<T::ListNumber> {
     let mut steps: Vec<SeatChangeStep<T::ListNumber>> = previous_steps.to_vec();
     let mut residual_seat_number = current_residual_seat_number;
@@ -30,9 +32,9 @@ pub fn assign_remainder<T: ListVotes>(
     while residual_seat_number != total_residual_seats {
         let residual_seats = total_residual_seats - residual_seat_number;
         residual_seat_number += 1;
-        let exhausted_list_numbers: Vec<T::ListNumber> = exclude_exhausted_lists
-            .map_or_else(Vec::new, |list_votes| {
-                list_numbers_without_empty_seats(current_standings.iter(), list_votes)
+        let exhausted_list_numbers: Vec<T::ListNumber> =
+            exclude_exhausted_lists.map_or_else(Vec::new, |(list_votes, deceased)| {
+                list_numbers_without_empty_seats(current_standings.iter(), list_votes, deceased)
             });
 
         let change = if seats >= LARGE_COUNCIL_THRESHOLD {
@@ -123,12 +125,14 @@ fn list_largest_remainder_assigned_seats<LN: Copy + Eq>(
 fn list_numbers_without_empty_seats<'a, T: ListVotes>(
     standings: impl Iterator<Item = &'a ListStanding<T::ListNumber>>,
     input_list_votes: &[T],
+    deceased_candidates: &DeceasedCandidates<T>,
 ) -> Vec<T::ListNumber>
 where
     T::ListNumber: 'a,
 {
     standings.fold(vec![], |mut list_numbers_without_empty_seats, s| {
-        let number_of_candidates = get_number_of_candidates(input_list_votes, s.list_number);
+        let number_of_candidates =
+            get_number_of_candidates(input_list_votes, s.list_number, deceased_candidates);
         if number_of_candidates.cmp(&s.total_seats()) == Ordering::Equal {
             list_numbers_without_empty_seats.push(s.list_number)
         }

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -1,4 +1,8 @@
-use std::fmt::Debug;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    hash::Hash,
+};
 
 use super::{
     candidate_nomination::CandidateNominationResult, fraction::Fraction,
@@ -15,11 +19,17 @@ pub enum ApportionmentError {
     ZeroVotesCast,
 }
 
+pub type DeceasedCandidates<T> = HashMap<
+    <T as ListVotes>::ListNumber,
+    HashSet<<<T as ListVotes>::Cv as CandidateVotes>::CandidateNumber>,
+>;
+
 pub trait ApportionmentInput {
     type List: ListVotes;
 
     fn number_of_seats(&self) -> u32;
     fn list_votes(&self) -> &[Self::List];
+    fn deceased_candidates(&self) -> &DeceasedCandidates<Self::List>;
 }
 
 pub struct ApportionmentOutput<'a, T: ListVotes> {
@@ -29,7 +39,7 @@ pub struct ApportionmentOutput<'a, T: ListVotes> {
 
 pub trait ListVotes: PartialEq + Debug {
     type Cv: CandidateVotes;
-    type ListNumber: Copy + Debug + Eq;
+    type ListNumber: Copy + Debug + Eq + Hash;
 
     fn number(&self) -> Self::ListNumber;
     fn total_votes(&self) -> u32 {
@@ -42,7 +52,7 @@ pub trait ListVotes: PartialEq + Debug {
 }
 
 pub trait CandidateVotes: PartialEq + Debug {
-    type CandidateNumber: Copy + Debug + Eq;
+    type CandidateNumber: Copy + Debug + Eq + Hash;
 
     fn number(&self) -> Self::CandidateNumber;
     fn votes(&self) -> u32;
@@ -52,6 +62,7 @@ pub trait CandidateVotes: PartialEq + Debug {
 pub(crate) struct CandidateNominationInput<'a, L: ListVotes> {
     pub number_of_seats: u32,
     pub list_votes: &'a [L],
+    pub deceased_candidates: &'a DeceasedCandidates<L>,
     pub quota: Fraction,
     pub total_seats_per_list: Vec<(L::ListNumber, u32)>,
 }

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -1,13 +1,15 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{ListVotes, fraction::Fraction, structs::CandidateNominationInput};
 use crate::{
     ApportionmentInput, CandidateVotes, SeatAssignmentResult,
     candidate_nomination::{Candidate, ListCandidateNomination, candidate_votes_numbers},
 };
 
-use super::{ListVotes, fraction::Fraction, structs::CandidateNominationInput};
-
 pub struct ApportionmentInputMock {
     pub number_of_seats: u32,
     pub list_votes: Vec<ListVotesMock>,
+    pub deceased_candidates: HashMap<u32, HashSet<u32>>,
 }
 
 impl ApportionmentInput for ApportionmentInputMock {
@@ -19,6 +21,10 @@ impl ApportionmentInput for ApportionmentInputMock {
 
     fn list_votes(&self) -> &[Self::List] {
         &self.list_votes
+    }
+
+    fn deceased_candidates(&self) -> &HashMap<u32, HashSet<u32>> {
+        &self.deceased_candidates
     }
 }
 
@@ -164,6 +170,7 @@ pub fn candidate_nomination_fixture_with_given_number_of_seats(
     CandidateNominationInput {
         number_of_seats: seat_assignment_input.number_of_seats,
         list_votes: &seat_assignment_input.list_votes,
+        deceased_candidates: &seat_assignment_input.deceased_candidates,
         quota,
         total_seats_per_list: total_seats_per_list
             .into_iter()
@@ -183,6 +190,7 @@ pub fn candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats(
     CandidateNominationInput {
         number_of_seats: seat_assignment_input.number_of_seats,
         list_votes: &seat_assignment_input.list_votes,
+        deceased_candidates: &seat_assignment_input.deceased_candidates,
         quota,
         total_seats_per_list: total_seats_per_list_number,
     }
@@ -209,6 +217,7 @@ pub fn seat_assignment_fixture_with_default_50_candidates(
     ApportionmentInputMock {
         number_of_seats,
         list_votes,
+        deceased_candidates: HashMap::new(),
     }
 }
 
@@ -228,6 +237,7 @@ pub fn seat_assignment_fixture_with_given_list_numbers_and_candidate_votes(
     ApportionmentInputMock {
         number_of_seats,
         list_votes,
+        deceased_candidates: HashMap::new(),
     }
 }
 
@@ -249,6 +259,7 @@ pub fn seat_assignment_fixture_with_given_candidate_votes(
     ApportionmentInputMock {
         number_of_seats,
         list_votes,
+        deceased_candidates: HashMap::new(),
     }
 }
 
@@ -276,5 +287,6 @@ pub fn seat_assignment_fixture_with_given_list_numbers_candidate_numbers_and_vot
     ApportionmentInputMock {
         number_of_seats,
         list_votes,
+        deceased_candidates: HashMap::new(),
     }
 }

--- a/backend/src/api/apportionment/handlers/get_apportionment_state.rs
+++ b/backend/src/api/apportionment/handlers/get_apportionment_state.rs
@@ -7,7 +7,7 @@ use sqlx::SqlitePool;
 use crate::{
     APIError, ErrorResponse,
     domain::{apportionment_state::ApportionmentState, election::ElectionId},
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service,
 };
 
@@ -34,7 +34,10 @@ pub async fn get_apportionment_state(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut conn = pool.acquire().await?;
 
-    let (_, state) = service::get_apportionment_state(&mut conn, user, election_id).await?;
+    let election = election_repo::get(&mut conn, election_id).await?;
+    user.role().is_authorized(&election.committee_category)?;
+
+    let (_, state) = service::get_apportionment_state(&mut conn, election_id).await?;
 
     Ok(Json(state))
 }

--- a/backend/src/api/apportionment/handlers/get_apportionment_state.rs
+++ b/backend/src/api/apportionment/handlers/get_apportionment_state.rs
@@ -35,7 +35,7 @@ pub async fn get_apportionment_state(
     let mut conn = pool.acquire().await?;
 
     let election = election_repo::get(&mut conn, election_id).await?;
-    user.role().is_authorized(&election.committee_category)?;
+    user.role().is_authorized(election.committee_category)?;
 
     let (_, state) = service::get_apportionment_state(&mut conn, election_id).await?;
 

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType},
     repository::{committee_session_repo, data_entry_repo, election_repo, user_repo::User},
+    service,
 };
 
 #[derive(Serialize)]
@@ -70,11 +71,13 @@ pub async fn process_apportionment(
         )
         .await?;
 
+        let (_, state) = service::get_apportionment_state(&mut conn, user, election.id).await?;
         let summary = ElectionSummary::from_results(&election, &results)?;
-        let input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: &summary.political_group_votes,
-        };
+        let input = ApportionmentInputData::new(
+            election.number_of_seats,
+            &summary.political_group_votes,
+            state.get_deceased_candidates(),
+        );
         let result = apportionment::process(&input)?;
 
         audit_service

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -71,7 +71,7 @@ pub async fn process_apportionment(
         )
         .await?;
 
-        let (_, state) = service::get_apportionment_state(&mut conn, user, election.id).await?;
+        let (_, state) = service::get_apportionment_state(&mut conn, election.id).await?;
         let summary = ElectionSummary::from_results(&election, &results)?;
         let input = ApportionmentInputData::new(
             election.number_of_seats,

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -1,9 +1,12 @@
+use std::collections::{HashMap, HashSet};
+
 use apportionment::{self};
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::domain::{
     apportionment::{CandidateNomination, SeatAssignment},
+    apportionment_state::DeceasedCandidate,
     election::{self, PGNumber},
     results::political_group_candidate_votes::{CandidateVotes, PoliticalGroupCandidateVotes},
     summary::ElectionSummary,
@@ -13,6 +16,30 @@ use crate::domain::{
 pub struct ApportionmentInputData<'a> {
     pub number_of_seats: u32,
     pub list_votes: &'a [PoliticalGroupCandidateVotes],
+    pub deceased_candidates: HashMap<PGNumber, HashSet<election::CandidateNumber>>,
+}
+
+impl<'a> ApportionmentInputData<'a> {
+    pub fn new(
+        number_of_seats: u32,
+        list_votes: &'a [PoliticalGroupCandidateVotes],
+        deceased_candidates: &[DeceasedCandidate],
+    ) -> Self {
+        let mut grouped: HashMap<PGNumber, HashSet<election::CandidateNumber>> = HashMap::new();
+
+        for dc in deceased_candidates {
+            grouped
+                .entry(dc.pg_number)
+                .or_default()
+                .insert(dc.candidate_number);
+        }
+
+        Self {
+            number_of_seats,
+            list_votes,
+            deceased_candidates: grouped,
+        }
+    }
 }
 
 impl<'a> apportionment::ApportionmentInput for ApportionmentInputData<'a> {
@@ -24,6 +51,10 @@ impl<'a> apportionment::ApportionmentInput for ApportionmentInputData<'a> {
 
     fn list_votes(&self) -> &[Self::List] {
         self.list_votes
+    }
+
+    fn deceased_candidates(&self) -> &HashMap<PGNumber, HashSet<election::CandidateNumber>> {
+        &self.deceased_candidates
     }
 }
 

--- a/backend/src/api/report/files.rs
+++ b/backend/src/api/report/files.rs
@@ -19,7 +19,7 @@ use crate::{
         data_entry_repo::are_results_complete_for_committee_session,
         file_repo,
     },
-    service::list_polling_stations_for_session,
+    service::{get_apportionment_state, list_polling_stations_for_session},
 };
 
 struct FileSaver<'a> {
@@ -109,10 +109,12 @@ async fn generate_and_save_files_csb_election(
         input: &input,
     };
 
-    let apportionment_input = ApportionmentInputData {
-        number_of_seats: input.election.number_of_seats,
-        list_votes: &input.summary.political_group_votes,
-    };
+    let (_, state) = get_apportionment_state(&mut conn, user, input.election.id).await?;
+    let apportionment_input = ApportionmentInputData::new(
+        input.election.number_of_seats,
+        &input.summary.political_group_votes,
+        state.get_deceased_candidates(),
+    );
     let apportionment_result = apportionment::process(&apportionment_input)?;
 
     let generated_files = input.generate_csb_files(&apportionment_result).await?;

--- a/backend/src/api/report/files.rs
+++ b/backend/src/api/report/files.rs
@@ -103,13 +103,13 @@ async fn generate_and_save_files_csb_election(
         ));
     }
 
+    let (_, state) = get_apportionment_state(conn, input.election.id).await?;
+
     let mut saver = FileSaver {
         conn,
         audit_service,
         input: &input,
     };
-
-    let (_, state) = get_apportionment_state(&mut conn, user, input.election.id).await?;
     let apportionment_input = ApportionmentInputData::new(
         input.election.number_of_seats,
         &input.summary.political_group_votes,

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -108,6 +108,18 @@ impl ApportionmentState {
         }
     }
 
+    pub fn get_deceased_candidates(&self) -> &[DeceasedCandidate] {
+        match self {
+            Self::Uninitialised => &[],
+            Self::RegisteringDeceasedCandidates {
+                deceased_candidates,
+            } => deceased_candidates,
+            Self::Finalised {
+                deceased_candidates,
+            } => deceased_candidates,
+        }
+    }
+
     pub fn add_deceased_candidate(
         self,
         candidate: DeceasedCandidate,

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -153,10 +153,8 @@ mod tests {
         );
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: list_votes.as_slice(),
-        };
+        let apportionment_input =
+            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -187,10 +185,8 @@ mod tests {
         );
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: list_votes.as_slice(),
-        };
+        let apportionment_input =
+            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -228,10 +224,8 @@ mod tests {
         );
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: list_votes.as_slice(),
-        };
+        let apportionment_input =
+            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -154,7 +154,7 @@ mod tests {
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -176,17 +176,16 @@ mod tests {
         ];
         let election = election_fixture_with_given_number_of_seats(
             CommitteeCategory::CSB,
-            candidate_votes
+            &candidate_votes
                 .iter()
                 .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>()
-                .as_slice(),
+                .collect::<Vec<u32>>(),
             15,
         );
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -215,17 +214,16 @@ mod tests {
         ];
         let election = election_fixture_with_given_number_of_seats(
             CommitteeCategory::CSB,
-            candidate_votes
+            &candidate_votes
                 .iter()
                 .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>()
-                .as_slice(),
+                .collect::<Vec<u32>>(),
             19,
         );
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);

--- a/backend/src/domain/models/enriched_candidate_nomination.rs
+++ b/backend/src/domain/models/enriched_candidate_nomination.rs
@@ -144,17 +144,16 @@ mod tests {
         ];
         let election = election_fixture_with_given_number_of_seats(
             CommitteeCategory::CSB,
-            candidate_votes
+            &candidate_votes
                 .iter()
                 .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>()
-                .as_slice(),
+                .collect::<Vec<u32>>(),
             15,
         );
         let political_groups = &election.political_groups;
         let list_votes = create_political_group_candidate_votes(political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let candidate_nomination = map_candidate_nomination(

--- a/backend/src/domain/models/enriched_candidate_nomination.rs
+++ b/backend/src/domain/models/enriched_candidate_nomination.rs
@@ -153,10 +153,8 @@ mod tests {
         );
         let political_groups = &election.political_groups;
         let list_votes = create_political_group_candidate_votes(political_groups, &candidate_votes);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: list_votes.as_slice(),
-        };
+        let apportionment_input =
+            ApportionmentInputData::new(election.number_of_seats, list_votes.as_slice(), &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let candidate_nomination = map_candidate_nomination(

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -333,10 +333,11 @@ mod tests {
         let political_groups = &election.political_groups;
         let summary = get_election_summary(&election, &candidate_votes);
         let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: summary.political_group_votes.as_slice(),
-        };
+        let apportionment_input = ApportionmentInputData::new(
+            election.number_of_seats,
+            summary.political_group_votes.as_slice(),
+            &[],
+        );
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -451,10 +452,11 @@ mod tests {
         let political_groups = &election.political_groups;
         let summary = get_election_summary(&election, &candidate_votes);
         let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: summary.political_group_votes.as_slice(),
-        };
+        let apportionment_input = ApportionmentInputData::new(
+            election.number_of_seats,
+            summary.political_group_votes.as_slice(),
+            &[],
+        );
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -537,10 +539,11 @@ mod tests {
         let political_groups = &election.political_groups;
         let summary = get_election_summary(&election, &candidate_votes);
         let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
-        let apportionment_input = ApportionmentInputData {
-            number_of_seats: election.number_of_seats,
-            list_votes: summary.political_group_votes.as_slice(),
-        };
+        let apportionment_input = ApportionmentInputData::new(
+            election.number_of_seats,
+            summary.political_group_votes.as_slice(),
+            &[],
+        );
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -323,11 +323,10 @@ mod tests {
         ];
         let election = election_fixture_with_given_number_of_seats(
             CommitteeCategory::CSB,
-            candidate_votes
+            &candidate_votes
                 .iter()
                 .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>()
-                .as_slice(),
+                .collect::<Vec<u32>>(),
             10,
         );
         let political_groups = &election.political_groups;
@@ -335,7 +334,7 @@ mod tests {
         let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
-            summary.political_group_votes.as_slice(),
+            &summary.political_group_votes,
             &[],
         );
         let apportionment_result =
@@ -442,11 +441,10 @@ mod tests {
         ];
         let election = election_fixture_with_given_number_of_seats(
             CommitteeCategory::CSB,
-            candidate_votes
+            &candidate_votes
                 .iter()
                 .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>()
-                .as_slice(),
+                .collect::<Vec<u32>>(),
             24,
         );
         let political_groups = &election.political_groups;
@@ -454,7 +452,7 @@ mod tests {
         let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
-            summary.political_group_votes.as_slice(),
+            &summary.political_group_votes,
             &[],
         );
         let apportionment_result =
@@ -529,11 +527,10 @@ mod tests {
         ];
         let election = election_fixture_with_given_number_of_seats(
             CommitteeCategory::CSB,
-            candidate_votes
+            &candidate_votes
                 .iter()
                 .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>()
-                .as_slice(),
+                .collect::<Vec<u32>>(),
             15,
         );
         let political_groups = &election.political_groups;
@@ -541,7 +538,7 @@ mod tests {
         let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
-            summary.political_group_votes.as_slice(),
+            &summary.political_group_votes,
             &[],
         );
         let apportionment_result =

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -756,10 +756,11 @@ async fn test_p_22_2() {
     let summary_gsb = random_election_summary(&mut rng, &election, &data_sources);
     let summary = random_election_summary_csb(&mut rng, &election, &data_sources, string_length);
 
-    let apportionment_input = ApportionmentInputData {
-        number_of_seats: election.number_of_seats,
-        list_votes: &summary_gsb.political_group_votes,
-    };
+    let apportionment_input = ApportionmentInputData::new(
+        election.number_of_seats,
+        &summary_gsb.political_group_votes,
+        &[],
+    );
     let apportionment_result =
         apportionment::process(&apportionment_input).expect("apportionment failed");
     let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -34,14 +34,12 @@ struct ApportionmentStateChange {
 /// and the committee session id to which this state belongs.
 pub async fn get_state(
     conn: &mut SqliteConnection,
-    user: User,
     election_id: ElectionId,
 ) -> Result<(CommitteeSessionId, ApportionmentState), APIError> {
     let election = election_repo::get(conn, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
-
     let committee_session =
-        committee_session_repo::get_election_committee_session(conn, election.id).await?;
+        committee_session_repo::get_election_committee_session(conn, election_id).await?;
 
     if committee_session.status != CommitteeSessionStatus::Completed {
         return Err(ApportionmentApiError::CommitteeSessionNotCompleted.into());
@@ -66,7 +64,10 @@ pub async fn update_state(
     election_id: ElectionId,
     update_fn: impl FnOnce(ApportionmentState) -> Result<ApportionmentState, ApportionmentStateError>,
 ) -> Result<ApportionmentState, APIError> {
-    let (id, state) = get_state(conn, user, election_id).await?;
+    let election = election_repo::get(conn, election_id).await?;
+    user.role().is_authorized(&election.committee_category)?;
+
+    let (id, state) = get_state(conn, election_id).await?;
 
     let state = update_fn(state).map_err(|err| APIError::Delegated(Box::new(err)))?;
 
@@ -191,13 +192,9 @@ mod tests {
         set_states(&mut conn, CommitteeSessionStatus::Completed, None).await;
 
         // Returns a new ApportionmentState::Uninitialised
-        let (id, state) = get_state(
-            &mut conn,
-            User::test_user(Role::CoordinatorGSB, UserId::from(1)),
-            ElectionId::from(ELECTION_ID),
-        )
-        .await
-        .expect("should get state");
+        let (id, state) = get_state(&mut conn, ElectionId::from(ELECTION_ID))
+            .await
+            .expect("should get state");
 
         assert_eq!(id, CommitteeSessionId::from(COMMITTEE_SESSION_ID));
         assert_eq!(state, ApportionmentState::Uninitialised);

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -36,8 +36,6 @@ pub async fn get_state(
     conn: &mut SqliteConnection,
     election_id: ElectionId,
 ) -> Result<(CommitteeSessionId, ApportionmentState), APIError> {
-    let election = election_repo::get(conn, election_id).await?;
-    user.role().is_authorized(election.committee_category)?;
     let committee_session =
         committee_session_repo::get_election_committee_session(conn, election_id).await?;
 
@@ -65,7 +63,7 @@ pub async fn update_state(
     update_fn: impl FnOnce(ApportionmentState) -> Result<ApportionmentState, ApportionmentStateError>,
 ) -> Result<ApportionmentState, APIError> {
     let election = election_repo::get(conn, election_id).await?;
-    user.role().is_authorized(&election.committee_category)?;
+    user.role().is_authorized(election.committee_category)?;
 
     let (id, state) = get_state(conn, election_id).await?;
 


### PR DESCRIPTION
Resolves #3164
Resolves #3286 

Adds deceased candidate functionality to apportionment crate. 

Changes:
- Added `deceased_candidates` to `ApportionmentInput` trait
  - Using `HashMap<ListNumber, HashSet<CandidateNumber>>` to avoid duplicates
- Added `get_deceased_candidates` to `impl ApportionmentState` to get deceased candidates from state
- Converting deceased candidates to apportionment format in `ApportionmentInputData::new()`
- Passing this list on to `seat_assignment` and `candidate_nomination` for filtering
- Moved `committee_category` check out of apportionment service back to handlers, since `report.rs` -> `generate_and_save_files_csb_election` needed to get the state without a user involved. (https://github.com/kiesraad/abacus/commit/e6339033565eca2d7dce5bba7ff2491d9a1f6b76)
- `candidate_nomination_per_list`: if there are deceased candidates involved, we always return an updated list. 
- Added empty list of deceased candidates to fuzzer. 
- Added tests
  -  `lib.rs`: 
     - `test_apportionment_process_with_deceased_candidates`: copy of `test_apportionment_process` but with deceased candidates. 
     - `test_apportionment_process_with_deceased_scenarios`: several scenarios to see how the seat distribution changes
  - `candidate_nomination/mod.rs`:
    - `test_filter_out_deceased_candidates`: test the filter function
    - `test_with_lt_19_seats_and_preferential_candidate_nomination_and_deceased_candidates`: test scenario with deceased candidates with preferential candidate nomination
    - `test_with_lt_19_seats_and_no_preferential_candidate_nomination_and_deceased_candidates`: test scenario with deceased candidates without preferential candidate nomination
  - `seat_assignment/mod.rs` -> `test_with_list_exhaustion_due_to_deceased_candidates` to test list exhaustion with deceased candidates for both >=19 and <19 seats

Easiest way to review is to start with `backend/apportionment/src/structs.rs`, then follow the `backend/apportionment/src/lib.rs` -> `fn process()` and go to `seat_assignment` and `candidate_nomination`. This way it is easy to follow what happens to the deceased candidates list. 