### PR TITLE
Add apportionment state checks and reset on resume data entry

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1719,7 +1719,7 @@
     "/api/elections/{election_id}/apportionment/reset": {
       "post": {
         "summary": "Reset apportionment state (coordinator_csb)",
-        "operationId": "reset",
+        "operationId": "reset_apportionment_state",
         "parameters": [
           {
             "name": "election_id",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6762,6 +6762,7 @@
           "EntryNotUnique",
           "Forbidden",
           "InternalServerError",
+          "InvalidApportionmentState",
           "InvalidCommitteeSessionStatus",
           "InvalidData",
           "InvalidHash",

--- a/backend/src/api/apportionment/handlers/add_deceased_candidate.rs
+++ b/backend/src/api/apportionment/handlers/add_deceased_candidate.rs
@@ -11,7 +11,7 @@ use crate::{
         election::ElectionId,
     },
     infra::audit_log::AuditService,
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service::update_apportionment_state,
 };
 
@@ -41,7 +41,10 @@ pub async fn add_deceased_candidate(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut tx = pool.begin_immediate().await?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, user, election_id, |state| {
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
         state.add_deceased_candidate(candidate)
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/delete_deceased_candidate.rs
+++ b/backend/src/api/apportionment/handlers/delete_deceased_candidate.rs
@@ -11,7 +11,7 @@ use crate::{
         election::ElectionId,
     },
     infra::audit_log::AuditService,
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service::update_apportionment_state,
 };
 
@@ -41,7 +41,10 @@ pub async fn delete_deceased_candidate(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut tx = pool.begin_immediate().await?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, user, election_id, |state| {
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
         state.delete_deceased_candidate(candidate)
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/finalise_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/finalise_deceased_candidates.rs
@@ -8,7 +8,7 @@ use crate::{
     APIError, ErrorResponse, SqlitePoolExt,
     domain::{apportionment_state::ApportionmentState, election::ElectionId},
     infra::audit_log::AuditService,
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service::update_apportionment_state,
 };
 
@@ -36,7 +36,10 @@ pub async fn finalise_deceased_candidates(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut tx = pool.begin_immediate().await?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, user, election_id, |state| {
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
         state.finalise_deceased_candidates()
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/mod.rs
+++ b/backend/src/api/apportionment/handlers/mod.rs
@@ -4,5 +4,5 @@ pub mod finalise_deceased_candidates;
 pub mod get_apportionment_state;
 pub mod process_apportionment;
 pub mod register_deceased_candidates;
-pub mod reset;
+pub mod reset_apportionment_state;
 pub mod skip_deceased_candidates;

--- a/backend/src/api/apportionment/handlers/register_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/register_deceased_candidates.rs
@@ -8,7 +8,7 @@ use crate::{
     APIError, ErrorResponse, SqlitePoolExt,
     domain::{apportionment_state::ApportionmentState, election::ElectionId},
     infra::audit_log::AuditService,
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service::update_apportionment_state,
 };
 
@@ -36,7 +36,10 @@ pub async fn register_deceased_candidates(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut tx = pool.begin_immediate().await?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, user, election_id, |state| {
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
         state.register_deceased_candidates()
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/reset.rs
+++ b/backend/src/api/apportionment/handlers/reset.rs
@@ -8,7 +8,7 @@ use crate::{
     APIError, ErrorResponse, SqlitePoolExt,
     domain::{apportionment_state::ApportionmentState, election::ElectionId},
     infra::audit_log::AuditService,
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service::update_apportionment_state,
 };
 
@@ -36,10 +36,12 @@ pub async fn reset(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut tx = pool.begin_immediate().await?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, user, election_id, |state| {
-        state.reset()
-    })
-    .await?;
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state =
+        update_apportionment_state(&mut tx, audit_service, election_id, |state| state.reset())
+            .await?;
 
     tx.commit().await?;
     Ok(Json(state))

--- a/backend/src/api/apportionment/handlers/reset_apportionment_state.rs
+++ b/backend/src/api/apportionment/handlers/reset_apportionment_state.rs
@@ -28,7 +28,7 @@ use crate::{
         ("election_id" = ElectionId, description = "Election database id"),
     ),
 )]
-pub async fn reset(
+pub async fn reset_apportionment_state(
     user: User,
     State(pool): State<SqlitePool>,
     audit_service: AuditService,
@@ -64,7 +64,7 @@ mod tests {
         path = "../../../../fixtures",
         scripts("election_5_with_results")
     )))]
-    async fn test_reset(pool: SqlitePool) {
+    async fn test_reset_apportionment_state(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
         let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
         let audit_service = AuditService::new(Some(user.clone()), None);
@@ -84,9 +84,10 @@ mod tests {
         .await
         .expect("should upsert initial state");
 
-        let state = reset(user, State(pool), audit_service, Path(ElectionId::from(5)))
-            .await
-            .expect("should call the handler successfully");
+        let state =
+            reset_apportionment_state(user, State(pool), audit_service, Path(ElectionId::from(5)))
+                .await
+                .expect("should call the handler successfully");
 
         assert_eq!(state.0, ApportionmentState::Uninitialised);
     }

--- a/backend/src/api/apportionment/handlers/skip_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/skip_deceased_candidates.rs
@@ -8,7 +8,7 @@ use crate::{
     APIError, ErrorResponse, SqlitePoolExt,
     domain::{apportionment_state::ApportionmentState, election::ElectionId},
     infra::audit_log::AuditService,
-    repository::user_repo::User,
+    repository::{election_repo, user_repo::User},
     service::update_apportionment_state,
 };
 
@@ -36,7 +36,10 @@ pub async fn skip_deceased_candidates(
 ) -> Result<Json<ApportionmentState>, APIError> {
     let mut tx = pool.begin_immediate().await?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, user, election_id, |state| {
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
         state.skip_deceased_candidates()
     })
     .await?;

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -93,7 +93,9 @@ pub fn router() -> OpenApiRouter<AppState> {
             routes!(register_deceased_candidates::register_deceased_candidates)
                 .authorize(ALLOWED_ROLES),
         )
-        .routes(routes!(reset::reset).authorize(ALLOWED_ROLES))
+        .routes(
+            routes!(reset_apportionment_state::reset_apportionment_state).authorize(ALLOWED_ROLES),
+        )
         .routes(
             routes!(skip_deceased_candidates::skip_deceased_candidates).authorize(ALLOWED_ROLES),
         )

--- a/backend/src/api/report/files.rs
+++ b/backend/src/api/report/files.rs
@@ -5,7 +5,10 @@ use crate::{
     APIError, SqlitePoolExt,
     api::{
         apportionment::ApportionmentInputData,
-        report::structs::{CsbFiles, FileCreatedAuditData, GeneratedFile, GsbFiles, ResultsInput},
+        report::{
+            ReportApiError,
+            structs::{CsbFiles, FileCreatedAuditData, GeneratedFile, GsbFiles, ResultsInput},
+        },
     },
     domain::{
         committee_session::{CommitteeSession, CommitteeSessionError, CommitteeSessionId},
@@ -214,6 +217,11 @@ pub async fn get_files_csb_election(
         return Err(CommitteeSessionError::InvalidCommitteeSessionStatus.into());
     }
 
+    let (_, state) = get_apportionment_state(&mut conn, committee_session.election_id).await?;
+    if !state.is_finalised() {
+        return Err(ReportApiError::ApportionmentStateNotFinalised.into());
+    }
+
     // Check if files exist, if so, get files from database
     let mut files = get_existing_csb_files(&mut conn, committee_session.id).await?;
     drop(conn);
@@ -237,6 +245,7 @@ mod tests {
     use super::*;
     use crate::{
         domain::{
+            election::ElectionId,
             file::FileId,
             investigation::{InvestigationConcludedWithoutNewResults, InvestigationStatus},
             polling_station::PollingStationId,
@@ -246,6 +255,7 @@ mod tests {
             committee_session_repo::{self, change_status},
             investigation_repo,
         },
+        service::update_apportionment_state,
     };
 
     #[test(sqlx::test(fixtures(path = "../../../fixtures", scripts("election_5_with_results"))))]
@@ -384,10 +394,11 @@ mod tests {
         path = "../../../fixtures",
         scripts("election_8_csb_with_results")
     )))]
-    async fn test_error_get_files_csb_election_not_completed(pool: SqlitePool) {
+    async fn test_error_get_files_csb_election_not_in_valid_state(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
         let audit_service = AuditService::new(None, None);
 
+        // Error because committee session is not completed
         let result =
             get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
                 .await;
@@ -413,6 +424,22 @@ mod tests {
             CommitteeSessionId::from(801),
             "Juinen".to_string(),
             NaiveDateTime::parse_from_str("2026-03-19T09:15", "%Y-%m-%dT%H:%M").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // Error because apportionment state is not finalised
+        let result =
+            get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
+                .await;
+        assert!(result.is_err());
+
+        // Finalise apportionment state
+        update_apportionment_state(
+            &mut conn,
+            audit_service.clone(),
+            ElectionId::from(8),
+            |state| state.skip_deceased_candidates(),
         )
         .await
         .unwrap();
@@ -450,6 +477,16 @@ mod tests {
         .await
         .unwrap();
 
+        // Finalise apportionment state
+        update_apportionment_state(
+            &mut conn,
+            audit_service.clone(),
+            ElectionId::from(8),
+            |state| state.skip_deceased_candidates(),
+        )
+        .await
+        .unwrap();
+
         // Files should be generated exactly once
         for _ in 1..=2 {
             let files =
@@ -481,7 +518,13 @@ mod tests {
 
             assert_eq!(
                 list_event_names(&mut conn).await.unwrap(),
-                ["FileCreated", "FileCreated", "FileCreated", "FileCreated"]
+                [
+                    "ApportionmentStateUpdated",
+                    "FileCreated",
+                    "FileCreated",
+                    "FileCreated",
+                    "FileCreated"
+                ]
             );
         }
     }

--- a/backend/src/api/report/files.rs
+++ b/backend/src/api/report/files.rs
@@ -250,6 +250,7 @@ mod tests {
             investigation::{InvestigationConcludedWithoutNewResults, InvestigationStatus},
             polling_station::PollingStationId,
         },
+        error::assert_delegated,
         infra::audit_log::list_event_names,
         repository::{
             committee_session_repo::{self, change_status},
@@ -398,11 +399,11 @@ mod tests {
         let mut conn = pool.acquire().await.unwrap();
         let audit_service = AuditService::new(None, None);
 
-        // Error because committee session is not completed
-        let result =
+        let error =
             get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
-                .await;
-        assert!(result.is_err());
+                .await
+                .expect_err("committee session should not be completed");
+        assert_delegated(error, &CommitteeSessionError::InvalidCommitteeSessionStatus);
 
         // Change committee session status to completed
         change_status(
@@ -413,10 +414,11 @@ mod tests {
         .await
         .unwrap();
 
-        let result =
+        let error =
             get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
-                .await;
-        assert!(result.is_err());
+                .await
+                .expect_err("committee session details should be missing");
+        assert_delegated(error, &CommitteeSessionError::InvalidCommitteeSessionStatus);
 
         // Change committee session details
         committee_session_repo::update(
@@ -428,11 +430,11 @@ mod tests {
         .await
         .unwrap();
 
-        // Error because apportionment state is not finalised
-        let result =
+        let error =
             get_files_csb_election(&pool, audit_service.clone(), CommitteeSessionId::from(801))
-                .await;
-        assert!(result.is_err());
+                .await
+                .expect_err("apportionment state should not be finalised");
+        assert_delegated(error, &ReportApiError::ApportionmentStateNotFinalised);
 
         // Finalise apportionment state
         update_apportionment_state(

--- a/backend/src/api/report/handlers.rs
+++ b/backend/src/api/report/handlers.rs
@@ -158,8 +158,6 @@ pub async fn election_download_zip_results_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
 
-    // TODO: #3160 check if apportionment state is finalised
-
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
@@ -226,8 +224,6 @@ pub async fn election_download_zip_attachment_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
 
-    // TODO: #3160 check if apportionment state is finalised
-
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
@@ -288,8 +284,6 @@ pub async fn election_download_zip_total_counts_csb(
     let committee_category =
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
-
-    // TODO: #3160 check if apportionment state is finalised
 
     let election = election_repo::get(&mut conn, election_id).await?;
     let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;

--- a/backend/src/api/report/mod.rs
+++ b/backend/src/api/report/mod.rs
@@ -29,7 +29,7 @@ impl ApiErrorResponse for ReportApiError {
     fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
         match self {
             ReportApiError::ApportionmentStateNotFinalised => (
-                StatusCode::PRECONDITION_FAILED,
+                StatusCode::CONFLICT,
                 ErrorResponse::new(
                     "Apportionment state not finalised",
                     ErrorReference::InvalidApportionmentState,

--- a/backend/src/api/report/mod.rs
+++ b/backend/src/api/report/mod.rs
@@ -1,6 +1,13 @@
+use axum::http::StatusCode;
+use tracing::error;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use crate::{AppState, api::middleware::authentication::RouteAuthorization, domain::role::Role};
+use crate::{
+    APIError, AppState,
+    api::middleware::authentication::RouteAuthorization,
+    domain::role::Role,
+    error::{ApiErrorResponse, ErrorReference, ErrorResponse},
+};
 
 mod files;
 mod handlers;
@@ -8,6 +15,36 @@ mod structs;
 
 /// Default date time format for reports
 pub const DEFAULT_DATE_TIME_FORMAT: &str = "%d-%m-%Y %H:%M:%S %Z";
+
+#[derive(Debug, PartialEq)]
+pub enum ReportApiError {
+    ApportionmentStateNotFinalised,
+}
+
+impl ApiErrorResponse for ReportApiError {
+    fn log(&self) {
+        error!("Report error: {:?}", self);
+    }
+
+    fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
+        match self {
+            ReportApiError::ApportionmentStateNotFinalised => (
+                StatusCode::PRECONDITION_FAILED,
+                ErrorResponse::new(
+                    "Apportionment state not finalised",
+                    ErrorReference::InvalidApportionmentState,
+                    false,
+                ),
+            ),
+        }
+    }
+}
+
+impl From<ReportApiError> for APIError {
+    fn from(err: ReportApiError) -> Self {
+        APIError::Delegated(Box::new(err))
+    }
+}
 
 pub fn router() -> OpenApiRouter<AppState> {
     use Role::*;

--- a/backend/src/api/report/structs.rs
+++ b/backend/src/api/report/structs.rs
@@ -100,6 +100,7 @@ pub struct CsbGeneratedFiles {
     pub attachment_pdf: GeneratedFile,
 }
 
+#[derive(Debug)]
 pub struct CsbFiles {
     pub results_eml: Option<File>,
     pub total_counts_eml: Option<File>,

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -164,6 +164,10 @@ impl ApportionmentState {
         }
     }
 
+    pub fn is_finalised(&self) -> bool {
+        matches!(self, Self::Finalised { .. })
+    }
+
     pub fn reset(self) -> Result<Self, ApportionmentStateError> {
         Ok(Self::Uninitialised)
     }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -56,6 +56,7 @@ pub enum ErrorReference {
     EntryNotUnique,
     Forbidden,
     InternalServerError,
+    InvalidApportionmentState,
     InvalidCommitteeSessionStatus,
     InvalidData,
     InvalidHash,

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -11,9 +11,7 @@ use crate::{
         election::ElectionId,
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
-    repository::{
-        apportionment_state_repo, committee_session_repo, election_repo, user_repo::User,
-    },
+    repository::{apportionment_state_repo, committee_session_repo},
 };
 
 #[derive(Serialize)]
@@ -58,13 +56,9 @@ pub async fn get_state(
 pub async fn update_state(
     conn: &mut SqliteConnection,
     audit_service: AuditService,
-    user: User,
     election_id: ElectionId,
     update_fn: impl FnOnce(ApportionmentState) -> Result<ApportionmentState, ApportionmentStateError>,
 ) -> Result<ApportionmentState, APIError> {
-    let election = election_repo::get(conn, election_id).await?;
-    user.role().is_authorized(election.committee_category)?;
-
     let (id, state) = get_state(conn, election_id).await?;
 
     let state = update_fn(state).map_err(|err| APIError::Delegated(Box::new(err)))?;
@@ -92,14 +86,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        api::middleware::authentication::error::AuthenticationError,
-        domain::{
-            apportionment_state::DeceasedCandidate, committee_session::CommitteeSessionId,
-            role::Role,
-        },
+        domain::{apportionment_state::DeceasedCandidate, committee_session::CommitteeSessionId},
         error::assert_delegated,
         infra::audit_log::assert_last_event,
-        repository::user_repo::UserId,
     };
 
     const ELECTION_ID: u32 = 5;
@@ -132,7 +121,6 @@ mod tests {
         let result = update_state(
             &mut conn,
             AuditService::new(None, None),
-            User::test_user(Role::CoordinatorGSB, UserId::from(1)),
             unknown_election,
             |_| panic!("should not call callback"),
         )
@@ -145,25 +133,6 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
-    async fn test_not_authorized(pool: SqlitePool) {
-        let mut conn = pool.acquire().await.unwrap();
-
-        let not_authorized = User::test_user(Role::CoordinatorCSB, UserId::from(1));
-
-        let err = update_state(
-            &mut conn,
-            AuditService::new(None, None),
-            not_authorized,
-            ElectionId::from(ELECTION_ID),
-            |_| panic!("should not call callback"),
-        )
-        .await
-        .expect_err("should return an error");
-
-        assert_delegated(err, &AuthenticationError::RoleNotAuthorizedError);
-    }
-
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_invalid_committee_session_status(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 
@@ -172,7 +141,6 @@ mod tests {
         let err = update_state(
             &mut conn,
             AuditService::new(None, None),
-            User::test_user(Role::CoordinatorGSB, UserId::from(1)),
             ElectionId::from(ELECTION_ID),
             |_| panic!("should not call callback"),
         )
@@ -209,7 +177,6 @@ mod tests {
         update_state(
             &mut conn,
             AuditService::new(None, None),
-            User::test_user(Role::CoordinatorGSB, UserId::from(1)),
             ElectionId::from(ELECTION_ID),
             Ok,
         )
@@ -240,7 +207,6 @@ mod tests {
         let returned_state = update_state(
             &mut conn,
             AuditService::new(None, None),
-            User::test_user(Role::CoordinatorGSB, UserId::from(1)),
             ElectionId::from(ELECTION_ID),
             |state| {
                 assert_eq!(state, ApportionmentState::Uninitialised);

--- a/backend/src/service/change_committee_session_status.rs
+++ b/backend/src/service/change_committee_session_status.rs
@@ -156,7 +156,6 @@ async fn delete_committee_session_files(
 
 #[cfg(test)]
 mod tests {
-
     use chrono::Utc;
     use sqlx::{SqliteConnection, SqlitePool};
     use test_log::test;
@@ -279,7 +278,7 @@ mod tests {
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_reset_apportionment_state_on_resume(pool: SqlitePool) -> Result<(), APIError> {
         let mut conn = pool.acquire().await?;
-        let audit_service = AuditService::new(None, Some(Ipv4Addr::new(203, 0, 113, 0).into()));
+        let audit_service = AuditService::new(None, Some(TEST_IP_V4_ADDR.into()));
 
         let committee_session_id = CommitteeSessionId::from(6);
 

--- a/backend/src/service/change_committee_session_status.rs
+++ b/backend/src/service/change_committee_session_status.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
     repository::{committee_session_repo, file_repo},
+    service::update_apportionment_state,
 };
 
 #[derive(Serialize)]
@@ -106,11 +107,19 @@ pub async fn change_committee_session_status(
     };
 
     // If resuming committee session, delete all files from committee session and files tables
+    // and reset apportionment state
     if committee_session.status == CommitteeSessionStatus::Completed
         && new_status == CommitteeSessionStatus::DataEntry
     {
         delete_committee_session_files(&mut tx, audit_service.clone(), committee_session.id)
             .await?;
+        update_apportionment_state(
+            &mut tx,
+            audit_service.clone(),
+            committee_session.election_id,
+            |state| state.reset(),
+        )
+        .await?;
     }
 
     let committee_session =
@@ -154,9 +163,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        domain::file::FileType,
+        domain::{apportionment_state::ApportionmentState, file::FileType},
         infra::audit_log::{AuditService, list_event_names},
-        repository::file_repo,
+        repository::{apportionment_state_repo, file_repo},
+        service::get_apportionment_state,
         test_support::TEST_IP_V4_ADDR,
     };
 
@@ -210,7 +220,11 @@ mod tests {
         // No FileDeleted events should be logged
         assert_eq!(
             list_event_names(&mut conn).await?,
-            ["CommitteeSessionUpdated", "CommitteeSessionUpdated"]
+            [
+                "CommitteeSessionUpdated",
+                "ApportionmentStateUpdated",
+                "CommitteeSessionUpdated"
+            ]
         );
         Ok(())
     }
@@ -255,9 +269,58 @@ mod tests {
                 "FileDeleted",
                 "FileDeleted",
                 "FileDeleted",
+                "ApportionmentStateUpdated",
                 "CommitteeSessionUpdated",
             ]
         );
+        Ok(())
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    async fn test_reset_apportionment_state_on_resume(pool: SqlitePool) -> Result<(), APIError> {
+        let mut conn = pool.acquire().await?;
+        let audit_service = AuditService::new(None, Some(Ipv4Addr::new(203, 0, 113, 0).into()));
+
+        let committee_session_id = CommitteeSessionId::from(6);
+
+        // DataEntry --> Completed
+        change_committee_session_status(
+            &mut conn,
+            committee_session_id,
+            CommitteeSessionStatus::Completed,
+            audit_service.clone(),
+        )
+        .await?;
+
+        // Finalise apportionment state
+        update_apportionment_state(
+            &mut conn,
+            audit_service.clone(),
+            ElectionId::from(5),
+            |state| state.skip_deceased_candidates(),
+        )
+        .await?;
+        let (_, state) = get_apportionment_state(&mut conn, ElectionId::from(5)).await?;
+        assert!(state.is_finalised());
+
+        // Completed --> DataEntry
+        change_committee_session_status(
+            &mut conn,
+            committee_session_id,
+            CommitteeSessionStatus::DataEntry,
+            audit_service,
+        )
+        .await?;
+        let state_result = get_apportionment_state(&mut conn, ElectionId::from(5)).await;
+        // Expect error, because apportionment state can only be retrieved when committee session is in Completed status
+        assert!(state_result.is_err());
+
+        // Check status directly
+        let apportionment_state = apportionment_state_repo::get(&mut conn, committee_session_id)
+            .await?
+            .unwrap();
+        assert_eq!(apportionment_state, ApportionmentState::Uninitialised);
+
         Ok(())
     }
 }

--- a/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p9.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p9.json
@@ -841,7 +841,7 @@
         "list_seats": 2,
         "preferential_nomination_columns": [
           {
-            "list_seat_number": 4,
+            "list_seat_number": 1,
             "candidate": {
               "number": 4,
               "initials": "T.J.",

--- a/backend/tests/report_integration_test.rs
+++ b/backend/tests/report_integration_test.rs
@@ -10,8 +10,9 @@ use test_log::test;
 
 use crate::{
     shared::{
-        FixtureUser::*, change_status_committee_session, create_cso_result,
-        get_election_committee_session, login, update_committee_session_details,
+        ApportionmentAction, FixtureUser::*, apportionment_state_action,
+        change_status_committee_session, create_cso_result, get_election_committee_session, login,
+        update_committee_session_details,
     },
     utils::serve_api,
 };
@@ -218,6 +219,13 @@ async fn test_csb_election_zip_download_results_works(pool: SqlitePool) {
         "10:45",
     )
     .await;
+    apportionment_state_action(
+        &addr,
+        &cookie,
+        election_id,
+        ApportionmentAction::SkipDeceasedCandidates,
+    )
+    .await;
 
     let url = format!(
         "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_results_csb"
@@ -254,14 +262,32 @@ async fn test_csb_election_zip_download_results_works(pool: SqlitePool) {
     path = "../fixtures",
     scripts("election_8_csb_with_results", "users")
 )))]
-async fn test_csb_election_zip_download_results_invalid_committee_session_state(pool: SqlitePool) {
+async fn test_csb_election_zip_download_results_invalid_state(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let cookie = login(&addr, CoordinatorCSB).await;
     let election_id = 8;
+    let committee_session_id = 801;
 
     let url = format!(
-        "http://{addr}/api/elections/{election_id}/committee_sessions/801/download_zip_results_csb"
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_results_csb"
     );
+
+    // Committee session is not completed
+    assert_zip_download_conflict(&cookie, &url).await;
+
+    complete_committee_session(&addr, &cookie, election_id, committee_session_id).await;
+    update_committee_session_details(
+        &addr,
+        &cookie,
+        election_id,
+        committee_session_id,
+        "Juinen",
+        "2026-03-18",
+        "10:45",
+    )
+    .await;
+
+    // Apportionment state is not finalised
     assert_zip_download_conflict(&cookie, &url).await;
 }
 
@@ -284,6 +310,13 @@ async fn test_csb_election_zip_download_attachment_works(pool: SqlitePool) {
         "Juinen",
         "2026-03-18",
         "10:45",
+    )
+    .await;
+    apportionment_state_action(
+        &addr,
+        &cookie,
+        election_id,
+        ApportionmentAction::SkipDeceasedCandidates,
     )
     .await;
 
@@ -311,16 +344,32 @@ async fn test_csb_election_zip_download_attachment_works(pool: SqlitePool) {
     path = "../fixtures",
     scripts("election_8_csb_with_results", "users")
 )))]
-async fn test_csb_election_zip_download_attachment_invalid_committee_session_state(
-    pool: SqlitePool,
-) {
+async fn test_csb_election_zip_download_attachment_invalid_state(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let cookie = login(&addr, CoordinatorCSB).await;
     let election_id = 8;
+    let committee_session_id = 801;
 
     let url = format!(
-        "http://{addr}/api/elections/{election_id}/committee_sessions/801/download_zip_attachment_csb"
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_attachment_csb"
     );
+
+    // Committee session is not completed
+    assert_zip_download_conflict(&cookie, &url).await;
+
+    complete_committee_session(&addr, &cookie, election_id, committee_session_id).await;
+    update_committee_session_details(
+        &addr,
+        &cookie,
+        election_id,
+        committee_session_id,
+        "Juinen",
+        "2026-03-18",
+        "10:45",
+    )
+    .await;
+
+    // Apportionment state is not finalised
     assert_zip_download_conflict(&cookie, &url).await;
 }
 
@@ -343,6 +392,13 @@ async fn test_csb_election_zip_download_total_counts_works(pool: SqlitePool) {
         "Juinen",
         "2026-03-18",
         "10:45",
+    )
+    .await;
+    apportionment_state_action(
+        &addr,
+        &cookie,
+        election_id,
+        ApportionmentAction::SkipDeceasedCandidates,
     )
     .await;
 
@@ -378,15 +434,31 @@ async fn test_csb_election_zip_download_total_counts_works(pool: SqlitePool) {
     path = "../fixtures",
     scripts("election_8_csb_with_results", "users")
 )))]
-async fn test_csb_election_zip_download_total_counts_invalid_committee_session_state(
-    pool: SqlitePool,
-) {
+async fn test_csb_election_zip_download_total_counts_invalid_state(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let cookie = login(&addr, CoordinatorCSB).await;
     let election_id = 8;
+    let committee_session_id = 801;
 
     let url = format!(
-        "http://{addr}/api/elections/{election_id}/committee_sessions/801/download_zip_total_counts_csb"
+        "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_total_counts_csb"
     );
+
+    // Committee session is not completed
+    assert_zip_download_conflict(&cookie, &url).await;
+
+    complete_committee_session(&addr, &cookie, election_id, committee_session_id).await;
+    update_committee_session_details(
+        &addr,
+        &cookie,
+        election_id,
+        committee_session_id,
+        "Juinen",
+        "2026-03-18",
+        "10:45",
+    )
+    .await;
+
+    // Apportionment state is not finalised
     assert_zip_download_conflict(&cookie, &url).await;
 }

--- a/backend/tests/shared/mod.rs
+++ b/backend/tests/shared/mod.rs
@@ -6,6 +6,7 @@ use abacus::domain::election::CommitteeCategory;
 use axum::http::{HeaderValue, StatusCode};
 use hyper::header::CONTENT_TYPE;
 use reqwest::Response;
+use serde::Serialize;
 
 pub fn differences_counts_zero() -> serde_json::Value {
     serde_json::json!({
@@ -524,6 +525,41 @@ pub async fn get_statuses(
             );
             acc
         })
+}
+
+#[derive(Serialize, strum::IntoStaticStr)]
+#[serde(untagged)]
+#[strum(serialize_all = "snake_case")]
+pub enum ApportionmentAction {
+    SkipDeceasedCandidates,
+    RegisterDeceasedCandidates,
+    AddDeceasedCandidate {
+        pg_number: u32,
+        candidate_number: u32,
+    },
+    DeleteDeceasedCandidate {
+        pg_number: u32,
+        candidate_number: u32,
+    },
+    FinaliseDeceasedCandidates,
+    Reset,
+}
+
+pub async fn apportionment_state_action(
+    addr: &SocketAddr,
+    cookie: &HeaderValue,
+    election_id: u32,
+    action: ApportionmentAction,
+) {
+    let path: &'static str = (&action).into();
+    let body = serde_json::to_value(&action).unwrap();
+    let url = format!("http://{addr}/api/elections/{election_id}/apportionment/{path}");
+    let mut request = reqwest::Client::new().post(&url).header("cookie", cookie);
+    if !body.is_null() {
+        request = request.json(&body);
+    }
+    let response = request.send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[derive(Clone, Copy)]

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -23,6 +23,7 @@
     "EntryNotUnique": "Deze invoer bestaat al",
     "Forbidden": "Je hebt niet de juiste rechten",
     "InternalServerError": "Er is een interne fout opgetreden",
+    "InvalidApportionmentState": "De zetelverdeling is niet in de juiste status voor deze actie",
     "InvalidCommitteeSessionStatus": "De zitting is niet in de juiste status voor deze actie",
     "InvalidData": "De invoer is niet geldig",
     "InvalidHash": "De hash is niet geldig",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -962,6 +962,7 @@ export const errorReferenceValues = [
   "EntryNotUnique",
   "Forbidden",
   "InternalServerError",
+  "InvalidApportionmentState",
   "InvalidCommitteeSessionStatus",
   "InvalidData",
   "InvalidHash",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -122,10 +122,10 @@ export type REGISTER_DECEASED_CANDIDATES_REQUEST_PATH =
   `/api/elections/${ElectionId}/apportionment/register_deceased_candidates`;
 
 // /api/elections/{election_id}/apportionment/reset
-export interface RESET_REQUEST_PARAMS {
+export interface RESET_APPORTIONMENT_STATE_REQUEST_PARAMS {
   election_id: ElectionId;
 }
-export type RESET_REQUEST_PATH = `/api/elections/${ElectionId}/apportionment/reset`;
+export type RESET_APPORTIONMENT_STATE_REQUEST_PATH = `/api/elections/${ElectionId}/apportionment/reset`;
 
 // /api/elections/{election_id}/apportionment/skip_deceased_candidates
 export interface SKIP_DECEASED_CANDIDATES_REQUEST_PARAMS {


### PR DESCRIPTION
Resolves #3338

Changes:
- Check if apportionment state is finalised in `get_files_csb_election` 
- Moved committee category check from `update_apportionment_state` to handlers 
- Reset apportionment state when updating committee session status from `Completed` to `DataEntry` 
- Added `apportionment_state_action` to easily update the state in integration tests
- Misc: fixed one incorrect number in a P22-2 input test file
- Misc: rename `reset` endpoint to `reset_apportionment_state`