### PR TITLE
Add add deceased candidates e2e test

### DIFF
--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -1,11 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { type APIRequestContext, test as base, expect, type Page } from "@playwright/test";
 import { DataEntryApiClient } from "e2e-tests/helpers-utils/api-clients";
-import { completePollingStationDataEntries } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
+import { completeDataEntries } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import { createRandomUsername } from "e2e-tests/helpers-utils/e2e-test-utils";
-import { type Eml230b, eml110a, eml230b } from "e2e-tests/test-data/eml-files";
+import { type Eml230b, eml110a, eml230b, eml230b_more_than_45_candidates } from "e2e-tests/test-data/eml-files";
 import {
   dataEntryRequest,
+  dataEntryRequestGSB,
   dataEntryWithDifferencesRequest,
   dataEntryWithErrorRequest,
   pollingStationRequests,
@@ -54,10 +55,15 @@ type Fixtures = {
   // page and request fixture for CSB typist two
   typistTwoCSB: { page: Page; request: APIRequestContext };
   eml230b: Eml230b;
+  eml230b_more_than_45_candidates: Eml230b;
   // GSB election without polling stations
   emptyElectionGSB: Election;
+  // CSB election
+  emptyElectionCSB: Election;
   // GSB election with two polling stations
   electionGSB: ElectionDetailsResponse;
+  // CSB election with one subcommittee
+  electionCSB: ElectionDetailsResponse;
   // First data entry of the GSB election
   dataEntryGSB: DataEntry;
   // First data entry of the GSB election with entry claimed by typist one
@@ -74,8 +80,12 @@ type Fixtures = {
   dataEntryGSBEntriesDifferentWithErrors: DataEntry;
   // GSB election with polling stations and two completed data entries for each
   completedElectionGSB: Election;
-  // The current committee session for the election
+  // CSB election with subcommittee and two completed data entries
+  completedElectionCSB: Election;
+  // The current committee session for the GSB election
   currentCommitteeSessionElectionGSB: CommitteeSession;
+  // The current committee session for the CSB election
+  currentCommitteeSessionElectionCSB: CommitteeSession;
   // Newly created GSB User
   newTypistGSB: User;
 };
@@ -124,6 +134,7 @@ export const test = base.extend<Fixtures>({
     await context.close();
   },
   eml230b: [eml230b, { option: true }],
+  eml230b_more_than_45_candidates: [eml230b_more_than_45_candidates, { option: true }],
   emptyElectionGSB: async ({ adminOne, eml230b }, use) => {
     const { request } = adminOne;
     const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
@@ -138,6 +149,25 @@ export const test = base.extend<Fixtures>({
         candidate_hash: eml230b.fullHash,
         number_of_voters: 1234,
         counting_method: "CSO",
+      },
+    });
+    expect(electionResponse.ok()).toBeTruthy();
+    const election = (await electionResponse.json()) as Election;
+
+    await use(election);
+  },
+  emptyElectionCSB: async ({ adminOne, eml230b_more_than_45_candidates }, use) => {
+    const { request } = adminOne;
+    const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
+    const election_data = await readFile(eml110a.path, "utf8");
+    const candidate_data = await readFile(eml230b_more_than_45_candidates.path, "utf8");
+    const electionResponse = await request.post(url, {
+      data: {
+        committee_category: "CSB",
+        election_data,
+        election_hash: eml110a.fullHash,
+        candidate_data,
+        candidate_hash: eml230b_more_than_45_candidates.fullHash,
       },
     });
     expect(electionResponse.ok()).toBeTruthy();
@@ -173,6 +203,31 @@ export const test = base.extend<Fixtures>({
       start_time: "21:45",
     };
     const detailsUpdateResponse = await coordinatorOneGSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
+    expect(detailsUpdateResponse.ok()).toBeTruthy();
+
+    await use(response);
+  },
+  electionCSB: async ({ adminOne, coordinatorOneCSB, emptyElectionCSB }, use) => {
+    // get election details
+    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionCSB.id}`;
+    const electionResponse = await adminOne.request.get(electionUrl);
+    expect(electionResponse.ok()).toBeTruthy();
+    const response = (await electionResponse.json()) as ElectionDetailsResponse;
+
+    // Set committee session status to DataEntry
+    const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}/status`;
+    const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status: "data_entry" };
+    const statusChangeResponse = await coordinatorOneCSB.request.put(statusChangeUrl, { data: statusChangeData });
+    expect(statusChangeResponse.ok()).toBeTruthy();
+
+    // Fill in committee session details
+    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}`;
+    const detailsUpdateData: COMMITTEE_SESSION_UPDATE_REQUEST_BODY = {
+      location: "Den Haag",
+      start_date: "2026-03-18",
+      start_time: "21:45",
+    };
+    const detailsUpdateResponse = await coordinatorOneCSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
     expect(detailsUpdateResponse.ok()).toBeTruthy();
 
     await use(response);
@@ -218,12 +273,12 @@ export const test = base.extend<Fixtures>({
     await use(dataEntryGSB);
   },
   dataEntryGSBDefinitive: async ({ dataEntryGSB, typistOneGSB, typistTwoGSB }, use) => {
-    await completePollingStationDataEntries(dataEntryGSB.id, typistOneGSB.request, typistTwoGSB.request);
+    await completeDataEntries(dataEntryGSB.id, typistOneGSB.request, typistTwoGSB.request);
 
     await use(dataEntryGSB);
   },
   dataEntryGSBEntriesDifferent: async ({ dataEntryGSB, typistOneGSB, typistTwoGSB }, use) => {
-    await completePollingStationDataEntries(
+    await completeDataEntries(
       dataEntryGSB.id,
       typistOneGSB.request,
       typistTwoGSB.request,
@@ -234,7 +289,7 @@ export const test = base.extend<Fixtures>({
     await use(dataEntryGSB);
   },
   dataEntryGSBEntriesDifferentWithErrors: async ({ dataEntryGSB, typistOneGSB, typistTwoGSB }, use) => {
-    await completePollingStationDataEntries(
+    await completeDataEntries(
       dataEntryGSB.id,
       typistOneGSB.request,
       typistTwoGSB.request,
@@ -247,13 +302,36 @@ export const test = base.extend<Fixtures>({
   completedElectionGSB: async ({ electionGSB, typistOneGSB, typistTwoGSB }, use) => {
     // finalise both data entries for all polling stations
     for (const ps of electionGSB.polling_stations) {
-      await completePollingStationDataEntries(ps.data_entry_id!, typistOneGSB.request, typistTwoGSB.request);
+      await completeDataEntries(ps.data_entry_id!, typistOneGSB.request, typistTwoGSB.request);
     }
 
     await use(electionGSB.election);
   },
+  completedElectionCSB: async ({ electionCSB, typistOneCSB, typistTwoCSB }, use) => {
+    const { request } = typistOneCSB;
+    // get the existing election statuses
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSB.election.id}/status`;
+    const response = await request.get(url);
+    expect(response.ok()).toBeTruthy();
+    const electionStatus = (await response.json()) as ElectionStatusResponse;
+    const dataEntryId = electionStatus.statuses[0]!.data_entry_id;
+
+    // finalise both data entries for the subcommittee
+    await completeDataEntries(
+      dataEntryId,
+      typistOneCSB.request,
+      typistTwoCSB.request,
+      dataEntryRequestGSB,
+      dataEntryRequestGSB,
+    );
+
+    await use(electionCSB.election);
+  },
   currentCommitteeSessionElectionGSB: async ({ electionGSB }, use) => {
     await use(electionGSB.current_committee_session);
+  },
+  currentCommitteeSessionElectionCSB: async ({ electionCSB }, use) => {
+    await use(electionCSB.current_committee_session);
   },
   newTypistGSB: async ({ adminOne }, use) => {
     const { request } = adminOne;

--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -41,37 +41,43 @@ export interface DataEntry {
 type Fixtures = {
   // page and request fixture for admin
   adminOne: { page: Page; request: APIRequestContext };
-  // page and request fixture for coordinator
-  coordinatorOne: { page: Page; request: APIRequestContext };
-  // page and request fixture for typist one
-  typistOne: { page: Page; request: APIRequestContext };
-  // page and request fixture for typist two
-  typistTwo: { page: Page; request: APIRequestContext };
+  // page and request fixture for GSB coordinator
+  coordinatorOneGSB: { page: Page; request: APIRequestContext };
+  // page and request fixture for GSB typist one
+  typistOneGSB: { page: Page; request: APIRequestContext };
+  // page and request fixture for GSB typist two
+  typistTwoGSB: { page: Page; request: APIRequestContext };
+  // page and request fixture for CSB coordinator
+  coordinatorOneCSB: { page: Page; request: APIRequestContext };
+  // page and request fixture for CSB typist one
+  typistOneCSB: { page: Page; request: APIRequestContext };
+  // page and request fixture for CSB typist two
+  typistTwoCSB: { page: Page; request: APIRequestContext };
   eml230b: Eml230b;
-  // Election without polling stations
-  emptyElection: Election;
-  // Election with two polling stations
-  election: ElectionDetailsResponse;
-  // First data entry of the election
+  // GSB election without polling stations
+  emptyElectionGSB: Election;
+  // GSB election with two polling stations
+  electionGSB: ElectionDetailsResponse;
+  // First data entry of the GSB election
   dataEntryGSB: DataEntry;
-  // First data entry of the election with entry claimed by typist one
+  // First data entry of the GSB election with entry claimed by typist one
   dataEntryGSBFirstEntryClaimed: DataEntry;
-  // First data entry of the election with first data entry done
+  // First data entry of the GSB election with first data entry done
   dataEntryGSBFirstEntryDone: DataEntry;
-  // First data entry of the election with first data entry with errors
+  // First data entry of the GSB election with first data entry with errors
   dataEntryGSBFirstEntryHasErrors: DataEntry;
-  // First data entry of the election with first and second data entries done
+  // First data entry of the GSB election with first and second data entries done
   dataEntryGSBDefinitive: DataEntry;
-  // First data entry of the election with differences between the first and second data entry
+  // First data entry of the GSB election with differences between the first and second data entry
   dataEntryGSBEntriesDifferent: DataEntry;
-  // First data entry of the election with second data entry that has errors and is therefore different
+  // First data entry of the GSB election with second data entry that has errors and is therefore different
   dataEntryGSBEntriesDifferentWithErrors: DataEntry;
-  // Election with two completed data entries for each polling station
-  completedElection: Election;
+  // GSB election with polling stations and two completed data entries for each
+  completedElectionGSB: Election;
   // The current committee session for the election
-  currentCommitteeSession: CommitteeSession;
-  // Newly created User
-  newTypist: User;
+  currentCommitteeSessionElectionGSB: CommitteeSession;
+  // Newly created GSB User
+  newTypistGSB: User;
 };
 
 export const test = base.extend<Fixtures>({
@@ -81,26 +87,44 @@ export const test = base.extend<Fixtures>({
     await use({ page: page, request: context.request });
     await context.close();
   },
-  coordinatorOne: async ({ browser }, use) => {
-    const context = await browser.newContext({ storageState: "e2e-tests/state/coordinator1.json" });
+  coordinatorOneGSB: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: "e2e-tests/state/coordinator1-GSB.json" });
     const page = await context.newPage();
     await use({ page: page, request: context.request });
     await context.close();
   },
-  typistOne: async ({ browser }, use) => {
-    const context = await browser.newContext({ storageState: "e2e-tests/state/typist1.json" });
+  typistOneGSB: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: "e2e-tests/state/typist1-GSB.json" });
     const page = await context.newPage();
     await use({ page: page, request: context.request });
     await context.close();
   },
-  typistTwo: async ({ browser }, use) => {
-    const context = await browser.newContext({ storageState: "e2e-tests/state/typist2.json" });
+  typistTwoGSB: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: "e2e-tests/state/typist2-GSB.json" });
+    const page = await context.newPage();
+    await use({ page: page, request: context.request });
+    await context.close();
+  },
+  coordinatorOneCSB: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: "e2e-tests/state/coordinator1-CSB.json" });
+    const page = await context.newPage();
+    await use({ page: page, request: context.request });
+    await context.close();
+  },
+  typistOneCSB: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: "e2e-tests/state/typist1-CSB.json" });
+    const page = await context.newPage();
+    await use({ page: page, request: context.request });
+    await context.close();
+  },
+  typistTwoCSB: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: "e2e-tests/state/typist2-CSB.json" });
     const page = await context.newPage();
     await use({ page: page, request: context.request });
     await context.close();
   },
   eml230b: [eml230b, { option: true }],
-  emptyElection: async ({ adminOne, eml230b }, use) => {
+  emptyElectionGSB: async ({ adminOne, eml230b }, use) => {
     const { request } = adminOne;
     const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
     const election_data = await readFile(eml110a.path, "utf8");
@@ -121,16 +145,16 @@ export const test = base.extend<Fixtures>({
 
     await use(election);
   },
-  election: async ({ adminOne, coordinatorOne, emptyElection }, use) => {
+  electionGSB: async ({ adminOne, coordinatorOneGSB, emptyElectionGSB }, use) => {
     // create polling stations in the existing emptyElection
-    const url: POLLING_STATION_CREATE_REQUEST_PATH = `/api/elections/${emptyElection.id}/polling_stations`;
+    const url: POLLING_STATION_CREATE_REQUEST_PATH = `/api/elections/${emptyElectionGSB.id}/polling_stations`;
     for (const pollingStationRequest of pollingStationRequests) {
       const pollingStationResponse = await adminOne.request.post(url, { data: pollingStationRequest });
       expect(pollingStationResponse.ok()).toBeTruthy();
     }
 
     // get election details
-    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElection.id}`;
+    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionGSB.id}`;
     const electionResponse = await adminOne.request.get(electionUrl);
     expect(electionResponse.ok()).toBeTruthy();
     const response = (await electionResponse.json()) as ElectionDetailsResponse;
@@ -138,7 +162,7 @@ export const test = base.extend<Fixtures>({
     // Set committee session status to DataEntry
     const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}/status`;
     const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status: "data_entry" };
-    const statusChangeResponse = await coordinatorOne.request.put(statusChangeUrl, { data: statusChangeData });
+    const statusChangeResponse = await coordinatorOneGSB.request.put(statusChangeUrl, { data: statusChangeData });
     expect(statusChangeResponse.ok()).toBeTruthy();
 
     // Fill in committee session details
@@ -148,35 +172,35 @@ export const test = base.extend<Fixtures>({
       start_date: "2026-03-18",
       start_time: "21:45",
     };
-    const detailsUpdateResponse = await coordinatorOne.request.put(detailsUpdateUrl, { data: detailsUpdateData });
+    const detailsUpdateResponse = await coordinatorOneGSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
     expect(detailsUpdateResponse.ok()).toBeTruthy();
 
     await use(response);
   },
-  dataEntryGSB: async ({ adminOne, election }, use) => {
+  dataEntryGSB: async ({ adminOne, electionGSB }, use) => {
     const { request } = adminOne;
     // get the first polling station of the existing election
-    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${election.election.id}/status`;
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionGSB.election.id}/status`;
     const response = await request.get(url);
     expect(response.ok()).toBeTruthy();
     const electionStatuses = (await response.json()) as ElectionStatusResponse;
     const electionStatus = electionStatuses.statuses[0]!;
 
     await use({
-      election_id: election.election.id,
+      election_id: electionGSB.election.id,
       id: electionStatus.data_entry_id,
       name: electionStatus.source.name,
       number: electionStatus.source.number.toString(),
     });
   },
-  dataEntryGSBFirstEntryClaimed: async ({ typistOne, dataEntryGSB }, use) => {
-    const { request } = typistOne;
+  dataEntryGSBFirstEntryClaimed: async ({ typistOneGSB, dataEntryGSB }, use) => {
+    const { request } = typistOneGSB;
     const firstDataEntry = new DataEntryApiClient(request, dataEntryGSB.id, 1);
     await firstDataEntry.claim();
     await use(dataEntryGSB);
   },
-  dataEntryGSBFirstEntryDone: async ({ dataEntryGSB, typistOne }, use) => {
-    const { request } = typistOne;
+  dataEntryGSBFirstEntryDone: async ({ dataEntryGSB, typistOneGSB }, use) => {
+    const { request } = typistOneGSB;
     const firstDataEntry = new DataEntryApiClient(request, dataEntryGSB.id, 1);
     await firstDataEntry.claim();
     await firstDataEntry.save(dataEntryRequest);
@@ -184,8 +208,8 @@ export const test = base.extend<Fixtures>({
 
     await use(dataEntryGSB);
   },
-  dataEntryGSBFirstEntryHasErrors: async ({ dataEntryGSB, typistOne }, use) => {
-    const { request } = typistOne;
+  dataEntryGSBFirstEntryHasErrors: async ({ dataEntryGSB, typistOneGSB }, use) => {
+    const { request } = typistOneGSB;
     const firstDataEntry = new DataEntryApiClient(request, dataEntryGSB.id, 1);
     await firstDataEntry.claim();
     await firstDataEntry.save(dataEntryWithErrorRequest);
@@ -193,45 +217,45 @@ export const test = base.extend<Fixtures>({
 
     await use(dataEntryGSB);
   },
-  dataEntryGSBDefinitive: async ({ dataEntryGSB, typistOne, typistTwo }, use) => {
-    await completePollingStationDataEntries(dataEntryGSB.id, typistOne.request, typistTwo.request);
+  dataEntryGSBDefinitive: async ({ dataEntryGSB, typistOneGSB, typistTwoGSB }, use) => {
+    await completePollingStationDataEntries(dataEntryGSB.id, typistOneGSB.request, typistTwoGSB.request);
 
     await use(dataEntryGSB);
   },
-  dataEntryGSBEntriesDifferent: async ({ dataEntryGSB, typistOne, typistTwo }, use) => {
+  dataEntryGSBEntriesDifferent: async ({ dataEntryGSB, typistOneGSB, typistTwoGSB }, use) => {
     await completePollingStationDataEntries(
       dataEntryGSB.id,
-      typistOne.request,
-      typistTwo.request,
+      typistOneGSB.request,
+      typistTwoGSB.request,
       dataEntryRequest,
       dataEntryWithDifferencesRequest,
     );
 
     await use(dataEntryGSB);
   },
-  dataEntryGSBEntriesDifferentWithErrors: async ({ dataEntryGSB, typistOne, typistTwo }, use) => {
+  dataEntryGSBEntriesDifferentWithErrors: async ({ dataEntryGSB, typistOneGSB, typistTwoGSB }, use) => {
     await completePollingStationDataEntries(
       dataEntryGSB.id,
-      typistOne.request,
-      typistTwo.request,
+      typistOneGSB.request,
+      typistTwoGSB.request,
       dataEntryRequest,
       dataEntryWithErrorRequest,
     );
 
     await use(dataEntryGSB);
   },
-  completedElection: async ({ election, typistOne, typistTwo }, use) => {
+  completedElectionGSB: async ({ electionGSB, typistOneGSB, typistTwoGSB }, use) => {
     // finalise both data entries for all polling stations
-    for (const ps of election.polling_stations) {
-      await completePollingStationDataEntries(ps.data_entry_id!, typistOne.request, typistTwo.request);
+    for (const ps of electionGSB.polling_stations) {
+      await completePollingStationDataEntries(ps.data_entry_id!, typistOneGSB.request, typistTwoGSB.request);
     }
 
-    await use(election.election);
+    await use(electionGSB.election);
   },
-  currentCommitteeSession: async ({ election }, use) => {
-    await use(election.current_committee_session);
+  currentCommitteeSessionElectionGSB: async ({ electionGSB }, use) => {
+    await use(electionGSB.current_committee_session);
   },
-  newTypist: async ({ adminOne }, use) => {
+  newTypistGSB: async ({ adminOne }, use) => {
     const { request } = adminOne;
     // create a new user
     const url: USER_CREATE_REQUEST_PATH = "/api/users";

--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -84,8 +84,6 @@ type Fixtures = {
   completedElectionCSB: Election;
   // The current committee session for the GSB election
   currentCommitteeSessionElectionGSB: CommitteeSession;
-  // The current committee session for the CSB election
-  currentCommitteeSessionElectionCSB: CommitteeSession;
   // Newly created GSB User
   newTypistGSB: User;
 };
@@ -329,9 +327,6 @@ export const test = base.extend<Fixtures>({
   },
   currentCommitteeSessionElectionGSB: async ({ electionGSB }, use) => {
     await use(electionGSB.current_committee_session);
-  },
-  currentCommitteeSessionElectionCSB: async ({ electionCSB }, use) => {
-    await use(electionCSB.current_committee_session);
   },
   newTypistGSB: async ({ adminOne }, use) => {
     const { request } = adminOne;

--- a/frontend/e2e-tests/helpers-utils/e2e-test-api-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-api-helpers.ts
@@ -1,6 +1,6 @@
 import { type APIRequestContext, expect } from "@playwright/test";
+import { dataEntryRequest } from "e2e-tests/test-data/request-response-templates";
 import type { TestUser } from "e2e-tests/test-data/users";
-import { dataEntryRequest } from "../test-data/request-response-templates";
 import { DataEntryApiClient } from "./api-clients";
 
 export function getTestPassword(username: string, prefix = ""): string {
@@ -22,7 +22,7 @@ export async function apiLogout(request: APIRequestContext) {
   return await request.post("/api/logout");
 }
 
-export async function completePollingStationDataEntries(
+export async function completeDataEntries(
   dataEntryId: number,
   typistOneRequest: APIRequestContext,
   typistTwoRequest: APIRequestContext,

--- a/frontend/e2e-tests/page-objects/apportionment/AddDeceasedCandidatePgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/AddDeceasedCandidatePgObj.ts
@@ -12,6 +12,10 @@ export class AddDeceasedCandidate {
     this.candidates = page.getByTestId("candidates").locator("tbody").getByRole("row");
   }
 
+  async clickList(listNumber: number) {
+    await this.page.getByTestId(`list-item-group-${listNumber}`).click();
+  }
+
   async clickCandidateFromList(candidateNumber: number) {
     await this.page.getByTestId(`candidate-${candidateNumber}`).click();
   }

--- a/frontend/e2e-tests/page-objects/apportionment/AddDeceasedCandidatePgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/AddDeceasedCandidatePgObj.ts
@@ -1,0 +1,18 @@
+import type { Locator, Page } from "@playwright/test";
+
+export class AddDeceasedCandidate {
+  readonly header: Locator;
+  readonly title: Locator;
+  readonly candidates: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.header = page.getByRole("heading", { level: 1, name: "Overleden kandidaat" });
+    this.title = page.getByRole("heading", { level: 3 });
+
+    this.candidates = page.getByTestId("candidates").locator("tbody").getByRole("row");
+  }
+
+  async clickCandidateFromList(candidateNumber: number) {
+    await this.page.getByTestId(`candidate-${candidateNumber}`).click();
+  }
+}

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentListDetailsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentListDetailsPgObj.ts
@@ -2,8 +2,11 @@ import type { Locator, Page } from "@playwright/test";
 
 export class ApportionmentListDetails {
   readonly header: Locator;
+  readonly alert: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1, name: /Lijst \d+ - \w+/ });
+
+    this.alert = page.getByRole("alert");
   }
 }

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
@@ -3,12 +3,14 @@ import type { Locator, Page } from "@playwright/test";
 export class Apportionment {
   readonly allSeatsAssigned: Locator;
   readonly allSeatsAssignedAlert: Locator;
+  readonly apportionmentTable: Locator;
   readonly header: Locator;
   readonly toReport: Locator;
   readonly fullSeatInformation: Locator;
   readonly fullSeatsPageLink: Locator;
   readonly residualSeatInformation: Locator;
   readonly residualSeatsPageLink: Locator;
+  readonly manageDeceasedCandidates: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1, name: "Zetelverdeling" });
@@ -16,6 +18,8 @@ export class Apportionment {
     this.allSeatsAssigned = page.getByRole("strong").filter({
       hasText: "Alle zetels zijn toegewezen",
     });
+
+    this.apportionmentTable = page.getByTestId("apportionment-table");
 
     this.allSeatsAssignedAlert = page.getByRole("alert").filter({ has: this.allSeatsAssigned });
     this.toReport = page.getByRole("link", { name: "Naar proces-verbaal" });
@@ -25,5 +29,11 @@ export class Apportionment {
 
     this.residualSeatInformation = page.getByText(/\d+ zetels werden als restzetel toegewezen/);
     this.residualSeatsPageLink = this.residualSeatInformation.getByRole("link", { name: "bekijk details" });
+
+    this.manageDeceasedCandidates = page.getByRole("link", { name: "Beheer overleden kandidaten" });
+  }
+
+  async clickList(listNumber: number) {
+    await this.page.getByTestId(`list-${listNumber}`).click();
   }
 }

--- a/frontend/e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj.ts
@@ -4,6 +4,7 @@ export class DeceasedCandidates {
   readonly header: Locator;
   readonly deceasedCandidates: Locator;
   readonly addCandidate: Locator;
+  readonly toApportionment: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1, name: "Overleden kandidaten" });
@@ -11,14 +12,16 @@ export class DeceasedCandidates {
     this.deceasedCandidates = page.getByTestId("deceased-candidates").locator("tbody").getByRole("row");
 
     this.addCandidate = page.getByRole("link", { name: "+ Kandidaat toevoegen" });
+
+    this.toApportionment = page.getByRole("button", { name: "Naar zetelverdeling" });
   }
 
-  findCandidateByNumber(candidateNumber: number) {
-    return this.page.getByTestId(`candidate-${candidateNumber}`);
+  findCandidate(listNumber: number, candidateNumber: number) {
+    return this.page.getByTestId(`list-${listNumber}-candidate-${candidateNumber}`);
   }
 
-  async clickDeleteCandidate(candidateNumber: number) {
-    const row = this.page.getByTestId(`candidate-${candidateNumber}`);
+  async clickDeleteCandidate(listNumber: number, candidateNumber: number) {
+    const row = this.page.getByTestId(`list-${listNumber}-candidate-${candidateNumber}`);
     await row.getByRole("button", { name: "Verwijderen" }).click();
   }
 }

--- a/frontend/e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj.ts
@@ -1,0 +1,24 @@
+import type { Locator, Page } from "@playwright/test";
+
+export class DeceasedCandidates {
+  readonly header: Locator;
+  readonly deceasedCandidates: Locator;
+  readonly addCandidate: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.header = page.getByRole("heading", { level: 1, name: "Overleden kandidaten" });
+
+    this.deceasedCandidates = page.getByTestId("deceased-candidates").locator("tbody").getByRole("row");
+
+    this.addCandidate = page.getByRole("link", { name: "+ Kandidaat toevoegen" });
+  }
+
+  findCandidateByNumber(candidateNumber: number) {
+    return this.page.getByTestId(`candidate-${candidateNumber}`);
+  }
+
+  async clickDeleteCandidate(candidateNumber: number) {
+    const row = this.page.getByTestId(`candidate-${candidateNumber}`);
+    await row.getByRole("button", { name: "Verwijderen" }).click();
+  }
+}

--- a/frontend/e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj.ts
@@ -5,6 +5,7 @@ export class DeceasedCandidates {
   readonly deceasedCandidates: Locator;
   readonly addCandidate: Locator;
   readonly toApportionment: Locator;
+  readonly resetApportionmentState: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1, name: "Overleden kandidaten" });
@@ -14,6 +15,8 @@ export class DeceasedCandidates {
     this.addCandidate = page.getByRole("link", { name: "+ Kandidaat toevoegen" });
 
     this.toApportionment = page.getByRole("button", { name: "Naar zetelverdeling" });
+
+    this.resetApportionmentState = page.getByRole("button", { name: "Doe dan de zetelverdeling opnieuw" });
   }
 
   findCandidate(listNumber: number, candidateNumber: number) {

--- a/frontend/e2e-tests/setup-test-users.ts
+++ b/frontend/e2e-tests/setup-test-users.ts
@@ -1,9 +1,9 @@
 import { expect, request, test } from "@playwright/test";
 import { apiLoginAs, createUser, firstLogin } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
-import { testUsers } from "e2e-tests/test-data/users";
+import { testUsers, testUsersCSB } from "e2e-tests/test-data/users";
 
 test.describe("setup test users", () => {
-  test("create test user accounts", async () => {
+  test("create test user accounts GSB", async () => {
     // create a new APIRequestContext
     const adminContext = await request.newContext();
     const loginResponse = await apiLoginAs(adminContext, "admin1");
@@ -12,6 +12,23 @@ test.describe("setup test users", () => {
     await adminContext.storageState({ path: "e2e-tests/state/admin1.json" });
 
     for (const user of testUsers) {
+      await createUser(adminContext, user);
+
+      const userContext = await request.newContext();
+      await firstLogin(userContext, user);
+      await userContext.storageState({ path: `e2e-tests/state/${user.username}.json` });
+    }
+  });
+
+  test("create test user accounts CSB", async () => {
+    // create a new APIRequestContext
+    const adminContext = await request.newContext();
+    const loginResponse = await apiLoginAs(adminContext, "admin1");
+    expect(loginResponse.status()).toBe(200);
+
+    await adminContext.storageState({ path: "e2e-tests/state/admin1.json" });
+
+    for (const user of testUsersCSB) {
       await createUser(adminContext, user);
 
       const userContext = await request.newContext();

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -602,6 +602,17 @@ export const dataEntryRequest: DataEntry = {
   },
 };
 
+export const dataEntryRequestGSB: DataEntry = {
+  progress: 88,
+  data: noRecountNoDifferencesDataEntryGSB,
+  client_state: {
+    furthest: "political_group_votes_9",
+    current: "political_group_votes_9",
+    acceptedErrorsAndWarnings: [],
+    continue: true,
+  },
+};
+
 export const dataEntryWithErrorRequest: DataEntry = {
   progress: 86,
   data: {

--- a/frontend/e2e-tests/test-data/users.ts
+++ b/frontend/e2e-tests/test-data/users.ts
@@ -19,23 +19,46 @@ export const testUsers: TestUser[] = [
     role: "administrator",
   },
   {
-    username: "coordinator1",
+    username: "coordinator1-GSB",
     fullname: "Mohammed van der Velden",
     role: "coordinator_gsb",
   },
   {
-    username: "coordinator2",
+    username: "coordinator2-GSB",
     fullname: "Mei Chen",
     role: "coordinator_gsb",
   },
   {
-    username: "typist1",
+    username: "typist1-GSB",
     fullname: "Sam Kuijpers",
     role: "typist_gsb",
   },
   {
-    username: "typist2",
+    username: "typist2-GSB",
     fullname: "Aliyah van den Berg",
     role: "typist_gsb",
+  },
+];
+
+export const testUsersCSB: TestUser[] = [
+  {
+    username: "coordinator1-CSB",
+    fullname: "Tinus Bakker",
+    role: "coordinator_csb",
+  },
+  {
+    username: "coordinator2-CSB",
+    fullname: "Molly Li",
+    role: "coordinator_csb",
+  },
+  {
+    username: "typist1-CSB",
+    fullname: "Fatima Muhammad",
+    role: "typist_csb",
+  },
+  {
+    username: "typist2-CSB",
+    fullname: "Jordy van Houten",
+    role: "typist_csb",
   },
 ];

--- a/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
@@ -1,0 +1,80 @@
+import { expect } from "@playwright/test";
+import { AddDeceasedCandidate } from "e2e-tests/page-objects/apportionment/AddDeceasedCandidatePgObj";
+import { ApportionmentFullSeats } from "e2e-tests/page-objects/apportionment/ApportionmentFullSeatsPgObj";
+import { Apportionment } from "e2e-tests/page-objects/apportionment/ApportionmentPgObj";
+import { ApportionmentResidualSeats } from "e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj";
+import { DeceasedCandidates } from "e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj";
+import { IncludeAllCandidates } from "e2e-tests/page-objects/apportionment/IncludeAllCandidatesPgObj";
+import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
+import { FinishDataEntry } from "e2e-tests/page-objects/election/FinishDataEntryPgObj";
+import { test } from "../../fixtures";
+
+test.use({
+  storageState: "e2e-tests/state/coordinator1-CSB.json",
+});
+
+test.describe("CSB election apportionment", () => {
+  test("is calculated after adding deceased candidates", async ({ page, completedElectionCSB }) => {
+    await page.goto(`/elections/${completedElectionCSB.id}/status`);
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.finish.click();
+
+    const finishDataEntryPage = new FinishDataEntry(page);
+    await finishDataEntryPage.finishDataEntry.click();
+
+    const includeAllCandidatesPage = new IncludeAllCandidates(page);
+    await expect(includeAllCandidatesPage.header).toBeVisible();
+    await expect(includeAllCandidatesPage.dataEntryFinishedAlert).toBeVisible();
+    await expect(includeAllCandidatesPage.title).toBeVisible();
+    await expect(includeAllCandidatesPage.yes).toBeVisible();
+    await expect(includeAllCandidatesPage.no).toBeVisible();
+    await includeAllCandidatesPage.no.click();
+    await includeAllCandidatesPage.next.click();
+
+    const addDeceasedCandidatesPage = new AddDeceasedCandidate(page);
+    await expect(addDeceasedCandidatesPage.header).toBeVisible();
+    await expect(addDeceasedCandidatesPage.title).toBeVisible();
+    await addDeceasedCandidatesPage.clickCandidateFromList(5);
+
+    const deceasedCandidatesPage = new DeceasedCandidates(page);
+    await expect(deceasedCandidatesPage.header).toBeVisible();
+    await expect(deceasedCandidatesPage.findCandidate(1, 5)).toBeVisible();
+    await expect(deceasedCandidatesPage.addCandidate).toBeVisible();
+    await deceasedCandidatesPage.addCandidate.click();
+
+    await expect(addDeceasedCandidatesPage.header).toBeVisible();
+    await expect(addDeceasedCandidatesPage.title).toBeVisible();
+    await addDeceasedCandidatesPage.clickList(5);
+    await addDeceasedCandidatesPage.clickCandidateFromList(3);
+
+    await expect(deceasedCandidatesPage.header).toBeVisible();
+    await expect(deceasedCandidatesPage.findCandidate(1, 5)).toBeVisible();
+    await expect(deceasedCandidatesPage.findCandidate(5, 3)).toBeVisible();
+    await deceasedCandidatesPage.clickDeleteCandidate(5, 3);
+    await expect(deceasedCandidatesPage.findCandidate(1, 5)).toBeVisible();
+    await expect(deceasedCandidatesPage.findCandidate(5, 3)).toBeHidden();
+
+    await deceasedCandidatesPage.toApportionment.click();
+
+    const apportionmentPage = new Apportionment(page);
+    await expect(apportionmentPage.header).toBeVisible();
+    await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
+
+    // TODO: Click "beheer overleden kandidaten" and check read only DeceasedCandidatesPage
+
+    await expect(apportionmentPage.fullSeatInformation).toBeVisible();
+    await apportionmentPage.fullSeatsPageLink.click();
+    const apportionmentFullSeatsPage = new ApportionmentFullSeats(page);
+    await expect(apportionmentFullSeatsPage.header).toBeVisible();
+
+    await page.goBack();
+    await expect(apportionmentPage.residualSeatInformation).toBeVisible();
+    await apportionmentPage.residualSeatsPageLink.click();
+    const apportionmentResidualSeatsPage = new ApportionmentResidualSeats(page);
+    await expect(apportionmentResidualSeatsPage.header).toBeVisible();
+
+    await page.goBack();
+    // TODO: Check ApportionmentListDetails of list 1, check for deceased candidate alert
+  });
+});

--- a/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
@@ -10,12 +10,9 @@ import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPg
 import { FinishDataEntry } from "e2e-tests/page-objects/election/FinishDataEntryPgObj";
 import { test } from "../../fixtures";
 
-test.use({
-  storageState: "e2e-tests/state/coordinator1-CSB.json",
-});
-
 test.describe("CSB election apportionment", () => {
-  test("is calculated after adding deceased candidates", async ({ page, completedElectionCSB }) => {
+  test("is calculated after adding deceased candidates", async ({ coordinatorOneCSB, completedElectionCSB }) => {
+    const page = coordinatorOneCSB.page;
     await page.goto(`/elections/${completedElectionCSB.id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
@@ -30,7 +27,7 @@ test.describe("CSB election apportionment", () => {
     await expect(includeAllCandidatesPage.title).toBeVisible();
     await expect(includeAllCandidatesPage.yes).toBeVisible();
     await expect(includeAllCandidatesPage.no).toBeVisible();
-    await includeAllCandidatesPage.no.click();
+    await includeAllCandidatesPage.no.check();
     await includeAllCandidatesPage.next.click();
 
     const addDeceasedCandidatesPage = new AddDeceasedCandidate(page);
@@ -41,7 +38,6 @@ test.describe("CSB election apportionment", () => {
     const deceasedCandidatesPage = new DeceasedCandidates(page);
     await expect(deceasedCandidatesPage.header).toBeVisible();
     await expect(deceasedCandidatesPage.findCandidate(1, 5)).toBeVisible();
-    await expect(deceasedCandidatesPage.addCandidate).toBeVisible();
     await deceasedCandidatesPage.addCandidate.click();
 
     await expect(addDeceasedCandidatesPage.header).toBeVisible();

--- a/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 import { AddDeceasedCandidate } from "e2e-tests/page-objects/apportionment/AddDeceasedCandidatePgObj";
 import { ApportionmentFullSeats } from "e2e-tests/page-objects/apportionment/ApportionmentFullSeatsPgObj";
+import { ApportionmentListDetails } from "e2e-tests/page-objects/apportionment/ApportionmentListDetailsPgObj";
 import { Apportionment } from "e2e-tests/page-objects/apportionment/ApportionmentPgObj";
 import { ApportionmentResidualSeats } from "e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj";
 import { DeceasedCandidates } from "e2e-tests/page-objects/apportionment/DeceasedCandidatesPgObj";
@@ -61,20 +62,45 @@ test.describe("CSB election apportionment", () => {
     await expect(apportionmentPage.header).toBeVisible();
     await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
 
-    // TODO: Click "beheer overleden kandidaten" and check read only DeceasedCandidatesPage
-
     await expect(apportionmentPage.fullSeatInformation).toBeVisible();
     await apportionmentPage.fullSeatsPageLink.click();
     const apportionmentFullSeatsPage = new ApportionmentFullSeats(page);
     await expect(apportionmentFullSeatsPage.header).toBeVisible();
 
     await page.goBack();
+
     await expect(apportionmentPage.residualSeatInformation).toBeVisible();
     await apportionmentPage.residualSeatsPageLink.click();
     const apportionmentResidualSeatsPage = new ApportionmentResidualSeats(page);
     await expect(apportionmentResidualSeatsPage.header).toBeVisible();
 
     await page.goBack();
-    // TODO: Check ApportionmentListDetails of list 1, check for deceased candidate alert
+
+    await expect(apportionmentPage.apportionmentTable).toBeVisible();
+    await apportionmentPage.clickList(1);
+
+    const listDetailsPage = new ApportionmentListDetails(page);
+    await expect(listDetailsPage.header).toBeVisible();
+    await expect(listDetailsPage.header).toContainText("Lijst 1 - Partijdige Partij");
+    await expect(listDetailsPage.alert).toBeVisible();
+    await expect(listDetailsPage.alert).toContainText(
+      "Kandidaat 5 is buiten beschouwing gelaten bij het verdelen van de zetels vanwege overlijden.Stemmen op overleden kandidaten zijn wel meegeteld als stemmen op diens lijst.",
+    );
+
+    await page.goBack();
+
+    await expect(apportionmentPage.manageDeceasedCandidates).toBeVisible();
+    await apportionmentPage.manageDeceasedCandidates.click();
+
+    await expect(deceasedCandidatesPage.header).toBeVisible();
+    await expect(deceasedCandidatesPage.findCandidate(1, 5)).toBeVisible();
+    await expect(deceasedCandidatesPage.findCandidate(5, 3)).toBeHidden();
+    await expect(deceasedCandidatesPage.addCandidate).toBeHidden();
+    await expect(deceasedCandidatesPage.resetApportionmentState).toBeVisible();
+    await deceasedCandidatesPage.resetApportionmentState.click();
+
+    await expect(includeAllCandidatesPage.header).toBeVisible();
+    await expect(includeAllCandidatesPage.dataEntryFinishedAlert).toBeVisible();
+    await expect(includeAllCandidatesPage.title).toBeVisible();
   });
 });

--- a/frontend/e2e-tests/tests/authentication.e2e.ts
+++ b/frontend/e2e-tests/tests/authentication.e2e.ts
@@ -34,9 +34,9 @@ test.describe("authentication", () => {
     await expect(loginPage.alert).toContainText("De gebruikersnaam of het wachtwoord is onjuist");
   });
 
-  test("first login", async ({ newTypist, page }) => {
+  test("first login", async ({ newTypistGSB, page }) => {
     // Login as a newly created user
-    const username = newTypist.username;
+    const username = newTypistGSB.username;
 
     const loginPage = new LoginPgObj(page);
     await page.goto("/account/login");
@@ -47,16 +47,16 @@ test.describe("authentication", () => {
     // Fill out the account setup page
     const password = "Sterk wachtwoord";
     const accountSetupPage = new AccountSetupPgObj(page);
-    await accountSetupPage.fullname.fill(newTypist.fullname!);
+    await accountSetupPage.fullname.fill(newTypistGSB.fullname!);
     await accountSetupPage.password.fill(password);
     await accountSetupPage.passwordRepeat.fill(password);
     await accountSetupPage.saveBtn.click();
 
     const userInfoTopBar = new UserInfoTopBar(page);
-    await expect(userInfoTopBar.username).toHaveText(newTypist.fullname!);
+    await expect(userInfoTopBar.username).toHaveText(newTypistGSB.fullname!);
 
     const overviewPage = new ElectionsOverviewPgObj(page);
-    await expect(userInfoTopBar.username).toHaveText(newTypist.fullname!);
+    await expect(userInfoTopBar.username).toHaveText(newTypistGSB.fullname!);
     await expect(overviewPage.alertAccountSetup).toBeVisible();
   });
 });
@@ -69,8 +69,10 @@ test.describe("navigation and redirects", () => {
     await expect(loginPage.alert).toContainText("Je hebt geen toegang tot deze pagina");
   });
 
-  test("completed and logged in user gets redirected from login page to elections page", async ({ coordinatorOne }) => {
-    const page = coordinatorOne.page;
+  test("completed and logged in user gets redirected from login page to elections page", async ({
+    coordinatorOneGSB,
+  }) => {
+    const page = coordinatorOneGSB.page;
 
     await page.goto("/elections");
     const electionsPage = new ElectionsOverviewPgObj(page);
@@ -81,9 +83,9 @@ test.describe("navigation and redirects", () => {
   });
 
   test("completed and logged in user gets redirected from account setup page to no access page", async ({
-    coordinatorOne,
+    coordinatorOneGSB,
   }) => {
-    const page = coordinatorOne.page;
+    const page = coordinatorOneGSB.page;
 
     await page.goto("/elections");
     const electionsPage = new ElectionsOverviewPgObj(page);
@@ -96,9 +98,9 @@ test.describe("navigation and redirects", () => {
 
   test("incomplete logged in user gets redirected from login page to account setup page", async ({
     page,
-    newTypist,
+    newTypistGSB,
   }) => {
-    const username = newTypist.username;
+    const username = newTypistGSB.username;
 
     const loginPage = new LoginPgObj(page);
     await page.goto("/account/login");
@@ -115,11 +117,11 @@ test.describe("navigation and redirects", () => {
 
   test("incomplete logged in user that refreshes the account setup page stays on that page", async ({
     page,
-    newTypist,
+    newTypistGSB,
   }) => {
     const loginPage = new LoginPgObj(page);
     await page.goto("/account/setup");
-    await loginPage.login(newTypist.username, FIXTURE_TYPIST_TEMP_PASSWORD);
+    await loginPage.login(newTypistGSB.username, FIXTURE_TYPIST_TEMP_PASSWORD);
 
     const accountSetupPage = new AccountSetupPgObj(page);
     await expect(accountSetupPage.heading).toBeVisible();
@@ -130,11 +132,11 @@ test.describe("navigation and redirects", () => {
 
   test("incomplete logged in user gets redirected from elections page to account setup page", async ({
     page,
-    newTypist,
+    newTypistGSB,
   }) => {
     const loginPage = new LoginPgObj(page);
     await page.goto("/account/setup");
-    await loginPage.login(newTypist.username, FIXTURE_TYPIST_TEMP_PASSWORD);
+    await loginPage.login(newTypistGSB.username, FIXTURE_TYPIST_TEMP_PASSWORD);
 
     const accountSetupPage = new AccountSetupPgObj(page);
     await expect(accountSetupPage.heading).toBeVisible();
@@ -143,10 +145,10 @@ test.describe("navigation and redirects", () => {
     await expect(accountSetupPage.heading).toBeVisible();
   });
 
-  test("incomplete logged in user can log out", async ({ page, newTypist }) => {
+  test("incomplete logged in user can log out", async ({ page, newTypistGSB }) => {
     const loginPage = new LoginPgObj(page);
     await page.goto("/account/setup");
-    await loginPage.login(newTypist.username, FIXTURE_TYPIST_TEMP_PASSWORD);
+    await loginPage.login(newTypistGSB.username, FIXTURE_TYPIST_TEMP_PASSWORD);
 
     const accountSetupPage = new AccountSetupPgObj(page);
     await expect(accountSetupPage.heading).toBeVisible();

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry-with-gaps.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry-with-gaps.e2e.ts
@@ -18,7 +18,7 @@ import type { VotersCounts, VotesCounts } from "@/types/generated/openapi";
 import { test } from "../../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
   eml230b: eml230b_with_gaps,
 });
 

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.api-errors.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.api-errors.e2e.ts
@@ -8,15 +8,15 @@ import { ErrorModalPgObj } from "e2e-tests/page-objects/ErrorModalPgObj";
 import { test } from "../../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
 });
 
 test.describe("data entry - api error responses", () => {
   test("UI Warning: Trying to load a data entry that was already claimed", async ({
-    typistTwo,
+    typistTwoGSB,
     dataEntryGSBFirstEntryClaimed,
   }) => {
-    const { page } = typistTwo;
+    const { page } = typistTwoGSB;
     await page.goto(
       `/elections/${dataEntryGSBFirstEntryClaimed.election_id}/data-entry/${dataEntryGSBFirstEntryClaimed.id}/1`,
     );

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.e2e.ts
@@ -27,7 +27,7 @@ import type { VotersCounts, VotesCounts } from "@/types/generated/openapi";
 import { test } from "../../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
 });
 
 test.describe("full data entry flow", () => {
@@ -524,8 +524,8 @@ test.describe("full data entry flow", () => {
 });
 
 test.describe("second data entry", () => {
-  test("equal second data entry after first data entry", async ({ typistTwo, dataEntryGSBFirstEntryDone }) => {
-    const { page } = typistTwo;
+  test("equal second data entry after first data entry", async ({ typistTwoGSB, dataEntryGSBFirstEntryDone }) => {
+    const { page } = typistTwoGSB;
     await page.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
@@ -555,11 +555,11 @@ test.describe("second data entry", () => {
   });
 
   test("different second data entry after first data entry but correct warnings", async ({
-    typistTwo,
-    coordinatorOne,
+    typistTwoGSB,
+    coordinatorOneGSB,
     dataEntryGSBFirstEntryDone,
   }) => {
-    const typistPage = typistTwo.page;
+    const typistPage = typistTwoGSB.page;
     await typistPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(typistPage);
@@ -624,7 +624,7 @@ test.describe("second data entry", () => {
     );
 
     // check if data entries are marked as definitive on coordinator status page
-    const coordinatorPage = coordinatorOne.page;
+    const coordinatorPage = coordinatorOneGSB.page;
     await coordinatorPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(coordinatorPage);
@@ -632,11 +632,11 @@ test.describe("second data entry", () => {
   });
 
   test("different second data entry after first data entry", async ({
-    typistTwo,
-    coordinatorOne,
+    typistTwoGSB,
+    coordinatorOneGSB,
     dataEntryGSBFirstEntryDone,
   }) => {
-    const typistPage = typistTwo.page;
+    const typistPage = typistTwoGSB.page;
     await typistPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(typistPage);
@@ -706,7 +706,7 @@ test.describe("second data entry", () => {
     );
 
     // check if data entries are marked as different on coordinator status page
-    const coordinatorPage = coordinatorOne.page;
+    const coordinatorPage = coordinatorOneGSB.page;
     await coordinatorPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(coordinatorPage);

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.error.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.error.model.e2e.ts
@@ -203,14 +203,14 @@ const votesEmpty: VotesCounts = {
 };
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
 });
 
 test.describe("Data entry model test - errors", () => {
   createTestModel(machine)
     .getSimplePaths()
     .forEach((path) => {
-      test(path.description, async ({ page, dataEntryGSB, election }) => {
+      test(path.description, async ({ page, dataEntryGSB, electionGSB }) => {
         const dataEntryHomePage = new DataEntryHomePage(page);
         const extraInvestigationPage = new ExtraInvestigationPage(page);
         const countingDifferencesPage = new CountingDifferencesPollingStationPage(page);
@@ -380,7 +380,7 @@ test.describe("Data entry model test - errors", () => {
             await votersAndVotesPage.abortInput.click();
           },
           NAV_TO_HOME_PAGE: async () => {
-            await navBar.clickElection(election.election.location, election.election.name);
+            await navBar.clickElection(electionGSB.election.location, electionGSB.election.name);
           },
           GO_TO_PREVIOUS_PAGE: async () => {
             await votersAndVotesPage.progressList.countingDifferencesPollingStation.click();

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.valid.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.valid.model.e2e.ts
@@ -184,14 +184,14 @@ const votesEmpty: VotesCounts = {
 };
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
 });
 
 test.describe("Data entry model test - valid data", () => {
   createTestModel(machine)
     .getSimplePaths()
     .forEach((path) => {
-      test(path.description, async ({ page, dataEntryGSB, election }) => {
+      test(path.description, async ({ page, dataEntryGSB, electionGSB }) => {
         const dataEntryHomePage = new DataEntryHomePage(page);
         const extraInvestigationPage = new ExtraInvestigationPage(page);
         const countingDifferencesPollingStationPage = new CountingDifferencesPollingStationPage(page);
@@ -335,7 +335,7 @@ test.describe("Data entry model test - valid data", () => {
             await votersAndVotesPage.abortInput.click();
           },
           NAV_TO_HOME_PAGE: async () => {
-            await navBar.clickElection(election.election.location, election.election.name);
+            await navBar.clickElection(electionGSB.election.location, electionGSB.election.name);
           },
           GO_TO_PREVIOUS_PAGE: async () => {
             await votersAndVotesPage.progressList.countingDifferencesPollingStation.click();

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.warning.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.warning.model.e2e.ts
@@ -200,14 +200,14 @@ const votesEmpty: VotesCounts = {
 };
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
 });
 
 test.describe("Data entry model test - warnings", () => {
   createTestModel(machine)
     .getSimplePaths()
     .forEach((path) => {
-      test(path.description, async ({ page, dataEntryGSB, election }) => {
+      test(path.description, async ({ page, dataEntryGSB, electionGSB }) => {
         const dataEntryHomePage = new DataEntryHomePage(page);
         const extraInvestigationPage = new ExtraInvestigationPage(page);
         const countingDifferencesPollingStationPage = new CountingDifferencesPollingStationPage(page);
@@ -421,7 +421,7 @@ test.describe("Data entry model test - warnings", () => {
             await abortModal.saveInput.click();
           },
           NAV_TO_HOME_PAGE: async () => {
-            await navBar.clickElection(election.election.location, election.election.name);
+            await navBar.clickElection(electionGSB.election.location, electionGSB.election.name);
           },
           SAVE_UNSUBMITTED_CHANGES: async () => {
             await votersAndVotesPage.unsavedChangesModal.saveInput.click();

--- a/frontend/e2e-tests/tests/data-entry-GSB/resolve-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/resolve-differences.e2e.ts
@@ -5,7 +5,7 @@ import { ResolveErrorsPgObj } from "e2e-tests/page-objects/election/ResolveError
 import { test } from "../../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/coordinator1.json",
+  storageState: "e2e-tests/state/coordinator1-GSB.json",
 });
 
 test.describe("resolve differences", () => {

--- a/frontend/e2e-tests/tests/data-entry-GSB/resolve-errors.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/resolve-errors.e2e.ts
@@ -4,7 +4,7 @@ import { ResolveErrorsPgObj } from "e2e-tests/page-objects/election/ResolveError
 import { test } from "../../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/coordinator1.json",
+  storageState: "e2e-tests/state/coordinator1-GSB.json",
 });
 
 test.describe("resolve errors", () => {

--- a/frontend/e2e-tests/tests/data-entry-GSB/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/resume-data-entry.e2e.ts
@@ -18,7 +18,7 @@ import type { ClaimDataEntryResponse, VotersCounts, VotesCounts } from "@/types/
 import { type DataEntry, test } from "../../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/typist1.json",
+  storageState: "e2e-tests/state/typist1-GSB.json",
 });
 
 test.describe("resume data entry flow", () => {
@@ -352,8 +352,8 @@ test.describe("resume data entry flow", () => {
       await expect(dataEntryHomePage.fieldset).toBeVisible();
     });
 
-    test("save input from check and save page", async ({ typistOne, dataEntryGSB }) => {
-      const { page } = typistOne;
+    test("save input from check and save page", async ({ typistOneGSB, dataEntryGSB }) => {
+      const { page } = typistOneGSB;
 
       await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
@@ -457,8 +457,8 @@ test.describe("resume data entry flow", () => {
       await expect(votersAndVotesPage.proxyCertificateCount).toBeEmpty();
     });
 
-    test("discard input from voters and votes page with error", async ({ typistOne, dataEntryGSB }) => {
-      const { page, request } = typistOne;
+    test("discard input from voters and votes page with error", async ({ typistOneGSB, dataEntryGSB }) => {
+      const { page, request } = typistOneGSB;
 
       await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
@@ -489,8 +489,8 @@ test.describe("resume data entry flow", () => {
       expect(await claimResponse.json()).toMatchObject({ data: emptyCSOFirstSessionResults() });
     });
 
-    test("discard input from voters and votes page with warning", async ({ typistOne, dataEntryGSB }) => {
-      const { page, request } = typistOne;
+    test("discard input from voters and votes page with warning", async ({ typistOneGSB, dataEntryGSB }) => {
+      const { page, request } = typistOneGSB;
 
       await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
@@ -537,8 +537,8 @@ test.describe("resume data entry flow", () => {
       expect(await claimResponse.json()).toMatchObject({ data: emptyCSOFirstSessionResults() });
     });
 
-    test("discard input from check and save page", async ({ typistOne, dataEntryGSB }) => {
-      const { page, request } = typistOne;
+    test("discard input from check and save page", async ({ typistOneGSB, dataEntryGSB }) => {
+      const { page, request } = typistOneGSB;
 
       await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 

--- a/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
@@ -324,7 +324,7 @@ test.describe("full flow CSB", () => {
     await expect(includeAllCandidatesPage.title).toBeVisible();
     await expect(includeAllCandidatesPage.yes).toBeVisible();
     await expect(includeAllCandidatesPage.no).toBeVisible();
-    await includeAllCandidatesPage.yes.click();
+    await includeAllCandidatesPage.yes.check();
     await includeAllCandidatesPage.next.click();
 
     const apportionmentPage = new Apportionment(page);

--- a/frontend/e2e-tests/tests/polling-station-crud.e2e.ts
+++ b/frontend/e2e-tests/tests/polling-station-crud.e2e.ts
@@ -5,15 +5,15 @@ import { PollingStationListPgObj } from "e2e-tests/page-objects/polling_station/
 import { test } from "../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/coordinator1.json",
+  storageState: "e2e-tests/state/coordinator1-GSB.json",
 });
 
 test.describe("Polling station CRUD", () => {
   test("it redirects correctly after successful create of first polling station of an election", async ({
     page,
-    emptyElection,
+    emptyElectionGSB,
   }) => {
-    await page.goto(`/elections/${emptyElection.id}/polling-stations`);
+    await page.goto(`/elections/${emptyElectionGSB.id}/polling-stations`);
 
     const pollingStationListEmptyPage = new PollingStationListEmptyPgObj(page);
     await pollingStationListEmptyPage.createPollingStation.click();
@@ -31,8 +31,8 @@ test.describe("Polling station CRUD", () => {
     expect(await pollingStationListPage.alert.textContent()).toContain("Stembureau 42 (test42) toegevoegd");
   });
 
-  test("it redirects correctly after successful create of another polling station", async ({ page, election }) => {
-    await page.goto(`/elections/${election.election.id}/polling-stations`);
+  test("it redirects correctly after successful create of another polling station", async ({ page, electionGSB }) => {
+    await page.goto(`/elections/${electionGSB.election.id}/polling-stations`);
 
     const pollingStationListPage = new PollingStationListPgObj(page);
     await pollingStationListPage.createPollingStation.click();

--- a/frontend/e2e-tests/tests/polling-station-import.e2e.ts
+++ b/frontend/e2e-tests/tests/polling-station-import.e2e.ts
@@ -6,12 +6,12 @@ import { eml110a, eml110b } from "e2e-tests/test-data/eml-files";
 import { test } from "../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/coordinator1.json",
+  storageState: "e2e-tests/state/coordinator1-GSB.json",
 });
 
 test.describe("Polling station import", () => {
-  test("As coordinator import polling stations from a file", async ({ page, emptyElection }) => {
-    await page.goto(`/elections/${emptyElection.id}/polling-stations`);
+  test("As coordinator import polling stations from a file", async ({ page, emptyElectionGSB }) => {
+    await page.goto(`/elections/${emptyElectionGSB.id}/polling-stations`);
 
     // Click file import button
     const emptyListPage = new PollingStationListEmptyPgObj(page);

--- a/frontend/e2e-tests/tests/users.e2e.ts
+++ b/frontend/e2e-tests/tests/users.e2e.ts
@@ -74,12 +74,12 @@ test.describe("Users", () => {
     await expect(userListPgObj.table).toContainText(username);
   });
 
-  test("update user", async ({ newTypist, page }) => {
+  test("update user", async ({ newTypistGSB, page }) => {
     await page.goto(`/users`);
 
     const userListPgObj = new UserListPgObj(page);
 
-    await userListPgObj.row(newTypist.username).click();
+    await userListPgObj.row(newTypistGSB.username).click();
 
     const userUpdatePgObj = new UserUpdatePgObj(page);
     await expect(userUpdatePgObj.fullname).toHaveValue("Gebruiker met Achternaam");
@@ -90,15 +90,15 @@ test.describe("Users", () => {
     await expect(userListPgObj.alert).toContainText(
       "De wijzigingen in het account van Gebruiker met Wijzigingen zijn opgeslagen",
     );
-    await expect(userListPgObj.row(newTypist.username)).toContainText("Gebruiker met Wijzigingen");
+    await expect(userListPgObj.row(newTypistGSB.username)).toContainText("Gebruiker met Wijzigingen");
   });
 
-  test("delete user", async ({ newTypist, page }) => {
+  test("delete user", async ({ newTypistGSB, page }) => {
     await page.goto(`/users`);
 
     const userListPgObj = new UserListPgObj(page);
 
-    await userListPgObj.row(newTypist.username).click();
+    await userListPgObj.row(newTypistGSB.username).click();
 
     const userUpdatePgObj = new UserUpdatePgObj(page);
     await expect(userUpdatePgObj.fullname).toHaveValue("Gebruiker met Achternaam");
@@ -109,6 +109,6 @@ test.describe("Users", () => {
 
     await expect(userListPgObj.alert).toContainText("Gebruiker verwijderd");
     await expect(userListPgObj.alert).toContainText("Het account van Gebruiker met Achternaam is verwijderd");
-    await expect(userListPgObj.row(newTypist.username)).toHaveCount(0);
+    await expect(userListPgObj.row(newTypistGSB.username)).toHaveCount(0);
   });
 });

--- a/frontend/e2e-tests/tests/zip-download-GSB.e2e.ts
+++ b/frontend/e2e-tests/tests/zip-download-GSB.e2e.ts
@@ -6,12 +6,16 @@ import { FinishDataEntry } from "e2e-tests/page-objects/election/FinishDataEntry
 import { test } from "../fixtures";
 
 test.use({
-  storageState: "e2e-tests/state/coordinator1.json",
+  storageState: "e2e-tests/state/coordinator1-GSB.json",
 });
 
-test.describe("election results zip", () => {
-  test("it downloads a zip", async ({ page, completedElection, currentCommitteeSession }) => {
-    await page.goto(`/elections/${completedElection.id}/status`);
+test.describe("GSB election results zip", () => {
+  test("it downloads the GSB election results zip", async ({
+    page,
+    completedElectionGSB,
+    currentCommitteeSessionElectionGSB,
+  }) => {
+    await page.goto(`/elections/${completedElectionGSB.id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
     await electionStatusPage.finish.click();
@@ -21,7 +25,7 @@ test.describe("election results zip", () => {
 
     const electionReportPage = new ElectionReport(page);
     const responsePromise = page.waitForResponse(
-      `/api/elections/${completedElection.id}/committee_sessions/${currentCommitteeSession.id}/download_zip_results`,
+      `/api/elections/${completedElectionGSB.id}/committee_sessions/${currentCommitteeSessionElectionGSB.id}/download_zip_results`,
     );
     const downloadPromise = page.waitForEvent("download");
     await electionReportPage.downloadFirstSessionZip.click();

--- a/frontend/src/components/ui/CandidateList/CandidateList.tsx
+++ b/frontend/src/components/ui/CandidateList/CandidateList.tsx
@@ -34,6 +34,7 @@ function CandidateListRow({ candidate, pgNumber, isDeceased, onClick }: Candidat
   if (onClick && !isDeceased) {
     return (
       <Table.ClickRow
+        id={`candidate-${candidate.number}`}
         onClick={() => {
           onClick(candidate.number, pgNumber);
         }}
@@ -43,7 +44,7 @@ function CandidateListRow({ candidate, pgNumber, isDeceased, onClick }: Candidat
     );
   } else {
     return (
-      <Table.Row>
+      <Table.Row id={`candidate-${candidate.number}`}>
         <CandidateListRowContent candidate={candidate} isDeceased={isDeceased} />
       </Table.Row>
     );
@@ -58,7 +59,7 @@ interface CandidateListTableProps {
 
 function CandidateListTable({ politicalGroup, deceasedCandidates, onClick }: CandidateListTableProps): ReactNode {
   return (
-    <Table>
+    <Table id="candidates">
       <Table.Header>
         <Table.HeaderCell className="text-align-r">{t("number")}</Table.HeaderCell>
         <Table.HeaderCell>{t("candidate.title.singular")}</Table.HeaderCell>

--- a/frontend/src/components/ui/Table/Table.tsx
+++ b/frontend/src/components/ui/Table/Table.tsx
@@ -83,12 +83,14 @@ function Row({ id, children, to, className }: { id?: string; children: ReactNode
 }
 
 function ClickRow({
+  id,
   children,
   onClick,
   downloadIcon,
   active,
   className,
 }: {
+  id?: string;
   children: ReactNode;
   onClick: () => void;
   downloadIcon?: boolean;
@@ -97,6 +99,7 @@ function ClickRow({
 }) {
   return (
     <tr
+      id={id}
       className={cn(cls.rowLink, downloadIcon && cls.downloadIcon, active && cls.active, className)}
       onClick={onClick}
     >

--- a/frontend/src/features/apportionment/components/ApportionmentTable.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentTable.tsx
@@ -38,7 +38,7 @@ export function ApportionmentTable({
       </Table.Header>
       <Table.Body>
         {finalStanding.map((standing: ListSeatAssignment) => (
-          <Table.Row key={standing.list_number} to={`./${standing.list_number}`}>
+          <Table.Row key={standing.list_number} id={`list-${standing.list_number}`} to={`./${standing.list_number}`}>
             <Table.Cell className={cn(cls.listNumberColumn, "text-align-r", "font-number")}>
               {standing.list_number}
             </Table.Cell>

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.tsx
@@ -50,7 +50,7 @@ function renderDeceasedCandidatesTable(
   withDeleteLink: boolean,
 ) {
   return (
-    <Table className={cls.deceasedCandidatesTable}>
+    <Table id="deceased-candidates" className={cls.deceasedCandidatesTable}>
       <Table.Header>
         <Table.HeaderCell>{t("candidate.deceased.singular")}</Table.HeaderCell>
         <Table.HeaderCell>{t("list")}</Table.HeaderCell>

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.tsx
@@ -60,7 +60,10 @@ function renderDeceasedCandidatesTable(
       <Table.Body>
         {deceasedCandidates.map((deceasedCandidate) => {
           return (
-            <Table.Row key={`${deceasedCandidate.list_number}-${deceasedCandidate.candidate.number}`}>
+            <Table.Row
+              key={`${deceasedCandidate.list_number}-${deceasedCandidate.candidate.number}`}
+              id={`list-${deceasedCandidate.list_number}-candidate-${deceasedCandidate.candidate.number}`}
+            >
               <Table.Cell className={"bold"}>
                 {getCandidateFullName(deceasedCandidate.candidate)}
                 {<span className="superscript">&nbsp;&nbsp;&dagger;</span>}


### PR DESCRIPTION
Closes #3272 

- Renamed existing fixtures and some files and folders to indicate they are related to GSB elections
- Added CSB fixtures
- Added add deceased candidates e2e test

N.B. We can add specific CSB data entry fixtures in the future as needed

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->