### PR TITLE
Add CSV file to descriptions in Election Report page

### DIFF
--- a/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
+++ b/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
@@ -100,7 +100,14 @@ describe("GSBElectionReportSection", () => {
       }),
     ).toBeVisible();
 
-    expect(await screen.findByText("In het ZIP-bestand zitten drie documenten:")).toBeInTheDocument();
+    expect(await screen.findByText("In het Zip bestand zitten de volgende documenten:")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document."),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document."),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("EML en CSV bestanden met digitale telresultaten.")).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: /Download definitieve documenten tweede zitting/ })).toBeVisible();
   });
 
@@ -138,7 +145,11 @@ describe("GSBElectionReportSection", () => {
       }),
     ).toBeVisible();
 
-    expect(await screen.findByText("In het ZIP-bestand zit één document:")).toBeInTheDocument();
+    expect(await screen.findByText("In het Zip bestand zitten de volgende documenten:")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document."),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("EML en CSV bestanden met digitale telresultaten.")).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: /Download definitieve documenten tweede zitting/ })).toBeVisible();
   });
 });

--- a/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
+++ b/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
@@ -149,7 +149,7 @@ describe("GSBElectionReportSection", () => {
     expect(
       await screen.findByText("Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document."),
     ).toBeInTheDocument();
-    expect(await screen.findByText("EML en CSV bestanden met digitale telresultaten.")).toBeInTheDocument();
+    expect(await screen.findByText("EML- en CSV-bestanden met digitale telresultaten.")).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: /Download definitieve documenten tweede zitting/ })).toBeVisible();
   });
 });

--- a/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
+++ b/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
@@ -107,7 +107,7 @@ describe("GSBElectionReportSection", () => {
     expect(
       await screen.findByText("Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document."),
     ).toBeInTheDocument();
-    expect(await screen.findByText("EML en CSV bestanden met digitale telresultaten.")).toBeInTheDocument();
+    expect(await screen.findByText("EML- en CSV-bestanden met digitale telresultaten.")).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: /Download definitieve documenten tweede zitting/ })).toBeVisible();
   });
 

--- a/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
+++ b/frontend/src/features/election_management/components/report/GSBElectionReportSection.test.tsx
@@ -100,7 +100,7 @@ describe("GSBElectionReportSection", () => {
       }),
     ).toBeVisible();
 
-    expect(await screen.findByText("In het Zip bestand zitten de volgende documenten:")).toBeInTheDocument();
+    expect(await screen.findByText("In het ZIP-bestand zitten de volgende documenten:")).toBeInTheDocument();
     expect(
       await screen.findByText("Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document."),
     ).toBeInTheDocument();
@@ -145,7 +145,7 @@ describe("GSBElectionReportSection", () => {
       }),
     ).toBeVisible();
 
-    expect(await screen.findByText("In het Zip bestand zitten de volgende documenten:")).toBeInTheDocument();
+    expect(await screen.findByText("In het ZIP-bestand zitten de volgende documenten:")).toBeInTheDocument();
     expect(
       await screen.findByText("Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document."),
     ).toBeInTheDocument();

--- a/frontend/src/features/election_management/components/report/GSBElectionReportSection.tsx
+++ b/frontend/src/features/election_management/components/report/GSBElectionReportSection.tsx
@@ -64,15 +64,7 @@ export function GSBElectionReportSection({ election, committeeSession, sessionLa
         <h3>{t("election_management.what_now")}?</h3>
         <p>{t(`election_management.GSB.download_definitive_files`)}</p>
         <section className="sm">
-          <p>
-            {t(
-              isFirstCommitteeSession
-                ? "election_management.GSB.first_session.zip_file_explanation"
-                : wasCorrected
-                  ? "election_management.GSB.next_session.with_corrections.zip_file_explanation"
-                  : "election_management.GSB.next_session.without_corrections.zip_file_explanation",
-            )}
-          </p>
+          <p>{t("election_management.zip_file_explanation")}</p>
           <ol>
             {tx(
               isFirstCommitteeSession

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -32,16 +32,13 @@
     "download_definitive_files": "Download de definitieve bestanden.",
     "first_session": {
       "documents": "<li><strong>PDF-document met het proces verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li>",
-      "zip_file_explanation": "In het ZIP-bestand zitten twee documenten:"
     },
     "next_session": {
       "with_corrections": {
         "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li>",
-        "zip_file_explanation": "In het ZIP-bestand zitten drie documenten:"
       },
       "without_corrections": {
         "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li>",
-        "zip_file_explanation": "In het ZIP-bestand zit één document:"
       }
     },
     "upload_the_zip": "Upload het volledige ZIP-bestand naar het overdrachtsplatform."
@@ -96,4 +93,6 @@
   "yes_add_session": "Ja, zitting toevoegen",
   "yes_delete_session": "Verwijder zitting",
   "zip_file": "ZIP-bestand"
+  "zip_file": "ZIP-bestand",
+  "zip_file_explanation": "In het ZIP-bestand zitten de volgende documenten:"
 }

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -31,14 +31,14 @@
     "download_definitive_documents": "Download definitieve documenten {sessionLabel}",
     "download_definitive_files": "Download de definitieve bestanden.",
     "first_session": {
-      "documents": "<li><strong>PDF-document met het proces-verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
+      "documents": "<li><strong>PDF-document met het proces-verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"
     },
     "next_session": {
       "with_corrections": {
-        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
+        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"
       },
       "without_corrections": {
-        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>CSV-bestand met telling.</strong></li>"
+        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"
       }
     },
     "upload_the_zip": "Upload het volledige ZIP-bestand naar het overdrachtsplatform."
@@ -93,5 +93,5 @@
   "yes_add_session": "Ja, zitting toevoegen",
   "yes_delete_session": "Verwijder zitting",
   "zip_file": "ZIP-bestand",
-  "zip_file_explanation": "In het ZIP-bestand zitten de volgende documenten:"
+  "zip_file_explanation": "In het Zip bestand zitten de volgende documenten:"
 }

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -35,7 +35,7 @@
     },
     "next_session": {
       "with_corrections": {
-        "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
+        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
       },
       "without_corrections": {
         "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>CSV-bestand met telling.</strong></li>"

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -31,14 +31,14 @@
     "download_definitive_documents": "Download definitieve documenten {sessionLabel}",
     "download_definitive_files": "Download de definitieve bestanden.",
     "first_session": {
-      "documents": "<li><strong>PDF-document met het proces verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li>",
+      "documents": "<li><strong>PDF-document met het proces verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
     },
     "next_session": {
       "with_corrections": {
-        "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li>",
+        "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
       },
       "without_corrections": {
-        "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li>",
+        "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>CSV-bestand met telling.</strong></li>"
       }
     },
     "upload_the_zip": "Upload het volledige ZIP-bestand naar het overdrachtsplatform."
@@ -92,7 +92,6 @@
   "what_now": "Wat nu",
   "yes_add_session": "Ja, zitting toevoegen",
   "yes_delete_session": "Verwijder zitting",
-  "zip_file": "ZIP-bestand"
   "zip_file": "ZIP-bestand",
   "zip_file_explanation": "In het ZIP-bestand zitten de volgende documenten:"
 }

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -38,7 +38,7 @@
         "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
       },
       "without_corrections": {
-        "documents": "<li><strong>Het proces verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>CSV-bestand met telling.</strong></li>"
+        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>CSV-bestand met telling.</strong></li>"
       }
     },
     "upload_the_zip": "Upload het volledige ZIP-bestand naar het overdrachtsplatform."

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -38,7 +38,7 @@
         "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML- en CSV-bestanden met digitale telresultaten.</strong></li>"
       },
       "without_corrections": {
-        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"
+        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML- en CSV-bestanden met digitale telresultaten.</strong></li>"
       }
     },
     "upload_the_zip": "Upload het volledige ZIP-bestand naar het overdrachtsplatform."

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -31,7 +31,7 @@
     "download_definitive_documents": "Download definitieve documenten {sessionLabel}",
     "download_definitive_files": "Download de definitieve bestanden.",
     "first_session": {
-      "documents": "<li><strong>PDF-document met het proces verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
+      "documents": "<li><strong>PDF-document met het proces-verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML-bestand met digitale telresultaten.</strong></li><li><strong>CSV-bestand met telling.</strong></li>"
     },
     "next_session": {
       "with_corrections": {

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -31,7 +31,7 @@
     "download_definitive_documents": "Download definitieve documenten {sessionLabel}",
     "download_definitive_files": "Download de definitieve bestanden.",
     "first_session": {
-      "documents": "<li><strong>PDF-document met het proces-verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"
+      "documents": "<li><strong>PDF-document met het proces-verbaal.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML- en CSV-bestanden met digitale telresultaten.</strong></li>"
     },
     "next_session": {
       "with_corrections": {

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -93,5 +93,5 @@
   "yes_add_session": "Ja, zitting toevoegen",
   "yes_delete_session": "Verwijder zitting",
   "zip_file": "ZIP-bestand",
-  "zip_file_explanation": "In het Zip bestand zitten de volgende documenten:"
+  "zip_file_explanation": "In het ZIP-bestand zitten de volgende documenten:"
 }

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -35,7 +35,7 @@
     },
     "next_session": {
       "with_corrections": {
-        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"
+        "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>Het corrigendum van het gemeentelijk stembureau (Na 14-2). Dit is een PDF-document.</strong> Bevat de gecorrigeerde telresultaten van de gemeente.</li><li><strong>EML- en CSV-bestanden met digitale telresultaten.</strong></li>"
       },
       "without_corrections": {
         "documents": "<li><strong>Het proces-verbaal van het gemeentelijk stembureau (P 2a). Dit is een PDF-document.</strong> Dit wordt tijdens de zitting van het gemeentelijk stembureau vastgesteld en ondertekend.</li><li><strong>EML en CSV bestanden met digitale telresultaten.</strong></li>"


### PR DESCRIPTION
Closes #3390 

- Generalizes ZIP content description by omitting the specific file count, as suggested by @Lionqueen94 in Figma
- Adds CSV file to the content description

Please check for spelling errors and if the descriptions are added to the correct places.

<!--
- What's the scope of the changes?
- What did you test? Which edge cases did you explicitly take into account?
- Are there things you want reviewers to definitely take a look at?
- Are there specific people you want feedback from?
- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
-->