### PR TITLE
Fix Lefthook in Git working trees

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -117,6 +117,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: "backend -> target"
+          cache-bin: "false"
       - name: Install Binstall
         uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # main
       - name: Create empty frontend build dir for memory-serve

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -86,6 +86,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       SQLX_OFFLINE: "true"
+      BINSTALL_DISABLE_TELEMETRY: "true"
     steps:
       # Free up runner disk space, so that our job has enough space to run
       # https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       SQLX_OFFLINE: "true"
+      BINSTALL_DISABLE_TELEMETRY: "true"
     steps:
       # Free up runner disk space, so that our job has enough space to run
       # https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
       run: >
         cargo sqlx database reset -y -D sqlite://sqlx-cache-tmp.sqlite &&
         cargo sqlx prepare -D sqlite://sqlx-cache-tmp.sqlite -- --all-targets &&
-        git add .sqlx &&
+        env -u GIT_DIR -u GIT_INDEX_FILE git add .sqlx &&
         rm sqlx-cache-tmp.sqlite
     backend-formatter:
       root: "backend/"
@@ -25,10 +25,10 @@ pre-commit:
       glob: "*.rs"
       run: >
         cargo run --package abacus --bin gen-openapi &&
-        git add openapi.json &&
+        env -u GIT_DIR -u GIT_INDEX_FILE git add openapi.json &&
         cd ../frontend &&
         pnpm gen:openapi &&
-        git add src/types/generated/openapi.ts
+        env -u GIT_DIR -u GIT_INDEX_FILE git add src/types/generated/openapi.ts
     frontend-formatter:
       root: "frontend/"
       run: pnpm format --staged --no-errors-on-unmatched --colors=off


### PR DESCRIPTION
Git has functionality to manage multiple working trees using `git-worktree`, but `git add` executed by Lefthook would commit changes to the main repository instead of the working tree. The fix is to unset the `GIT_DIR` and `GIT_INDEX_FILE` environment variables when executing `git add` in a worktree, and let Git resolve the repository by itself.

Upstream issue: https://github.com/evilmartians/lefthook/issues/1077