### PR TITLE
Rewrite fixtures and data entry e2e tests to use data entry instead of polling station

### DIFF
--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -18,17 +18,24 @@ import type {
   CommitteeSession,
   ELECTION_DETAILS_REQUEST_PATH,
   ELECTION_IMPORT_REQUEST_PATH,
+  ELECTION_STATUS_REQUEST_PATH,
   Election,
   ElectionDetailsResponse,
+  ElectionStatusResponse,
   POLLING_STATION_CREATE_REQUEST_PATH,
-  POLLING_STATION_GET_REQUEST_PATH,
-  PollingStation,
   USER_CREATE_REQUEST_BODY,
   USER_CREATE_REQUEST_PATH,
   User,
 } from "@/types/generated/openapi";
 
 export const FIXTURE_TYPIST_TEMP_PASSWORD: string = "temp_password_9876";
+
+export interface DataEntry {
+  election_id: number;
+  id: number;
+  name: string;
+  number: string;
+}
 
 // Regular fixtures need to be passed into the test's arguments.
 type Fixtures = {
@@ -45,21 +52,21 @@ type Fixtures = {
   emptyElection: Election;
   // Election with two polling stations
   election: ElectionDetailsResponse;
-  // First polling station of the election
-  pollingStation: PollingStation;
-  // First polling station of the election with entry claimed by typist one
-  pollingStationFirstEntryClaimed: PollingStation;
-  // First polling station of the election with first data entry done
-  pollingStationFirstEntryDone: PollingStation;
-  // First polling station of the election with first data entry with errors
-  pollingStationFirstEntryHasErrors: PollingStation;
-  // First polling station of the election with first and second data entries done
-  pollingStationDefinitive: PollingStation;
-  // First polling station of the election with differences between the first and second data entry
-  pollingStationEntriesDifferent: PollingStation;
-  // First polling station of the election with second data entry that has errors and is therefore different
-  pollingStationEntriesDifferentWithErrors: PollingStation;
-  // Election with polling stations and two completed data entries for each
+  // First data entry of the election
+  dataEntryGSB: DataEntry;
+  // First data entry of the election with entry claimed by typist one
+  dataEntryGSBFirstEntryClaimed: DataEntry;
+  // First data entry of the election with first data entry done
+  dataEntryGSBFirstEntryDone: DataEntry;
+  // First data entry of the election with first data entry with errors
+  dataEntryGSBFirstEntryHasErrors: DataEntry;
+  // First data entry of the election with first and second data entries done
+  dataEntryGSBDefinitive: DataEntry;
+  // First data entry of the election with differences between the first and second data entry
+  dataEntryGSBEntriesDifferent: DataEntry;
+  // First data entry of the election with second data entry that has errors and is therefore different
+  dataEntryGSBEntriesDifferentWithErrors: DataEntry;
+  // Election with two completed data entries for each polling station
   completedElection: Election;
   // The current committee session for the election
   currentCommitteeSession: CommitteeSession;
@@ -91,12 +98,6 @@ export const test = base.extend<Fixtures>({
     const page = await context.newPage();
     await use({ page: page, request: context.request });
     await context.close();
-  },
-  pollingStationFirstEntryClaimed: async ({ typistOne, pollingStation }, use) => {
-    const { request } = typistOne;
-    const firstDataEntry = new DataEntryApiClient(request, pollingStation.data_entry_id!, 1);
-    await firstDataEntry.claim();
-    await use(pollingStation);
   },
   eml230b: [eml230b, { option: true }],
   emptyElection: async ({ adminOne, eml230b }, use) => {
@@ -152,60 +153,72 @@ export const test = base.extend<Fixtures>({
 
     await use(response);
   },
-  pollingStation: async ({ adminOne, election }, use) => {
+  dataEntryGSB: async ({ adminOne, election }, use) => {
     const { request } = adminOne;
     // get the first polling station of the existing election
-    const url: POLLING_STATION_GET_REQUEST_PATH = `/api/elections/${election.election.id}/polling_stations/${election.polling_stations[0]?.id ?? 0}`;
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${election.election.id}/status`;
     const response = await request.get(url);
     expect(response.ok()).toBeTruthy();
-    const pollingStation = (await response.json()) as PollingStation;
+    const electionStatuses = (await response.json()) as ElectionStatusResponse;
+    const electionStatus = electionStatuses.statuses[0]!;
 
-    await use(pollingStation);
+    await use({
+      election_id: election.election.id,
+      id: electionStatus.data_entry_id,
+      name: electionStatus.source.name,
+      number: electionStatus.source.number.toString(),
+    });
   },
-  pollingStationFirstEntryDone: async ({ pollingStation, typistOne }, use) => {
+  dataEntryGSBFirstEntryClaimed: async ({ typistOne, dataEntryGSB }, use) => {
     const { request } = typistOne;
-    const firstDataEntry = new DataEntryApiClient(request, pollingStation.data_entry_id!, 1);
+    const firstDataEntry = new DataEntryApiClient(request, dataEntryGSB.id, 1);
+    await firstDataEntry.claim();
+    await use(dataEntryGSB);
+  },
+  dataEntryGSBFirstEntryDone: async ({ dataEntryGSB, typistOne }, use) => {
+    const { request } = typistOne;
+    const firstDataEntry = new DataEntryApiClient(request, dataEntryGSB.id, 1);
     await firstDataEntry.claim();
     await firstDataEntry.save(dataEntryRequest);
     await firstDataEntry.finalise();
 
-    await use(pollingStation);
+    await use(dataEntryGSB);
   },
-  pollingStationFirstEntryHasErrors: async ({ pollingStation, typistOne }, use) => {
+  dataEntryGSBFirstEntryHasErrors: async ({ dataEntryGSB, typistOne }, use) => {
     const { request } = typistOne;
-    const firstDataEntry = new DataEntryApiClient(request, pollingStation.data_entry_id!, 1);
+    const firstDataEntry = new DataEntryApiClient(request, dataEntryGSB.id, 1);
     await firstDataEntry.claim();
     await firstDataEntry.save(dataEntryWithErrorRequest);
     await firstDataEntry.finalise();
 
-    await use(pollingStation);
+    await use(dataEntryGSB);
   },
-  pollingStationDefinitive: async ({ pollingStation, typistOne, typistTwo }, use) => {
-    await completePollingStationDataEntries(pollingStation.data_entry_id!, typistOne.request, typistTwo.request);
+  dataEntryGSBDefinitive: async ({ dataEntryGSB, typistOne, typistTwo }, use) => {
+    await completePollingStationDataEntries(dataEntryGSB.id, typistOne.request, typistTwo.request);
 
-    await use(pollingStation);
+    await use(dataEntryGSB);
   },
-  pollingStationEntriesDifferent: async ({ pollingStation, typistOne, typistTwo }, use) => {
+  dataEntryGSBEntriesDifferent: async ({ dataEntryGSB, typistOne, typistTwo }, use) => {
     await completePollingStationDataEntries(
-      pollingStation.data_entry_id!,
+      dataEntryGSB.id,
       typistOne.request,
       typistTwo.request,
       dataEntryRequest,
       dataEntryWithDifferencesRequest,
     );
 
-    await use(pollingStation);
+    await use(dataEntryGSB);
   },
-  pollingStationEntriesDifferentWithErrors: async ({ pollingStation, typistOne, typistTwo }, use) => {
+  dataEntryGSBEntriesDifferentWithErrors: async ({ dataEntryGSB, typistOne, typistTwo }, use) => {
     await completePollingStationDataEntries(
-      pollingStation.data_entry_id!,
+      dataEntryGSB.id,
       typistOne.request,
       typistTwo.request,
       dataEntryRequest,
       dataEntryWithErrorRequest,
     );
 
-    await use(pollingStation);
+    await use(dataEntryGSB);
   },
   completedElection: async ({ election, typistOne, typistTwo }, use) => {
     // finalise both data entries for all polling stations

--- a/frontend/e2e-tests/page-objects/data_entry/DataEntryHomePgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/DataEntryHomePgObj.ts
@@ -42,9 +42,9 @@ export class DataEntryHomePage {
     this.allDataEntriesInProgress = this.alertDataEntryInProgress.getByRole("link");
   }
 
-  async enterNumberAndClickStart(dataEntrySource: { number: number; name: string }) {
-    await this.number.pressSequentially(dataEntrySource.number.toString(), { delay: 50 });
-    await expect(this.feedback).toContainText(dataEntrySource.name);
+  async enterNumberAndClickStart(dataEntry: { number: string; name: string }) {
+    await this.number.pressSequentially(dataEntry.number, { delay: 50 });
+    await expect(this.feedback).toContainText(dataEntry.name);
     await this.start.click();
   }
 
@@ -52,9 +52,9 @@ export class DataEntryHomePage {
     await this.page.getByTestId(`data-entry-row-${number}`).click();
   }
 
-  async clickDataEntryInProgress(dataEntrySource: { number: number; name: string }) {
+  async clickDataEntryInProgress(dataEntry: { number: string; name: string }) {
     const dataEntryLink = this.alertDataEntryInProgress.getByRole("link", {
-      name: `${dataEntrySource.number} - ${dataEntrySource.name}`,
+      name: `${dataEntry.number} - ${dataEntry.name}`,
     });
     await dataEntryLink.click();
   }

--- a/frontend/e2e-tests/tests/data-entry/data-entry-with-gaps.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry-with-gaps.e2e.ts
@@ -23,13 +23,13 @@ test.use({
 });
 
 test.describe("full data entry flow with gaps in party/candidate numbers", () => {
-  test("no recount, no differences", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+  test("no recount, no differences", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.number.fill(pollingStation.number.toString());
-    await expect(dataEntryHomePage.feedback).toContainText(pollingStation.name);
+    await dataEntryHomePage.number.fill(dataEntryGSB.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSB.name);
     await dataEntryHomePage.start.click();
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);

--- a/frontend/e2e-tests/tests/data-entry/data-entry.api-errors.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.api-errors.e2e.ts
@@ -14,11 +14,12 @@ test.use({
 test.describe("data entry - api error responses", () => {
   test("UI Warning: Trying to load a data entry that was already claimed", async ({
     typistTwo,
-    pollingStationFirstEntryClaimed,
+    dataEntryGSBFirstEntryClaimed,
   }) => {
     const { page } = typistTwo;
-    const pollingStation = pollingStationFirstEntryClaimed;
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    await page.goto(
+      `/elections/${dataEntryGSBFirstEntryClaimed.election_id}/data-entry/${dataEntryGSBFirstEntryClaimed.id}/1`,
+    );
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
@@ -31,10 +32,10 @@ test.describe("data entry - api error responses", () => {
 
   test("UI Warning: Trying to load the same finalised data entry again", async ({
     page,
-    pollingStationFirstEntryDone,
+    dataEntryGSBFirstEntryDone,
   }) => {
     await page.goto(
-      `/elections/${pollingStationFirstEntryDone.election_id}/data-entry/${pollingStationFirstEntryDone.id}/1`,
+      `/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry/${dataEntryGSBFirstEntryDone.id}/1`,
     );
 
     const dataEntryHomePage = new DataEntryHomePage(page);
@@ -46,9 +47,9 @@ test.describe("data entry - api error responses", () => {
 
   test("UI Warning: Trying to load a data entry for a polling station with status definitive", async ({
     page,
-    pollingStationDefinitive,
+    dataEntryGSBDefinitive,
   }) => {
-    await page.goto(`/elections/${pollingStationDefinitive.election_id}/data-entry/${pollingStationDefinitive.id}/1`);
+    await page.goto(`/elections/${dataEntryGSBDefinitive.election_id}/data-entry/${dataEntryGSBDefinitive.id}/1`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
@@ -59,11 +60,11 @@ test.describe("data entry - api error responses", () => {
 
   test("UI Warning: Trying to load a second data entry when the first is in progress", async ({
     page,
-    pollingStationFirstEntryClaimed,
+    dataEntryGSBFirstEntryClaimed,
   }) => {
-    const pollingStation = pollingStationFirstEntryClaimed;
-
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2`);
+    await page.goto(
+      `/elections/${dataEntryGSBFirstEntryClaimed.election_id}/data-entry/${dataEntryGSBFirstEntryClaimed.id}/2`,
+    );
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
@@ -74,20 +75,20 @@ test.describe("data entry - api error responses", () => {
 
   test("UI Warning: Second data entry user must be different from first entry", async ({
     page,
-    pollingStationFirstEntryDone,
+    dataEntryGSBFirstEntryDone,
   }) => {
-    await page.goto(`/elections/${pollingStationFirstEntryDone.election_id}/data-entry`);
+    await page.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
     const dataEntryHomePage = new DataEntryHomePage(page);
 
-    await dataEntryHomePage.number.fill(pollingStationFirstEntryDone.number.toString());
+    await dataEntryHomePage.number.fill(dataEntryGSBFirstEntryDone.number);
 
     await expect(dataEntryHomePage.feedback).toContainText(
-      `Je mag stembureau ${pollingStationFirstEntryDone.number} niet nog een keer invoeren`,
+      `Je mag stembureau ${dataEntryGSBFirstEntryDone.number} niet nog een keer invoeren`,
     );
   });
 
-  test("4xx non-fatal response results in error shown", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("4xx non-fatal response results in error shown", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await expect(extraInvestigationPage.fieldset).toBeVisible();
@@ -114,8 +115,8 @@ test.describe("data entry - api error responses", () => {
     await expect(extraInvestigationPage.fieldset).toBeVisible();
   });
 
-  test("5xx fatal response results in error shown", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("5xx fatal response results in error shown", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     await page.route(`*/**/api/data_entries/*/1`, async (route) => {
       await route.fulfill({

--- a/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.e2e.ts
@@ -31,13 +31,13 @@ test.use({
 });
 
 test.describe("full data entry flow", () => {
-  test("no recount, no differences", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+  test("no recount, no differences", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.number.fill(pollingStation.number.toString());
-    await expect(dataEntryHomePage.feedback).toContainText(pollingStation.name);
+    await dataEntryHomePage.number.fill(dataEntryGSB.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSB.name);
     await dataEntryHomePage.start.click();
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -134,12 +134,12 @@ test.describe("full data entry flow", () => {
     );
   });
 
-  test("no differences", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+  test("no differences", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+    await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -197,12 +197,12 @@ test.describe("full data entry flow", () => {
     await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
   });
 
-  test("difference of more ballots counted", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+  test("difference of more ballots counted", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+    await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -273,12 +273,12 @@ test.describe("full data entry flow", () => {
     await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
   });
 
-  test("difference of fewer ballots counted", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+  test("difference of fewer ballots counted", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+    await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -349,8 +349,8 @@ test.describe("full data entry flow", () => {
     await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
   });
 
-  test("submit with accepted warning on voters and votes page", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("submit with accepted warning on voters and votes page", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -441,11 +441,8 @@ test.describe("full data entry flow", () => {
     await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
   });
 
-  test("submit with accepted errors on voters and votes and candidate votes pages", async ({
-    page,
-    pollingStation,
-  }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("submit with accepted errors on voters and votes and candidate votes pages", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -527,21 +524,18 @@ test.describe("full data entry flow", () => {
 });
 
 test.describe("second data entry", () => {
-  test("equal second data entry after first data entry", async ({
-    typistTwo,
-    pollingStationFirstEntryDone: pollingStation,
-  }) => {
+  test("equal second data entry after first data entry", async ({ typistTwo, dataEntryGSBFirstEntryDone }) => {
     const { page } = typistTwo;
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
+    await page.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(page);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.number.fill(pollingStation.number.toString());
-    await expect(dataEntryHomePage.feedback).toContainText(pollingStation.name);
+    await dataEntryHomePage.number.fill(dataEntryGSBFirstEntryDone.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSBFirstEntryDone.name);
     await dataEntryHomePage.start.click();
 
     await expect(page).toHaveURL(
-      `/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2/extra_investigation`,
+      `/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry/${dataEntryGSBFirstEntryDone.id}/2/extra_investigation`,
     );
 
     await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntry);
@@ -552,7 +546,7 @@ test.describe("second data entry", () => {
     );
 
     await expect(dataEntryHomePage.fieldsetContinueNext).toBeVisible();
-    await dataEntryHomePage.number.fill(pollingStation.number.toString());
+    await dataEntryHomePage.number.fill(dataEntryGSBFirstEntryDone.number);
     await expect(dataEntryHomePage.feedback).toContainText("Stembureau 33 (Op Rolletjes) is al twee keer ingevoerd");
     await dataEntryHomePage.start.click();
     await expect(dataEntryHomePage.submitFeedback).toContainText(
@@ -563,19 +557,19 @@ test.describe("second data entry", () => {
   test("different second data entry after first data entry but correct warnings", async ({
     typistTwo,
     coordinatorOne,
-    pollingStationFirstEntryDone: pollingStation,
+    dataEntryGSBFirstEntryDone,
   }) => {
     const typistPage = typistTwo.page;
-    await typistPage.goto(`/elections/${pollingStation.election_id}/data-entry`);
+    await typistPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(typistPage);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.number.fill(pollingStation.number.toString());
-    await expect(dataEntryHomePage.feedback).toContainText(pollingStation.name);
+    await dataEntryHomePage.number.fill(dataEntryGSBFirstEntryDone.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSBFirstEntryDone.name);
     await dataEntryHomePage.start.click();
 
     await expect(typistPage).toHaveURL(
-      `/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2/extra_investigation`,
+      `/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry/${dataEntryGSBFirstEntryDone.id}/2/extra_investigation`,
     );
 
     // fill first section equal to first data entry
@@ -631,28 +625,28 @@ test.describe("second data entry", () => {
 
     // check if data entries are marked as definitive on coordinator status page
     const coordinatorPage = coordinatorOne.page;
-    await coordinatorPage.goto(`/elections/${pollingStation.election_id}/status`);
+    await coordinatorPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(coordinatorPage);
-    await expect(electionStatusPage.definitive).toContainText(pollingStation.name);
+    await expect(electionStatusPage.definitive).toContainText(dataEntryGSBFirstEntryDone.name);
   });
 
   test("different second data entry after first data entry", async ({
     typistTwo,
     coordinatorOne,
-    pollingStationFirstEntryDone: pollingStation,
+    dataEntryGSBFirstEntryDone,
   }) => {
     const typistPage = typistTwo.page;
-    await typistPage.goto(`/elections/${pollingStation.election_id}/data-entry`);
+    await typistPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry`);
 
     const dataEntryHomePage = new DataEntryHomePage(typistPage);
     await expect(dataEntryHomePage.fieldset).toBeVisible();
-    await dataEntryHomePage.number.fill(pollingStation.number.toString());
-    await expect(dataEntryHomePage.feedback).toContainText(pollingStation.name);
+    await dataEntryHomePage.number.fill(dataEntryGSBFirstEntryDone.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSBFirstEntryDone.name);
     await dataEntryHomePage.start.click();
 
     await expect(typistPage).toHaveURL(
-      `/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/2/extra_investigation`,
+      `/elections/${dataEntryGSBFirstEntryDone.election_id}/data-entry/${dataEntryGSBFirstEntryDone.id}/2/extra_investigation`,
     );
 
     // fill first section equal to first data entry
@@ -713,16 +707,16 @@ test.describe("second data entry", () => {
 
     // check if data entries are marked as different on coordinator status page
     const coordinatorPage = coordinatorOne.page;
-    await coordinatorPage.goto(`/elections/${pollingStation.election_id}/status`);
+    await coordinatorPage.goto(`/elections/${dataEntryGSBFirstEntryDone.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(coordinatorPage);
-    await expect(electionStatusPage.errorsAndWarnings).toContainText(pollingStation.name);
+    await expect(electionStatusPage.errorsAndWarnings).toContainText(dataEntryGSBFirstEntryDone.name);
   });
 });
 
 test.describe("errors and warnings", () => {
-  test("correct error on voters and votes page", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("correct error on voters and votes page", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // fill first section without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -771,8 +765,8 @@ test.describe("errors and warnings", () => {
     await expect(differencesPage.progressList.votersAndVotesIcon).toHaveAccessibleName("opgeslagen");
   });
 
-  test("correct warning on voters and votes page", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("correct warning on voters and votes page", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // fill extra investigation section without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -827,9 +821,9 @@ test.describe("errors and warnings", () => {
 
   test("remove option to accept warning on voters and votes page after input change", async ({
     page,
-    pollingStation,
+    dataEntryGSB,
   }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // fill extra investigation section without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -874,9 +868,9 @@ test.describe("errors and warnings", () => {
 
   test("scroll to top when warning/errors, unless accept checkbox or trailing error is visible", async ({
     page,
-    pollingStation,
+    dataEntryGSB,
   }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // Fill sections without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -953,8 +947,8 @@ test.describe("errors and warnings", () => {
     expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   });
 
-  test("user can accept errors", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("user can accept errors", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // fill extra investigation section without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -993,8 +987,8 @@ test.describe("errors and warnings", () => {
 });
 
 test.describe("navigation", () => {
-  test("navigate away from Differences page without saving", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("navigate away from Differences page without saving", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // fill extra investigation section without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -1039,8 +1033,8 @@ test.describe("navigation", () => {
     await expect(votersAndVotesPage.pollCardCount).toHaveValue("95");
   });
 
-  test("navigate away from Differences page with saving", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("navigate away from Differences page with saving", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
     // fill extra investigation section without errors or warnings
     const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -1086,11 +1080,8 @@ test.describe("navigation", () => {
   });
 
   test.describe("progress list icons", () => {
-    test("check icons for accept, active, empty, error, warning, unsaved statuses", async ({
-      page,
-      pollingStation,
-    }) => {
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    test("check icons for accept, active, empty, error, warning, unsaved statuses", async ({ page, dataEntryGSB }) => {
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await expect(extraInvestigationPage.progressList.extraInvestigationIcon).toHaveAccessibleName("je bent hier");

--- a/frontend/e2e-tests/tests/data-entry/data-entry.error.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.error.model.e2e.ts
@@ -210,7 +210,7 @@ test.describe("Data entry model test - errors", () => {
   createTestModel(machine)
     .getSimplePaths()
     .forEach((path) => {
-      test(path.description, async ({ page, pollingStation, election }) => {
+      test(path.description, async ({ page, dataEntryGSB, election }) => {
         const dataEntryHomePage = new DataEntryHomePage(page);
         const extraInvestigationPage = new ExtraInvestigationPage(page);
         const countingDifferencesPage = new CountingDifferencesPollingStationPage(page);
@@ -219,8 +219,8 @@ test.describe("Data entry model test - errors", () => {
         const abortModal = new AbortInputModal(page);
         const navBar = new TypistNavBar(page);
 
-        await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-        await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+        await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
+        await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
         await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
         await countingDifferencesPage.fillAndClickNext(noDifferences);
 
@@ -228,13 +228,13 @@ test.describe("Data entry model test - errors", () => {
           dataEntryHomePageErrorSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageChangedToErrorSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageDiscarded: async () => {
@@ -244,7 +244,7 @@ test.describe("Data entry model test - errors", () => {
         };
         const dataEntryHomePageEvents = {
           RESUME_DATA_ENTRY: async () => {
-            await dataEntryHomePage.clickDataEntryInProgress(pollingStation);
+            await dataEntryHomePage.clickDataEntryInProgress(dataEntryGSB);
           },
         };
 

--- a/frontend/e2e-tests/tests/data-entry/data-entry.valid.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.valid.model.e2e.ts
@@ -191,7 +191,7 @@ test.describe("Data entry model test - valid data", () => {
   createTestModel(machine)
     .getSimplePaths()
     .forEach((path) => {
-      test(path.description, async ({ page, pollingStation, election }) => {
+      test(path.description, async ({ page, dataEntryGSB, election }) => {
         const dataEntryHomePage = new DataEntryHomePage(page);
         const extraInvestigationPage = new ExtraInvestigationPage(page);
         const countingDifferencesPollingStationPage = new CountingDifferencesPollingStationPage(page);
@@ -200,8 +200,8 @@ test.describe("Data entry model test - valid data", () => {
         const abortModal = new AbortInputModal(page);
         const navBar = new TypistNavBar(page);
 
-        await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-        await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+        await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
+        await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
         await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
         await countingDifferencesPollingStationPage.fillAndClickNext(noDifferences);
 
@@ -213,26 +213,26 @@ test.describe("Data entry model test - valid data", () => {
           dataEntryHomePageEmptySaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageFilledSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageChangedSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
         };
 
         const dataEntryHomePageEvents = {
           RESUME_DATA_ENTRY: async () => {
-            await dataEntryHomePage.clickDataEntryInProgress(pollingStation);
+            await dataEntryHomePage.clickDataEntryInProgress(dataEntryGSB);
           },
         };
 

--- a/frontend/e2e-tests/tests/data-entry/data-entry.warning.model.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/data-entry.warning.model.e2e.ts
@@ -207,7 +207,7 @@ test.describe("Data entry model test - warnings", () => {
   createTestModel(machine)
     .getSimplePaths()
     .forEach((path) => {
-      test(path.description, async ({ page, pollingStation, election }) => {
+      test(path.description, async ({ page, dataEntryGSB, election }) => {
         const dataEntryHomePage = new DataEntryHomePage(page);
         const extraInvestigationPage = new ExtraInvestigationPage(page);
         const countingDifferencesPollingStationPage = new CountingDifferencesPollingStationPage(page);
@@ -216,8 +216,8 @@ test.describe("Data entry model test - warnings", () => {
         const abortModal = new AbortInputModal(page);
         const navBar = new TypistNavBar(page);
 
-        await page.goto(`/elections/${pollingStation.election_id}/data-entry`);
-        await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+        await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry`);
+        await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
         await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
         await countingDifferencesPollingStationPage.fillAndClickNext(noDifferences);
 
@@ -225,13 +225,13 @@ test.describe("Data entry model test - warnings", () => {
           dataEntryHomePageWarningSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageChangedToWarningSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageDiscarded: async () => {
@@ -242,7 +242,7 @@ test.describe("Data entry model test - warnings", () => {
 
         const dataEntryHomePageEvents = {
           RESUME_DATA_ENTRY: async () => {
-            await dataEntryHomePage.clickDataEntryInProgress(pollingStation);
+            await dataEntryHomePage.clickDataEntryInProgress(dataEntryGSB);
           },
         };
 
@@ -455,7 +455,7 @@ test.describe("Data entry model test - warnings", () => {
           dataEntryHomePageWarningSaved: async () => {
             await expect(dataEntryHomePage.fieldset).toBeVisible();
             await expect(dataEntryHomePage.allDataEntriesInProgress).toHaveText([
-              `${pollingStation.number} - ${pollingStation.name}`,
+              `${dataEntryGSB.number} - ${dataEntryGSB.name}`,
             ]);
           },
           dataEntryHomePageDiscarded: async () => {

--- a/frontend/e2e-tests/tests/data-entry/resolve-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resolve-differences.e2e.ts
@@ -9,22 +9,22 @@ test.use({
 });
 
 test.describe("resolve differences", () => {
-  test("do not proceed when no action is chosen", async ({ page, pollingStationEntriesDifferent: pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("do not proceed when no action is chosen", async ({ page, dataEntryGSBEntriesDifferent }) => {
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBEntriesDifferent.name }).click();
 
     const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
     await resolveDifferencesPage.save.click();
     await expect(resolveDifferencesPage.validationError).toBeVisible();
   });
 
-  test("keep first entry", async ({ page, pollingStationEntriesDifferent: pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("keep first entry", async ({ page, dataEntryGSBEntriesDifferent }) => {
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBEntriesDifferent.name }).click();
 
     const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
     await resolveDifferencesPage.keepFirstEntry.click();
@@ -32,18 +32,20 @@ test.describe("resolve differences", () => {
     await expect(resolveDifferencesPage.secondValue).toHaveClass(/discard/);
     await resolveDifferencesPage.save.click();
 
-    await expect(electionStatusPage.firstEntryFinished).toContainText(`${pollingStation.name}Sam Kuijpers`);
+    await expect(electionStatusPage.firstEntryFinished).toContainText(
+      `${dataEntryGSBEntriesDifferent.name}Sam Kuijpers`,
+    );
     await expect(electionStatusPage.alertDifferencesResolved).toBeVisible();
     await expect(electionStatusPage.alertDifferencesResolved).toContainText(
       "Omdat er nog maar één invoer over is, moet er een nieuwe tweede invoer gedaan worden. Kies hiervoor een andere invoerder dan Sam Kuijpers.",
     );
   });
 
-  test("keep second entry", async ({ page, pollingStationEntriesDifferent: pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("keep second entry", async ({ page, dataEntryGSBEntriesDifferent }) => {
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBEntriesDifferent.name }).click();
 
     const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
     await resolveDifferencesPage.keepSecondEntry.click();
@@ -51,18 +53,20 @@ test.describe("resolve differences", () => {
     await expect(resolveDifferencesPage.secondValue).toHaveClass(/keep/);
     await resolveDifferencesPage.save.click();
 
-    await expect(electionStatusPage.firstEntryFinished).toContainText(`${pollingStation.name}Aliyah van den Berg`);
+    await expect(electionStatusPage.firstEntryFinished).toContainText(
+      `${dataEntryGSBEntriesDifferent.name}Aliyah van den Berg`,
+    );
     await expect(electionStatusPage.alertDifferencesResolved).toBeVisible();
     await expect(electionStatusPage.alertDifferencesResolved).toContainText(
       "Omdat er nog maar één invoer over is, moet er een nieuwe tweede invoer gedaan worden. Kies hiervoor een andere invoerder dan Aliyah van den Berg.",
     );
   });
 
-  test("discard both", async ({ page, pollingStationEntriesDifferent: pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("discard both", async ({ page, dataEntryGSBEntriesDifferent }) => {
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBEntriesDifferent.name }).click();
 
     const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
     await resolveDifferencesPage.discardBothEntries.click();
@@ -70,7 +74,7 @@ test.describe("resolve differences", () => {
     await expect(resolveDifferencesPage.secondValue).toHaveClass(/discard/);
     await resolveDifferencesPage.save.click();
 
-    await expect(electionStatusPage.notStarted).toContainText(pollingStation.name);
+    await expect(electionStatusPage.notStarted).toContainText(dataEntryGSBEntriesDifferent.name);
     await expect(electionStatusPage.alertDifferencesResolved).toBeVisible();
     await expect(electionStatusPage.alertDifferencesResolved).toContainText(
       "Omdat beide invoeren zijn verwijderd, moet stembureau 33 twee keer opnieuw ingevoerd worden.",
@@ -81,12 +85,14 @@ test.describe("resolve differences", () => {
 test.describe("resolve differences then errors", () => {
   test("keep second entry with errors then resolve errors", async ({
     page,
-    pollingStationEntriesDifferentWithErrors: pollingStation,
+    dataEntryGSBEntriesDifferentWithErrors,
   }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferentWithErrors.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings
+      .getByRole("row", { name: dataEntryGSBEntriesDifferentWithErrors.name })
+      .click();
 
     const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
     await expect(resolveDifferencesPage.title).toBeVisible();
@@ -99,7 +105,7 @@ test.describe("resolve differences then errors", () => {
     await resolveErrorsPage.resumeFirstEntry.click();
     await resolveErrorsPage.save.click();
 
-    await expect(electionStatusPage.inProgress).toContainText(pollingStation.name);
+    await expect(electionStatusPage.inProgress).toContainText(dataEntryGSBEntriesDifferentWithErrors.name);
     await expect(electionStatusPage.alertFirstDataEntryResumed).toBeVisible();
   });
 });

--- a/frontend/e2e-tests/tests/data-entry/resolve-errors.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resolve-errors.e2e.ts
@@ -8,45 +8,42 @@ test.use({
 });
 
 test.describe("resolve errors", () => {
-  test("do not proceed when no action is chosen", async ({
-    page,
-    pollingStationFirstEntryHasErrors: pollingStation,
-  }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("do not proceed when no action is chosen", async ({ page, dataEntryGSBFirstEntryHasErrors }) => {
+    await page.goto(`/elections/${dataEntryGSBFirstEntryHasErrors.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBFirstEntryHasErrors.name }).click();
 
     const resolveErrorsPage = new ResolveErrorsPgObj(page);
     await resolveErrorsPage.save.click();
     await expect(resolveErrorsPage.validationError).toBeVisible();
   });
 
-  test("resume first entry", async ({ page, pollingStationFirstEntryHasErrors: pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("resume first entry", async ({ page, dataEntryGSBFirstEntryHasErrors }) => {
+    await page.goto(`/elections/${dataEntryGSBFirstEntryHasErrors.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBFirstEntryHasErrors.name }).click();
 
     const resolveErrorsPage = new ResolveErrorsPgObj(page);
     await resolveErrorsPage.resumeFirstEntry.click();
     await resolveErrorsPage.save.click();
 
-    await expect(electionStatusPage.inProgress).toContainText(pollingStation.name);
+    await expect(electionStatusPage.inProgress).toContainText(dataEntryGSBFirstEntryHasErrors.name);
     await expect(electionStatusPage.alertFirstDataEntryResumed).toBeVisible();
   });
 
-  test("discard first entry", async ({ page, pollingStationFirstEntryHasErrors: pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/status`);
+  test("discard first entry", async ({ page, dataEntryGSBFirstEntryHasErrors }) => {
+    await page.goto(`/elections/${dataEntryGSBFirstEntryHasErrors.election_id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
-    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: pollingStation.name }).click();
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBFirstEntryHasErrors.name }).click();
 
     const resolveErrorsPage = new ResolveErrorsPgObj(page);
     await resolveErrorsPage.discardFirstEntry.click();
     await resolveErrorsPage.save.click();
 
-    await expect(electionStatusPage.notStarted).toContainText(pollingStation.name);
+    await expect(electionStatusPage.notStarted).toContainText(dataEntryGSBFirstEntryHasErrors.name);
     await expect(electionStatusPage.alertFirstDataEntryDiscarded).toBeVisible();
   });
 });

--- a/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry/resume-data-entry.e2e.ts
@@ -14,16 +14,16 @@ import {
 } from "e2e-tests/page-objects/data_entry/ExtraInvestigationPgObj";
 import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
 import { emptyCSOFirstSessionResults } from "e2e-tests/test-data/request-response-templates";
-import type { ClaimDataEntryResponse, PollingStation, VotersCounts, VotesCounts } from "@/types/generated/openapi";
-import { test } from "../../fixtures";
+import type { ClaimDataEntryResponse, VotersCounts, VotesCounts } from "@/types/generated/openapi";
+import { type DataEntry, test } from "../../fixtures";
 
 test.use({
   storageState: "e2e-tests/state/typist1.json",
 });
 
 test.describe("resume data entry flow", () => {
-  const fillFirstTwoPagesAndAbort = async (page: Page, pollingStation: PollingStation) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  const fillFirstTwoPagesAndAbort = async (page: Page, dataEntry: DataEntry) => {
+    await page.goto(`/elections/${dataEntry.election_id}/data-entry/${dataEntry.id}/1`);
 
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -55,8 +55,8 @@ test.describe("resume data entry flow", () => {
     return new AbortInputModal(page);
   };
 
-  test("Closing abort modal with X only closes the modal", async ({ page, pollingStation }) => {
-    await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+  test("Closing abort modal with X only closes the modal", async ({ page, dataEntryGSB }) => {
+    await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
     const extraInvestigationPage = new ExtraInvestigationPage(page);
     await extraInvestigationPage.abortInput.click();
 
@@ -77,15 +77,15 @@ test.describe("resume data entry flow", () => {
   });
 
   test.describe("resume after saving", () => {
-    test("resuming data entry shows previous data", async ({ page, pollingStation }) => {
-      const abortInputModal = await fillFirstTwoPagesAndAbort(page, pollingStation);
+    test("resuming data entry shows previous data", async ({ page, dataEntryGSB }) => {
+      const abortInputModal = await fillFirstTwoPagesAndAbort(page, dataEntryGSB);
       await expect(abortInputModal.heading).toBeFocused();
       await abortInputModal.saveInput.click();
 
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const differencesPage = new DifferencesPage(page);
       await expect(differencesPage.fieldset).toBeVisible();
@@ -107,14 +107,14 @@ test.describe("resume data entry flow", () => {
 
     // Reproduce issue where navigating between sections is blocked by modal, even though there are no changes.
     // https://github.com/kiesraad/abacus/pull/417#pullrequestreview-2347886699
-    test("navigation works after resuming data entry", async ({ page, pollingStation }) => {
-      const abortInputModal = await fillFirstTwoPagesAndAbort(page, pollingStation);
+    test("navigation works after resuming data entry", async ({ page, dataEntryGSB }) => {
+      const abortInputModal = await fillFirstTwoPagesAndAbort(page, dataEntryGSB);
       await abortInputModal.saveInput.click();
 
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const differencesPage = new DifferencesPage(page);
       await differencesPage.admittedVotersEqualsVotesCastCheckbox.check();
@@ -133,8 +133,8 @@ test.describe("resume data entry flow", () => {
       await expect(candidatesListPage_1.fieldset).toBeVisible();
     });
 
-    test("save input from voters and votes page with error", async ({ page, request, pollingStation }) => {
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    test("save input from voters and votes page with error", async ({ page, request, dataEntryGSB }) => {
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -160,7 +160,7 @@ test.describe("resume data entry flow", () => {
       await expect(dataEntryHomePage.fieldset).toBeVisible();
       await expect(dataEntryHomePage.alertDataEntryInProgress).toBeVisible();
 
-      const dataEntryResponse = await request.post(`/api/data_entries/${pollingStation.data_entry_id!}/1/claim`);
+      const dataEntryResponse = await request.post(`/api/data_entries/${dataEntryGSB.id}/1/claim`);
       expect(dataEntryResponse.status()).toBe(200);
       expect(await dataEntryResponse.json()).toMatchObject({
         data: {
@@ -197,12 +197,12 @@ test.describe("resume data entry flow", () => {
         },
       });
 
-      await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+      await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
       await expect(votersAndVotesPage.fieldset).toBeVisible();
     });
 
-    test("save input from voters and votes page with warning", async ({ page, request, pollingStation }) => {
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    test("save input from voters and votes page with warning", async ({ page, request, dataEntryGSB }) => {
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -242,7 +242,7 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      const dataEntryResponse = await request.post(`/api/data_entries/${pollingStation.data_entry_id!}/1/claim`);
+      const dataEntryResponse = await request.post(`/api/data_entries/${dataEntryGSB.id}/1/claim`);
       expect(dataEntryResponse.status()).toBe(200);
       expect(await dataEntryResponse.json()).toMatchObject({
         data: {
@@ -287,12 +287,12 @@ test.describe("resume data entry flow", () => {
         },
       } satisfies Partial<ClaimDataEntryResponse>);
 
-      await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+      await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
       await expect(votersAndVotesPage.fieldset).toBeVisible();
     });
 
-    test("resuming with unsubmitted input (cached data) shows that data", async ({ page, pollingStation }) => {
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    test("resuming with unsubmitted input (cached data) shows that data", async ({ page, dataEntryGSB }) => {
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -314,7 +314,7 @@ test.describe("resume data entry flow", () => {
       await abortInputModal.saveInput.click();
 
       const dataEntryHomePage = new DataEntryHomePage(page);
-      await dataEntryHomePage.enterNumberAndClickStart(pollingStation);
+      await dataEntryHomePage.enterNumberAndClickStart(dataEntryGSB);
 
       await expect(votersAndVotesPage.fieldset).toBeVisible();
       await expect(votersAndVotesPage.pollCardCount).toHaveValue("42");
@@ -322,8 +322,8 @@ test.describe("resume data entry flow", () => {
       await expect(votersAndVotesPage.totalAdmittedVotersCount).toHaveValue("42");
     });
 
-    test("save unsubmitted input when changing voters data works", async ({ page, pollingStation }) => {
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+    test("save unsubmitted input when changing voters data works", async ({ page, dataEntryGSB }) => {
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -352,10 +352,10 @@ test.describe("resume data entry flow", () => {
       await expect(dataEntryHomePage.fieldset).toBeVisible();
     });
 
-    test("save input from check and save page", async ({ typistOne, pollingStation }) => {
+    test("save input from check and save page", async ({ typistOne, dataEntryGSB }) => {
       const { page } = typistOne;
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -423,15 +423,15 @@ test.describe("resume data entry flow", () => {
   });
 
   test.describe("resume after deleting", () => {
-    test("deleting data entry doesn't show previous data", async ({ page, pollingStation }) => {
-      const abortInputModal = await fillFirstTwoPagesAndAbort(page, pollingStation);
+    test("deleting data entry doesn't show previous data", async ({ page, dataEntryGSB }) => {
+      const abortInputModal = await fillFirstTwoPagesAndAbort(page, dataEntryGSB);
       await expect(abortInputModal.heading).toBeFocused();
       await abortInputModal.discardInput.click();
 
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       // extra investigation section should be empty
       const extraInvestigationPage = new ExtraInvestigationPage(page);
@@ -457,10 +457,10 @@ test.describe("resume data entry flow", () => {
       await expect(votersAndVotesPage.proxyCertificateCount).toBeEmpty();
     });
 
-    test("discard input from voters and votes page with error", async ({ typistOne, pollingStation }) => {
+    test("discard input from voters and votes page with error", async ({ typistOne, dataEntryGSB }) => {
       const { page, request } = typistOne;
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -484,15 +484,15 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      const claimResponse = await request.post(`/api/data_entries/${pollingStation.data_entry_id!}/1/claim`);
+      const claimResponse = await request.post(`/api/data_entries/${dataEntryGSB.id}/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject({ data: emptyCSOFirstSessionResults() });
     });
 
-    test("discard input from voters and votes page with warning", async ({ typistOne, pollingStation }) => {
+    test("discard input from voters and votes page with warning", async ({ typistOne, dataEntryGSB }) => {
       const { page, request } = typistOne;
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -532,15 +532,15 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      const claimResponse = await request.post(`/api/data_entries/${pollingStation.data_entry_id!}/1/claim`);
+      const claimResponse = await request.post(`/api/data_entries/${dataEntryGSB.id}/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject({ data: emptyCSOFirstSessionResults() });
     });
 
-    test("discard input from check and save page", async ({ typistOne, pollingStation }) => {
+    test("discard input from check and save page", async ({ typistOne, dataEntryGSB }) => {
       const { page, request } = typistOne;
 
-      await page.goto(`/elections/${pollingStation.election_id}/data-entry/${pollingStation.id}/1`);
+      await page.goto(`/elections/${dataEntryGSB.election_id}/data-entry/${dataEntryGSB.id}/1`);
 
       const extraInvestigationPage = new ExtraInvestigationPage(page);
       await extraInvestigationPage.fillAndClickNext(noExtraInvestigation);
@@ -595,7 +595,7 @@ test.describe("resume data entry flow", () => {
       const dataEntryHomePage = new DataEntryHomePage(page);
       await expect(dataEntryHomePage.fieldset).toBeVisible();
 
-      const claimResponse = await request.post(`/api/data_entries/${pollingStation.data_entry_id!}/1/claim`);
+      const claimResponse = await request.post(`/api/data_entries/${dataEntryGSB.id}/1/claim`);
       expect(claimResponse.status()).toBe(200);
       expect(await claimResponse.json()).toMatchObject({ data: emptyCSOFirstSessionResults() });
     });


### PR DESCRIPTION
Since [Use data entry instead of polling station in frontend data entry flow #3029](https://github.com/kiesraad/abacus/issues/3029) we use data entry ids instead of polling station ids in data entry. This change also updates the fixtures to do the same.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->