### PR TITLE
Do not run PDF diff workflow for PRs from forks

### DIFF
--- a/.github/workflows/pdf-diff.yml
+++ b/.github/workflows/pdf-diff.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   diff:
+    if: "!github.event.pull_request.head.repo.fork"
     name: Diff PDFs
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
PR comments don't work because CI jobs from forks don't have permission for that.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->