### PR TITLE
Update React Router to v7.17.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "lightningcss": "1.32.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-router": "7.14.0",
+    "react-router": "7.17.0",
     "vite": "8.0.15"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   '@vitest/expect': 4.1.7
   vite: 8.0.15
-  undici@<7.24.0: '>=7.24.0'
 
 importers:
 
@@ -2916,13 +2915,13 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
-
-  undici@8.2.0:
-    resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
-    engines: {node: '>=22.19.0'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -3167,17 +3166,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
-      undici: 8.2.0
+      undici: 6.26.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.2.0
+      undici: 6.26.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.2.0
+      undici: 6.26.0
 
   '@actions/io@3.0.2': {}
 
@@ -5667,9 +5666,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.25.0: {}
+  undici@6.26.0: {}
 
-  undici@8.2.0: {}
+  undici@7.25.0: {}
 
   universal-user-agent@7.0.3: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
       react-router:
-        specifier: 7.14.0
-        version: 7.14.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 7.17.0
+        version: 7.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite:
         specifier: 8.0.15
         version: 8.0.15(@types/node@24.12.4)(esbuild@0.27.7)
@@ -2655,8 +2655,8 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -5404,7 +5404,7 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-router@7.14.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router@7.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       cookie: 1.1.1
       react: 19.2.6

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -5,13 +5,7 @@ allowBuilds:
   unrs-resolver: true
 blockExoticSubdeps: true
 minimumReleaseAge: 4320
-minimumReleaseAgeExclude:
-  - vite@8.0.6
 trustPolicy: no-downgrade
-trustPolicyExclude:
-  - semver@6.3.1
-  - "@octokit/plugin-paginate-rest@9.2.2"
-  - "@octokit/endpoint@9.0.6"
 engineStrict: true
 packageManagerStrict: true
 packageManagerStrictVersion: true
@@ -23,10 +17,3 @@ overrides:
   # @codecov/vite-plugin does not have official support for Vite 8, but works:
   # https://github.com/codecov/codecov-javascript-bundler-plugins/issues/264
   "vite": "$vite"
-  # Fix GHSA-2mjp-6q6p-2qxm / CVE-2026-1525
-  # Fix GHSA-vrm6-8vpv-qv8q / CVE-2026-1526
-  # Fix GHSA-4992-7rv2-5pvq / CVE-2026-1527
-  # Fix GHSA-f269-vfmq-vjvj / CVE-2026-1528
-  # Fix GHSA-v9p9-hfj2-hcw8 / CVE-2026-2229
-  # Fix GHSA-phc3-fgpg-7m6h / CVE-2026-2581
-  "undici@<7.24.0": ">=7.24.0"


### PR DESCRIPTION
# What & why

Update React Router to v7.17.0 to fix GHSA-49rj-9fvp-4h2h, GHSA-8x6r-g9mw-2r78, GHSA-2j2x-hqr9-3h42. These vulnerabilities have no impact to Abacus (afaik) but do trigger warnings from GitHub, Sigrid and pnpm so it's easy enough to patch them.

Also clean up the pnpm workspace config to remove overrides and excludes that we no longer needed because those fixes are part of the transitive dependency tree now.

# How to test

Click through the application to see if there are any obvious failures.

# Reviewer notes

The React Router changelog can be found at https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v7170. We updated from v7.14.0 to v7.17.0.