### PR TITLE
Configure Sigrid to ignore RSA crate vuln

### DIFF
--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -49,6 +49,9 @@ dependencychecker:
     - "apportionment"
     - "apportionment-fuzz"
   transitive: true
+  exclude:
+    # Marvin Attack on RSA crate, which we do not use (Cargo weak dependency, https://github.com/rust-lang/cargo/issues/10801)
+    - vulnerability: "CVE-2023-49092"
 
 architecture:
   enabled: true


### PR DESCRIPTION
## What & why

From the Sigrid PR feedback:

<blockquote>

## 😑 You have findings that need to be investigated

> You have **1** open source libraries with issues that don't have an easy solution.  
> You'll need to investigate the risks, and discuss how to manage them accordingly.

| Vulnerabilities | License | Library | Latest version | Location(s) |
|----|----|----|----|----|
| ⚠️ | ✅ | rsa 0.9.10<br />*(Transitive) [RUSTSEC-2023-0071](https://nvd.nist.gov/vuln/detail/CVE-2023-49092).* | 0.9.10 | [backend/fuzz/Cargo.lock](https://github.com/kiesraad/abacus/blob/review-guidelines/backend/fuzz/Cargo.lock#L0)<br />[backend/Cargo.lock](https://github.com/kiesraad/abacus/blob/review-guidelines/backend/Cargo.lock#L0) |

</blockquote>

We have a weak dependency on the RSA crate through sqlx, so we do not actually include this crate in any builds and are thus not vulnerable. To avoid it from being reported on every PR we exclude this specific vulnerability in our Sigrid configuration.

## How to test

Check if Sigrid CI no longer reports this vulnerability.

## Reviewer notes

Sigrid config docs can be found at https://docs.sigrid-says.com/reference/analysis-scope-configuration.html#exclude-open-source-health-risks.