### PR TITLE
Change deceased candidates copy

### DIFF
--- a/frontend/e2e-tests/page-objects/apportionment/IncludeAllCandidatesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/IncludeAllCandidatesPgObj.ts
@@ -5,8 +5,8 @@ export class IncludeAllCandidates {
   readonly dataEntryFinished: Locator;
   readonly dataEntryFinishedAlert: Locator;
   readonly title: Locator;
-  readonly yes: Locator;
-  readonly no: Locator;
+  readonly noDeceased: Locator;
+  readonly hasDeceased: Locator;
   readonly next: Locator;
 
   constructor(protected readonly page: Page) {
@@ -17,10 +17,10 @@ export class IncludeAllCandidates {
     });
     this.dataEntryFinishedAlert = page.getByRole("alert").filter({ has: this.dataEntryFinished });
 
-    this.title = page.getByRole("heading", { level: 2, name: "Kunnen alle kandidaten worden meegenomen?" });
+    this.title = page.getByRole("heading", { level: 2, name: "Zijn er overleden kandidaten?" });
 
-    this.yes = page.getByRole("radio", { name: "Ja. Er zijn geen kandidaten overleden." });
-    this.no = page.getByRole("radio", { name: "Nee. Eén of meerdere kandidaten zijn overleden." });
+    this.noDeceased = page.getByRole("radio", { name: "Er zijn geen overleden kandidaten" });
+    this.hasDeceased = page.getByRole("radio", { name: "Eén of meerdere kandidaten zijn overleden" });
     this.next = page.getByRole("button", { name: "Volgende" });
   }
 }

--- a/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/add-deceased-candidates.e2e.ts
@@ -25,9 +25,9 @@ test.describe("CSB election apportionment", () => {
     await expect(includeAllCandidatesPage.header).toBeVisible();
     await expect(includeAllCandidatesPage.dataEntryFinishedAlert).toBeVisible();
     await expect(includeAllCandidatesPage.title).toBeVisible();
-    await expect(includeAllCandidatesPage.yes).toBeVisible();
-    await expect(includeAllCandidatesPage.no).toBeVisible();
-    await includeAllCandidatesPage.no.check();
+    await expect(includeAllCandidatesPage.noDeceased).toBeVisible();
+    await expect(includeAllCandidatesPage.hasDeceased).toBeVisible();
+    await includeAllCandidatesPage.hasDeceased.check();
     await includeAllCandidatesPage.next.click();
 
     const addDeceasedCandidatesPage = new AddDeceasedCandidate(page);

--- a/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
@@ -322,9 +322,9 @@ test.describe("full flow CSB", () => {
     await expect(includeAllCandidatesPage.header).toBeVisible();
     await expect(includeAllCandidatesPage.dataEntryFinishedAlert).toBeVisible();
     await expect(includeAllCandidatesPage.title).toBeVisible();
-    await expect(includeAllCandidatesPage.yes).toBeVisible();
-    await expect(includeAllCandidatesPage.no).toBeVisible();
-    await includeAllCandidatesPage.yes.check();
+    await expect(includeAllCandidatesPage.noDeceased).toBeVisible();
+    await expect(includeAllCandidatesPage.hasDeceased).toBeVisible();
+    await includeAllCandidatesPage.noDeceased.check();
     await includeAllCandidatesPage.next.click();
 
     const apportionmentPage = new Apportionment(page);

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
@@ -118,12 +118,12 @@ describe("IncludeAllCandidatesPage", () => {
     renderIncludeAllCandidatesPage(3);
     expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
 
-    const yes = await screen.findByRole("radio", { name: "Ja. Er zijn geen kandidaten overleden." });
-    const no = await screen.findByRole("radio", { name: "Nee. Eén of meerdere kandidaten zijn overleden." });
-    expect(yes).toBeVisible();
-    expect(yes).not.toBeChecked();
-    expect(no).toBeVisible();
-    expect(no).not.toBeChecked();
+    const noDeceased = await screen.findByRole("radio", { name: "Er zijn geen overleden kandidaten" });
+    const hasDeceased = await screen.findByRole("radio", { name: "Eén of meerdere kandidaten zijn overleden" });
+    expect(noDeceased).toBeVisible();
+    expect(noDeceased).not.toBeChecked();
+    expect(hasDeceased).toBeVisible();
+    expect(hasDeceased).not.toBeChecked();
     await user.click(screen.getByRole("button", { name: "Volgende" }));
 
     expect(await screen.findByText("Deze vraag is verplicht")).toBeVisible();
@@ -142,9 +142,9 @@ describe("IncludeAllCandidatesPage", () => {
     renderIncludeAllCandidatesPage(3);
     expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
 
-    const yes = await screen.findByRole("radio", { name: "Ja. Er zijn geen kandidaten overleden." });
-    expect(yes).toBeVisible();
-    await user.click(yes);
+    const noDeceased = await screen.findByRole("radio", { name: "Er zijn geen overleden kandidaten" });
+    expect(noDeceased).toBeVisible();
+    await user.click(noDeceased);
     await user.click(screen.getByRole("button", { name: "Volgende" }));
 
     expect(skipDeceasedCandidates).toHaveBeenCalled();
@@ -161,9 +161,9 @@ describe("IncludeAllCandidatesPage", () => {
     renderIncludeAllCandidatesPage(3);
     expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" }));
 
-    const no = await screen.findByRole("radio", { name: "Nee. Eén of meerdere kandidaten zijn overleden." });
-    expect(no).toBeVisible();
-    await user.click(no);
+    const hasDeceased = await screen.findByRole("radio", { name: "Eén of meerdere kandidaten zijn overleden" });
+    expect(hasDeceased).toBeVisible();
+    await user.click(hasDeceased);
     await user.click(screen.getByRole("button", { name: "Volgende" }));
 
     expect(registerDeceasedCandidates).toHaveBeenCalled();

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.tsx
@@ -40,16 +40,16 @@ function renderForm(radioError: boolean, handleSubmit: (e: SubmitEvent<HTMLFormE
               </ChoiceList.Error>
             )}
             <ChoiceList.Radio
-              id="yes"
+              id="no_deceased"
               name="include_all_candidates"
-              label={t("apportionment.include_all_candidates.yes")}
-              value="yes"
+              label={t("apportionment.include_all_candidates.no_deceased")}
+              value="no_deceased"
             />
             <ChoiceList.Radio
-              id="no"
+              id="has_deceased"
               name="include_all_candidates"
-              label={t("apportionment.include_all_candidates.no")}
-              value="no"
+              label={t("apportionment.include_all_candidates.has_deceased")}
+              value="has_deceased"
             />
           </ChoiceList>
         </FormLayout.Section>
@@ -102,7 +102,7 @@ export function IncludeAllCandidatesPage() {
     }
 
     const path: REGISTER_DECEASED_CANDIDATES_REQUEST_PATH | SKIP_DECEASED_CANDIDATES_REQUEST_PATH =
-      `/api/elections/${election.id}/apportionment/${includeAllCandidatesChoice === "yes" ? "skip_deceased_candidates" : "register_deceased_candidates"}`;
+      `/api/elections/${election.id}/apportionment/${includeAllCandidatesChoice === "no_deceased" ? "skip_deceased_candidates" : "register_deceased_candidates"}`;
     const response: ApiResult<ApportionmentState> = await client.postRequest(path);
 
     if (isSuccess(response)) {

--- a/frontend/src/i18n/locales/nl/apportionment.json
+++ b/frontend/src/i18n/locales/nl/apportionment.json
@@ -28,11 +28,11 @@
   "how_often_is_quota_met": "Hoe vaak haalde elke partij de kiesdeler?",
   "in_alphabetical_order": "In alfabetische volgorde",
   "include_all_candidates": {
-    "description": "Voordat de zetelverdeling kan worden uitgevoerd, is het belangrijk dat de kandidatenlijst volledig en correct is. In de uitzonderlijke situatie dat een kandidaat is overleden, wordt deze buiten beschouwing gelaten bij het verdelen van de zetels.\n\nStemmen op de overleden kandidaat tellen wel mee als stemmen op diens partij. Dat staat zo in de Kieswet.",
+    "description": "Voordat de zetelverdeling kan worden uitgevoerd, is het belangrijk dat de kandidatenlijst volledig en correct is. Kandidaten die zijn overleden worden niet meegenomen bij het verdelen van de zetels. Stemmen op de overleden kandidaat tellen wel mee als stemmen op diens partij. Dat staat zo in de Kieswet.",
+    "has_deceased": "Eén of meerdere kandidaten zijn overleden",
     "mandatory_question": "Deze vraag is verplicht",
-    "no": "Nee. Eén of meerdere kandidaten zijn overleden.",
-    "title": "Kunnen alle kandidaten worden meegenomen?",
-    "yes": "Ja. Er zijn geen kandidaten overleden."
+    "no_deceased": "Er zijn geen overleden kandidaten",
+    "title": "Zijn er overleden kandidaten?"
   },
   "indicate_deceased_candidate": "Geef aan welke kandidaat of kandidaten als gevolg van overlijden bij de zetelverdeling buiten beschouwing moeten worden gelaten.",
   "information_highest_averages": "Er zijn 19 of meer zetels. Daarom worden restzetels toegewezen volgens het <strong>systeem van de grootste gemiddelden</strong>. De partij die na toewijzing van een restzetel het hoogste aantal stemmen per zetel heeft, krijgt de restzetel.\nIn de tabel is het gemiddeld aantal stemmen per zetel te vinden dat elke lijst zou krijgen als een restzetel zou worden toegekend.",


### PR DESCRIPTION
And rename yes/no radios to match labels.

Resolves #3391.

To test: complete data entry for CSB to start apportionment.

Screenshot:
<img width="1695" height="1218" alt="Screenshot 2026-06-08 at 21-07-08 Zetelverdeling - Abacus" src="https://github.com/user-attachments/assets/d32000fa-74af-478b-a26c-461c55638b3f" />
