### PR TITLE
Add deceased_candidates to anonymity and population_monotonicity fuzzers

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
@@ -1,5 +1,7 @@
 #![no_main]
 
+use std::collections::HashMap;
+
 use apportionment::{CandidateVotes, process};
 use apportionment_fuzz::{FuzzedApportionmentInput, SimpleListVotes, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
@@ -34,6 +36,7 @@ fuzz_target!(
                 )
             })
             .collect(),
+        deceased_candidates: HashMap::new()
     };
 
     let (new_alloc, log2) = run_with_log(|| process(&reordered_input));

--- a/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
@@ -1,5 +1,7 @@
 #![no_main]
 
+use std::collections::HashMap;
+
 use apportionment::{CandidateVotes, process};
 use apportionment_fuzz::{
     FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log,
@@ -30,6 +32,7 @@ fuzz_target!(
                 )
             })
             .collect(),
+        deceased_candidates: HashMap::new()
     };
 
     if let Some(first_list) = new_data.list_votes.first_mut()


### PR DESCRIPTION
Two of the apportionment fuzzers were missing deceased_candidates. This PR fixes that.

@praseodym will submit a separate PR to run `cargo check` on the apportionment fuzzers.