### PR TITLE
Use fixtures for as_eml_count_contest test

### DIFF
--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -911,12 +911,12 @@ pub fn polling_stations_eml_matches_election(
 
 #[cfg(test)]
 mod tests {
+    use eml_nl::utils::StringValue;
+
     use super::*;
     use crate::domain::{
-        election::{ElectionCategory, ElectionWithPoliticalGroups},
-        summary::{SumCount, SummaryDifferencesCounts},
+        committee_session::committee_session_fixture, election::tests::election_fixture,
     };
-    use eml_nl::utils::StringValue;
 
     #[test]
     fn test_election_validate_missing_election_domain() {
@@ -944,99 +944,29 @@ mod tests {
         assert!(matches!(res, EMLImportError::OnlyMunicipalSupported));
     }
 
-    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_as_eml_count_contest() {
-        let candidate = ElectionWithPoliticalGroups {
-            id: Default::default(),
-            name: "".to_string(),
-            committee_category: CommitteeCategory::GSB,
-            counting_method: None,
-            election_id: "".to_string(),
-            location: "".to_string(),
-            domain_id: "".to_string(),
-            category: ElectionCategory::Municipal,
-            number_of_seats: 0,
-            number_of_voters: 6,
-            election_date: Default::default(),
-            nomination_date: Default::default(),
-            political_groups: vec![],
-        };
-        let result_gsb = candidate
-            .as_eml_count_contest(
-                &CommitteeSession {
-                    id: Default::default(),
-                    number: 0,
-                    election_id: Default::default(),
-                    location: "".to_string(),
-                    start_date_time: None,
-                    status: Default::default(),
-                },
-                &[],
-                &ElectionSummary {
-                    voters_counts: Default::default(),
-                    votes_counts: Default::default(),
-                    differences_counts: SummaryDifferencesCounts {
-                        more_ballots_count: SumCount {
-                            count: 0,
-                            data_entry_sources: vec![],
-                        },
-                        fewer_ballots_count: SumCount {
-                            count: 0,
-                            data_entry_sources: vec![],
-                        },
-                    },
-                    political_group_votes: vec![PoliticalGroupCandidateVotes {
-                        number: 1.into(),
-                        total: 0,
-                        candidate_votes: vec![],
-                    }],
-                    polling_station_investigations: Default::default(),
-                    number_of_voters: Some(5),
-                },
-            )
+        // Default number_of_voters=1000
+        let mut election = election_fixture(CommitteeCategory::CSB, &[0]);
+        let committee_session = committee_session_fixture(election.id);
+        let mut summary = ElectionSummary::from_results(&election, &[]).unwrap();
+
+        let result_csb = election
+            .as_eml_count_contest(&committee_session, &[], &summary)
             .unwrap();
-        let result_csb = candidate
-            .as_eml_count_contest(
-                &CommitteeSession {
-                    id: Default::default(),
-                    number: 0,
-                    election_id: Default::default(),
-                    location: "".to_string(),
-                    start_date_time: None,
-                    status: Default::default(),
-                },
-                &[],
-                &ElectionSummary {
-                    voters_counts: Default::default(),
-                    votes_counts: Default::default(),
-                    differences_counts: SummaryDifferencesCounts {
-                        more_ballots_count: SumCount {
-                            count: 0,
-                            data_entry_sources: vec![],
-                        },
-                        fewer_ballots_count: SumCount {
-                            count: 0,
-                            data_entry_sources: vec![],
-                        },
-                    },
-                    political_group_votes: vec![PoliticalGroupCandidateVotes {
-                        number: 1.into(),
-                        total: 0,
-                        candidate_votes: vec![],
-                    }],
-                    polling_station_investigations: Default::default(),
-                    number_of_voters: None,
-                },
-            )
+        assert_eq!(
+            result_csb.total_votes.unwrap().eligible_voter_count,
+            StringValue::from_value(1000u64)
+        );
+
+        election.committee_category = CommitteeCategory::GSB;
+        summary.number_of_voters = Some(1001);
+        let result_gsb = election
+            .as_eml_count_contest(&committee_session, &[], &summary)
             .unwrap();
         assert_eq!(
             result_gsb.total_votes.unwrap().eligible_voter_count,
-            StringValue::from_value(5u64)
-        );
-        assert_eq!(
-            result_csb.total_votes.unwrap().eligible_voter_count,
-            StringValue::from_value(6u64)
+            StringValue::from_value(1001u64)
         );
     }
 }


### PR DESCRIPTION
I was too late to add my review for https://github.com/kiesraad/abacus/pull/3319. The test can use our existing fixtures, so I've adjusted the test here. 