### PR TITLE
Add apportionment warning for P 9 + P 10 case

### DIFF
--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -17,7 +17,8 @@ pub use self::{
     candidate_nomination::{CandidateNominationResult, PreferenceThreshold},
     fraction::Fraction,
     seat_assignment::{
-        HighestAverageAssignedSeat, SeatAssignmentResult, SeatChange, SeatChangeStep,
+        ApportionmentWarning, HighestAverageAssignedSeat, SeatAssignmentResult, SeatChange,
+        SeatChangeStep,
     },
     structs::{
         ApportionmentError, ApportionmentInput, ApportionmentOutput, CandidateVotes, ListVotes,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -3,8 +3,8 @@ use std::cmp::Ordering;
 mod residual_seat_assignment;
 mod structs;
 pub use structs::{
-    AbsoluteMajorityReassignedSeat, HighestAverageAssignedSeat, ListExhaustionRemovedSeat,
-    ListStanding, SeatAssignmentResult, SeatChange, SeatChangeStep,
+    AbsoluteMajorityReassignedSeat, ApportionmentWarning, HighestAverageAssignedSeat,
+    ListExhaustionRemovedSeat, ListStanding, SeatAssignmentResult, SeatChange, SeatChangeStep,
 };
 use tracing::info;
 
@@ -345,17 +345,9 @@ pub(crate) mod tests {
         ListVotes, SeatAssignmentResult,
         fraction::Fraction,
         seat_assignment::{
-            ListStanding, SeatChange, get_total_seats_per_list_number_from_apportionment_result,
-            list_numbers,
+            ListStanding, get_total_seats_per_list_number_from_apportionment_result, list_numbers,
         },
     };
-
-    impl SeatChange<u32> {
-        /// Returns true if the seat was changed through the list exhaustion removal
-        pub fn is_changed_by_list_exhaustion_removal(&self) -> bool {
-            matches!(self, Self::ListExhaustionRemoval(_))
-        }
-    }
 
     fn check_total_seats_per_list<T: ListVotes>(
         result: &SeatAssignmentResult<T>,
@@ -581,6 +573,7 @@ pub(crate) mod tests {
             assert_eq!(result.steps[3].change.list_number_assigned(), 1);
             let total_seats = get_total_seats_from_apportionment_result(&result);
             assert_eq!(total_seats, vec![8, 3, 2, 1, 1]);
+            assert!(result.warnings().is_empty());
         }
 
         mod drawing_of_lots {
@@ -649,7 +642,7 @@ pub(crate) mod tests {
 
             use super::get_total_seats_from_apportionment_result;
             use crate::{
-                seat_assignment::seat_assignment,
+                ApportionmentWarning, seat_assignment::seat_assignment,
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
@@ -686,6 +679,7 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[1].change.list_number_assigned(), 5);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![4, 4, 3, 2, 2]);
+                assert!(result.warnings().is_empty());
             }
 
             /// Apportionment with residual seats assigned with largest remainders method  
@@ -740,6 +734,7 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[7].change.list_number_assigned(), 6);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![3, 1, 2, 2, 1, 2, 1, 0, 3, 1, 1]);
+                assert!(result.warnings().is_empty());
             }
 
             /// Apportionment with residual seats assigned with largest remainders and highest averages methods
@@ -958,6 +953,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[5].change.list_number_assigned(), 4);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![7, 3, 2, 2, 1]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::AbsoluteMajorityAndListExhaustion],
+                );
             }
 
             /// Apportionment with residual seats assigned with largest remainders and highest averages methods  
@@ -1009,6 +1008,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[5].change.list_number_assigned(), 3);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, [4, 3, 1]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::AbsoluteMajorityAndListExhaustion],
+                );
             }
 
             /// Apportionment with residual seats assigned with largest remainders and highest averages methods  
@@ -1070,6 +1073,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[7].change.list_number_assigned(), 2);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, [2, 1, 5]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::AbsoluteMajorityAndListExhaustion],
+                );
             }
 
             /// Apportionment with no residual seats  
@@ -1104,6 +1111,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[0].change.list_number_retracted(), 1);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![4, 4, 3, 2, 1]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::NotAllSeatsAssigned],
+                );
             }
 
             /// Apportionment with no residual seats  
@@ -1154,6 +1165,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[2].change.list_number_assigned(), 4);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![4, 4, 3, 2, 1]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::NotAllSeatsAssigned],
+                );
             }
 
             /// Apportionment where deceased candidates cause a list to be exhausted.
@@ -1375,6 +1390,7 @@ pub(crate) mod tests {
             assert_eq!(result.steps[6].change.list_number_assigned(), 1);
             let total_seats = get_total_seats_from_apportionment_result(&result);
             assert_eq!(total_seats, vec![13, 2, 2, 2, 2, 2, 1, 0]);
+            assert!(result.warnings().is_empty());
         }
 
         mod drawing_of_lots {
@@ -1429,7 +1445,7 @@ pub(crate) mod tests {
 
             use super::get_total_seats_from_apportionment_result;
             use crate::{
-                seat_assignment::seat_assignment,
+                ApportionmentWarning, seat_assignment::seat_assignment,
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
@@ -1465,6 +1481,7 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[1].change.list_number_assigned(), 5);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![4, 5, 4, 4, 3]);
+                assert!(result.warnings().is_empty());
             }
 
             /// Apportionment with residual seats assigned with highest averages method  
@@ -1501,6 +1518,7 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[2].change.list_number_assigned(), 1);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![5, 4, 4, 4, 2]);
+                assert!(result.warnings().is_empty());
             }
 
             /// Apportionment with residual seats assigned with highest averages method  
@@ -1558,6 +1576,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[8].change.list_number_assigned(), 7);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![12, 2, 2, 2, 2, 2, 2, 0]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::AbsoluteMajorityAndListExhaustion],
+                );
             }
 
             /// Apportionment with no residual seats  
@@ -1592,6 +1614,10 @@ pub(crate) mod tests {
                 assert_eq!(result.steps[0].change.list_number_retracted(), 1);
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![4, 5, 4, 4, 2]);
+                assert_eq!(
+                    result.warnings(),
+                    vec![ApportionmentWarning::NotAllSeatsAssigned],
+                );
             }
 
             /// Apportionment with no residual seats  

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -19,6 +19,37 @@ pub struct SeatAssignmentResult<T: ListVotes> {
     pub final_standing: Vec<ListSeatAssignment<T::ListNumber>>,
 }
 
+impl<T: ListVotes> SeatAssignmentResult<T> {
+    pub fn warnings(&self) -> Vec<ApportionmentWarning> {
+        let mut warnings = Vec::new();
+        let has_p9 = self
+            .steps
+            .iter()
+            .any(|s| s.change.is_changed_by_absolute_majority_reassignment());
+        let has_p10 = self
+            .steps
+            .iter()
+            .any(|s| s.change.is_changed_by_list_exhaustion_removal());
+        if has_p9 && has_p10 {
+            warnings.push(ApportionmentWarning::AbsoluteMajorityAndListExhaustion);
+        }
+        if self.full_seats + self.residual_seats < self.seats {
+            warnings.push(ApportionmentWarning::NotAllSeatsAssigned);
+        }
+        warnings
+    }
+}
+
+/// Warnings derived from a completed seat assignment
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApportionmentWarning {
+    /// Both an absolute-majority reassignment (P9) and a list-exhaustion
+    /// removal (P10) occurred in the same apportionment.
+    AbsoluteMajorityAndListExhaustion,
+    /// Not all seats could be assigned (e.g. all eligible lists exhausted).
+    NotAllSeatsAssigned,
+}
+
 /// Contains information about the final assignment of seats for a specific list.
 #[derive(Debug, PartialEq)]
 pub struct ListSeatAssignment<LN> {
@@ -227,6 +258,11 @@ impl<LN: Copy> SeatChange<LN> {
     /// Returns true if the seat was changed through the absolute majority reassignment
     pub fn is_changed_by_absolute_majority_reassignment(&self) -> bool {
         matches!(self, Self::AbsoluteMajorityReassignment(_))
+    }
+
+    /// Whether the seat was changed through the list exhaustion removal
+    pub fn is_changed_by_list_exhaustion_removal(&self) -> bool {
+        matches!(self, Self::ListExhaustionRemoval(_))
     }
 }
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5223,6 +5223,13 @@
           }
         ]
       },
+      "ApportionmentWarning": {
+        "type": "string",
+        "enum": [
+          "AbsoluteMajorityAndListExhaustion",
+          "NotAllSeatsAssigned"
+        ]
+      },
       "AuditEventLevel": {
         "type": "string",
         "enum": [
@@ -6317,7 +6324,8 @@
         "required": [
           "seat_assignment",
           "candidate_nomination",
-          "election_summary"
+          "election_summary",
+          "warnings"
         ],
         "properties": {
           "candidate_nomination": {
@@ -6328,6 +6336,12 @@
           },
           "seat_assignment": {
             "$ref": "#/components/schemas/SeatAssignment"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApportionmentWarning"
+            }
           }
         }
       },

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     audit_log::AuditService,
     domain::{
+        apportionment::ApportionmentWarning,
         committee_session_status::CommitteeSessionStatus,
         election::{Election, ElectionId},
         summary::ElectionSummary,
@@ -88,13 +89,20 @@ pub async fn process_apportionment(
             )
             .await?;
 
+        let seat_assignment = map_seat_assignment(&result.seat_assignment);
+        let candidate_nomination =
+            map_candidate_nomination(&result.candidate_nomination, election.political_groups);
+        let warnings = result
+            .seat_assignment
+            .warnings()
+            .into_iter()
+            .map(ApportionmentWarning::from)
+            .collect();
         Ok(Json(ElectionApportionmentResponse {
-            seat_assignment: map_seat_assignment(&result.seat_assignment),
-            candidate_nomination: map_candidate_nomination(
-                &result.candidate_nomination,
-                election.political_groups,
-            ),
+            seat_assignment,
+            candidate_nomination,
             election_summary: summary,
+            warnings,
         }))
     } else {
         Err(ApportionmentApiError::CommitteeSessionNotCompleted.into())

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::domain::{
-    apportionment::{CandidateNomination, SeatAssignment},
+    apportionment::{ApportionmentWarning, CandidateNomination, SeatAssignment},
     apportionment_state::DeceasedCandidate,
     election::{self, PGNumber},
     results::political_group_candidate_votes::{CandidateVotes, PoliticalGroupCandidateVotes},
@@ -88,4 +88,5 @@ pub struct ElectionApportionmentResponse {
     pub seat_assignment: SeatAssignment,
     pub candidate_nomination: CandidateNomination,
     pub election_summary: ElectionSummary,
+    pub warnings: Vec<ApportionmentWarning>,
 }

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -6,6 +6,23 @@ use crate::domain::{
     results::political_group_candidate_votes::CandidateVotes,
 };
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+pub enum ApportionmentWarning {
+    AbsoluteMajorityAndListExhaustion,
+    NotAllSeatsAssigned,
+}
+
+impl From<apportionment::ApportionmentWarning> for ApportionmentWarning {
+    fn from(w: apportionment::ApportionmentWarning) -> Self {
+        match w {
+            apportionment::ApportionmentWarning::AbsoluteMajorityAndListExhaustion => {
+                Self::AbsoluteMajorityAndListExhaustion
+            }
+            apportionment::ApportionmentWarning::NotAllSeatsAssigned => Self::NotAllSeatsAssigned,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SeatAssignment {
     pub seats: u32,

--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -3,6 +3,7 @@ import { userEvent } from "@testing-library/user-event";
 import * as ReactRouter from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import alertCls from "@/components/ui/Alert/Alert.module.css";
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
@@ -85,6 +86,7 @@ describe("ApportionmentPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
 
@@ -122,6 +124,7 @@ describe("ApportionmentPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     server.use(GetApportionmentStateRequestHandler);
     server.use(RegisterDeceasedCandidatesRequestHandler);
@@ -137,6 +140,8 @@ describe("ApportionmentPage", () => {
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent("Alle zetels zijn toegewezen");
     expect(alert).toHaveTextContent("Je kunt de zetelverdeling nu definitief maken en het proces-verbaal downloaden.");
+    // No warnings, so the finalised alert should be a success alert
+    expect(alert).toHaveClass(alertCls.success!);
     expect(within(alert).getByRole("link", { name: "Naar proces-verbaal" })).toHaveAttribute(
       "href",
       "/report/committee-session/3/download",
@@ -174,6 +179,7 @@ describe("ApportionmentPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [],
@@ -187,6 +193,8 @@ describe("ApportionmentPage", () => {
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent("Alle zetels zijn toegewezen");
     expect(alert).toHaveTextContent("Je kunt de zetelverdeling nu definitief maken en het proces-verbaal downloaden.");
+    // No warnings, so the finalised alert should be a success alert
+    expect(alert).toHaveClass(alertCls.success!);
     expect(within(alert).getByRole("link", { name: "Naar proces-verbaal" })).toHaveAttribute(
       "href",
       "/report/committee-session/3/download",
@@ -275,9 +283,38 @@ describe("ApportionmentPage", () => {
     const getApportionmentState = spyOnHandler(GetApportionmentStateRequestHandler);
     overrideOnce("get", "/api/elections/3", 200, getElectionMockData(election, committee_session));
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
-      seat_assignment: { ...seat_assignment, residual_seats: seat_assignment.residual_seats - 2 },
+      seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: ["NotAllSeatsAssigned"],
+    } satisfies ElectionApportionmentResponse);
+    overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
+      deceased_candidates: [],
+      type: "Finalised",
+    } satisfies ApportionmentState);
+
+    renderApportionmentPage(3, false);
+
+    const alerts = await screen.findAllByRole("alert");
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]).toHaveTextContent("Niet alle zetels zijn toegewezen");
+    alerts.forEach((alert) => {
+      expect(alert).not.toHaveTextContent("Alle zetels zijn toegewezen");
+    });
+
+    const finalisedAlert = alerts[1] as HTMLElement;
+    await user.click(within(finalisedAlert).getByRole("button", { name: "Zetelverdeling opnieuw doen" }));
+    expect(resetApportionmentState).toHaveBeenCalled();
+    expect(getApportionmentState).toHaveBeenCalled();
+  });
+
+  test("Renders P9+P10 warning when both articles were applied", async () => {
+    overrideOnce("get", "/api/elections/3", 200, getElectionMockData(election, committee_session));
+    overrideOnce("post", "/api/elections/3/apportionment", 200, {
+      seat_assignment: seat_assignment,
+      candidate_nomination: candidate_nomination,
+      election_summary: election_summary,
+      warnings: ["AbsoluteMajorityAndListExhaustion"],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [],
@@ -287,20 +324,15 @@ describe("ApportionmentPage", () => {
     renderApportionmentPage(3, false);
     expect(await screen.findByTestId("election-summary-table")).toBeVisible();
 
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent("Niet alle zetels zijn toegewezen");
-    expect(alert).not.toHaveTextContent("Alle zetels zijn toegewezen");
-    expect(alert).toHaveTextContent("Je kunt de zetelverdeling nu definitief maken en het proces-verbaal downloaden.");
-    expect(within(alert).getByRole("link", { name: "Naar proces-verbaal" })).toHaveAttribute(
-      "href",
-      "/report/committee-session/3/download",
+    const alerts = await screen.findAllByRole("alert");
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]).toHaveTextContent(
+      "Zowel art. P 9 (volstrekte meerderheid) als art. P 10 (lijstuitputting) van de Kieswet zijn toegepast tijdens het berekenen van de zetelverdeling. Neem contact op met de Kiesraad om te overleggen of er extra controles nodig zijn.",
     );
-    const resetButton = within(alert).getByRole("button", { name: "Zetelverdeling opnieuw doen" });
-    expect(resetButton).toBeVisible();
-    await user.click(resetButton);
-
-    expect(resetApportionmentState).toHaveBeenCalled();
-    expect(getApportionmentState).toHaveBeenCalled();
+    expect(alerts[1]).toHaveTextContent("Alle zetels zijn toegewezen");
+    // Finalised alert should be neutral (not success) because there is a warning
+    expect(alerts[1]).toHaveClass(alertCls.notify!);
+    expect(alerts[1]).not.toHaveClass(alertCls.success!);
   });
 
   describe("Apportionment not yet available", () => {

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -9,6 +9,7 @@ import { useElection } from "@/hooks/election/useElection";
 import { t } from "@/i18n/translate";
 import type {
   ApportionmentState,
+  ApportionmentWarning,
   RESET_APPORTIONMENT_STATE_REQUEST_PATH,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -29,17 +30,41 @@ function getNumberOfSeatsAssignedSentence(seats: number, type: "residual_seat" |
   });
 }
 
+function renderApportionmentWarning(warning: ApportionmentWarning) {
+  switch (warning) {
+    case "AbsoluteMajorityAndListExhaustion":
+      return (
+        <Alert key={warning} type="warning" variant="no-icon">
+          <p>{t("apportionment.warning.absolute_majority_and_list_exhaustion")}</p>
+        </Alert>
+      );
+    case "NotAllSeatsAssigned":
+      return (
+        <Alert key={warning} type="warning" variant="no-icon">
+          <p>{t("apportionment.warning.not_all_seats_assigned")}</p>
+        </Alert>
+      );
+  }
+}
+
+function renderApportionmentWarnings(warnings: ApportionmentWarning[]) {
+  if (warnings.length === 0) {
+    return null;
+  }
+  return <FormLayout.Alert>{warnings.map(renderApportionmentWarning)}</FormLayout.Alert>;
+}
+
 function renderFinalisedAlert(
-  unassignedSeats: number,
+  warnings: ApportionmentWarning[],
   currentCommitteeSessionId: number,
   handleResetApportionmentState: () => void,
 ) {
+  const notAllAssigned = warnings.some((w) => w === "NotAllSeatsAssigned");
+  const hasWarnings = warnings.length > 0;
   return (
     <FormLayout.Alert>
-      <Alert type={unassignedSeats > 0 ? "warning" : "success"}>
-        <strong className="heading-md">
-          {t(unassignedSeats > 0 ? "apportionment.not_all_seats_assigned" : "apportionment.all_seats_assigned")}
-        </strong>
+      <Alert type={hasWarnings ? "notify" : "success"}>
+        {!notAllAssigned && <strong className="heading-md">{t("apportionment.all_seats_assigned")}</strong>}
         <p>{t("apportionment.make_apportionment_definitive")}</p>
         <div className={cls.alertButtons}>
           <Button.Link size="md" to={`../report/committee-session/${currentCommitteeSessionId}/download`}>
@@ -72,7 +97,7 @@ function renderLinksToSeatAssignmentPages(seatAssignment: SeatAssignment) {
 export function ApportionmentPage() {
   const navigate = useNavigate();
   const { currentCommitteeSession, election } = useElection();
-  const { seatAssignment, candidateNomination, electionSummary, state, error, refetchState } =
+  const { seatAssignment, candidateNomination, electionSummary, warnings, state, error, refetchState } =
     useApportionmentContext();
   const [apiError, setApiError] = useState<AnyApiError>();
   const client = useApiClient();
@@ -85,9 +110,6 @@ export function ApportionmentPage() {
     apportionmentCheckStateAndRedirect(state, election.id, navigate);
   });
 
-  const unassignedSeats = seatAssignment
-    ? seatAssignment.seats - seatAssignment.full_seats - seatAssignment.residual_seats
-    : 0;
   const renderTables = seatAssignment && candidateNomination && electionSummary && state?.type === "Finalised";
 
   async function handleResetApportionmentState() {
@@ -111,11 +133,8 @@ export function ApportionmentPage() {
           ) : (
             renderTables && (
               <>
-                {renderFinalisedAlert(
-                  unassignedSeats,
-                  currentCommitteeSession.id,
-                  () => void handleResetApportionmentState(),
-                )}
+                {renderApportionmentWarnings(warnings)}
+                {renderFinalisedAlert(warnings, currentCommitteeSession.id, () => void handleResetApportionmentState())}
                 <div className={cn(cls.tableDiv, "mb-lg")}>
                   <div>
                     <h2 className={cls.tableTitle}>{t("apportionment.election_summary")}</h2>

--- a/frontend/src/features/apportionment/components/ApportionmentProvider.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentProvider.tsx
@@ -31,6 +31,7 @@ export function ApportionmentProvider({ children, electionId }: ElectionApportio
         seatAssignment: data?.seat_assignment,
         candidateNomination: data?.candidate_nomination,
         electionSummary: data?.election_summary,
+        warnings: data?.warnings ?? [],
         state,
         error,
         isLoading: requestState.status === "loading",

--- a/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
@@ -43,6 +43,7 @@ describe("AddDeceasedCandidatesPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     server.use(GetApportionmentStateRequestHandler);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
@@ -60,6 +60,7 @@ describe("DeceasedCandidatesPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     server.use(GetApportionmentStateRequestHandler);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
@@ -43,6 +43,7 @@ describe("IncludeAllCandidatesPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     server.use(GetApportionmentStateRequestHandler);
   });

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
@@ -52,6 +52,7 @@ describe("ApportionmentFullSeatsPage", () => {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
       election_summary: lt19Seats.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
 
@@ -73,6 +74,7 @@ describe("ApportionmentFullSeatsPage", () => {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
       election_summary: lt19Seats.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [],
@@ -125,6 +127,7 @@ describe("ApportionmentFullSeatsPage", () => {
       seat_assignment: lt19SeatsAndP9AndP10.seat_assignment,
       candidate_nomination: lt19SeatsAndP9AndP10.candidate_nomination,
       election_summary: lt19SeatsAndP9AndP10.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/4/apportionment/state", 200, {
       deceased_candidates: [],

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -47,6 +47,7 @@ describe("ApportionmentListDetailsPage", () => {
       seat_assignment: seat_assignment,
       candidate_nomination: candidate_nomination,
       election_summary: election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
   });
 

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -55,6 +55,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
       election_summary: lt19Seats.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
 
@@ -81,6 +82,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       seat_assignment: gte19Seats.seat_assignment,
       candidate_nomination: gte19Seats.candidate_nomination,
       election_summary: gte19Seats.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/2/apportionment/state", 200, {
       deceased_candidates: [],
@@ -125,6 +127,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       seat_assignment: gte19SeatsAndP9.seat_assignment,
       candidate_nomination: gte19SeatsAndP9.candidate_nomination,
       election_summary: gte19SeatsAndP9.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/5/apportionment/state", 200, {
       deceased_candidates: [],
@@ -250,6 +253,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
       election_summary: lt19Seats.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [],
@@ -302,6 +306,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       },
       candidate_nomination: lt19Seats.candidate_nomination,
       election_summary: lt19Seats.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [],
@@ -342,6 +347,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       seat_assignment: lt19SeatsAndP9AndP10.seat_assignment,
       candidate_nomination: lt19SeatsAndP9AndP10.candidate_nomination,
       election_summary: lt19SeatsAndP9AndP10.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/4/apportionment/state", 200, {
       deceased_candidates: [],
@@ -400,6 +406,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       seat_assignment: lt19SeatsAndP10.seat_assignment,
       candidate_nomination: lt19SeatsAndP10.candidate_nomination,
       election_summary: lt19SeatsAndP10.election_summary,
+      warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/6/apportionment/state", 200, {
       deceased_candidates: [],

--- a/frontend/src/features/apportionment/hooks/ApportionmentProviderContext.tsx
+++ b/frontend/src/features/apportionment/hooks/ApportionmentProviderContext.tsx
@@ -3,6 +3,7 @@ import { createContext } from "react";
 import type { ApiError, ApiResult } from "@/api/ApiResult";
 import type {
   ApportionmentState,
+  ApportionmentWarning,
   CandidateNomination,
   ElectionSummary,
   SeatAssignment,
@@ -12,6 +13,7 @@ export interface iElectionApportionmentProviderContext {
   seatAssignment?: SeatAssignment;
   candidateNomination?: CandidateNomination;
   electionSummary?: ElectionSummary;
+  warnings: ApportionmentWarning[];
   state?: ApportionmentState;
   error?: ApiError;
   isLoading: boolean;

--- a/frontend/src/i18n/locales/nl/apportionment.json
+++ b/frontend/src/i18n/locales/nl/apportionment.json
@@ -52,7 +52,6 @@
   "manage_deceased_candidates": "Beheer overleden kandidaten",
   "minus": "min",
   "no_candidates_are_deceased": "Alle kandidaten zijn meegenomen bij het verdelen van de zetels. Er zijn geen kandidaten buiten beschouwing gelaten vanwege overlijden.",
-  "not_all_seats_assigned": "Niet alle zetels zijn toegewezen",
   "not_possible": "Zetelverdeling is niet mogelijk",
   "not_yet_available": "Zetelverdeling is nog niet beschikbaar",
   "no_residual_seats_to_assign": "Er zijn geen restzetels te verdelen.",
@@ -113,5 +112,9 @@
   "view_details": "bekijk details",
   "voters": "Kiesgerechtigden",
   "want_to_make_changes": "Wil je wijzigingen aanbrengen in de buiten beschouwing gelaten kandidaten?",
+  "warning": {
+    "absolute_majority_and_list_exhaustion": "Zowel art. P 9 (volstrekte meerderheid) als art. P 10 (lijstuitputting) van de Kieswet zijn toegepast tijdens het berekenen van de zetelverdeling. Neem contact op met de Kiesraad om te overleggen of er extra controles nodig zijn.",
+    "not_all_seats_assigned": "Niet alle zetels zijn toegewezen."
+  },
   "which_candidates_are_deceased": "Geef aan welke kandidaat of kandidaten als gevolg van overlijden bij de zetelverdeling buiten beschouwing moeten worden gelaten."
 }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -401,6 +401,9 @@ export type ApportionmentState =
   | { deceased_candidates: DeceasedCandidate[]; type: "RegisteringDeceasedCandidates" }
   | { deceased_candidates: DeceasedCandidate[]; type: "Finalised" };
 
+export const apportionmentWarningValues = ["AbsoluteMajorityAndListExhaustion", "NotAllSeatsAssigned"] as const;
+export type ApportionmentWarning = (typeof apportionmentWarningValues)[number];
+
 export const auditEventLevelValues = ["info", "success", "warning", "error"] as const;
 export type AuditEventLevel = (typeof auditEventLevelValues)[number];
 
@@ -821,6 +824,7 @@ export interface ElectionApportionmentResponse {
   candidate_nomination: CandidateNomination;
   election_summary: ElectionSummary;
   seat_assignment: SeatAssignment;
+  warnings: ApportionmentWarning[];
 }
 
 /**


### PR DESCRIPTION
Add apportionment warning for P 9 + P 10 case (absolute majority and list exhaustion). The apportionment crate now returns `ApportionmentWarning`s. The existing 'not seats assigned' frontend warning is now also returned from the crate. Resolves #3219 (the differential fuzzer was already updated in #3351).

The absolute majority and list exhaustion warning looks like this:

<img width="1651" height="1523" alt="AbsoluteMajorityAndListExhaustion" src="https://github.com/user-attachments/assets/d0321742-a0dd-4b1e-9500-5a6eaa4bc7d0" />

It can be tested using the [`election_11_csb_with_results.sql`](https://gist.github.com/praseodym/d1991934a741346c2037f5b5dccc26a0) fixture.

The not all seats assigned warning looks like this:

<img width="1651" height="1523" alt="NotAllSeatsAssigned" src="https://github.com/user-attachments/assets/0bdbbf6a-1d6d-4c96-b253-59f855a9f5e8" />

It can be tested by creating a CSB election with more seats than candidates using the 'Genereer testverkiezing' dev tool.