### PR TITLE
Use TEST-NET IPv4 address

### DIFF
--- a/backend/src/api/audit.rs
+++ b/backend/src/api/audit.rs
@@ -140,7 +140,6 @@ async fn audit_log_list_users(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
 
     use axum::{extract::State, response::IntoResponse};
     use axum_extra::extract::Query;
@@ -155,10 +154,11 @@ mod tests {
         },
         infra::audit_log::{AuditLogListResponse, AuditLogUser, AuditService},
         repository::user_repo::{self, User},
+        test_support::TEST_IP_V4_ADDR,
     };
 
     fn new_test_audit_service(user: Option<User>) -> AuditService {
-        AuditService::new(user, Some(Ipv4Addr::new(203, 0, 113, 0).into()))
+        AuditService::new(user, Some(TEST_IP_V4_ADDR.into()))
     }
 
     async fn create_log_entries(pool: SqlitePool) {

--- a/backend/src/api/middleware/authentication/middleware.rs
+++ b/backend/src/api/middleware/authentication/middleware.rs
@@ -145,7 +145,7 @@ pub(crate) async fn extend_session(
 
 #[cfg(test)]
 mod test {
-    use std::{net::Ipv4Addr, str::FromStr};
+    use std::str::FromStr;
 
     use axum::http::header::{COOKIE, USER_AGENT};
     use chrono::TimeDelta;
@@ -157,14 +157,12 @@ mod test {
         api::middleware::authentication::{DO_NOT_EXTEND_SESSION_HEADER, SESSION_LIFE_TIME},
         domain::role::Role,
         repository::{session_repo, user_repo::UserId},
+        test_support::{TEST_IP_V4_ADDR, TEST_UNSPECIFIED_IP_ADDRESS, TEST_USER_AGENT},
     };
 
     fn api_account_uri() -> OriginalUri {
         OriginalUri("/api/account".parse().unwrap())
     }
-
-    const TEST_USER_AGENT: &str = "TestAgent/1.0";
-    const TEST_IP_ADDRESS: &str = "0.0.0.0";
 
     #[test(sqlx::test(fixtures("../../../../fixtures/users.sql")))]
     async fn test_inject_user(pool: SqlitePool) {
@@ -180,7 +178,7 @@ mod test {
         let session = Session::create(
             user.id(),
             TEST_USER_AGENT,
-            TEST_IP_ADDRESS,
+            TEST_UNSPECIFIED_IP_ADDRESS,
             SESSION_LIFE_TIME,
         );
         session_repo::save(&mut conn, &session).await.unwrap();
@@ -214,10 +212,7 @@ mod test {
     async fn test_extend_session(pool: SqlitePool) {
         let user = User::test_user(Role::Administrator, UserId::from(1));
 
-        let audit_service = AuditService::new(
-            Some(user.clone()),
-            Some(Ipv4Addr::new(203, 0, 113, 0).into()),
-        );
+        let audit_service = AuditService::new(Some(user.clone()), Some(TEST_IP_V4_ADDR.into()));
 
         let updated_response = extend_session(
             State(pool.clone()),
@@ -240,7 +235,12 @@ mod test {
 
         let life_time = SESSION_MIN_LIFE_TIME + TimeDelta::seconds(30); // min life time + 30 seconds
         let mut conn = pool.acquire().await.unwrap();
-        let session = Session::create(user.id(), TEST_USER_AGENT, TEST_IP_ADDRESS, life_time);
+        let session = Session::create(
+            user.id(),
+            TEST_USER_AGENT,
+            TEST_UNSPECIFIED_IP_ADDRESS,
+            life_time,
+        );
         session_repo::save(&mut conn, &session).await.unwrap();
 
         let updated_response = extend_session(
@@ -268,7 +268,12 @@ mod test {
         );
 
         let life_time = SESSION_MIN_LIFE_TIME - TimeDelta::seconds(30); // min life time - 30 seconds
-        let session = Session::create(user.id(), TEST_USER_AGENT, TEST_IP_ADDRESS, life_time);
+        let session = Session::create(
+            user.id(),
+            TEST_USER_AGENT,
+            TEST_UNSPECIFIED_IP_ADDRESS,
+            life_time,
+        );
         session_repo::save(&mut conn, &session).await.unwrap();
 
         let updated_response = extend_session(
@@ -306,14 +311,16 @@ mod test {
     async fn test_extend_session_do_not_extend_header(pool: SqlitePool) {
         let user = User::test_user(Role::Administrator, UserId::from(1));
 
-        let audit_service = AuditService::new(
-            Some(user.clone()),
-            Some(Ipv4Addr::new(203, 0, 113, 0).into()),
-        );
+        let audit_service = AuditService::new(Some(user.clone()), Some(TEST_IP_V4_ADDR.into()));
 
         let life_time = SESSION_MIN_LIFE_TIME - TimeDelta::seconds(30); // min life time - 30 seconds
         let mut conn = pool.acquire().await.unwrap();
-        let session = Session::create(user.id(), TEST_USER_AGENT, TEST_IP_ADDRESS, life_time);
+        let session = Session::create(
+            user.id(),
+            TEST_USER_AGENT,
+            TEST_UNSPECIFIED_IP_ADDRESS,
+            life_time,
+        );
         session_repo::save(&mut conn, &session).await.unwrap();
 
         let mut headers = HeaderMap::new();

--- a/backend/src/api/middleware/authentication/mod.rs
+++ b/backend/src/api/middleware/authentication/mod.rs
@@ -806,7 +806,7 @@ mod tests {
         // manually set a different IP address
         request
             .extensions_mut()
-            .insert(ConnectInfo(SocketAddr::from(([1, 2, 3, 4], 1234))));
+            .insert(ConnectInfo(SocketAddr::from(([203, 0, 113, 0], 49152))));
 
         let response = app.clone().oneshot(request).await.unwrap();
 

--- a/backend/src/api/middleware/authentication/mod.rs
+++ b/backend/src/api/middleware/authentication/mod.rs
@@ -60,10 +60,10 @@ mod tests {
             session_repo::{self, Session},
             user_repo::{self, User, UserId},
         },
+        test_support::{
+            TEST_EPHEMERAL_PORT, TEST_IP_V4_ADDR, TEST_UNSPECIFIED_IP_ADDRESS, TEST_USER_AGENT,
+        },
     };
-
-    const TEST_USER_AGENT: &str = "TestAgent/1.0";
-    const TEST_IP_ADDRESS: &str = "0.0.0.0";
 
     fn create_app(pool: SqlitePool) -> Router {
         let state = AppState {
@@ -153,7 +153,7 @@ mod tests {
         let admin1_session = Session::create(
             UserId::from(1),
             TEST_USER_AGENT,
-            TEST_IP_ADDRESS,
+            TEST_UNSPECIFIED_IP_ADDRESS,
             SESSION_MIN_LIFE_TIME / 2,
         );
         session_repo::save(&mut conn, &admin1_session)
@@ -569,7 +569,7 @@ mod tests {
         let session = Session::create(
             UserId::from(1),
             TEST_USER_AGENT,
-            TEST_IP_ADDRESS,
+            TEST_UNSPECIFIED_IP_ADDRESS,
             SESSION_LIFE_TIME,
         );
         session_repo::save(&mut conn, &session).await.unwrap();
@@ -604,7 +604,7 @@ mod tests {
         let session = Session::create(
             UserId::from(1),
             TEST_USER_AGENT,
-            TEST_IP_ADDRESS,
+            TEST_UNSPECIFIED_IP_ADDRESS,
             SESSION_LIFE_TIME,
         );
         session_repo::save(&mut conn, &session).await.unwrap();
@@ -632,7 +632,7 @@ mod tests {
         let session = Session::create(
             UserId::from(1),
             TEST_USER_AGENT,
-            TEST_IP_ADDRESS,
+            TEST_UNSPECIFIED_IP_ADDRESS,
             SESSION_MIN_LIFE_TIME / 2,
         );
         session_repo::save(&mut conn, &session).await.unwrap();
@@ -739,7 +739,7 @@ mod tests {
         let session = Session::create(
             UserId::from(5),
             TEST_USER_AGENT,
-            TEST_IP_ADDRESS,
+            TEST_UNSPECIFIED_IP_ADDRESS,
             SESSION_LIFE_TIME,
         );
         session_repo::save(&mut conn, &session).await.unwrap();
@@ -806,7 +806,10 @@ mod tests {
         // manually set a different IP address
         request
             .extensions_mut()
-            .insert(ConnectInfo(SocketAddr::from(([203, 0, 113, 0], 49152))));
+            .insert(ConnectInfo(SocketAddr::from((
+                TEST_IP_V4_ADDR,
+                TEST_EPHEMERAL_PORT,
+            ))));
 
         let response = app.clone().oneshot(request).await.unwrap();
 

--- a/backend/src/infra/audit_log/service.rs
+++ b/backend/src/infra/audit_log/service.rs
@@ -72,7 +72,6 @@ impl AuditService {
 // write some tests
 #[cfg(test)]
 mod test {
-    use std::net::Ipv4Addr;
 
     use serde_json::json;
     use sqlx::SqlitePool;
@@ -84,13 +83,14 @@ mod test {
         api::authentication::UserLoggedInAuditData,
         infra::audit_log::AuditEventLevel,
         repository::user_repo::{self, UserId},
+        test_support::TEST_IP_V4_ADDR,
     };
 
     #[test(sqlx::test(fixtures("../../../fixtures/users.sql")))]
     async fn test_log_event(pool: SqlitePool) {
         let mut tx = pool.begin_immediate().await.unwrap();
         let service = AuditService {
-            ip: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 0))),
+            ip: Some(IpAddr::V4(TEST_IP_V4_ADDR)),
             user: user_repo::get_by_username(&mut tx, "admin1").await.unwrap(),
         };
 
@@ -120,6 +120,6 @@ mod test {
         assert_eq!(event.message(), Some(&"User logged in".to_string()));
         assert_eq!(event.user_id(), Some(UserId::from(1)));
         assert_eq!(event.username(), Some("admin1"));
-        assert_eq!(event.ip(), Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 0))));
+        assert_eq!(event.ip(), Some(IpAddr::V4(TEST_IP_V4_ADDR)));
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -20,6 +20,8 @@ pub mod repository;
 pub mod service;
 #[cfg(feature = "dev-database")]
 pub mod test_data_gen;
+#[cfg(test)]
+pub(crate) mod test_support;
 
 pub use app_error::AppError;
 pub use error::{APIError, ErrorResponse};

--- a/backend/src/service/change_committee_session_status.rs
+++ b/backend/src/service/change_committee_session_status.rs
@@ -147,7 +147,6 @@ async fn delete_committee_session_files(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
 
     use chrono::Utc;
     use sqlx::{SqliteConnection, SqlitePool};
@@ -158,6 +157,7 @@ mod tests {
         domain::file::FileType,
         infra::audit_log::{AuditService, list_event_names},
         repository::file_repo,
+        test_support::TEST_IP_V4_ADDR,
     };
 
     async fn generate_test_file(
@@ -181,7 +181,7 @@ mod tests {
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_delete_files_on_resume_no_files(pool: SqlitePool) -> Result<(), APIError> {
         let mut conn = pool.acquire().await?;
-        let audit_service = AuditService::new(None, Some(Ipv4Addr::new(203, 0, 113, 0).into()));
+        let audit_service = AuditService::new(None, Some(TEST_IP_V4_ADDR.into()));
 
         let committee_session_id = CommitteeSessionId::from(6);
 
@@ -218,7 +218,7 @@ mod tests {
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_delete_files_on_resume_with_files(pool: SqlitePool) -> Result<(), APIError> {
         let mut conn = pool.acquire().await?;
-        let audit_service = AuditService::new(None, Some(Ipv4Addr::new(203, 0, 113, 0).into()));
+        let audit_service = AuditService::new(None, Some(TEST_IP_V4_ADDR.into()));
 
         let committee_session_id = CommitteeSessionId::from(6);
 

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -1,0 +1,6 @@
+use std::net::Ipv4Addr;
+
+pub(crate) const TEST_USER_AGENT: &str = "TestAgent/1.0";
+pub(crate) const TEST_UNSPECIFIED_IP_ADDRESS: &str = "0.0.0.0";
+pub(crate) const TEST_IP_V4_ADDR: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 0); // Part of the TEST-NET-3 IP range
+pub(crate) const TEST_EPHEMERAL_PORT: u16 = 49152; // First ephemeral port per RFC 6335


### PR DESCRIPTION
#### What's the scope of the changes?

Replace the use of an APNIC-owned IP address in tests with one from the TEST-NET-3 block and clean up the use of such test constants to avoid future divergence.

Resolves #2929

#### What did you test? Which edge cases did you explicitly take into account?

N/A. This is mostly a refactoring change, with a single functional difference in a test (i.e. the IP address swap). No additonal tests beyond `cargo test` were performed, which succeeded locally.

#### Are there things you want reviewers to definitely take a look at?

Does the addition and use of the `test_support` module make sense, as a pattern? Is this a good way of unifying the use of such constants?

#### Are there specific people you want feedback from?

No, beyond the individual(s) having familiarity with Rust and with the codebase.

#### Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)

Also N/A. See previous response about testing.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->