### PR TITLE
Make fuzzer more specific for drawing lots

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -1,6 +1,7 @@
 #![no_main]
 
 use std::{
+    collections::BTreeSet,
     io::{BufRead, BufReader, Write},
     process::{Command, Stdio},
     sync::{Mutex, OnceLock},
@@ -102,6 +103,51 @@ fn report_mismatch(
     panic!("{message}");
 }
 
+/// Parse a bracketed list of numbers (e.g. `[1, 2, 3]`) that follows `prefix`.
+/// Returns None when the prefix or no valid list is not found.
+fn parse_last_bracketed_list_numbers(log: &str, prefix: &str) -> Option<BTreeSet<u32>> {
+    let line = log.lines().rev().find(|l| l.contains(prefix))?;
+    let start = line.find(prefix)? + prefix.len();
+    let lists = &line[start..line[start..].find(']')? + start];
+    lists
+        .split(',')
+        .map(|s| s.trim().parse::<u32>())
+        .collect::<Result<BTreeSet<u32>, _>>()
+        .ok()
+}
+
+/// Parse the list numbers from Abacus's
+/// "Drawing of lots is required for lists: [..]" log line.
+/// Returns None when there is no drawing of lots for lists.
+fn parse_abacus_lots_options(abacus_log: &str) -> Option<BTreeSet<u32>> {
+    parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for lists: [")
+}
+
+/// Parse the list numbers from OSV2020's
+/// "... Alternativen: List2, List3." log line
+/// Returns None when there is no drawing of lots for lists.
+fn parse_osv2020_lots_options(osv2020_log: &[String]) -> Option<BTreeSet<u32>> {
+    let prefix = "Alternativen: ";
+    let line = osv2020_log.iter().rev().find(|l| l.contains(prefix))?;
+    let start = line.find(prefix)? + prefix.len();
+    let lists = line[start..]
+        .trim()
+        .strip_suffix('.')
+        .unwrap_or(line[start..].trim());
+    lists
+        .split(", ")
+        .map(|name| {
+            name.strip_prefix("List")
+                .and_then(|n| n.parse::<u32>().ok())
+        })
+        .collect::<Option<BTreeSet<u32>>>()
+}
+
+/// Whether Abacus hit Article P 10 (list exhaustion) during seat assignment.
+fn abacus_applied_list_exhaustion(abacus_log: &str) -> bool {
+    abacus_log.contains("Exhausted lists in accordance with Article P 10 Kieswet")
+}
+
 fn init() {
     let osv2020_wrapper_bin = std::env::var("OSV2020_WRAPPER_BIN")
         .expect("OSV2020_WRAPPER_BIN environment variable must point to the apportionment-wrapper launcher script");
@@ -159,12 +205,8 @@ fn fuzz(data: FuzzedApportionmentInput) {
         && osv2020_log
             .iter()
             .any(|line| line.contains("Erschöpfte Listen"))
-        && abacus_log.contains(
-            "in accordance with Article P 9 Kieswet"
-        )
-        && abacus_log.contains(
-            "assigned to another list in accordance with Article P 10 Kieswet"
-        )
+        && abacus_log.contains("in accordance with Article P 9 Kieswet")
+        && abacus_log.contains("assigned to another list in accordance with Article P 10 Kieswet")
     {
         return;
     }
@@ -187,23 +229,20 @@ fn fuzz(data: FuzzedApportionmentInput) {
                     }
                 }
                 Osv2020Result::Conflict => {
-                    // Accept case where OSV does drawing of lots and Abacus has allocation, when
-                    // 1. greatest averages is applied (art. P7)
-                    // 2. list exhaustion is applied
-                    // In most (all?) cases the difference under these circumstances is caused by the fact that OSV and Abacus handle list exhaustion differently.
-                    // related issue: #3214
-                    if osv2020_log
+                    // OSV2020 can require a drawing lots (P 7) for a residual seat while
+                    // Abacus assigns it directly.
+                    // 
+                    // This is because OSV2020 does not enforce list exhaustion (P 10) during
+                    // its residual seat assignment, it only retracts seats after assigning.
+                    // Abacus takes will not assign a residual seat to a list that is already
+                    // exhausted, so it never sees the same drawing lots.
+                    //
+                    // Related issues: #3214, #3219
+                    let osv_p7_conflict = osv2020_log
                         .last()
-                        .unwrap()
-                        .contains(&String::from("Conflict: Auslosung bezüglich P7."))
-                        && osv2020_log
-                            .iter()
-                            .any(|line| line.contains("Erschöpfte Listen"))
-                        && abacus_log.contains(
-                            "assigned to another list in accordance with Article P 10 Kieswet"
-                        )
-                    {
-                        //do nothing, continue
+                        .is_some_and(|l| l.contains("Conflict: Auslosung bezüglich P7."));
+                    if osv_p7_conflict && abacus_applied_list_exhaustion(&abacus_log) {
+                        // accept, do nothing
                     } else {
                         report_mismatch(
                             &data,
@@ -229,7 +268,31 @@ fn fuzz(data: FuzzedApportionmentInput) {
                         &format!("OSV2020 has allocation where Abacus has {e:?}"),
                     );
                 }
-                Osv2020Result::Conflict => {} // both agree
+                Osv2020Result::Conflict => {
+                    // OSV2020 assigns residual seats to exhausted lists via drawing of lots,
+                    // so accept if Abacus also applied list exhaustion.
+                    // 
+                    // Related issues: #3214, #3367
+                    if abacus_applied_list_exhaustion(&abacus_log) {
+                        // accept, do nothing
+                    } else {
+                        // No exhaustion: the options for drawing lots must match.
+                        let abacus_options = parse_abacus_lots_options(&abacus_log);
+                        let osv2020_options = parse_osv2020_lots_options(&osv2020_log);
+                        if abacus_options != osv2020_options {
+                            report_mismatch(
+                                &data,
+                                &format!(
+                                    "Err({e:?}) Abacus lots options: {abacus_options:?}"
+                                ),
+                                &abacus_log,
+                                &format!("OSV2020 lots options: {osv2020_options:?}"),
+                                &osv2020_log,
+                                "OSV2020 and Abacus require drawing lots, but the options do not match",
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -234,7 +234,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
                     // 
                     // This is because OSV2020 does not enforce list exhaustion (P 10) during
                     // its residual seat assignment, it only retracts seats after assigning.
-                    // Abacus takes will not assign a residual seat to a list that is already
+                    // Abacus will not assign a residual seat to a list that is already
                     // exhausted, so it never sees the same drawing lots.
                     //
                     // Related issues: #3214, #3219

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -30,10 +30,8 @@ pub fn assign_remainder<T: ListVotes>(
     let mut current_standings = initial_standings.to_vec();
 
     while residual_seat_number != total_residual_seats {
-        let exhausted_list_numbers: Vec<T::ListNumber> =
-            exclude_exhausted_lists.map_or_else(Vec::new, |(list_votes, deceased)| {
-                list_numbers_without_empty_seats(current_standings.iter(), list_votes, deceased)
-            });
+        let exhausted_list_numbers =
+            exhausted_list_numbers(&current_standings, exclude_exhausted_lists);
 
         // Stop assigning when no list is eligible, either when every non-exhausted list has zero
         // votes or every list is exhausted. Any remaining seats will be reported as unassigned.
@@ -51,25 +49,14 @@ pub fn assign_remainder<T: ListVotes>(
         let residual_seats = total_residual_seats - residual_seat_number;
         residual_seat_number += 1;
 
-        let change = if seats >= LARGE_COUNCIL_THRESHOLD {
-            debug!("Assign residual seat using highest averages method");
-            // [Artikel P 7 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP7)
-            step_assign_remainder_using_highest_averages(
-                current_standings.iter(),
-                residual_seats,
-                &steps,
-                &exhausted_list_numbers,
-                false,
-            )?
-        } else {
-            // [Artikel P 8 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP8)
-            step_assign_remainder_using_largest_remainder(
-                &current_standings,
-                residual_seats,
-                &steps,
-                &exhausted_list_numbers,
-            )?
-        };
+        let change = step_assign_residual_seat(
+            &current_standings,
+            seats,
+            residual_seats,
+            residual_seat_number,
+            &steps,
+            &exhausted_list_numbers,
+        )?;
 
         let standings = current_standings.clone();
 
@@ -152,6 +139,21 @@ where
         }
         list_numbers_without_empty_seats
     })
+}
+
+/// Determine which lists are exhausted (have no empty seats left) under
+/// Artikel P 10 Kieswet.
+fn exhausted_list_numbers<T: ListVotes>(
+    standings: &[ListStanding<T::ListNumber>],
+    exclude_exhausted_lists: Option<(&[T], &DeceasedCandidates<T>)>,
+) -> Vec<T::ListNumber> {
+    let exhausted = exclude_exhausted_lists.map_or_else(Vec::new, |(list_votes, deceased)| {
+        list_numbers_without_empty_seats(standings.iter(), list_votes, deceased)
+    });
+    if !exhausted.is_empty() {
+        debug!("Exhausted lists in accordance with Article P 10 Kieswet: {exhausted:?}");
+    }
+    exhausted
 }
 
 /// Returns if a list qualifies for an extra seat.
@@ -357,6 +359,38 @@ fn lists_with_largest_remainder<'a, LN: Copy + Debug>(
         Err(ApportionmentError::DrawingOfLotsNotImplemented)
     } else {
         Ok(lists)
+    }
+}
+
+/// Assign the next residual seat using the procedure for the council size:
+/// highest averages for large councils (Artikel P 7 Kieswet), largest
+/// remainder otherwise (Artikel P 8 Kieswet).
+fn step_assign_residual_seat<LN: Copy + Debug + Eq>(
+    standings: &[ListStanding<LN>],
+    seats: u32,
+    residual_seats: u32,
+    residual_seat_number: u32,
+    previous_steps: &[SeatChangeStep<LN>],
+    exhausted_list_numbers: &[LN],
+) -> Result<SeatChange<LN>, ApportionmentError> {
+    if seats >= LARGE_COUNCIL_THRESHOLD {
+        debug!("Assigning residual seat {residual_seat_number} using highest averages method");
+        // [Artikel P 7 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP7)
+        step_assign_remainder_using_highest_averages(
+            standings.iter(),
+            residual_seats,
+            previous_steps,
+            exhausted_list_numbers,
+            false,
+        )
+    } else {
+        // [Artikel P 8 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP8)
+        step_assign_remainder_using_largest_remainder(
+            standings,
+            residual_seats,
+            previous_steps,
+            exhausted_list_numbers,
+        )
     }
 }
 

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29409e213680d4babde216488b01df40603871171260af0a50fda0e1a9b055b"
+checksum = "142068a435989dcdc985d6a0a7cd701e87c3b6eb79c24ae8f94c0ccc4900c675"
 dependencies = [
  "chrono",
  "quick-xml 0.38.4",


### PR DESCRIPTION
- Improve apportionment debug logging
  And extract helpers from `assign_remainder` to fix Clippy cognitive complexity lint after adding an extra debug line.
- Make fuzzer more specific for drawing lots
  Ignore cases where OSV requires drawing after list exhaustion because of different implementations in OSV and Abacus (#3214, #3367). Require matching options for drawing lots when there is no list exhaustion.

I've ran the differential fuzzer for a while and found no new cases.

Closes #3214 
Closes #3367 