### PR TITLE
Configure Sigrid CI security feedback

### DIFF
--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -26,6 +26,7 @@ jobs:
           customer: kiesraad
           system: abacus
           convert: rust
+          capability: maintainability,osh,security
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
       - name: "Sigrid PR feedback"
@@ -33,4 +34,4 @@ jobs:
         if: always()
         with:
           message-id: sigrid
-          message-path: sigrid-ci-output/feedback.md
+          message-path: sigrid-ci-output/*feedback.md

--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -23,6 +23,7 @@ jobs:
           customer: kiesraad
           system: abacus
           convert: rust
+          capability: maintainability,osh,security
           publishonly: true
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"


### PR DESCRIPTION
See https://docs.sigrid-says.com/sigridci-integration/using-sigridci.html#adding-security-feedback-to-an-existing-sigrid-ci-configuration

Not sure if this will be helpful but it should get rid of the nag message in the Sigrid CI comment:
> 🔒Enable security insights in your CI pipeline to detect vulnerabilities early.
Start using Sigrid CI for Security today. [Learn more](https://docs.sigrid-says.com/sigridci-integration/using-sigridci.html#security-feedback-beta).