### PR TITLE
differential fuzzer: make condition to skip case related to #3219 more specific

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -130,25 +130,6 @@ fn init() {
 }
 
 fn fuzz(data: FuzzedApportionmentInput) {
-    // Skip cases where any list has an absolute majority of votes
-    // related issue: #3219
-    let total_votes = data
-        .list_votes
-        .iter()
-        .flat_map(|list| list.candidate_votes.iter())
-        .map(|cv| cv.votes())
-        .sum::<u32>();
-    
-    if data.list_votes.iter().any(|list| {
-        list.candidate_votes
-            .iter()
-            .map(|cv| cv.votes())
-            .sum::<u32>()
-            > (total_votes / 2)
-    }) {
-        return;
-    }
-
     // Convert current data structure to OSV2020 wrapper format
     let pg_candidates: Vec<i64> = data
         .list_votes
@@ -167,6 +148,26 @@ fn fuzz(data: FuzzedApportionmentInput) {
         osv2020_apportionment(data.seats.into(), &pg_candidates, &votes);
 
     let (abacus_result, abacus_log) = run_with_log(|| process(&data));
+
+    // Skip cases where there are fewer than 19 seats and both art. P 9 (absolute majority) and art. P 10 (list exhaustion) are applied.
+    // Reason is that Abacus does not include the P 9-seat for the max. one seat requirement when assiging residual seats.
+    // related issue: #3219
+    if data.seats < 19
+        && osv2020_log
+            .iter()
+            .any(|line| line.contains("Absolute Mehrheit"))
+        && osv2020_log
+            .iter()
+            .any(|line| line.contains("Erschöpfte Listen"))
+        && abacus_log.contains(
+            "in accordance with Article P 9 Kieswet"
+        )
+        && abacus_log.contains(
+            "assigned to another list in accordance with Article P 10 Kieswet"
+        )
+    {
+        return;
+    }
 
     match abacus_result {
         Ok(ref output) => {
@@ -199,7 +200,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
                             .iter()
                             .any(|line| line.contains("Erschöpfte Listen"))
                         && abacus_log.contains(
-                            "assigned to another list in accordance with Article P 10 Kieswet",
+                            "assigned to another list in accordance with Article P 10 Kieswet"
                         )
                     {
                         //do nothing, continue


### PR DESCRIPTION
relates to #3219 OSV considers a P 9 seat assignment as part of the "max one seat" condition, Abacus doesn't

### Scope
For #3219 the differential fuzzer skipped all cases where one list had an absolute majority. That is a significantly broader condition than is required. So this PR updates the skip to: fewer than 19 seats, art. P 9 applied, art. P 10 applied.

### Testing
Ran the differential fuzzer for about 2 hours with 4 jobs:
```
#1620879: cov: 2057 ft: 9619 corp: 724 exec/s: 52 oom/timeout/crash: 0/0/0 time: 7419s job: 240 dft_time: 0
```
I did run the test when the code still contained an additional but duplicate condition, i.e. it included a check if there was a list with an absolute majority of votes in the input data. We already check this in the output of OSV and Abacus. Removing it saved a handful lines of code.

### Questions
I suspect the condition can be made even more specific. If after list exhaustion the residual seats are assigned through non-unique highest averages, Abacus and OSV should return the same result. Is that worth the effort, though?