### PR TITLE
Fix capitalisation of contributor names in YAML

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -20,11 +20,11 @@
 - stacktraceghost
 - Roheryn5
 - pohlm01
-- robbepop
+- Robbepop
 - atezet
 - jkarinkl
-- nullp01nt
+- NullP01nt
 - syberant
 - hvanu-os
 - sitegui
-- dusterthefirst
+- DusterTheFirst


### PR DESCRIPTION
Corrected capitalization of contributor names, because our CLA bot is case sensitive.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->