### PR TITLE
Add list and candidate drawn to API and apportionment input data

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1383,7 +1383,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CandidateDrawn"
+                  "$ref": "#/components/schemas/ApportionmentState"
                 }
               }
             }
@@ -1575,7 +1575,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListDrawn"
+                  "$ref": "#/components/schemas/ApportionmentState"
                 }
               }
             }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1352,6 +1352,102 @@
         ]
       }
     },
+    "/api/elections/{election_id}/apportionment/add_candidate_drawn": {
+      "post": {
+        "summary": "Add candidate to drawing lots (coordinator_csb)",
+        "operationId": "add_candidate_drawn",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CandidateDrawn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Add candidate to drawing lots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateDrawn"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "coordinator_csb"
+            ]
+          }
+        ]
+      }
+    },
     "/api/elections/{election_id}/apportionment/add_deceased_candidate": {
       "post": {
         "summary": "Add deceased candidate (coordinator_csb)",
@@ -1384,6 +1480,102 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApportionmentState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "coordinator_csb"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/elections/{election_id}/apportionment/add_list_drawn": {
+      "post": {
+        "summary": "Add list to drawing lots (coordinator_csb)",
+        "operationId": "add_list_drawn",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListDrawn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Add list to drawing lots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDrawn"
                 }
               }
             }

--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -19,8 +19,9 @@ use crate::{
 #[utoipa::path(
     post,
     path = "/api/elections/{election_id}/apportionment/add_candidate_drawn",
+    request_body = CandidateDrawn,
     responses(
-        (status = 200, description = "Add candidate to drawing lots", body = CandidateDrawn),
+        (status = 200, description = "Add candidate to drawing lots", body = ApportionmentState),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),

--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -1,0 +1,132 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    APIError, ErrorResponse, SqlitePoolExt,
+    domain::{
+        apportionment::CandidateDrawn, apportionment_state::ApportionmentState,
+        election::ElectionId,
+    },
+    infra::audit_log::AuditService,
+    repository::{election_repo, user_repo::User},
+    service::update_apportionment_state,
+};
+
+/// Add candidate to drawing lots
+#[utoipa::path(
+    post,
+    path = "/api/elections/{election_id}/apportionment/add_candidate_drawn",
+    responses(
+        (status = 200, description = "Add candidate to drawing lots", body = CandidateDrawn),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Invalid state", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+pub async fn add_candidate_drawn(
+    user: User,
+    State(pool): State<SqlitePool>,
+    audit_service: AuditService,
+    Path(election_id): Path<ElectionId>,
+    Json(candidate_drawn): Json<CandidateDrawn>,
+) -> Result<Json<ApportionmentState>, APIError> {
+    let mut tx = pool.begin_immediate().await?;
+
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+        state.add_candidate_drawn(candidate_drawn)
+    })
+    .await?;
+
+    tx.commit().await?;
+    Ok(Json(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use super::*;
+    use crate::{
+        domain::{
+            apportionment_state::{
+                ApportionmentState, CandidateDrawingLotsRequired, DrawingLotsDetails,
+            },
+            committee_session::CommitteeSessionId,
+            committee_session_status::CommitteeSessionStatus,
+            election::{CandidateNumber, PGNumber},
+            role::Role,
+        },
+        repository::{apportionment_state_repo, committee_session_repo, user_repo::UserId},
+    };
+
+    #[test(sqlx::test(fixtures(
+        path = "../../../../fixtures",
+        scripts("election_5_with_results")
+    )))]
+    async fn test_add_candidate_drawn(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let audit_service = AuditService::new(Some(user.clone()), None);
+        let id = CommitteeSessionId::from(6);
+
+        committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
+            .await
+            .expect("should change committee session status");
+
+        let drawing_lots_details: DrawingLotsDetails = CandidateDrawingLotsRequired {
+            list: PGNumber::from(3),
+            options: CandidateNumber::from_values(vec![1, 2]),
+        }
+        .into();
+
+        apportionment_state_repo::upsert(
+            &mut conn,
+            id,
+            &ApportionmentState::DrawingLots {
+                drawing_lots_details: drawing_lots_details.clone(),
+                deceased_candidates: vec![],
+                lists_drawn: vec![],
+                candidates_drawn: vec![],
+            },
+        )
+        .await
+        .expect("should upsert initial state");
+
+        let candidate_drawn = CandidateDrawn {
+            list: PGNumber::from(3),
+            options: CandidateNumber::from_values(vec![1, 2]),
+            drawn: CandidateNumber::from(2),
+        };
+
+        let state = add_candidate_drawn(
+            user,
+            State(pool),
+            audit_service,
+            Path(ElectionId::from(5)),
+            Json::from(candidate_drawn.clone()),
+        )
+        .await
+        .expect("should call the handler successfully");
+
+        assert_eq!(
+            state.0,
+            ApportionmentState::DrawingLots {
+                drawing_lots_details,
+                deceased_candidates: vec![],
+                lists_drawn: vec![],
+                candidates_drawn: vec![candidate_drawn],
+            }
+        );
+    }
+}

--- a/backend/src/api/apportionment/handlers/add_list_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_list_drawn.rs
@@ -1,0 +1,131 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    APIError, ErrorResponse, SqlitePoolExt,
+    domain::{
+        apportionment::ListDrawn, apportionment_state::ApportionmentState, election::ElectionId,
+    },
+    infra::audit_log::AuditService,
+    repository::{election_repo, user_repo::User},
+    service::update_apportionment_state,
+};
+
+/// Add list to drawing lots
+#[utoipa::path(
+    post,
+    path = "/api/elections/{election_id}/apportionment/add_list_drawn",
+    responses(
+        (status = 200, description = "Add list to drawing lots", body = ListDrawn),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Invalid state", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+pub async fn add_list_drawn(
+    user: User,
+    State(pool): State<SqlitePool>,
+    audit_service: AuditService,
+    Path(election_id): Path<ElectionId>,
+    Json(list_drawn): Json<ListDrawn>,
+) -> Result<Json<ApportionmentState>, APIError> {
+    let mut tx = pool.begin_immediate().await?;
+
+    let election = election_repo::get(&mut tx, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+        state.add_list_drawn(list_drawn)
+    })
+    .await?;
+
+    tx.commit().await?;
+    Ok(Json(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use super::*;
+    use crate::{
+        api::apportionment::ListDrawingLotsRequired,
+        domain::{
+            apportionment::ListDrawingLotsVariant,
+            apportionment_state::{ApportionmentState, DrawingLotsDetails},
+            committee_session::CommitteeSessionId,
+            committee_session_status::CommitteeSessionStatus,
+            election::PGNumber,
+            role::Role,
+        },
+        repository::{apportionment_state_repo, committee_session_repo, user_repo::UserId},
+    };
+
+    #[test(sqlx::test(fixtures(
+        path = "../../../../fixtures",
+        scripts("election_5_with_results")
+    )))]
+    async fn test_add_list_drawn(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let audit_service = AuditService::new(Some(user.clone()), None);
+        let id = CommitteeSessionId::from(6);
+
+        committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
+            .await
+            .expect("should change committee session status");
+
+        let drawing_lots_details: DrawingLotsDetails = ListDrawingLotsRequired {
+            variant: ListDrawingLotsVariant::AbsoluteMajority,
+            options: PGNumber::from_values(vec![8, 9]),
+        }
+        .into();
+
+        apportionment_state_repo::upsert(
+            &mut conn,
+            id,
+            &ApportionmentState::DrawingLots {
+                drawing_lots_details: drawing_lots_details.clone(),
+                deceased_candidates: vec![],
+                lists_drawn: vec![],
+                candidates_drawn: vec![],
+            },
+        )
+        .await
+        .expect("should upsert initial state");
+
+        let list_drawn = ListDrawn {
+            variant: ListDrawingLotsVariant::AbsoluteMajority,
+            options: PGNumber::from_values(vec![8, 9]),
+            drawn: PGNumber::from(8),
+        };
+
+        let state = add_list_drawn(
+            user,
+            State(pool),
+            audit_service,
+            Path(ElectionId::from(5)),
+            Json::from(list_drawn.clone()),
+        )
+        .await
+        .expect("should call the handler successfully");
+
+        assert_eq!(
+            state.0,
+            ApportionmentState::DrawingLots {
+                drawing_lots_details,
+                deceased_candidates: vec![],
+                lists_drawn: vec![list_drawn],
+                candidates_drawn: vec![],
+            }
+        );
+    }
+}

--- a/backend/src/api/apportionment/handlers/add_list_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_list_drawn.rs
@@ -18,8 +18,9 @@ use crate::{
 #[utoipa::path(
     post,
     path = "/api/elections/{election_id}/apportionment/add_list_drawn",
+    request_body = ListDrawn,
     responses(
-        (status = 200, description = "Add list to drawing lots", body = ListDrawn),
+        (status = 200, description = "Add list to drawing lots", body = ApportionmentState),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),

--- a/backend/src/api/apportionment/handlers/mod.rs
+++ b/backend/src/api/apportionment/handlers/mod.rs
@@ -1,4 +1,6 @@
+pub mod add_candidate_drawn;
 pub mod add_deceased_candidate;
+pub mod add_list_drawn;
 pub mod delete_deceased_candidate;
 pub mod finalise_deceased_candidates;
 pub mod get_apportionment_state;

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -83,7 +83,9 @@ pub fn router() -> OpenApiRouter<AppState> {
     const ALLOWED_ROLES: &[Role] = &[CoordinatorCSB];
 
     OpenApiRouter::default()
+        .routes(routes!(add_candidate_drawn::add_candidate_drawn).authorize(ALLOWED_ROLES))
         .routes(routes!(add_deceased_candidate::add_deceased_candidate).authorize(ALLOWED_ROLES))
+        .routes(routes!(add_list_drawn::add_list_drawn).authorize(ALLOWED_ROLES))
         .routes(
             routes!(delete_deceased_candidate::delete_deceased_candidate).authorize(ALLOWED_ROLES),
         )

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -20,6 +20,8 @@ pub struct ApportionmentInputData<'a> {
     pub number_of_seats: u32,
     pub list_votes: &'a [PoliticalGroupCandidateVotes],
     pub deceased_candidates: HashMap<PGNumber, HashSet<CandidateNumber>>,
+    pub lists_drawn: &'a [ListDrawn],
+    pub candidates_drawn: &'a [CandidateDrawn],
 }
 
 impl<'a> ApportionmentInputData<'a> {
@@ -27,6 +29,8 @@ impl<'a> ApportionmentInputData<'a> {
         number_of_seats: u32,
         list_votes: &'a [PoliticalGroupCandidateVotes],
         deceased_candidates: &[DeceasedCandidate],
+        lists_drawn: &'a [ListDrawn],
+        candidates_drawn: &'a [CandidateDrawn],
     ) -> Self {
         let mut grouped: HashMap<PGNumber, HashSet<CandidateNumber>> = HashMap::new();
 
@@ -41,6 +45,8 @@ impl<'a> ApportionmentInputData<'a> {
             number_of_seats,
             list_votes,
             deceased_candidates: grouped,
+            lists_drawn,
+            candidates_drawn,
         }
     }
 }
@@ -63,11 +69,11 @@ impl<'a> apportionment::ApportionmentInput for ApportionmentInputData<'a> {
     }
 
     fn lists_drawn(&self) -> impl Iterator<Item = &ListDrawn> {
-        std::iter::empty()
+        self.lists_drawn.iter()
     }
 
     fn candidates_drawn(&self) -> impl Iterator<Item = &CandidateDrawn> {
-        std::iter::empty()
+        self.candidates_drawn.iter()
     }
 }
 

--- a/backend/src/api/report/files.rs
+++ b/backend/src/api/report/files.rs
@@ -117,6 +117,8 @@ async fn generate_and_save_files_csb_election(
         input.election.number_of_seats,
         &input.summary.political_group_votes,
         state.get_deceased_candidates(),
+        state.get_lists_drawn(),
+        state.get_candidates_drawn(),
     );
     let apportionment_result = apportionment::process(&apportionment_input)?;
 

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -157,6 +157,49 @@ impl ApportionmentState {
         }
     }
 
+    pub fn add_list_drawn(self, list_drawn: ListDrawn) -> Result<Self, ApportionmentStateError> {
+        match self {
+            Self::DrawingLots {
+                drawing_lots_details,
+                deceased_candidates,
+                mut lists_drawn,
+                candidates_drawn,
+            } => Ok(Self::DrawingLots {
+                drawing_lots_details,
+                deceased_candidates,
+                lists_drawn: {
+                    lists_drawn.push(list_drawn);
+                    lists_drawn
+                },
+                candidates_drawn,
+            }),
+            _ => Err(ApportionmentStateError::InvalidState),
+        }
+    }
+
+    pub fn add_candidate_drawn(
+        self,
+        candidate_drawn: CandidateDrawn,
+    ) -> Result<Self, ApportionmentStateError> {
+        match self {
+            Self::DrawingLots {
+                drawing_lots_details,
+                deceased_candidates,
+                lists_drawn,
+                mut candidates_drawn,
+            } => Ok(Self::DrawingLots {
+                drawing_lots_details,
+                deceased_candidates,
+                lists_drawn,
+                candidates_drawn: {
+                    candidates_drawn.push(candidate_drawn);
+                    candidates_drawn
+                },
+            }),
+            _ => Err(ApportionmentStateError::InvalidState),
+        }
+    }
+
     pub fn finalise(self) -> Result<Self, ApportionmentStateError> {
         match self {
             Self::Uninitialised => Ok(Self::Finalised {
@@ -271,12 +314,28 @@ mod tests {
         .into()
     }
 
+    fn list_drawn() -> ListDrawn {
+        ListDrawn {
+            variant: ListDrawingLotsVariant::AbsoluteMajority,
+            options: PGNumber::from_values(vec![8, 9]),
+            drawn: PGNumber::from(8),
+        }
+    }
+
     fn candidate_drawing_lots_details() -> DrawingLotsDetails {
         CandidateDrawingLotsRequired {
             list: PGNumber::from(1),
             options: CandidateNumber::from_values(vec![3, 4, 5]),
         }
         .into()
+    }
+
+    fn candidate_drawn() -> CandidateDrawn {
+        CandidateDrawn {
+            list: PGNumber::from(1),
+            options: CandidateNumber::from_values(vec![3, 4, 5]),
+            drawn: CandidateNumber::from(4),
+        }
     }
 
     mod state_transitions {
@@ -299,6 +358,90 @@ mod tests {
                     from.clone().draw_lots(candidate_drawing_lots_details()),
                     expected,
                     "from state {from:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn add_list_drawn() {
+            let state = DrawingLots {
+                drawing_lots_details: list_drawing_lots_details(),
+                deceased_candidates: vec![],
+                lists_drawn: vec![],
+                candidates_drawn: vec![],
+            };
+
+            assert_eq!(
+                state
+                    .add_list_drawn(list_drawn())
+                    .expect("add_list_drawn should succeed"),
+                DrawingLots {
+                    drawing_lots_details: list_drawing_lots_details(),
+                    deceased_candidates: vec![],
+                    lists_drawn: vec![list_drawn()],
+                    candidates_drawn: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn add_list_drawn_invalid() {
+            #[rustfmt::skip]
+            let invalid_states = vec![
+                Uninitialised,
+                RegisteringDeceasedCandidates {deceased_candidates: Vec::new() },
+                Finalised {deceased_candidates: vec![],lists_drawn: vec![],candidates_drawn: vec![] },
+            ];
+
+            for state in invalid_states {
+                assert_eq!(
+                    state.clone().add_list_drawn(list_drawn()),
+                    Err(InvalidState),
+                    "from {state:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn add_candidate_drawn() {
+            let state = DrawingLots {
+                drawing_lots_details: candidate_drawing_lots_details(),
+                deceased_candidates: vec![],
+                lists_drawn: vec![],
+                candidates_drawn: vec![],
+            };
+
+            assert_eq!(
+                state
+                    .add_candidate_drawn(candidate_drawn())
+                    .expect("add_candidate_drawn should succeed"),
+                DrawingLots {
+                    drawing_lots_details: candidate_drawing_lots_details(),
+                    deceased_candidates: vec![],
+                    lists_drawn: vec![],
+                    candidates_drawn: vec![candidate_drawn()],
+                }
+            );
+        }
+
+        #[test]
+        fn add_candidate_drawn_invalid() {
+            #[rustfmt::skip]
+            let invalid_states = vec![
+                Uninitialised,
+                RegisteringDeceasedCandidates {deceased_candidates: Vec::new() },
+                Finalised {deceased_candidates: vec![],lists_drawn: vec![],candidates_drawn: vec![] },
+            ];
+
+            for state in invalid_states {
+                assert_eq!(
+                    state.clone().add_candidate_drawn(CandidateDrawn {
+                        list: PGNumber::from(1),
+                        options: CandidateNumber::from_values(vec![3, 4, 5]),
+                        drawn: CandidateNumber::from(4),
+                    }),
+                    Err(InvalidState),
+                    "from {state:?}"
                 );
             }
         }

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -177,6 +177,15 @@ impl ApportionmentState {
         }
     }
 
+    pub fn get_lists_drawn(&self) -> &[ListDrawn] {
+        match self {
+            ApportionmentState::Uninitialised
+            | ApportionmentState::RegisteringDeceasedCandidates { .. } => &[],
+            ApportionmentState::DrawingLots { lists_drawn, .. }
+            | ApportionmentState::Finalised { lists_drawn, .. } => lists_drawn,
+        }
+    }
+
     pub fn add_candidate_drawn(
         self,
         candidate_drawn: CandidateDrawn,
@@ -197,6 +206,19 @@ impl ApportionmentState {
                 },
             }),
             _ => Err(ApportionmentStateError::InvalidState),
+        }
+    }
+
+    pub fn get_candidates_drawn(&self) -> &[CandidateDrawn] {
+        match self {
+            ApportionmentState::Uninitialised
+            | ApportionmentState::RegisteringDeceasedCandidates { .. } => &[],
+            ApportionmentState::DrawingLots {
+                candidates_drawn, ..
+            }
+            | ApportionmentState::Finalised {
+                candidates_drawn, ..
+            } => candidates_drawn,
         }
     }
 

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -154,7 +154,7 @@ mod tests {
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -185,7 +185,7 @@ mod tests {
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
@@ -223,7 +223,7 @@ mod tests {
         let list_votes =
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);

--- a/backend/src/domain/models/enriched_candidate_nomination.rs
+++ b/backend/src/domain/models/enriched_candidate_nomination.rs
@@ -153,7 +153,7 @@ mod tests {
         let political_groups = &election.political_groups;
         let list_votes = create_political_group_candidate_votes(political_groups, &candidate_votes);
         let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[]);
+            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
         let candidate_nomination =

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -336,6 +336,8 @@ mod tests {
             election.number_of_seats,
             &summary.political_group_votes,
             &[],
+            &[],
+            &[],
         );
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
@@ -454,6 +456,8 @@ mod tests {
             election.number_of_seats,
             &summary.political_group_votes,
             &[],
+            &[],
+            &[],
         );
         let apportionment_result =
             apportionment::process(&apportionment_input).expect("apportionment failed");
@@ -539,6 +543,8 @@ mod tests {
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
             &summary.political_group_votes,
+            &[],
+            &[],
             &[],
         );
         let apportionment_result =

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -762,6 +762,8 @@ async fn test_p_22_2() {
         election.number_of_seats,
         &summary_gsb.political_group_votes,
         &[],
+        &[],
+        &[],
     );
     let apportionment_result =
         apportionment::process(&apportionment_input).expect("apportionment failed");

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -173,6 +173,8 @@ pub async fn process(
         election.number_of_seats,
         &election_summary.political_group_votes,
         state.get_deceased_candidates(),
+        state.get_lists_drawn(),
+        state.get_candidates_drawn(),
     );
 
     let apportionment_result = match apportionment::process(&input) {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -92,12 +92,26 @@ export interface PROCESS_APPORTIONMENT_REQUEST_PARAMS {
 }
 export type PROCESS_APPORTIONMENT_REQUEST_PATH = `/api/elections/${ElectionId}/apportionment`;
 
+// /api/elections/{election_id}/apportionment/add_candidate_drawn
+export interface ADD_CANDIDATE_DRAWN_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type ADD_CANDIDATE_DRAWN_REQUEST_PATH = `/api/elections/${ElectionId}/apportionment/add_candidate_drawn`;
+export type ADD_CANDIDATE_DRAWN_REQUEST_BODY = CandidateDrawn;
+
 // /api/elections/{election_id}/apportionment/add_deceased_candidate
 export interface ADD_DECEASED_CANDIDATE_REQUEST_PARAMS {
   election_id: ElectionId;
 }
 export type ADD_DECEASED_CANDIDATE_REQUEST_PATH = `/api/elections/${ElectionId}/apportionment/add_deceased_candidate`;
 export type ADD_DECEASED_CANDIDATE_REQUEST_BODY = DeceasedCandidate;
+
+// /api/elections/{election_id}/apportionment/add_list_drawn
+export interface ADD_LIST_DRAWN_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type ADD_LIST_DRAWN_REQUEST_PATH = `/api/elections/${ElectionId}/apportionment/add_list_drawn`;
+export type ADD_LIST_DRAWN_REQUEST_BODY = ListDrawn;
 
 // /api/elections/{election_id}/apportionment/delete_deceased_candidate
 export interface DELETE_DECEASED_CANDIDATE_REQUEST_PARAMS {


### PR DESCRIPTION
In preparation of issues ["Backend: process drawing lots for X"](https://github.com/kiesraad/abacus/issues/788), in two commits:
- Add apportionment state changes and API endpoints for `add_list_drawn` and `add_candidate_drawn`
- Add `lists_drawn` and `candidates_drawn` to `ApportionmentInputData` from apportionment state