### PR TITLE
Implement GSB OSV4-3 CSV export

### DIFF
--- a/backend/src/api/report/files.rs
+++ b/backend/src/api/report/files.rs
@@ -74,6 +74,7 @@ async fn generate_and_save_files_gsb_election(
         results_eml: None,
         results_pdf: None,
         overview_pdf: None,
+        results_csv: None,
     };
 
     let generated_files = input.generate_gsb_files().await?;
@@ -82,6 +83,7 @@ async fn generate_and_save_files_gsb_election(
     // For next sessions without corrections, we don't store these
     if !committee_session.is_next_session() || corrections {
         files.results_eml = Some(saver.save(generated_files.results_eml).await?);
+        files.results_csv = Some(saver.save(generated_files.results_csv).await?);
 
         files.results_pdf = Some(saver.save(generated_files.results_pdf).await?);
     }
@@ -147,6 +149,7 @@ async fn get_existing_gsb_files(
         results_pdf: file_repo::get_for_session(conn, committee_session_id, GsbResultsPdf).await?,
         overview_pdf: file_repo::get_for_session(conn, committee_session_id, GsbOverviewPdf)
             .await?,
+        results_csv: file_repo::get_for_session(conn, committee_session_id, GsbCsvCounts).await?,
     })
 }
 
@@ -311,17 +314,20 @@ mod tests {
                     .await
                     .expect("should return files");
             let eml = files.results_eml.expect("should have generated eml");
+            let csv = files.results_csv.expect("should have generated csv");
             let pdf = files.results_pdf.expect("should have generated pdf");
 
             assert_eq!(eml.name, "Telling_GR2026_GroteStad.eml.xml");
             assert_eq!(eml.id, FileId::from(1));
+            assert_eq!(csv.name, "osv4-3_telling_gr2026_grotestad.csv");
+            assert_eq!(csv.id, FileId::from(2));
             assert_eq!(pdf.name, "Model_Na31-2.pdf");
-            assert_eq!(pdf.id, FileId::from(2));
+            assert_eq!(pdf.id, FileId::from(3));
             assert!(files.overview_pdf.is_none());
 
             assert_eq!(
                 list_event_names(&mut conn).await.unwrap(),
-                ["FileCreated", "FileCreated"]
+                ["FileCreated", "FileCreated", "FileCreated"]
             );
         }
     }
@@ -339,19 +345,22 @@ mod tests {
                     .expect("should return files");
 
             let eml = files.results_eml.expect("should have generated eml");
+            let csv = files.results_csv.expect("should have generated csv");
             let pdf = files.results_pdf.expect("should have generated pdf");
             let overview = files.overview_pdf.expect("should have generated overview");
 
             assert_eq!(eml.name, "Telling_GR2026_GroteStad.eml.xml");
             assert_eq!(eml.id, FileId::from(1));
+            assert_eq!(csv.name, "osv4-3_telling_gr2026_grotestad.csv");
+            assert_eq!(csv.id, FileId::from(2));
             assert_eq!(pdf.name, "Model_Na14-2.pdf");
-            assert_eq!(pdf.id, FileId::from(2));
+            assert_eq!(pdf.id, FileId::from(3));
             assert_eq!(overview.name, "Leeg_Model_P2a.pdf");
-            assert_eq!(overview.id, FileId::from(3));
+            assert_eq!(overview.id, FileId::from(4));
 
             assert_eq!(
                 list_event_names(&mut conn).await.unwrap(),
-                ["FileCreated", "FileCreated", "FileCreated"]
+                ["FileCreated", "FileCreated", "FileCreated", "FileCreated"]
             );
         }
     }

--- a/backend/src/api/report/handlers.rs
+++ b/backend/src/api/report/handlers.rs
@@ -108,6 +108,10 @@ pub async fn election_download_zip_results_gsb(
             zip_writer.add_file(&xml_zip_filename, &xml_zip).await?;
         }
 
+        if let Some(csv_file) = files.results_csv {
+            zip_writer.add_file(&csv_file.name, &csv_file.data).await?;
+        }
+
         if let Some(overview_file) = files.overview_pdf {
             zip_writer
                 .add_file(&overview_file.name, &overview_file.data)

--- a/backend/src/api/report/structs.rs
+++ b/backend/src/api/report/structs.rs
@@ -56,12 +56,14 @@ pub struct GsbGeneratedFiles {
     pub results_eml: GeneratedFile,
     pub results_pdf: GeneratedFile,
     pub overview_pdf: Option<GeneratedFile>,
+    pub results_csv: GeneratedFile,
 }
 
 pub struct GsbFiles {
     pub results_eml: Option<File>,
     pub results_pdf: Option<File>,
     pub overview_pdf: Option<File>,
+    pub results_csv: Option<File>,
 }
 
 impl GsbFiles {
@@ -70,6 +72,7 @@ impl GsbFiles {
             .as_ref()
             .or(self.results_pdf.as_ref())
             .or(self.overview_pdf.as_ref())
+            .or(self.results_csv.as_ref())
             .map(|f| f.created_at)
             .expect("At least one file should be present")
     }
@@ -84,6 +87,7 @@ impl GsbFiles {
                 self.results_eml.is_none()
                     || self.results_pdf.is_none()
                     || self.overview_pdf.is_none()
+                    || self.results_csv.is_none()
             } else {
                 self.overview_pdf.is_none()
             }
@@ -253,6 +257,7 @@ impl ResultsInput {
             CsbResultsPdf => "Model P22-2.pdf".to_string(),
             CsbAttachmentPdf => "Model P22-2 bijlage.pdf".to_string(),
             CsbCsvCounts => self.csv_filename(),
+            GsbCsvCounts => self.csv_filename(),
         };
 
         slugify_filename(&filename)
@@ -377,11 +382,14 @@ impl ResultsInput {
     pub async fn generate_gsb_files(&self) -> Result<GsbGeneratedFiles, APIError> {
         let creation_date_time = self.created_at.format(DEFAULT_DATE_TIME_FORMAT).to_string();
 
-        let xml_string = self.as_xml()?.write_eml_root_str(true, true)?;
+        let xml = self.as_xml()?;
+        let xml_string = xml.write_eml_root_str(true, true)?;
         let xml_bytes = xml_string.as_bytes();
         let xml_hash = EmlHash::from(xml_bytes).into();
+        let svg_string = xml.as_osv4_3_csv(&self.election, true, false)?;
 
         let results_eml = self.generated_file(FileType::GsbResultsEml, xml_bytes.to_vec());
+        let results_csv = self.generated_file(FileType::GsbCsvCounts, svg_string.into_bytes());
 
         let overview_pdf = if self.committee_session.is_next_session() {
             let pdf_model = self.get_p2a_pdf_file(self.filename_for(FileType::GsbOverviewPdf));
@@ -428,6 +436,7 @@ impl ResultsInput {
             results_eml,
             results_pdf,
             overview_pdf,
+            results_csv,
         })
     }
 

--- a/backend/src/api/report/structs.rs
+++ b/backend/src/api/report/structs.rs
@@ -92,7 +92,7 @@ impl GsbFiles {
                 self.overview_pdf.is_none()
             }
         } else {
-            self.results_eml.is_none() || self.results_pdf.is_none()
+            self.results_eml.is_none() || self.results_pdf.is_none() || self.results_csv.is_none()
         }
     }
 }
@@ -389,7 +389,7 @@ impl ResultsInput {
         let csv_string = xml.as_osv4_3_csv(&self.election, true, false)?;
 
         let results_eml = self.generated_file(FileType::GsbResultsEml, xml_bytes.to_vec());
-        let results_csv = self.generated_file(FileType::GsbCsvCounts, svg_string.into_bytes());
+        let results_csv = self.generated_file(FileType::GsbCsvCounts, csv_string.into_bytes());
 
         let overview_pdf = if self.committee_session.is_next_session() {
             let pdf_model = self.get_p2a_pdf_file(self.filename_for(FileType::GsbOverviewPdf));

--- a/backend/src/api/report/structs.rs
+++ b/backend/src/api/report/structs.rs
@@ -386,7 +386,7 @@ impl ResultsInput {
         let xml_string = xml.write_eml_root_str(true, true)?;
         let xml_bytes = xml_string.as_bytes();
         let xml_hash = EmlHash::from(xml_bytes).into();
-        let svg_string = xml.as_osv4_3_csv(&self.election, true, false)?;
+        let csv_string = xml.as_osv4_3_csv(&self.election, true, false)?;
 
         let results_eml = self.generated_file(FileType::GsbResultsEml, xml_bytes.to_vec());
         let results_csv = self.generated_file(FileType::GsbCsvCounts, svg_string.into_bytes());

--- a/backend/src/domain/file.rs
+++ b/backend/src/domain/file.rs
@@ -28,6 +28,8 @@ pub enum FileType {
     CsbAttachmentPdf,
     /// CSB CSV counts file (OSV4-3)
     CsbCsvCounts,
+    /// GSB CSV counts file (OSV4-3)
+    GsbCsvCounts,
 }
 
 impl FileType {
@@ -35,7 +37,7 @@ impl FileType {
         use FileType::*;
 
         match self {
-            CsbCsvCounts => "text/csv",
+            CsbCsvCounts | GsbCsvCounts => "text/csv",
             GsbResultsEml | CsbResultsEml | CsbTotalCountsEml => "text/xml",
             GsbResultsPdf | GsbOverviewPdf | CsbResultsPdf | CsbAttachmentPdf => "application/pdf",
         }

--- a/backend/tests/report_integration_test.rs
+++ b/backend/tests/report_integration_test.rs
@@ -105,9 +105,11 @@ async fn test_gsb_election_first_session_zip_download_works(pool: SqlitePool) {
 
     let bytes = download_zip_assert(&cookie, &url, prefix).await;
     let archive = ZipFileReader::new(bytes).await.unwrap();
-    assert_eq!(archive.file().entries().len(), 2);
+    assert_eq!(archive.file().entries().len(), 3);
     let pdf_hash1 = sha2::Sha256::digest(read_zip_entry(&archive, 0, "Model_Na31-2.pdf").await);
     let xml_zip = read_zip_entry(&archive, 1, "Telling_GR2024_Heemdamseburg.zip").await;
+    let csv = read_zip_entry(&archive, 2, "osv4-3_telling_gr2024_heemdamseburg.csv").await;
+    assert!(csv.len() > 1024);
     let xml_archive = ZipFileReader::new(xml_zip).await.unwrap();
     assert_eq!(xml_archive.file().entries().len(), 1);
     let eml_hash1 = sha2::Sha256::digest(
@@ -116,9 +118,11 @@ async fn test_gsb_election_first_session_zip_download_works(pool: SqlitePool) {
 
     let bytes2 = download_zip_assert(&cookie, &url, prefix).await;
     let archive2 = ZipFileReader::new(bytes2).await.unwrap();
-    assert_eq!(archive2.file().entries().len(), 2);
+    assert_eq!(archive2.file().entries().len(), 3);
     let pdf_hash2 = sha2::Sha256::digest(read_zip_entry(&archive2, 0, "Model_Na31-2.pdf").await);
     let xml_zip2 = read_zip_entry(&archive2, 1, "Telling_GR2024_Heemdamseburg.zip").await;
+    let csv2 = read_zip_entry(&archive2, 2, "osv4-3_telling_gr2024_heemdamseburg.csv").await;
+    assert_eq!(csv, csv2, "CSV count files should be the same");
     let xml_archive2 = ZipFileReader::new(xml_zip2).await.unwrap();
     assert_eq!(xml_archive2.file().entries().len(), 1);
     let eml_hash2 = sha2::Sha256::digest(
@@ -155,29 +159,33 @@ async fn test_gsb_election_next_session_zip_download_works(pool: SqlitePool) {
 
     let bytes = download_zip_assert(&cookie, &url, prefix).await;
     let archive = ZipFileReader::new(bytes).await.unwrap();
-    assert_eq!(archive.file().entries().len(), 3);
+    assert_eq!(archive.file().entries().len(), 4);
     let pdf_hash1 = sha2::Sha256::digest(read_zip_entry(&archive, 0, "Model_Na14-2.pdf").await);
     let xml_zip = read_zip_entry(&archive, 1, "Telling_GR2026_GroteStad.zip").await;
+    let csv = read_zip_entry(&archive, 2, "osv4-3_telling_gr2026_grotestad.csv").await;
+    assert!(csv.len() > 1024);
     let xml_archive = ZipFileReader::new(xml_zip).await.unwrap();
     assert_eq!(xml_archive.file().entries().len(), 1);
     let eml_hash1 = sha2::Sha256::digest(
         read_zip_entry(&xml_archive, 0, "Telling_GR2026_GroteStad.eml.xml").await,
     );
     let pdf_overview_hash1 =
-        sha2::Sha256::digest(read_zip_entry(&archive, 2, "Leeg_Model_P2a.pdf").await);
+        sha2::Sha256::digest(read_zip_entry(&archive, 3, "Leeg_Model_P2a.pdf").await);
 
     let bytes2 = download_zip_assert(&cookie, &url, prefix).await;
     let archive2 = ZipFileReader::new(bytes2).await.unwrap();
-    assert_eq!(archive2.file().entries().len(), 3);
+    assert_eq!(archive2.file().entries().len(), 4);
     let pdf_hash2 = sha2::Sha256::digest(read_zip_entry(&archive2, 0, "Model_Na14-2.pdf").await);
     let xml_zip2 = read_zip_entry(&archive2, 1, "Telling_GR2026_GroteStad.zip").await;
+    let csv2 = read_zip_entry(&archive2, 2, "osv4-3_telling_gr2026_grotestad.csv").await;
+    assert_eq!(csv, csv2, "CSV count files should be the same");
     let xml_archive2 = ZipFileReader::new(xml_zip2).await.unwrap();
     assert_eq!(xml_archive2.file().entries().len(), 1);
     let eml_hash2 = sha2::Sha256::digest(
         read_zip_entry(&xml_archive2, 0, "Telling_GR2026_GroteStad.eml.xml").await,
     );
     let pdf_overview_hash2 =
-        sha2::Sha256::digest(read_zip_entry(&archive2, 2, "Leeg_Model_P2a.pdf").await);
+        sha2::Sha256::digest(read_zip_entry(&archive2, 3, "Leeg_Model_P2a.pdf").await);
 
     assert_eq!(pdf_hash1, pdf_hash2, "PDF files should have the same hash");
     assert_eq!(eml_hash1, eml_hash2, "EML files should have the same hash");


### PR DESCRIPTION
This basically copies most of the changes of the CSB OSV4-3 CSV export, but now for the GSB (the eml-nl code is the same for GSB and CSB)