### PR TITLE
Refactoring validate function signature

### DIFF
--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -215,9 +215,8 @@ impl Validate for DataEntryStatus {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         match self {
             DataEntryStatus::FirstEntryInProgress(FirstEntryInProgress {
                 first_entry: entry,
@@ -230,14 +229,10 @@ impl Validate for DataEntryStatus {
             | DataEntryStatus::FirstEntryFinalised(FirstEntryFinalised {
                 finalised_first_entry: entry,
                 ..
-            }) => {
-                entry.validate(election, validation_results, &"data".into())?;
-                Ok(())
-            }
+            }) => entry.validate(election, &"data".into()),
             DataEntryStatus::SecondEntryInProgress(state) => {
-                state
-                    .second_entry
-                    .validate(election, validation_results, &"data".into())?;
+                let mut validation_results =
+                    state.second_entry.validate(election, &"data".into())?;
                 let mut different_fields: Vec<String> = vec![];
                 state.second_entry.compare(
                     &state.finalised_first_entry,
@@ -251,9 +246,9 @@ impl Validate for DataEntryStatus {
                         context: None,
                     });
                 }
-                Ok(())
+                Ok(validation_results)
             }
-            _ => Ok(()),
+            _ => Ok(ValidationResults::default()),
         }
     }
 }

--- a/backend/src/domain/results/common_polling_station_results.rs
+++ b/backend/src/domain/results/common_polling_station_results.rs
@@ -94,20 +94,21 @@ impl Validate for CommonPollingStationResults {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
+        let mut validation_results = ValidationResults::default();
         let total_votes_count = self.votes_counts.total_votes_cast_count;
 
-        self.votes_counts
-            .validate(election, validation_results, &path.field("votes_counts"))?;
+        validation_results.join(
+            self.votes_counts
+                .validate(election, &path.field("votes_counts"))?,
+        );
 
         let votes_counts_path = path.field("votes_counts");
         let voters_counts_path = path.field("voters_counts");
 
         let total_voters_count = self.voters_counts.total_admitted_voters_count;
-        self.voters_counts
-            .validate(election, validation_results, &voters_counts_path)?;
+        validation_results.join(self.voters_counts.validate(election, &voters_counts_path)?);
 
         if difference_admitted_voters_count_and_votes_cast_count_above_threshold(
             total_voters_count,
@@ -129,29 +130,30 @@ impl Validate for CommonPollingStationResults {
 
         let differences_counts_path = path.field("differences_counts");
 
-        self.differences_counts
-            .validate(election, validation_results, &differences_counts_path)?;
+        validation_results.join(
+            self.differences_counts
+                .validate(election, &differences_counts_path)?,
+        );
 
         validate_differences_counts(
             &self.differences_counts,
             total_voters_count,
             total_votes_count,
-            validation_results,
+            &mut validation_results,
             &differences_counts_path,
         )?;
 
-        self.political_group_votes.validate(
-            election,
-            validation_results,
-            &path.field("political_group_votes"),
-        )?;
+        validation_results.join(
+            self.political_group_votes
+                .validate(election, &path.field("political_group_votes"))?,
+        );
 
         for (i, pgcv) in self.political_group_votes.iter().enumerate() {
             let pgcv_path = path.field("political_group_votes").index(i);
-            self.validate_political_group_votes_errors(pgcv, validation_results, &pgcv_path)?;
+            self.validate_political_group_votes_errors(pgcv, &mut validation_results, &pgcv_path)?;
         }
 
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -219,8 +221,6 @@ mod tests {
     }
 
     fn validate(data: CommonPollingStationResults) -> Result<ValidationResults, DataError> {
-        let mut validation_results = ValidationResults::default();
-
         data.validate(
             // Adjust election political group list to the given test data
             &election_fixture(
@@ -231,11 +231,8 @@ mod tests {
                     .map(|pg| u32::try_from(pg.candidate_votes.len()).unwrap())
                     .collect::<Vec<_>>(),
             ),
-            &mut validation_results,
             &"data".into(),
-        )?;
-
-        Ok(validation_results)
+        )
     }
 
     #[test]

--- a/backend/src/domain/results/count.rs
+++ b/backend/src/domain/results/count.rs
@@ -24,13 +24,12 @@ impl Validate for Count {
     fn validate(
         &self,
         _election: &ElectionWithPoliticalGroups,
-        _validation_results: &mut ValidationResults,
-        _field_name: &FieldPath,
-    ) -> Result<(), DataError> {
+        _path: &FieldPath,
+    ) -> Result<ValidationResults, DataError> {
         if self > &999_999_999 {
             return Err(DataError::new("count out of range"));
         }
-        Ok(())
+        Ok(ValidationResults::default())
     }
 }
 
@@ -40,14 +39,9 @@ mod tests {
     use crate::domain::election::{CommitteeCategory, tests::election_fixture};
     #[test]
     fn test_count_err_out_of_range() {
-        let mut validation_results = ValidationResults::default();
         let count: Count = 1_000_000_000;
 
-        let result = count.validate(
-            &election_fixture(CommitteeCategory::GSB, &[]),
-            &mut validation_results,
-            &"".into(),
-        );
+        let result = count.validate(&election_fixture(CommitteeCategory::GSB, &[]), &"".into());
 
         assert!(result.is_err());
         assert!(result.unwrap_err().message.eq("count out of range"),);

--- a/backend/src/domain/results/counting_differences_polling_station.rs
+++ b/backend/src/domain/results/counting_differences_polling_station.rs
@@ -26,9 +26,9 @@ impl Validate for CountingDifferencesPollingStation {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
+        let mut validation_results = ValidationResults::default();
         if election.committee_category == CommitteeCategory::GSB {
             if self.unexplained_difference_ballots_voters.is_empty()
                 || self.difference_ballots_per_list.is_empty()
@@ -51,7 +51,7 @@ impl Validate for CountingDifferencesPollingStation {
             }
         }
 
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -100,10 +100,8 @@ mod tests {
             difference_ballots_per_list: ballots,
         };
 
-        let mut validation_results = ValidationResults::default();
-        counting_differences_polling_station.validate(
+        let validation_results = counting_differences_polling_station.validate(
             &election_fixture(committee_category, &[]),
-            &mut validation_results,
             &"counting_differences_polling_station".into(),
         )?;
 

--- a/backend/src/domain/results/differences_counts.rs
+++ b/backend/src/domain/results/differences_counts.rs
@@ -333,21 +333,16 @@ impl Validate for DifferencesCounts {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         // validate all counts
-        self.more_ballots_count.validate(
-            election,
-            validation_results,
-            &path.field("more_ballots_count"),
-        )?;
-        self.fewer_ballots_count.validate(
-            election,
-            validation_results,
-            &path.field("fewer_ballots_count"),
-        )?;
-        Ok(())
+        Ok(self
+            .more_ballots_count
+            .validate(election, &path.field("more_ballots_count"))?
+            .merge(
+                self.fewer_ballots_count
+                    .validate(election, &path.field("fewer_ballots_count"))?,
+            ))
     }
 }
 

--- a/backend/src/domain/results/extra_investigation.rs
+++ b/backend/src/domain/results/extra_investigation.rs
@@ -41,9 +41,9 @@ impl Validate for ExtraInvestigation {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
+        let mut validation_results = ValidationResults::default();
         if election.committee_category == CommitteeCategory::GSB {
             if self.extra_investigation_other_reason.is_empty()
                 != self.ballots_recounted_extra_investigation.is_empty()
@@ -66,7 +66,7 @@ impl Validate for ExtraInvestigation {
             }
         }
 
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -96,10 +96,8 @@ pub mod tests {
             ballots_recounted_extra_investigation: recounted,
         };
 
-        let mut validation_results = ValidationResults::default();
-        extra_investigation.validate(
+        let validation_results = extra_investigation.validate(
             &election_fixture(committee_category, &[]),
-            &mut validation_results,
             &"extra_investigation".into(),
         )?;
 

--- a/backend/src/domain/results/gsb_differences_counts.rs
+++ b/backend/src/domain/results/gsb_differences_counts.rs
@@ -73,21 +73,16 @@ impl Validate for GSBDifferencesCounts {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         // validate all counts
-        self.more_ballots_count.validate(
-            election,
-            validation_results,
-            &path.field("more_ballots_count"),
-        )?;
-        self.fewer_ballots_count.validate(
-            election,
-            validation_results,
-            &path.field("fewer_ballots_count"),
-        )?;
-        Ok(())
+        Ok(self
+            .more_ballots_count
+            .validate(election, &path.field("more_ballots_count"))?
+            .merge(
+                self.fewer_ballots_count
+                    .validate(election, &path.field("fewer_ballots_count"))?,
+            ))
     }
 }
 

--- a/backend/src/domain/results/gsb_results.rs
+++ b/backend/src/domain/results/gsb_results.rs
@@ -134,17 +134,16 @@ impl Validate for GSBResults {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
-        self.number_of_voters.validate(
-            election,
-            validation_results,
-            &path.field("number_of_voters"),
-        )?;
+    ) -> Result<ValidationResults, DataError> {
+        let mut validation_results = self
+            .number_of_voters
+            .validate(election, &path.field("number_of_voters"))?;
 
-        self.voters_counts
-            .validate(election, validation_results, &path.field("voters_counts"))?;
+        validation_results.join(
+            self.voters_counts
+                .validate(election, &path.field("voters_counts"))?,
+        );
 
         if self.number_of_voters == 0 {
             validation_results.warnings.push(ValidationResult {
@@ -160,34 +159,34 @@ impl Validate for GSBResults {
             });
         }
 
-        self.votes_counts
-            .validate(election, validation_results, &path.field("votes_counts"))?;
+        validation_results.join(
+            self.votes_counts
+                .validate(election, &path.field("votes_counts"))?,
+        );
 
-        self.differences_counts.validate(
-            election,
-            validation_results,
-            &path.field("differences_counts"),
-        )?;
+        validation_results.join(
+            self.differences_counts
+                .validate(election, &path.field("differences_counts"))?,
+        );
 
         self.differences_counts.validate_sum(
             self.voters_counts.total_admitted_voters_count,
             self.votes_counts.total_votes_cast_count,
-            validation_results,
+            &mut validation_results,
             &path.field("differences_counts"),
         );
 
-        self.political_group_votes.validate(
-            election,
-            validation_results,
-            &path.field("political_group_votes"),
-        )?;
+        validation_results.join(
+            self.political_group_votes
+                .validate(election, &path.field("political_group_votes"))?,
+        );
 
         for (i, pgcv) in self.political_group_votes.iter().enumerate() {
             let pgcv_path = path.field("political_group_votes").index(i);
-            self.validate_political_group_votes_errors(pgcv, validation_results, &pgcv_path)?;
+            self.validate_political_group_votes_errors(pgcv, &mut validation_results, &pgcv_path)?;
         }
 
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -234,8 +233,6 @@ mod tests {
     }
 
     fn validate(data: GSBResults) -> Result<ValidationResults, DataError> {
-        let mut validation_results = ValidationResults::default();
-
         data.validate(
             // Adjust election political group list to the given test data
             &election_fixture(
@@ -246,11 +243,8 @@ mod tests {
                     .map(|pg| u32::try_from(pg.candidate_votes.len()).unwrap())
                     .collect::<Vec<_>>(),
             ),
-            &mut validation_results,
             &"data".into(),
-        )?;
-
-        Ok(validation_results)
+        )
     }
 
     #[test]

--- a/backend/src/domain/results/mod.rs
+++ b/backend/src/domain/results/mod.rs
@@ -303,33 +303,22 @@ impl Validate for Results {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         match self {
             Results::CSOFirstSession(results) => {
-                results.extra_investigation.validate(
+                let mut validation_results = results
+                    .extra_investigation
+                    .validate(election, &path.field("extra_investigation"))?;
+                validation_results.join(results.counting_differences_polling_station.validate(
                     election,
-                    validation_results,
-                    &path.field("extra_investigation"),
-                )?;
-
-                results.counting_differences_polling_station.validate(
-                    election,
-                    validation_results,
                     &path.field("counting_differences_polling_station"),
-                )?;
-
-                results
-                    .as_common()
-                    .validate(election, validation_results, path)
+                )?);
+                validation_results.join(results.as_common().validate(election, path)?);
+                Ok(validation_results)
             }
-            Results::CSONextSession(results) => {
-                results
-                    .as_common()
-                    .validate(election, validation_results, path)
-            }
-            Results::GSB(results) => results.validate(election, validation_results, path),
+            Results::CSONextSession(results) => results.as_common().validate(election, path),
+            Results::GSB(results) => results.validate(election, path),
         }
     }
 }

--- a/backend/src/domain/results/political_group_candidate_votes.rs
+++ b/backend/src/domain/results/political_group_candidate_votes.rs
@@ -107,9 +107,8 @@ impl Validate for Vec<PoliticalGroupCandidateVotes> {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         // check if the list of political groups has the correct length
         if election.political_groups.len() != self.len() {
             return Err(DataError::new(
@@ -119,6 +118,7 @@ impl Validate for Vec<PoliticalGroupCandidateVotes> {
 
         // check each political group
         let mut previous_number = PGNumber::from(0);
+        let mut validation_results = ValidationResults::default();
         for (i, pgv) in self.iter().enumerate() {
             let number = pgv.number;
             if number <= previous_number {
@@ -126,9 +126,9 @@ impl Validate for Vec<PoliticalGroupCandidateVotes> {
             }
             previous_number = number;
 
-            pgv.validate(election, validation_results, &path.index(i))?;
+            validation_results.join(pgv.validate(election, &path.index(i))?);
         }
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -136,9 +136,8 @@ impl Validate for PoliticalGroupCandidateVotes {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         // check if the list of candidates has the correct length
         let pg = election
             .political_groups
@@ -153,6 +152,7 @@ impl Validate for PoliticalGroupCandidateVotes {
 
         // validate all candidates
         let mut prev_number = CandidateNumber::from(0);
+        let mut validation_results = ValidationResults::default();
         for (i, cv) in self.candidate_votes.iter().enumerate() {
             let number = cv.number;
             if number <= prev_number {
@@ -160,18 +160,14 @@ impl Validate for PoliticalGroupCandidateVotes {
             }
             prev_number = number;
 
-            cv.validate(
-                election,
-                validation_results,
-                &path.field("candidate_votes").index(i),
-            )?;
+            validation_results
+                .join(cv.validate(election, &path.field("candidate_votes").index(i))?);
         }
 
         // validate the total number of votes
-        self.total
-            .validate(election, validation_results, &path.field("total"))?;
+        validation_results.join(self.total.validate(election, &path.field("total"))?);
 
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -195,11 +191,9 @@ impl Validate for CandidateVotes {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
-        self.votes
-            .validate(election, validation_results, &path.field("votes"))
+    ) -> Result<ValidationResults, DataError> {
+        self.votes.validate(election, &path.field("votes"))
     }
 }
 

--- a/backend/src/domain/results/political_group_total_votes.rs
+++ b/backend/src/domain/results/political_group_total_votes.rs
@@ -45,9 +45,8 @@ impl Validate for Vec<PoliticalGroupTotalVotes> {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
         // check if the list of political group total votes has the correct length
         if election.political_groups.len() != self.len() {
             return Err(DataError::new(
@@ -57,6 +56,7 @@ impl Validate for Vec<PoliticalGroupTotalVotes> {
 
         // check each political group total votes
         let mut previous_number = PGNumber::from(0);
+        let mut validation_results = ValidationResults::default();
         for (i, pgv) in self.iter().enumerate() {
             let number = pgv.number;
             if number <= previous_number {
@@ -66,10 +66,12 @@ impl Validate for Vec<PoliticalGroupTotalVotes> {
             }
             previous_number = number;
 
-            pgv.total
-                .validate(election, validation_results, &path.index(i).field("total"))?;
+            validation_results.join(
+                pgv.total
+                    .validate(election, &path.index(i).field("total"))?,
+            );
         }
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -126,14 +128,8 @@ mod tests {
         // Remove first political group from election
         election.political_groups.remove(0);
 
-        let mut validation_results = ValidationResults::default();
-        let result = political_group_votes.validate(
-            &election,
-            &mut validation_results,
-            &"political_group_votes".into(),
-        );
+        let result = political_group_votes.validate(&election, &"political_group_votes".into());
 
-        assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
@@ -151,12 +147,8 @@ mod tests {
         political_group_votes[1].number = PGNumber::from(3);
         election.political_groups[1].number = PGNumber::from(3);
 
-        let mut validation_results = ValidationResults::default();
-        let result: Result<(), DataError> = political_group_votes.validate(
-            &election,
-            &mut validation_results,
-            &"political_group_votes".into(),
-        );
+        let result: Result<ValidationResults, DataError> =
+            political_group_votes.validate(&election, &"political_group_votes".into());
 
         assert!(result.is_ok());
     }
@@ -170,12 +162,8 @@ mod tests {
         political_group_votes[0].number = PGNumber::from(3);
         election.political_groups[0].number = PGNumber::from(3);
 
-        let mut validation_results = ValidationResults::default();
-        let result: Result<(), DataError> = political_group_votes.validate(
-            &election,
-            &mut validation_results,
-            &"political_group_votes".into(),
-        );
+        let result: Result<ValidationResults, DataError> =
+            political_group_votes.validate(&election, &"political_group_votes".into());
 
         assert!(result.is_err());
     }
@@ -193,14 +181,8 @@ mod tests {
                 votes: 0,
             });
 
-        let mut validation_results = ValidationResults::default();
-        let result = political_group_votes.validate(
-            &election,
-            &mut validation_results,
-            &"political_group_votes".into(),
-        );
+        let result = political_group_votes.validate(&election, &"political_group_votes".into());
 
-        assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
@@ -217,12 +199,7 @@ mod tests {
         // Change number of the last candidate on the first list
         political_group_votes[0].candidate_votes[2].number = CandidateNumber::from(5);
 
-        let mut validation_results = ValidationResults::default();
-        let result = political_group_votes.validate(
-            &election,
-            &mut validation_results,
-            &"political_group_votes".into(),
-        );
+        let result = political_group_votes.validate(&election, &"political_group_votes".into());
 
         assert!(result.is_ok());
     }
@@ -235,12 +212,7 @@ mod tests {
         // Change number of the second candidate on the first list to a non-increasing number
         political_group_votes[0].candidate_votes[1].number = CandidateNumber::from(1);
 
-        let mut validation_results = ValidationResults::default();
-        let result = political_group_votes.validate(
-            &election,
-            &mut validation_results,
-            &"political_group_votes".into(),
-        );
+        let result = political_group_votes.validate(&election, &"political_group_votes".into());
 
         assert!(result.is_err());
     }

--- a/backend/src/domain/results/voters_counts.rs
+++ b/backend/src/domain/results/voters_counts.rs
@@ -59,25 +59,22 @@ impl Validate for VotersCounts {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
+        let mut validation_results = ValidationResults::default();
         // validate all counts
-        self.poll_card_count.validate(
-            election,
-            validation_results,
-            &path.field("poll_card_count"),
-        )?;
-        self.proxy_certificate_count.validate(
-            election,
-            validation_results,
-            &path.field("proxy_certificate_count"),
-        )?;
-        self.total_admitted_voters_count.validate(
-            election,
-            validation_results,
-            &path.field("total_admitted_voters_count"),
-        )?;
+        validation_results.join(
+            self.poll_card_count
+                .validate(election, &path.field("poll_card_count"))?,
+        );
+        validation_results.join(
+            self.proxy_certificate_count
+                .validate(election, &path.field("proxy_certificate_count"))?,
+        );
+        validation_results.join(
+            self.total_admitted_voters_count
+                .validate(election, &path.field("total_admitted_voters_count"))?,
+        );
 
         if self.poll_card_count + self.proxy_certificate_count != self.total_admitted_voters_count {
             validation_results.errors.push(ValidationResult {
@@ -90,7 +87,7 @@ impl Validate for VotersCounts {
                 context: None,
             });
         }
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -134,14 +131,10 @@ mod tests {
             total_admitted_voters_count,
         };
 
-        let mut validation_results = ValidationResults::default();
         voters_counts.validate(
             &election_fixture(committee_category, &[]),
-            &mut validation_results,
             &"voters_counts".into(),
-        )?;
-
-        Ok(validation_results)
+        )
     }
 
     /// GSB CSO, GSB DSO, CSB | F.201: 'Aantal kiezers en stemmen': stempassen + volmachten <> totaal toegelaten kiezers

--- a/backend/src/domain/results/votes_counts.rs
+++ b/backend/src/domain/results/votes_counts.rs
@@ -260,41 +260,36 @@ impl Validate for VotesCounts {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError> {
+    ) -> Result<ValidationResults, DataError> {
+        let mut validation_results = ValidationResults::default();
         // validate all counts
-        self.political_group_total_votes.validate(
-            election,
-            validation_results,
-            &path.field("political_group_total_votes"),
-        )?;
-        self.total_votes_candidates_count.validate(
-            election,
-            validation_results,
-            &path.field("total_votes_candidates_count"),
-        )?;
-        self.blank_votes_count.validate(
-            election,
-            validation_results,
-            &path.field("blank_votes_count"),
-        )?;
-        self.invalid_votes_count.validate(
-            election,
-            validation_results,
-            &path.field("invalid_votes_count"),
-        )?;
-        self.total_votes_cast_count.validate(
-            election,
-            validation_results,
-            &path.field("total_votes_cast_count"),
-        )?;
+        validation_results.join(
+            self.political_group_total_votes
+                .validate(election, &path.field("political_group_total_votes"))?,
+        );
+        validation_results.join(
+            self.total_votes_candidates_count
+                .validate(election, &path.field("total_votes_candidates_count"))?,
+        );
+        validation_results.join(
+            self.blank_votes_count
+                .validate(election, &path.field("blank_votes_count"))?,
+        );
+        validation_results.join(
+            self.invalid_votes_count
+                .validate(election, &path.field("invalid_votes_count"))?,
+        );
+        validation_results.join(
+            self.total_votes_cast_count
+                .validate(election, &path.field("total_votes_cast_count"))?,
+        );
 
-        self.validate_votes_counts_errors(validation_results, path);
+        self.validate_votes_counts_errors(&mut validation_results, path);
 
-        self.validate_votes_counts_warnings(election, validation_results, path);
+        self.validate_votes_counts_warnings(election, &mut validation_results, path);
 
-        Ok(())
+        Ok(validation_results)
     }
 }
 
@@ -413,14 +408,10 @@ mod tests {
             total_votes_cast_count,
         };
 
-        let mut validation_results = ValidationResults::default();
         votes_counts.validate(
             &election_fixture(committee_category, &[1, 1, 1]),
-            &mut validation_results,
             &"votes_counts".into(),
-        )?;
-
-        Ok(validation_results)
+        )
     }
 
     /// GSB CSO, GSB DSO, CSB | F.202: 'Aantal kiezers en stemmen': (Als F.204 niet getoond wordt) E.1 t/m E.n tellen niet op naar E

--- a/backend/src/domain/summary.rs
+++ b/backend/src/domain/summary.rs
@@ -18,7 +18,7 @@ use crate::{
             voters_counts::VotersCounts,
             votes_counts::{EnrichedVotesCounts, VotesCounts},
         },
-        validate::{Validate, ValidationResults},
+        validate::Validate,
     },
     error::ErrorReference,
 };
@@ -85,8 +85,7 @@ impl ElectionSummary {
             }
 
             // validate result and make sure that there are no errors
-            let mut validation_results = ValidationResults::default();
-            result.validate(election, &mut validation_results, &"data".into())?;
+            let validation_results = result.validate(election, &"data".into())?;
             if validation_results.has_errors() {
                 return Err(APIError::AddError(
                     format!(

--- a/backend/src/domain/validate.rs
+++ b/backend/src/domain/validate.rs
@@ -10,6 +10,7 @@ use crate::domain::{
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
+#[must_use = "The validation results may contain error information."]
 pub struct ValidationResults {
     pub errors: Vec<ValidationResult>,
     pub warnings: Vec<ValidationResult>,
@@ -19,6 +20,18 @@ impl ValidationResults {
     pub fn append(&mut self, other: &mut Self) {
         self.errors.append(&mut other.errors);
         self.warnings.append(&mut other.warnings);
+    }
+
+    /// essentially a variant of append, that consumes the source result
+    pub fn join(&mut self, mut other: Self) -> &Self {
+        self.append(&mut other);
+        self
+    }
+
+    /// essentially a variant of append, that consumes the source result
+    pub fn merge(mut self, mut other: Self) -> Self {
+        self.append(&mut other);
+        self
     }
 
     pub fn has_errors(&self) -> bool {
@@ -136,9 +149,8 @@ pub trait Validate {
     fn validate(
         &self,
         election: &ElectionWithPoliticalGroups,
-        validation_results: &mut ValidationResults,
         path: &FieldPath,
-    ) -> Result<(), DataError>;
+    ) -> Result<ValidationResults, DataError>;
 }
 
 pub trait ValidateRoot: Validate {
@@ -146,8 +158,7 @@ pub trait ValidateRoot: Validate {
         &self,
         election: &ElectionWithPoliticalGroups,
     ) -> Result<ValidationResults, DataError> {
-        let mut validation_results = ValidationResults::default();
-        self.validate(election, &mut validation_results, &"data".into())?;
+        let mut validation_results = self.validate(election, &"data".into())?;
         validation_results
             .errors
             .sort_by(|a, b| a.code.cmp(&b.code));

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -471,24 +471,24 @@ async fn generate_gsb_data_entry(
             ));
 
             // Validate the generated results to catch issues early
-            let finalised_with_warnings: bool;
-            match results.validate(election, &FieldPath::new("data".to_string())) {
-                Ok(vr) => {
-                    if vr.has_errors() {
+            let finalised_with_warnings =
+                match results.validate(election, &FieldPath::new("data".to_string())) {
+                    Ok(vr) => {
+                        if vr.has_errors() {
+                            panic!(
+                                "Generated invalid results for polling station {}: {:?}",
+                                ps.number, vr.errors
+                            );
+                        }
+                        vr.has_warnings()
+                    }
+                    Err(e) => {
                         panic!(
-                            "Generated invalid results for polling station {}: {:?}",
-                            ps.number, vr.errors
+                            "Failed to validate generated results for polling station {}: {}",
+                            ps.number, e
                         );
                     }
-                    finalised_with_warnings = vr.has_warnings();
-                }
-                Err(e) => {
-                    panic!(
-                        "Failed to validate generated results for polling station {}: {}",
-                        ps.number, e
-                    );
-                }
-            }
+                };
 
             if rng.random_ratio(second_entry_chance, 100) {
                 // generate a definitive data entry
@@ -578,24 +578,24 @@ async fn generate_csb_data_entry(
         };
 
         // Validate the generated results to catch issues early
-        let finalised_with_warnings: bool;
-        match results.validate(election, &FieldPath::new("data".to_string())) {
-            Ok(vr) => {
-                if vr.has_errors() {
+        let finalised_with_warnings =
+            match results.validate(election, &FieldPath::new("data".to_string())) {
+                Ok(vr) => {
+                    if vr.has_errors() {
+                        panic!(
+                            "Generated invalid results for sub committee number {}: {:?}",
+                            sub_committee_first_session.sub_committee.number, vr.errors
+                        );
+                    }
+                    vr.has_warnings()
+                }
+                Err(e) => {
                     panic!(
-                        "Generated invalid results for sub committee number {}: {:?}",
-                        sub_committee_first_session.sub_committee.number, vr.errors
+                        "Failed to validate generated results for sub committee number {}: {}",
+                        sub_committee_first_session.sub_committee.number, e
                     );
                 }
-                finalised_with_warnings = vr.has_warnings();
-            }
-            Err(e) => {
-                panic!(
-                    "Failed to validate generated results for sub committee number {}: {}",
-                    sub_committee_first_session.sub_committee.number, e
-                );
-            }
-        }
+            };
 
         if rng.random_ratio(second_entry_chance, 100) {
             // generate a definitive data entry

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -37,7 +37,7 @@ use crate::{
             yes_no::YesNo,
         },
         sub_committee::SubCommitteeFirstSession,
-        validate::{Validate, ValidationResults},
+        validate::Validate,
     },
     repository::{
         committee_session_repo,
@@ -471,22 +471,23 @@ async fn generate_gsb_data_entry(
             ));
 
             // Validate the generated results to catch issues early
-            let mut validation_results = ValidationResults::default();
-            if let Err(e) = results.validate(
-                election,
-                &mut validation_results,
-                &FieldPath::new("data".to_string()),
-            ) {
-                panic!(
-                    "Failed to validate generated results for polling station {}: {}",
-                    ps.number, e
-                );
-            }
-            if validation_results.has_errors() {
-                panic!(
-                    "Generated invalid results for polling station {}: {:?}",
-                    ps.number, validation_results.errors
-                );
+            let finalised_with_warnings: bool;
+            match results.validate(election, &FieldPath::new("data".to_string())) {
+                Ok(vr) => {
+                    if vr.has_errors() {
+                        panic!(
+                            "Generated invalid results for polling station {}: {:?}",
+                            ps.number, vr.errors
+                        );
+                    }
+                    finalised_with_warnings = vr.has_warnings();
+                }
+                Err(e) => {
+                    panic!(
+                        "Failed to validate generated results for polling station {}: {}",
+                        ps.number, e
+                    );
+                }
             }
 
             if rng.random_ratio(second_entry_chance, 100) {
@@ -495,7 +496,7 @@ async fn generate_gsb_data_entry(
                     first_entry_user_id: UserId::from(5), // first typist from users in fixtures
                     second_entry_user_id: UserId::from(6), // second typist from users in fixtures
                     finished_at: ts,
-                    finalised_with_warnings: validation_results.has_warnings(),
+                    finalised_with_warnings,
                     results: results.clone(),
                 });
 
@@ -509,7 +510,7 @@ async fn generate_gsb_data_entry(
                     first_entry_user_id: UserId::from(5), // first typist from users in fixtures
                     finalised_first_entry: results.clone(),
                     first_entry_finished_at: ts,
-                    finalised_with_warnings: validation_results.has_warnings(),
+                    finalised_with_warnings,
                 });
                 data_entry_repo::update(conn, *data_entry_id, &state)
                     .await
@@ -577,22 +578,23 @@ async fn generate_csb_data_entry(
         };
 
         // Validate the generated results to catch issues early
-        let mut validation_results = ValidationResults::default();
-        if let Err(e) = results.validate(
-            election,
-            &mut validation_results,
-            &FieldPath::new("data".to_string()),
-        ) {
-            panic!(
-                "Failed to validate generated results for sub committee number {}: {}",
-                sub_committee_first_session.sub_committee.number, e
-            );
-        }
-        if validation_results.has_errors() {
-            panic!(
-                "Generated invalid results for sub committee number {}: {:?}",
-                sub_committee_first_session.sub_committee.number, validation_results.errors
-            );
+        let finalised_with_warnings: bool;
+        match results.validate(election, &FieldPath::new("data".to_string())) {
+            Ok(vr) => {
+                if vr.has_errors() {
+                    panic!(
+                        "Generated invalid results for sub committee number {}: {:?}",
+                        sub_committee_first_session.sub_committee.number, vr.errors
+                    );
+                }
+                finalised_with_warnings = vr.has_warnings();
+            }
+            Err(e) => {
+                panic!(
+                    "Failed to validate generated results for sub committee number {}: {}",
+                    sub_committee_first_session.sub_committee.number, e
+                );
+            }
         }
 
         if rng.random_ratio(second_entry_chance, 100) {
@@ -601,7 +603,7 @@ async fn generate_csb_data_entry(
                 first_entry_user_id: UserId::from(9), // first typist from users in fixtures
                 second_entry_user_id: UserId::from(10), // second typist from users in fixtures
                 finished_at: ts,
-                finalised_with_warnings: validation_results.has_warnings(),
+                finalised_with_warnings,
                 results: results.clone(),
             });
 
@@ -615,7 +617,7 @@ async fn generate_csb_data_entry(
                 first_entry_user_id: UserId::from(9), // first typist from users in fixtures
                 finalised_first_entry: results.clone(),
                 first_entry_finished_at: ts,
-                finalised_with_warnings: validation_results.has_warnings(),
+                finalised_with_warnings,
             });
             data_entry_repo::update(conn, data_entry_id, &state)
                 .await


### PR DESCRIPTION
Instead of providing a result to a validate function, the validate function should provide a result. Additionally I flagged the ValidationResults Type as a must_use, to make sure it never goes unhandled.
