### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,21 @@
+## What & why
+
+<!-- What does this change do, and why is it needed? Link the issue(s). -->
+
+## How to test
+
+<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->
+
+## Reviewer notes
+
+<!-- Suggested review order, non-obvious parts, anything that needs context. -->
+
 <!--
-- What's the scope of the changes?
-- What did you test? Which edge cases did you explicitly take into account?
-- Are there things you want reviewers to definitely take a look at?
-- Are there specific people you want feedback from?
-- Do you have tips on how to test? (For example: data setup, triggering specific errors, etc.)
+## Checklist
+
+- [ ] Single, focused change: unrelated changes split into separate PRs
+- [ ] I've self-reviewed the diff
+- [ ] Formatter and linter pass locally
+- [ ] Tests added/updated and passing
+- [ ] Description explains how to test
 -->


### PR DESCRIPTION
## What & why

Update PR template to ask more context and get reviewers up to speed more quickly. This was one of the points from the last retro.

## How to test

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

Read the changes, no code changes to test.

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

The checklist is commented out because I think that while it's useful as a reminder, it is too verbose to always display in the PR. However, [e-KS does use a PR checklist](https://github.com/kiesraad/e-ks/blob/main/.github/pull_request_template.md).

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->