### PR TITLE
fix CSB test data generator

### DIFF
--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -563,14 +563,15 @@ async fn generate_csb_data_entry(
             ))
         } else {
             let turnout = rng.random_range(args.turnout.clone());
-            let voters_turned_out = (election.number_of_voters * turnout) / 100;
+            let number_of_eligible_voters = rng.random_range(args.voters.clone());
+            let voters_turned_out = (number_of_eligible_voters * turnout) / 100;
             let candidate_slope =
                 rng.random_range(args.candidate_distribution_slope.clone()) as f64 / 1000.0;
 
             Results::GSB(generate_gsb_results(
                 rng,
                 &election.political_groups,
-                election.number_of_voters,
+                number_of_eligible_voters,
                 voters_turned_out,
                 &group_weights,
                 candidate_slope,


### PR DESCRIPTION
### Scope

In a previous PR (#3300) I updated the test data generator to [set the value of `number_of_voters`](https://github.com/kiesraad/abacus/pull/3300/changes#diff-d2f10f44b9ebbfcfa876831ff67384799b109a7a023521e33b9403467ecafffdR315) in the `elections` table to 1 for non-GSB elections. While that is correct, I hadn't taken into account that `number_of_voters` is also used when generating the CSB data entry. So the total number of actual voters was then calculated as `1 * turnout percentage`, i.e. `0`. This PR fixes that by using the `voters` from `args` as the number of eligible voters.

Note that the `number_of_voters` argument of `generate_gsb_results` is somewhat confusingly named. It's the number of eligible voters, not the number of actual voters. I also noticed this when [testing election creation](https://github.com/kiesraad/abacus/issues/3068#issuecomment-4442685343). As I said there: in context it's clear enough if number of voters refers to the eligible or actual ones, so I don't see a need to refactor this at this time.

### Testing
I tested the following:
- generating an election and checking in the UI and in the database that the values in `elections` and `data_entries` make sense
- generating CSB elections and downloading the three zip files with the results
  - "Inclusief invoer" not checked
  - "Inclusief invoer" checked, 0% 1ste invoer, 0% 2de invoer
  - "Inclusief invoer" checked, 100% 1ste invoer, 0% 2de invoer
  - "Inclusief invoer" checked, 100% 1ste invoer, 100% 2de invoer
  - "Genereer meerdere verkiezingen voor P 22-2 varianten (CSB)" checked