### PR TITLE
Return extra information when drawing lots is required

### DIFF
--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -67,18 +67,13 @@ impl apportionment::ListVotes for SimpleListVotes {
 
 /// Used when drawing lots for lists is needed
 pub struct SimpleListDrawn {
-    variant: apportionment::ListDrawingLotsVariant,
-    options: Vec<u32>,
+    variant: apportionment::ListDrawingLotsVariant<u32>,
     drawn: u32,
 }
 
 impl apportionment::ListDrawn<u32> for SimpleListDrawn {
-    fn variant(&self) -> apportionment::ListDrawingLotsVariant {
-        self.variant
-    }
-
-    fn options(&self) -> &[u32] {
-        &self.options
+    fn variant(&self) -> apportionment::ListDrawingLotsVariant<u32> {
+        self.variant.clone()
     }
 
     fn drawn(&self) -> &u32 {
@@ -88,18 +83,13 @@ impl apportionment::ListDrawn<u32> for SimpleListDrawn {
 
 /// Used when drawing lots for candidates is needed
 pub struct SimpleCandidateDrawn {
-    list: u32,
-    options: Vec<u32>,
+    variant: apportionment::CandidateDrawingLotsVariant<u32, u32>,
     drawn: u32,
 }
 
 impl apportionment::CandidateDrawn<u32, u32> for SimpleCandidateDrawn {
-    fn list(&self) -> &u32 {
-        &self.list
-    }
-
-    fn options(&self) -> &[u32] {
-        &self.options
+    fn variant(&self) -> apportionment::CandidateDrawingLotsVariant<u32, u32> {
+        self.variant.clone()
     }
 
     fn drawn(&self) -> &u32 {

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -9,13 +9,13 @@ use crate::{
     CandidateVotes, ListVotes,
     fraction::Fraction,
     structs::{
-        CandidateDrawingLotsRequired, CandidateNominationInput, CandidateNumber,
-        DeceasedCandidates, LARGE_COUNCIL_THRESHOLD, ListNumber,
+        CandidateDrawingLotsError, CandidateDrawingLotsVariant, CandidateNominationInput,
+        CandidateNumber, DeceasedCandidates, LARGE_COUNCIL_THRESHOLD, ListNumber,
     },
 };
 
-/// Defines a CandidateNominationError, for more details, check [CandidateDrawingLotsRequired]
-type CandidateNominationErr<LV> = CandidateDrawingLotsRequired<ListNumber<LV>, CandidateNumber<LV>>;
+/// Defines a CandidateNominationErr, for more details, check [CandidateDrawingLotsError]
+type CandidateNominationErr<LV> = CandidateDrawingLotsError<ListNumber<LV>, CandidateNumber<LV>>;
 
 /// Candidate nomination
 #[allow(clippy::cognitive_complexity)]
@@ -254,10 +254,12 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
                     "Drawing of lots is required for candidates: {:?}, only {non_assigned_seats} seat(s) available",
                     candidate_votes_numbers(&same_votes_candidates)
                 );
-                return Err(CandidateDrawingLotsRequired {
-                    list,
-                    options: candidate_votes_numbers(&same_votes_candidates),
-                });
+                return Err(CandidateDrawingLotsError::DrawingLotsRequired(
+                    CandidateDrawingLotsVariant {
+                        list,
+                        options: candidate_votes_numbers(&same_votes_candidates),
+                    },
+                ));
             } else {
                 // Nominate candidate to seat
                 preferential_candidate_nomination
@@ -302,7 +304,7 @@ mod tests {
         ListVotes,
         candidate_nomination::candidate_nomination,
         fraction::Fraction,
-        structs::{CandidateDrawingLotsRequired, DeceasedCandidates},
+        structs::{CandidateDrawingLotsError, CandidateDrawingLotsVariant, DeceasedCandidates},
         test_helpers::{
             ListVotesMock,
             candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats,
@@ -1133,10 +1135,12 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(CandidateDrawingLotsRequired {
-                list: 2,
-                options: vec![1, 2, 3, 4, 5, 6]
-            })
+            Err(CandidateDrawingLotsError::DrawingLotsRequired(
+                CandidateDrawingLotsVariant {
+                    list: 2,
+                    options: vec![1, 2, 3, 4, 5, 6]
+                }
+            ))
         );
     }
 }

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -23,9 +23,10 @@ pub use self::{
         SeatChangeStep,
     },
     structs::{
-        ApportionmentError, ApportionmentInput, ApportionmentOutput, CandidateDrawingLotsRequired,
-        CandidateDrawn, CandidateVotes, ListDrawingLotsRequired, ListDrawingLotsVariant, ListDrawn,
-        ListVotes,
+        AbsoluteMajorityDrawingLots, ApportionmentError, ApportionmentInput, ApportionmentOutput,
+        CandidateDrawingLotsVariant, CandidateDrawn, CandidateVotes,
+        HighestAverageResidualSeatDrawingLots, LargestRemainderResidualSeatDrawingLots,
+        ListDrawingLotsError, ListDrawingLotsVariant, ListDrawn, ListVotes,
     },
 };
 

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -16,8 +16,8 @@ use crate::{
     ApportionmentInput, ListVotes,
     fraction::Fraction,
     structs::{
-        CandidateNominationInput, CandidateNominationInputType, DeceasedCandidates,
-        ListDrawingLotsRequired, ListDrawingLotsVariant, ListNumber,
+        AbsoluteMajorityDrawingLots, CandidateNominationInput, CandidateNominationInputType,
+        DeceasedCandidates, ListDrawingLotsError, ListDrawingLotsVariant, ListNumber,
     },
 };
 
@@ -25,7 +25,7 @@ use crate::{
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub(crate) fn seat_assignment<T: ApportionmentInput>(
     input: &T,
-) -> Result<SeatAssignmentResult<T::List>, ListDrawingLotsRequired<ListNumber<T::List>>> {
+) -> Result<SeatAssignmentResult<T::List>, ListDrawingLotsError<ListNumber<T::List>>> {
     info!("Seat assignment");
     info!("Seats: {}", input.number_of_seats());
 
@@ -239,10 +239,11 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
                 "Drawing of lots is required for lists: {:?} to pick a list which the residual seat gets retracted from",
                 lists_last_residual_seat
             );
-            return Err(ListDrawingLotsRequired {
-                variant: ListDrawingLotsVariant::AbsoluteMajority,
-                options: lists_last_residual_seat.to_vec(),
-            });
+            return Err(ListDrawingLotsError::DrawingLotsRequired(
+                ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                    options: lists_last_residual_seat.to_vec(),
+                }),
+            ));
         }
 
         // Reassign the seat
@@ -583,12 +584,16 @@ pub(crate) mod tests {
             use test_log::test;
 
             use crate::{
-                seat_assignment,
-                structs::{ListDrawingLotsRequired, ListDrawingLotsVariant},
+                Fraction, seat_assignment,
+                structs::{
+                    AbsoluteMajorityDrawingLots, LargestRemainderResidualSeatDrawingLots,
+                    ListDrawingLotsError, ListDrawingLotsVariant,
+                },
                 test_helpers::seat_assignment_fixture_with_default_50_candidates,
             };
 
-            /// Apportionment with residual seats assigned with largest remainders method  
+            /// Apportionment with residual seats assigned with largest remainders method
+            ///
             /// This test triggers Kieswet Article P 9
             ///
             /// Full seats: [7, 1, 1, 1, 1, 1] - Remainder seats: 3  
@@ -606,10 +611,11 @@ pub(crate) mod tests {
                 let result = seat_assignment(&input);
                 assert_eq!(
                     result,
-                    Err(ListDrawingLotsRequired {
-                        variant: ListDrawingLotsVariant::AbsoluteMajority,
-                        options: vec![2, 3, 4]
-                    })
+                    Err(ListDrawingLotsError::DrawingLotsRequired(
+                        ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                            options: vec![2, 3, 4]
+                        })
+                    ))
                 );
             }
 
@@ -628,10 +634,15 @@ pub(crate) mod tests {
                 let result = seat_assignment(&input);
                 assert_eq!(
                     result,
-                    Err(ListDrawingLotsRequired {
-                        variant: ListDrawingLotsVariant::LargestRemainderResidualSeat,
-                        options: vec![2, 3, 4, 5, 6]
-                    })
+                    Err(ListDrawingLotsError::DrawingLotsRequired(
+                        ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                            LargestRemainderResidualSeatDrawingLots {
+                                remainder: Fraction::new(0, 15),
+                                residual_seat_numbers: vec![],
+                                options: vec![2, 3, 4, 5, 6]
+                            }
+                        )
+                    ))
                 );
             }
 
@@ -649,10 +660,15 @@ pub(crate) mod tests {
                 let result = seat_assignment(&input);
                 assert_eq!(
                     result,
-                    Err(ListDrawingLotsRequired {
-                        variant: ListDrawingLotsVariant::LargestRemainderResidualSeat,
-                        options: vec![2, 3, 4, 5, 6]
-                    })
+                    Err(ListDrawingLotsError::DrawingLotsRequired(
+                        ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                            LargestRemainderResidualSeatDrawingLots {
+                                remainder: Fraction::new(60, 1),
+                                residual_seat_numbers: vec![],
+                                options: vec![2, 3, 4, 5, 6]
+                            }
+                        )
+                    ))
                 );
             }
         }
@@ -1419,8 +1435,12 @@ pub(crate) mod tests {
             use test_log::test;
 
             use crate::{
+                Fraction,
                 seat_assignment::seat_assignment,
-                structs::{ListDrawingLotsRequired, ListDrawingLotsVariant},
+                structs::{
+                    AbsoluteMajorityDrawingLots, HighestAverageResidualSeatDrawingLots,
+                    ListDrawingLotsError, ListDrawingLotsVariant,
+                },
                 test_helpers::seat_assignment_fixture_with_default_50_candidates,
             };
 
@@ -1445,10 +1465,11 @@ pub(crate) mod tests {
                 let result = seat_assignment(&input);
                 assert_eq!(
                     result,
-                    Err(ListDrawingLotsRequired {
-                        variant: ListDrawingLotsVariant::AbsoluteMajority,
-                        options: vec![6, 7]
-                    })
+                    Err(ListDrawingLotsError::DrawingLotsRequired(
+                        ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                            options: vec![6, 7]
+                        })
+                    ))
                 );
             }
 
@@ -1466,10 +1487,15 @@ pub(crate) mod tests {
                 let result = seat_assignment(&input);
                 assert_eq!(
                     result,
-                    Err(ListDrawingLotsRequired {
-                        variant: ListDrawingLotsVariant::HighestAverageResidualSeat,
-                        options: vec![2, 3, 4, 5, 6]
-                    })
+                    Err(ListDrawingLotsError::DrawingLotsRequired(
+                        ListDrawingLotsVariant::HighestAverageResidualSeat(
+                            HighestAverageResidualSeatDrawingLots {
+                                average: Fraction::new(140, 3),
+                                residual_seat_numbers: vec![],
+                                options: vec![2, 3, 4, 5, 6]
+                            }
+                        )
+                    ))
                 );
             }
         }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -12,8 +12,9 @@ use super::{
 use crate::{
     fraction::Fraction,
     structs::{
-        DeceasedCandidates, LARGE_COUNCIL_THRESHOLD, ListDrawingLotsRequired,
-        ListDrawingLotsVariant, ListVotes,
+        DeceasedCandidates, HighestAverageResidualSeatDrawingLots, LARGE_COUNCIL_THRESHOLD,
+        LargestRemainderResidualSeatDrawingLots, ListDrawingLotsError, ListDrawingLotsVariant,
+        ListVotes,
     },
 };
 
@@ -262,7 +263,8 @@ fn list_unique_highest_average_assigned_seats<LN: Copy + Eq>(
         .count()
 }
 
-/// Compute the lists with the highest average votes per seats.  
+/// Compute the lists with the highest average votes per seats.
+///
 /// This is determined based on seeing what would happen to the average votes
 /// per seat if one additional seat would be assigned to each list.
 ///
@@ -274,7 +276,7 @@ fn list_unique_highest_average_assigned_seats<LN: Copy + Eq>(
 fn lists_with_highest_average<'a, LN: Copy + Debug>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
     residual_seats: u32,
-) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsRequired<LN>> {
+) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsError<LN>> {
     // We are now going to find the lists that have the highest average
     // votes per seat if we would were to add one additional seat to them
     let (max_average, lists) = standings.fold(
@@ -308,10 +310,16 @@ fn lists_with_highest_average<'a, LN: Copy + Debug>(
             "Drawing of lots is required for lists: {:?}, only {residual_seats} seat(s) available",
             list_numbers(&lists)
         );
-        Err(ListDrawingLotsRequired {
-            variant: ListDrawingLotsVariant::HighestAverageResidualSeat,
-            options: list_numbers(&lists),
-        })
+        Err(ListDrawingLotsError::DrawingLotsRequired(
+            ListDrawingLotsVariant::HighestAverageResidualSeat(
+                HighestAverageResidualSeatDrawingLots {
+                    average: max_average,
+                    // TODO set actual residual_seat_numbers in #1264
+                    residual_seat_numbers: Vec::new(),
+                    options: list_numbers(&lists),
+                },
+            ),
+        ))
     } else {
         Ok(lists)
     }
@@ -327,7 +335,7 @@ fn lists_with_highest_average<'a, LN: Copy + Debug>(
 fn lists_with_largest_remainder<'a, LN: Copy + Debug>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
     residual_seats: u32,
-) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsRequired<LN>> {
+) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsError<LN>> {
     // We are now going to find the lists that have the largest remainder
     let (max_remainder, lists) = standings.fold(
         (Fraction::ZERO, vec![]),
@@ -360,10 +368,16 @@ fn lists_with_largest_remainder<'a, LN: Copy + Debug>(
             "Drawing of lots is required for lists: {:?}, only {residual_seats} seat(s) available",
             list_numbers(&lists)
         );
-        Err(ListDrawingLotsRequired {
-            variant: ListDrawingLotsVariant::LargestRemainderResidualSeat,
-            options: list_numbers(&lists),
-        })
+        Err(ListDrawingLotsError::DrawingLotsRequired(
+            ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                LargestRemainderResidualSeatDrawingLots {
+                    remainder: max_remainder,
+                    // TODO set actual residual_seat_numbers in #1264
+                    residual_seat_numbers: Vec::new(),
+                    options: list_numbers(&lists),
+                },
+            ),
+        ))
     } else {
         Ok(lists)
     }
@@ -379,7 +393,7 @@ fn step_assign_residual_seat<LN: Copy + Debug + Eq>(
     residual_seat_number: u32,
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
-) -> Result<SeatChange<LN>, ListDrawingLotsRequired<LN>> {
+) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
     if seats >= LARGE_COUNCIL_THRESHOLD {
         debug!("Assigning residual seat {residual_seat_number} using highest averages method");
         // [Artikel P 7 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP7)
@@ -409,7 +423,7 @@ fn step_assign_remainder_using_highest_averages<'a, LN: Copy + Debug + Eq + 'a>(
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
     unique: bool,
-) -> Result<SeatChange<LN>, ListDrawingLotsRequired<LN>> {
+) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
     // Get an iterator that lists all the list standings without exhausted lists
     // and without lists that have zero votes cast.
     let mut qualifying_for_highest_average = standings
@@ -455,7 +469,7 @@ fn step_assign_remainder_using_largest_remainder<LN: Copy + Debug + Eq>(
     residual_seats: u32,
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
-) -> Result<SeatChange<LN>, ListDrawingLotsRequired<LN>> {
+) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
     // first we check if there are any lists that still qualify for a largest remainder assigned seat
     let mut qualifying_for_remainder = list_standings_qualifying_for_largest_remainder(
         standings,

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use tracing::{debug, info};
 
 use super::Fraction;
-use crate::{ListVotes, structs::ListDrawingLotsRequired};
+use crate::{ListVotes, structs::ListDrawingLotsError};
 
 /// The result of the seat assignment procedure. This contains the number of seats and the quota
 /// that was used. It then contains the initial standing after full seats were assigned,
@@ -314,8 +314,8 @@ pub struct ListExhaustionRemovedSeat<LN> {
 
 /// Result type for residual seat (re)assignment: steps taken and final standings.
 pub type RemainderAssignmentResult<LN> =
-    Result<(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>), ListDrawingLotsRequired<LN>>;
+    Result<(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>), ListDrawingLotsError<LN>>;
 
 /// Result type for absolute majority reassignment: updated standings and optional seat change.
 pub type AbsoluteMajorityResult<LN> =
-    Result<(Vec<ListStanding<LN>>, Option<SeatChange<LN>>), ListDrawingLotsRequired<LN>>;
+    Result<(Vec<ListStanding<LN>>, Option<SeatChange<LN>>), ListDrawingLotsError<LN>>;

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -19,64 +19,92 @@ pub type CandidateNumber<LV> = <<LV as ListVotes>::Cv as CandidateVotes>::Candid
 /// Errors that can occur during apportionment
 #[derive(Debug, PartialEq)]
 pub enum ApportionmentError<LN, CN> {
-    ListDrawingLotsRequired(ListDrawingLotsRequired<LN>),
-    CandidateDrawingLotsRequired(CandidateDrawingLotsRequired<LN, CN>),
+    ListDrawingLotsRequired(ListDrawingLotsVariant<LN>),
+    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant<LN, CN>),
 }
 
 /// Used in [ApportionmentError] to indicate that drawing lots for a list is needed,
 /// containing all the information needed to do the drawing
 #[derive(Debug, PartialEq)]
-pub struct ListDrawingLotsRequired<LN> {
-    pub variant: ListDrawingLotsVariant,
+pub enum ListDrawingLotsError<LN> {
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
+}
+
+impl<LN, CN> From<ListDrawingLotsError<LN>> for ApportionmentError<LN, CN> {
+    fn from(value: ListDrawingLotsError<LN>) -> Self {
+        match value {
+            ListDrawingLotsError::DrawingLotsRequired(variant) => {
+                ApportionmentError::ListDrawingLotsRequired(variant)
+            }
+        }
+    }
+}
+
+/// Errors that can occur when drawing lots for a candidate  is needed during apportionment
+#[derive(Debug, PartialEq)]
+pub enum CandidateDrawingLotsError<LN, CN> {
+    DrawingLotsRequired(CandidateDrawingLotsVariant<LN, CN>),
+}
+
+impl<LN, CN> From<CandidateDrawingLotsError<LN, CN>> for ApportionmentError<LN, CN> {
+    fn from(value: CandidateDrawingLotsError<LN, CN>) -> Self {
+        match value {
+            CandidateDrawingLotsError::DrawingLotsRequired(variant) => {
+                ApportionmentError::CandidateDrawingLotsRequired(variant)
+            }
+        }
+    }
+}
+
+/// Different variants of drawing lots for lists, with all the information needed to do the drawing
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ListDrawingLotsVariant<LN> {
+    /// Draw lots for assigning a highest average residual seat
+    HighestAverageResidualSeat(HighestAverageResidualSeatDrawingLots<LN>),
+    /// Draw lots for assigning a largest remainder residual seat
+    LargestRemainderResidualSeat(LargestRemainderResidualSeatDrawingLots<LN>),
+    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9)
+    AbsoluteMajority(AbsoluteMajorityDrawingLots<LN>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HighestAverageResidualSeatDrawingLots<LN> {
+    pub average: Fraction,
+    pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<LN>,
 }
 
-impl<LN, CN> From<ListDrawingLotsRequired<LN>> for ApportionmentError<LN, CN> {
-    fn from(value: ListDrawingLotsRequired<LN>) -> Self {
-        ApportionmentError::ListDrawingLotsRequired(value)
-    }
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LargestRemainderResidualSeatDrawingLots<LN> {
+    pub remainder: Fraction,
+    pub residual_seat_numbers: Vec<u32>,
+    pub options: Vec<LN>,
 }
 
-/// Used in [ApportionmentError] to indicate that drawing lots for a candidate is needed,
-/// containing all the information needed to do the drawing
-#[derive(Debug, PartialEq)]
-pub struct CandidateDrawingLotsRequired<LN, CN> {
-    pub list: LN,
-    pub options: Vec<CN>,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AbsoluteMajorityDrawingLots<LN> {
+    pub options: Vec<LN>,
 }
 
-impl<LN, CN> From<CandidateDrawingLotsRequired<LN, CN>> for ApportionmentError<LN, CN> {
-    fn from(value: CandidateDrawingLotsRequired<LN, CN>) -> Self {
-        ApportionmentError::CandidateDrawingLotsRequired(value)
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum ListDrawingLotsVariant {
-    /// Draw lots for assigning a highest average residual seat
-    HighestAverageResidualSeat,
-    /// Draw lots for assigning a largest remainder residual seat
-    LargestRemainderResidualSeat,
-    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9)
-    AbsoluteMajority,
-}
-
-/// The list that has been drawn plus information to assert the correct drawing
+/// The list that has been drawn and the variant with all information about the drawing
 pub trait ListDrawn<LN> {
     /// The type of seat assignment or retraction that lots need to be drawn for
-    fn variant(&self) -> ListDrawingLotsVariant;
-    /// The lists that lots are drawn for
-    fn options(&self) -> &[LN];
+    fn variant(&self) -> ListDrawingLotsVariant<LN>;
     /// The list that the lot was drawn for
     fn drawn(&self) -> &LN;
 }
 
-/// The candidate that has been drawn plus information to assert the correct drawing
+/// Variant of drawing lots for candidates, with all the information needed to do the drawing
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CandidateDrawingLotsVariant<LN, CN> {
+    pub list: LN,
+    pub options: Vec<CN>,
+}
+
+/// The candidate that has been drawn and the variant with all information about the drawing
 pub trait CandidateDrawn<LN, CN> {
-    /// The list the candidate needs to be drawn from
-    fn list(&self) -> &LN;
-    /// The candidates that lots are drawn for
-    fn options(&self) -> &[CN];
+    /// The type and information for drawing lots
+    fn variant(&self) -> CandidateDrawingLotsVariant<LN, CN>;
     /// The candidate that the lot was drawn for
     fn drawn(&self) -> &CN;
 }

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use super::{ListVotes, fraction::Fraction, structs::CandidateNominationInput};
+use super::{
+    CandidateDrawingLotsVariant, ListVotes, fraction::Fraction, structs::CandidateNominationInput,
+};
 use crate::{
     ApportionmentInput, CandidateVotes, SeatAssignmentResult,
     candidate_nomination::{Candidate, ListCandidateNomination, candidate_votes_numbers},
@@ -95,18 +97,13 @@ impl ListVotesMock {
 }
 
 pub struct ListDrawnMock {
-    variant: ListDrawingLotsVariant,
-    options: Vec<u32>,
+    variant: ListDrawingLotsVariant<u32>,
     drawn: u32,
 }
 
 impl ListDrawn<u32> for ListDrawnMock {
-    fn variant(&self) -> ListDrawingLotsVariant {
-        self.variant
-    }
-
-    fn options(&self) -> &[u32] {
-        &self.options
+    fn variant(&self) -> ListDrawingLotsVariant<u32> {
+        self.variant.clone()
     }
 
     fn drawn(&self) -> &u32 {
@@ -115,18 +112,13 @@ impl ListDrawn<u32> for ListDrawnMock {
 }
 
 pub struct CandidateDrawnMock {
-    list: u32,
-    options: Vec<u32>,
+    variant: CandidateDrawingLotsVariant<u32, u32>,
     drawn: u32,
 }
 
 impl CandidateDrawn<u32, u32> for CandidateDrawnMock {
-    fn list(&self) -> &u32 {
-        &self.list
-    }
-
-    fn options(&self) -> &[u32] {
-        &self.options
+    fn variant(&self) -> CandidateDrawingLotsVariant<u32, u32> {
+        self.variant.clone()
     }
 
     fn drawn(&self) -> &u32 {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5321,6 +5321,20 @@
   },
   "components": {
     "schemas": {
+      "AbsoluteMajorityDrawingLots": {
+        "type": "object",
+        "required": [
+          "options"
+        ],
+        "properties": {
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PGNumber"
+            }
+          }
+        }
+      },
       "AbsoluteMajorityReassignedSeat": {
         "type": "object",
         "required": [
@@ -5395,7 +5409,7 @@
           {
             "type": "object",
             "required": [
-              "drawing_lots_details",
+              "drawing_lots_required",
               "deceased_candidates",
               "lists_drawn",
               "candidates_drawn",
@@ -5414,8 +5428,8 @@
                   "$ref": "#/components/schemas/DeceasedCandidate"
                 }
               },
-              "drawing_lots_details": {
-                "$ref": "#/components/schemas/DrawingLotsDetails"
+              "drawing_lots_required": {
+                "$ref": "#/components/schemas/DrawingLotsRequired"
               },
               "lists_drawn": {
                 "type": "array",
@@ -5866,37 +5880,13 @@
         },
         "additionalProperties": false
       },
-      "CandidateDrawingLotsRequired": {
+      "CandidateDrawingLotsVariant": {
         "type": "object",
         "required": [
           "list",
           "options"
         ],
         "properties": {
-          "list": {
-            "$ref": "#/components/schemas/PGNumber"
-          },
-          "options": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CandidateNumber"
-            }
-          }
-        }
-      },
-      "CandidateDrawn": {
-        "type": "object",
-        "description": "The candidate that has been drawn plus information to assert the correct drawing",
-        "required": [
-          "list",
-          "options",
-          "drawn"
-        ],
-        "properties": {
-          "drawn": {
-            "$ref": "#/components/schemas/CandidateNumber",
-            "description": "The candidate that the lot was drawn for"
-          },
           "list": {
             "$ref": "#/components/schemas/PGNumber",
             "description": "The list the candidate needs to be drawn from"
@@ -5907,6 +5897,24 @@
               "$ref": "#/components/schemas/CandidateNumber"
             },
             "description": "The candidates that lots are drawn for"
+          }
+        }
+      },
+      "CandidateDrawn": {
+        "type": "object",
+        "description": "The candidate that has been drawn plus information to assert the correct drawing",
+        "required": [
+          "variant",
+          "drawn"
+        ],
+        "properties": {
+          "drawn": {
+            "$ref": "#/components/schemas/CandidateNumber",
+            "description": "The candidate that the lot was drawn for"
+          },
+          "variant": {
+            "$ref": "#/components/schemas/CandidateDrawingLotsVariant",
+            "description": "The type and information for drawing lots"
           }
         }
       },
@@ -6546,12 +6554,12 @@
           }
         }
       },
-      "DrawingLotsDetails": {
+      "DrawingLotsRequired": {
         "oneOf": [
           {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ListDrawingLotsRequired"
+                "$ref": "#/components/schemas/ListDrawingLotsVariant"
               },
               {
                 "type": "object",
@@ -6572,7 +6580,7 @@
           {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CandidateDrawingLotsRequired"
+                "$ref": "#/components/schemas/CandidateDrawingLotsVariant"
               },
               {
                 "type": "object",
@@ -7468,6 +7476,33 @@
           }
         }
       },
+      "HighestAverageResidualSeatDrawingLots": {
+        "type": "object",
+        "required": [
+          "average",
+          "residual_seat_numbers",
+          "options"
+        ],
+        "properties": {
+          "average": {
+            "$ref": "#/components/schemas/DisplayFraction"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PGNumber"
+            }
+          },
+          "residual_seat_numbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        }
+      },
       "InvestigationConcludedWithNewResults": {
         "type": "object",
         "required": [
@@ -7615,6 +7650,33 @@
           }
         }
       },
+      "LargestRemainderResidualSeatDrawingLots": {
+        "type": "object",
+        "required": [
+          "remainder",
+          "residual_seat_numbers",
+          "options"
+        ],
+        "properties": {
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PGNumber"
+            }
+          },
+          "remainder": {
+            "$ref": "#/components/schemas/DisplayFraction"
+          },
+          "residual_seat_numbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        }
+      },
       "ListCandidateNomination": {
         "type": "object",
         "required": [
@@ -7657,30 +7719,77 @@
           }
         }
       },
-      "ListDrawingLotsRequired": {
-        "type": "object",
-        "required": [
-          "variant",
-          "options"
-        ],
-        "properties": {
-          "options": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PGNumber"
-            }
-          },
-          "variant": {
-            "$ref": "#/components/schemas/ListDrawingLotsVariant"
-          }
-        }
-      },
       "ListDrawingLotsVariant": {
-        "type": "string",
-        "enum": [
-          "HighestAverageResidualSeat",
-          "LargestRemainderResidualSeat",
-          "AbsoluteMajority"
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HighestAverageResidualSeatDrawingLots",
+                "description": "Draw lots for assigning a highest average residual seat"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "variant"
+                ],
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "enum": [
+                      "HighestAverageResidualSeat"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Draw lots for assigning a highest average residual seat"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LargestRemainderResidualSeatDrawingLots",
+                "description": "Draw lots for assigning a largest remainder residual seat"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "variant"
+                ],
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "enum": [
+                      "LargestRemainderResidualSeat"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Draw lots for assigning a largest remainder residual seat"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AbsoluteMajorityDrawingLots",
+                "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9)"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "variant"
+                ],
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "enum": [
+                      "AbsoluteMajority"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9)"
+          }
         ]
       },
       "ListDrawn": {
@@ -7688,20 +7797,12 @@
         "description": "The list that has been drawn plus information to assert the correct drawing",
         "required": [
           "variant",
-          "options",
           "drawn"
         ],
         "properties": {
           "drawn": {
             "$ref": "#/components/schemas/PGNumber",
             "description": "The list that the lot was drawn for"
-          },
-          "options": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PGNumber"
-            },
-            "description": "The lists that lots are drawn for"
           },
           "variant": {
             "$ref": "#/components/schemas/ListDrawingLotsVariant",

--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -60,9 +60,8 @@ mod tests {
     use super::*;
     use crate::{
         domain::{
-            apportionment_state::{
-                ApportionmentState, CandidateDrawingLotsRequired, DrawingLotsDetails,
-            },
+            apportionment::CandidateDrawingLotsVariant,
+            apportionment_state::{ApportionmentState, DrawingLotsRequired},
             committee_session::CommitteeSessionId,
             committee_session_status::CommitteeSessionStatus,
             election::{CandidateNumber, PGNumber},
@@ -85,17 +84,17 @@ mod tests {
             .await
             .expect("should change committee session status");
 
-        let drawing_lots_details: DrawingLotsDetails = CandidateDrawingLotsRequired {
-            list: PGNumber::from(3),
-            options: CandidateNumber::from_values(vec![1, 2]),
-        }
-        .into();
+        let drawing_lots_required =
+            DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
+                list: PGNumber::from(3),
+                options: CandidateNumber::from_values(vec![1, 2]),
+            });
 
         apportionment_state_repo::upsert(
             &mut conn,
             id,
             &ApportionmentState::DrawingLots {
-                drawing_lots_details: drawing_lots_details.clone(),
+                drawing_lots_required: drawing_lots_required.clone(),
                 deceased_candidates: vec![],
                 lists_drawn: vec![],
                 candidates_drawn: vec![],
@@ -105,8 +104,10 @@ mod tests {
         .expect("should upsert initial state");
 
         let candidate_drawn = CandidateDrawn {
-            list: PGNumber::from(3),
-            options: CandidateNumber::from_values(vec![1, 2]),
+            variant: CandidateDrawingLotsVariant {
+                list: PGNumber::from(3),
+                options: CandidateNumber::from_values(vec![1, 2]),
+            },
             drawn: CandidateNumber::from(2),
         };
 
@@ -123,7 +124,7 @@ mod tests {
         assert_eq!(
             state.0,
             ApportionmentState::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates: vec![],
                 lists_drawn: vec![],
                 candidates_drawn: vec![candidate_drawn],

--- a/backend/src/api/apportionment/handlers/add_list_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_list_drawn.rs
@@ -58,10 +58,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        api::apportionment::ListDrawingLotsRequired,
         domain::{
-            apportionment::ListDrawingLotsVariant,
-            apportionment_state::{ApportionmentState, DrawingLotsDetails},
+            apportionment::{AbsoluteMajorityDrawingLots, ListDrawingLotsVariant},
+            apportionment_state::{ApportionmentState, DrawingLotsRequired},
             committee_session::CommitteeSessionId,
             committee_session_status::CommitteeSessionStatus,
             election::PGNumber,
@@ -84,17 +83,17 @@ mod tests {
             .await
             .expect("should change committee session status");
 
-        let drawing_lots_details: DrawingLotsDetails = ListDrawingLotsRequired {
-            variant: ListDrawingLotsVariant::AbsoluteMajority,
-            options: PGNumber::from_values(vec![8, 9]),
-        }
-        .into();
+        let drawing_lots_required = DrawingLotsRequired::ListDrawingLotsRequired(
+            ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                options: PGNumber::from_values(vec![8, 9]),
+            }),
+        );
 
         apportionment_state_repo::upsert(
             &mut conn,
             id,
             &ApportionmentState::DrawingLots {
-                drawing_lots_details: drawing_lots_details.clone(),
+                drawing_lots_required: drawing_lots_required.clone(),
                 deceased_candidates: vec![],
                 lists_drawn: vec![],
                 candidates_drawn: vec![],
@@ -104,8 +103,9 @@ mod tests {
         .expect("should upsert initial state");
 
         let list_drawn = ListDrawn {
-            variant: ListDrawingLotsVariant::AbsoluteMajority,
-            options: PGNumber::from_values(vec![8, 9]),
+            variant: ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                options: PGNumber::from_values(vec![8, 9]),
+            }),
             drawn: PGNumber::from(8),
         };
 
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(
             state.0,
             ApportionmentState::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates: vec![],
                 lists_drawn: vec![list_drawn],
                 candidates_drawn: vec![],

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -11,9 +11,6 @@ pub use self::{
     mapping::{map_candidate_nomination, map_seat_assignment},
     structs::{ApportionmentInputData, ElectionApportionmentResponse},
 };
-pub use crate::domain::apportionment_state::{
-    CandidateDrawingLotsRequired, ListDrawingLotsRequired,
-};
 use crate::{
     APIError, AppState,
     api::middleware::authentication::RouteAuthorization,

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -6,8 +6,9 @@ use utoipa::ToSchema;
 
 use crate::domain::{
     apportionment::{
-        ApportionmentWarning, CandidateDrawn, CandidateNomination, ListDrawingLotsVariant,
-        ListDrawn, SeatAssignment,
+        AbsoluteMajorityDrawingLots, ApportionmentWarning, CandidateDrawingLotsVariant,
+        CandidateDrawn, CandidateNomination, HighestAverageResidualSeatDrawingLots,
+        LargestRemainderResidualSeatDrawingLots, ListDrawingLotsVariant, ListDrawn, SeatAssignment,
     },
     apportionment_state::DeceasedCandidate,
     election::{CandidateNumber, PGNumber},
@@ -102,29 +103,45 @@ impl apportionment::CandidateVotes for CandidateVotes {
     }
 }
 
-impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant {
+impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNumber> {
     fn from(value: ListDrawingLotsVariant) -> Self {
         match value {
-            ListDrawingLotsVariant::HighestAverageResidualSeat => {
-                apportionment::ListDrawingLotsVariant::HighestAverageResidualSeat
-            }
-            ListDrawingLotsVariant::LargestRemainderResidualSeat => {
-                apportionment::ListDrawingLotsVariant::LargestRemainderResidualSeat
-            }
-            ListDrawingLotsVariant::AbsoluteMajority => {
-                apportionment::ListDrawingLotsVariant::AbsoluteMajority
+            ListDrawingLotsVariant::HighestAverageResidualSeat(
+                HighestAverageResidualSeatDrawingLots {
+                    average,
+                    residual_seat_numbers,
+                    options,
+                },
+            ) => Self::HighestAverageResidualSeat(
+                apportionment::HighestAverageResidualSeatDrawingLots {
+                    average: average.into(),
+                    residual_seat_numbers,
+                    options,
+                },
+            ),
+            ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                LargestRemainderResidualSeatDrawingLots {
+                    remainder,
+                    residual_seat_numbers,
+                    options,
+                },
+            ) => Self::LargestRemainderResidualSeat(
+                apportionment::LargestRemainderResidualSeatDrawingLots {
+                    remainder: remainder.into(),
+                    residual_seat_numbers,
+                    options,
+                },
+            ),
+            ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots { options }) => {
+                Self::AbsoluteMajority(apportionment::AbsoluteMajorityDrawingLots { options })
             }
         }
     }
 }
 
 impl apportionment::ListDrawn<PGNumber> for ListDrawn {
-    fn variant(&self) -> apportionment::ListDrawingLotsVariant {
-        self.variant.into()
-    }
-
-    fn options(&self) -> &[PGNumber] {
-        &self.options
+    fn variant(&self) -> apportionment::ListDrawingLotsVariant<PGNumber> {
+        self.variant.clone().into()
     }
 
     fn drawn(&self) -> &PGNumber {
@@ -132,13 +149,17 @@ impl apportionment::ListDrawn<PGNumber> for ListDrawn {
     }
 }
 
-impl apportionment::CandidateDrawn<PGNumber, CandidateNumber> for CandidateDrawn {
-    fn list(&self) -> &PGNumber {
-        &self.list
+impl From<CandidateDrawingLotsVariant>
+    for apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>
+{
+    fn from(CandidateDrawingLotsVariant { list, options }: CandidateDrawingLotsVariant) -> Self {
+        Self { list, options }
     }
+}
 
-    fn options(&self) -> &[CandidateNumber] {
-        &self.options
+impl apportionment::CandidateDrawn<PGNumber, CandidateNumber> for CandidateDrawn {
+    fn variant(&self) -> apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber> {
+        self.variant.clone().into()
     }
 
     fn drawn(&self) -> &CandidateNumber {

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -268,6 +268,17 @@ impl From<apportionment::Fraction> for DisplayFraction {
     }
 }
 
+impl From<DisplayFraction> for apportionment::Fraction {
+    fn from(display_fraction: DisplayFraction) -> Self {
+        let numerator =
+            display_fraction.integer * display_fraction.denominator + display_fraction.numerator;
+        Self {
+            numerator,
+            denominator: display_fraction.denominator,
+        }
+    }
+}
+
 /// Chosen candidate
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -310,14 +321,34 @@ impl ChosenCandidate {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[serde(tag = "variant")]
 pub enum ListDrawingLotsVariant {
     /// Draw lots for assigning a highest average residual seat
-    HighestAverageResidualSeat,
+    HighestAverageResidualSeat(HighestAverageResidualSeatDrawingLots),
     /// Draw lots for assigning a largest remainder residual seat
-    LargestRemainderResidualSeat,
+    LargestRemainderResidualSeat(LargestRemainderResidualSeatDrawingLots),
     /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9)
-    AbsoluteMajority,
+    AbsoluteMajority(AbsoluteMajorityDrawingLots),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+pub struct HighestAverageResidualSeatDrawingLots {
+    pub average: DisplayFraction,
+    pub residual_seat_numbers: Vec<u32>,
+    pub options: Vec<PGNumber>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+pub struct LargestRemainderResidualSeatDrawingLots {
+    pub remainder: DisplayFraction,
+    pub residual_seat_numbers: Vec<u32>,
+    pub options: Vec<PGNumber>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+pub struct AbsoluteMajorityDrawingLots {
+    pub options: Vec<PGNumber>,
 }
 
 /// The list that has been drawn plus information to assert the correct drawing
@@ -325,19 +356,65 @@ pub enum ListDrawingLotsVariant {
 pub struct ListDrawn {
     /// The type of seat assignment or retraction that lots need to be drawn for
     pub variant: ListDrawingLotsVariant,
-    /// The lists that lots are drawn for
-    pub options: Vec<PGNumber>,
     /// The list that the lot was drawn for
     pub drawn: PGNumber,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+pub struct CandidateDrawingLotsVariant {
+    /// The list the candidate needs to be drawn from
+    pub list: PGNumber,
+    /// The candidates that lots are drawn for
+    pub options: Vec<CandidateNumber>,
 }
 
 /// The candidate that has been drawn plus information to assert the correct drawing
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct CandidateDrawn {
-    /// The list the candidate needs to be drawn from
-    pub list: PGNumber,
-    /// The candidates that lots are drawn for
-    pub options: Vec<CandidateNumber>,
+    /// The type and information for drawing lots
+    pub variant: CandidateDrawingLotsVariant,
     /// The candidate that the lot was drawn for
     pub drawn: CandidateNumber,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_from_display_fraction_for_fraction() {
+        let fraction: apportionment::Fraction = DisplayFraction {
+            integer: 1,
+            numerator: 2,
+            denominator: 3,
+        }
+        .into();
+
+        assert_eq!(
+            fraction,
+            apportionment::Fraction {
+                numerator: 5,
+                denominator: 3,
+            }
+        )
+    }
+
+    #[test]
+    fn test_from_fraction_for_display_fraction() {
+        let display_fraction: DisplayFraction = apportionment::Fraction {
+            numerator: 5,
+            denominator: 3,
+        }
+        .into();
+
+        assert_eq!(
+            display_fraction,
+            DisplayFraction {
+                integer: 1,
+                numerator: 2,
+                denominator: 3,
+            }
+        )
+    }
 }

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -5,7 +5,9 @@ use utoipa::ToSchema;
 use crate::{
     ErrorResponse,
     domain::{
-        apportionment::{CandidateDrawn, ListDrawingLotsVariant, ListDrawn},
+        apportionment::{
+            CandidateDrawingLotsVariant, CandidateDrawn, ListDrawingLotsVariant, ListDrawn,
+        },
         election::{CandidateNumber, PGNumber},
     },
     error::{ApiErrorResponse, ErrorReference},
@@ -63,33 +65,9 @@ impl DeceasedCandidate {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[serde(tag = "type")]
-pub enum DrawingLotsDetails {
-    ListDrawingLotsRequired(ListDrawingLotsRequired),
-    CandidateDrawingLotsRequired(CandidateDrawingLotsRequired),
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
-pub struct ListDrawingLotsRequired {
-    pub variant: ListDrawingLotsVariant,
-    pub options: Vec<PGNumber>,
-}
-
-impl From<ListDrawingLotsRequired> for DrawingLotsDetails {
-    fn from(drawing_lots_details: ListDrawingLotsRequired) -> Self {
-        Self::ListDrawingLotsRequired(drawing_lots_details)
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
-pub struct CandidateDrawingLotsRequired {
-    pub list: PGNumber,
-    pub options: Vec<CandidateNumber>,
-}
-
-impl From<CandidateDrawingLotsRequired> for DrawingLotsDetails {
-    fn from(drawing_lots_details: CandidateDrawingLotsRequired) -> Self {
-        Self::CandidateDrawingLotsRequired(drawing_lots_details)
-    }
+pub enum DrawingLotsRequired {
+    ListDrawingLotsRequired(ListDrawingLotsVariant),
+    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant),
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, ToSchema, strum::Display)]
@@ -101,7 +79,7 @@ pub enum ApportionmentState {
         deceased_candidates: Vec<DeceasedCandidate>,
     },
     DrawingLots {
-        drawing_lots_details: DrawingLotsDetails,
+        drawing_lots_required: DrawingLotsRequired,
         deceased_candidates: Vec<DeceasedCandidate>,
         lists_drawn: Vec<ListDrawn>,
         candidates_drawn: Vec<CandidateDrawn>,
@@ -125,11 +103,11 @@ impl ApportionmentState {
 
     pub fn draw_lots(
         self,
-        drawing_lots_details: DrawingLotsDetails,
+        drawing_lots_required: DrawingLotsRequired,
     ) -> Result<Self, ApportionmentStateError> {
         match self {
             Self::Uninitialised => Ok(Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates: Vec::new(),
                 lists_drawn: Vec::new(),
                 candidates_drawn: Vec::new(),
@@ -137,7 +115,7 @@ impl ApportionmentState {
             Self::RegisteringDeceasedCandidates {
                 deceased_candidates,
             } => Ok(Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates,
                 lists_drawn: Vec::new(),
                 candidates_drawn: Vec::new(),
@@ -148,7 +126,7 @@ impl ApportionmentState {
                 candidates_drawn,
                 ..
             } => Ok(Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates,
                 lists_drawn,
                 candidates_drawn,
@@ -160,12 +138,12 @@ impl ApportionmentState {
     pub fn add_list_drawn(self, list_drawn: ListDrawn) -> Result<Self, ApportionmentStateError> {
         match self {
             Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates,
                 mut lists_drawn,
                 candidates_drawn,
             } => Ok(Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates,
                 lists_drawn: {
                     lists_drawn.push(list_drawn);
@@ -192,12 +170,12 @@ impl ApportionmentState {
     ) -> Result<Self, ApportionmentStateError> {
         match self {
             Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates,
                 lists_drawn,
                 mut candidates_drawn,
             } => Ok(Self::DrawingLots {
-                drawing_lots_details,
+                drawing_lots_required,
                 deceased_candidates,
                 lists_drawn,
                 candidates_drawn: {
@@ -327,35 +305,42 @@ mod tests {
     use ApportionmentStateError::*;
 
     use super::*;
+    use crate::domain::apportionment::{AbsoluteMajorityDrawingLots, CandidateDrawingLotsVariant};
 
-    fn list_drawing_lots_details() -> DrawingLotsDetails {
-        ListDrawingLotsRequired {
-            variant: ListDrawingLotsVariant::AbsoluteMajority,
-            options: PGNumber::from_values(vec![8, 9]),
-        }
-        .into()
+    fn list_required() -> DrawingLotsRequired {
+        DrawingLotsRequired::ListDrawingLotsRequired(ListDrawingLotsVariant::AbsoluteMajority(
+            AbsoluteMajorityDrawingLots {
+                options: PGNumber::from_values(vec![8, 9]),
+            },
+        ))
     }
 
     fn list_drawn() -> ListDrawn {
+        let DrawingLotsRequired::ListDrawingLotsRequired(variant) = list_required() else {
+            panic!("should be ListDrawingLotsRequired");
+        };
+
         ListDrawn {
-            variant: ListDrawingLotsVariant::AbsoluteMajority,
-            options: PGNumber::from_values(vec![8, 9]),
+            variant,
             drawn: PGNumber::from(8),
         }
     }
 
-    fn candidate_drawing_lots_details() -> DrawingLotsDetails {
-        CandidateDrawingLotsRequired {
+    fn candidate_required() -> DrawingLotsRequired {
+        DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
             list: PGNumber::from(1),
             options: CandidateNumber::from_values(vec![3, 4, 5]),
-        }
-        .into()
+        })
     }
 
     fn candidate_drawn() -> CandidateDrawn {
+        let DrawingLotsRequired::CandidateDrawingLotsRequired(variant) = candidate_required()
+        else {
+            panic!("should be CandidateDrawingLotsRequired");
+        };
+
         CandidateDrawn {
-            list: PGNumber::from(1),
-            options: CandidateNumber::from_values(vec![3, 4, 5]),
+            variant,
             drawn: CandidateNumber::from(4),
         }
     }
@@ -369,15 +354,15 @@ mod tests {
         fn draw_lots() {
             #[rustfmt::skip]
             let scenarios = vec![
-                (Uninitialised, Ok(DrawingLots { drawing_lots_details: candidate_drawing_lots_details(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]})),
-                (RegisteringDeceasedCandidates { deceased_candidates: vec![] }, Ok(DrawingLots { drawing_lots_details: candidate_drawing_lots_details(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]})),
-                (DrawingLots { drawing_lots_details: list_drawing_lots_details(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]}, Ok(DrawingLots { drawing_lots_details: candidate_drawing_lots_details(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]})),
+                (Uninitialised, Ok(DrawingLots { drawing_lots_required: candidate_required(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]})),
+                (RegisteringDeceasedCandidates { deceased_candidates: vec![] }, Ok(DrawingLots { drawing_lots_required: candidate_required(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]})),
+                (DrawingLots { drawing_lots_required: list_required(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]}, Ok(DrawingLots { drawing_lots_required: candidate_required(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]})),
                 (Finalised { deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]}, Err(InvalidState)),
             ];
 
             for (from, expected) in scenarios {
                 assert_eq!(
-                    from.clone().draw_lots(candidate_drawing_lots_details()),
+                    from.clone().draw_lots(candidate_required()),
                     expected,
                     "from state {from:?}"
                 );
@@ -387,7 +372,7 @@ mod tests {
         #[test]
         fn add_list_drawn() {
             let state = DrawingLots {
-                drawing_lots_details: list_drawing_lots_details(),
+                drawing_lots_required: list_required(),
                 deceased_candidates: vec![],
                 lists_drawn: vec![],
                 candidates_drawn: vec![],
@@ -398,7 +383,7 @@ mod tests {
                     .add_list_drawn(list_drawn())
                     .expect("add_list_drawn should succeed"),
                 DrawingLots {
-                    drawing_lots_details: list_drawing_lots_details(),
+                    drawing_lots_required: list_required(),
                     deceased_candidates: vec![],
                     lists_drawn: vec![list_drawn()],
                     candidates_drawn: vec![],
@@ -427,7 +412,7 @@ mod tests {
         #[test]
         fn add_candidate_drawn() {
             let state = DrawingLots {
-                drawing_lots_details: candidate_drawing_lots_details(),
+                drawing_lots_required: candidate_required(),
                 deceased_candidates: vec![],
                 lists_drawn: vec![],
                 candidates_drawn: vec![],
@@ -438,7 +423,7 @@ mod tests {
                     .add_candidate_drawn(candidate_drawn())
                     .expect("add_candidate_drawn should succeed"),
                 DrawingLots {
-                    drawing_lots_details: candidate_drawing_lots_details(),
+                    drawing_lots_required: candidate_required(),
                     deceased_candidates: vec![],
                     lists_drawn: vec![],
                     candidates_drawn: vec![candidate_drawn()],
@@ -458,8 +443,10 @@ mod tests {
             for state in invalid_states {
                 assert_eq!(
                     state.clone().add_candidate_drawn(CandidateDrawn {
-                        list: PGNumber::from(1),
-                        options: CandidateNumber::from_values(vec![3, 4, 5]),
+                        variant: CandidateDrawingLotsVariant {
+                            list: PGNumber::from(1),
+                            options: CandidateNumber::from_values(vec![3, 4, 5]),
+                        },
                         drawn: CandidateNumber::from(4),
                     }),
                     Err(InvalidState),
@@ -474,7 +461,7 @@ mod tests {
             let scenarios = vec![
                 (Uninitialised, Ok(RegisteringDeceasedCandidates { deceased_candidates: vec![] })),
                 (RegisteringDeceasedCandidates { deceased_candidates: vec![] }, Err(InvalidState)),
-                (DrawingLots { drawing_lots_details: list_drawing_lots_details(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]}, Err(InvalidState)),
+                (DrawingLots { drawing_lots_required: list_required(), deceased_candidates: vec![], lists_drawn: vec![],candidates_drawn: vec![]}, Err(InvalidState)),
                 (Finalised { deceased_candidates: vec![], lists_drawn: vec![], candidates_drawn: vec![]}, Err(InvalidState)),
             ];
 
@@ -495,7 +482,7 @@ mod tests {
             let scenarios = vec![
                 (Uninitialised, Ok(Finalised { deceased_candidates: vec![], lists_drawn: vec![], candidates_drawn: vec![] })),
                 (RegisteringDeceasedCandidates { deceased_candidates: vec![candidate] }, Ok(Finalised { deceased_candidates: vec![candidate], lists_drawn: vec![], candidates_drawn: vec![] })),
-                (DrawingLots { drawing_lots_details: candidate_drawing_lots_details(), deceased_candidates: vec![candidate], lists_drawn: vec![], candidates_drawn: vec![] }, Ok(Finalised { deceased_candidates: vec![candidate], lists_drawn: vec![], candidates_drawn: vec![] })),
+                (DrawingLots { drawing_lots_required: candidate_required(), deceased_candidates: vec![candidate], lists_drawn: vec![], candidates_drawn: vec![] }, Ok(Finalised { deceased_candidates: vec![candidate], lists_drawn: vec![], candidates_drawn: vec![] })),
                 (Finalised { deceased_candidates: vec![], lists_drawn: vec![], candidates_drawn: vec![] }, Err(InvalidState)),
             ];
 
@@ -510,7 +497,7 @@ mod tests {
             let scenarios = vec![
                 Uninitialised,
                 RegisteringDeceasedCandidates { deceased_candidates: Vec::new() },
-                DrawingLots { drawing_lots_details: candidate_drawing_lots_details(), deceased_candidates: vec![], lists_drawn: vec![], candidates_drawn: vec![]},
+                DrawingLots { drawing_lots_required: candidate_required(), deceased_candidates: vec![], lists_drawn: vec![], candidates_drawn: vec![]},
                 Finalised {deceased_candidates: vec![], lists_drawn: vec![], candidates_drawn: vec![]},
             ];
 
@@ -532,7 +519,7 @@ mod tests {
                 let invalid_states = vec![
                     Uninitialised,
                     DrawingLots {
-                        drawing_lots_details: candidate_drawing_lots_details(),
+                        drawing_lots_required: candidate_required(),
                         deceased_candidates: vec![],
                         lists_drawn: vec![],
                         candidates_drawn: vec![],

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -54,8 +54,12 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        apportionment::{CandidateDrawn, ListDrawingLotsVariant, ListDrawn},
-        apportionment_state::{DeceasedCandidate, DrawingLotsDetails, ListDrawingLotsRequired},
+        apportionment::{
+            AbsoluteMajorityDrawingLots, CandidateDrawingLotsVariant, CandidateDrawn,
+            DisplayFraction, HighestAverageResidualSeatDrawingLots, ListDrawingLotsVariant,
+            ListDrawn,
+        },
+        apportionment_state::{DeceasedCandidate, DrawingLotsRequired},
         election::{CandidateNumber, PGNumber},
     };
 
@@ -76,16 +80,26 @@ mod tests {
                 deceased_candidates: vec![DeceasedCandidate::from(4, 4)],
             },
             ApportionmentState::DrawingLots {
-                drawing_lots_details: DrawingLotsDetails::ListDrawingLotsRequired(
-                    ListDrawingLotsRequired {
-                        variant: ListDrawingLotsVariant::HighestAverageResidualSeat,
-                        options: PGNumber::from_values(vec![1, 2, 3]),
-                    },
+                drawing_lots_required: DrawingLotsRequired::ListDrawingLotsRequired(
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            average: DisplayFraction {
+                                integer: 0,
+                                numerator: 0,
+                                denominator: 0,
+                            },
+                            residual_seat_numbers: vec![],
+                            options: PGNumber::from_values(vec![1, 2, 3]),
+                        },
+                    ),
                 ),
                 deceased_candidates: vec![DeceasedCandidate::from(4, 4)],
                 lists_drawn: vec![ListDrawn {
-                    variant: ListDrawingLotsVariant::AbsoluteMajority,
-                    options: PGNumber::from_values(vec![2, 3, 4]),
+                    variant: ListDrawingLotsVariant::AbsoluteMajority(
+                        AbsoluteMajorityDrawingLots {
+                            options: PGNumber::from_values(vec![2, 3, 4]),
+                        },
+                    ),
                     drawn: PGNumber::from(2),
                 }],
                 candidates_drawn: vec![],
@@ -94,8 +108,10 @@ mod tests {
                 deceased_candidates: vec![DeceasedCandidate::from(4, 4)],
                 lists_drawn: vec![],
                 candidates_drawn: vec![CandidateDrawn {
-                    list: PGNumber::from(1),
-                    options: CandidateNumber::from_values(vec![2, 3, 4]),
+                    variant: CandidateDrawingLotsVariant {
+                        list: PGNumber::from(1),
+                        options: CandidateNumber::from_values(vec![2, 3, 4]),
+                    },
                     drawn: CandidateNumber::from(1),
                 }],
             },

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -9,11 +9,12 @@ use crate::{
         map_candidate_nomination, map_seat_assignment,
     },
     domain::{
-        apportionment::{ApportionmentWarning, ListDrawingLotsVariant},
-        apportionment_state::{
-            ApportionmentState, ApportionmentStateError, CandidateDrawingLotsRequired,
-            ListDrawingLotsRequired,
+        apportionment::{
+            AbsoluteMajorityDrawingLots, ApportionmentWarning, CandidateDrawingLotsVariant,
+            HighestAverageResidualSeatDrawingLots, LargestRemainderResidualSeatDrawingLots,
+            ListDrawingLotsVariant,
         },
+        apportionment_state::{ApportionmentState, ApportionmentStateError, DrawingLotsRequired},
         committee_session::CommitteeSessionId,
         committee_session_status::CommitteeSessionStatus,
         election::{CandidateNumber, ElectionId, ElectionWithPoliticalGroups, PGNumber},
@@ -101,11 +102,11 @@ pub async fn next_state(
 
     update_state(tx, audit_service, election.id, |state| match result {
         ApportionmentResult::Ok(_) => state.finalise(),
-        ApportionmentResult::ListDrawingLotsRequired(drawing_lots_details) => {
-            state.draw_lots(drawing_lots_details.into())
+        ApportionmentResult::ListDrawingLotsRequired(variant) => {
+            state.draw_lots(DrawingLotsRequired::ListDrawingLotsRequired(variant))
         }
-        ApportionmentResult::CandidateDrawingLotsRequired(drawing_lots_details) => {
-            state.draw_lots(drawing_lots_details.into())
+        ApportionmentResult::CandidateDrawingLotsRequired(variant) => {
+            state.draw_lots(DrawingLotsRequired::CandidateDrawingLotsRequired(variant))
         }
     })
     .await
@@ -114,41 +115,53 @@ pub async fn next_state(
 #[allow(clippy::large_enum_variant)]
 pub enum ApportionmentResult {
     Ok(ElectionApportionmentResponse),
-    ListDrawingLotsRequired(ListDrawingLotsRequired),
-    CandidateDrawingLotsRequired(CandidateDrawingLotsRequired),
+    ListDrawingLotsRequired(ListDrawingLotsVariant),
+    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant),
 }
 
-impl From<apportionment::ListDrawingLotsRequired<PGNumber>> for ListDrawingLotsRequired {
-    fn from(value: apportionment::ListDrawingLotsRequired<PGNumber>) -> Self {
-        ListDrawingLotsRequired {
-            variant: value.variant.into(),
-            options: value.options,
-        }
-    }
-}
-impl From<apportionment::CandidateDrawingLotsRequired<PGNumber, CandidateNumber>>
-    for CandidateDrawingLotsRequired
+impl From<apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>>
+    for CandidateDrawingLotsVariant
 {
-    fn from(value: apportionment::CandidateDrawingLotsRequired<PGNumber, CandidateNumber>) -> Self {
-        CandidateDrawingLotsRequired {
+    fn from(value: apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>) -> Self {
+        CandidateDrawingLotsVariant {
             list: value.list,
             options: value.options,
         }
     }
 }
 
-impl From<apportionment::ListDrawingLotsVariant> for ListDrawingLotsVariant {
-    fn from(value: apportionment::ListDrawingLotsVariant) -> Self {
+impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVariant {
+    fn from(value: apportionment::ListDrawingLotsVariant<PGNumber>) -> Self {
         match value {
-            apportionment::ListDrawingLotsVariant::HighestAverageResidualSeat => {
-                ListDrawingLotsVariant::HighestAverageResidualSeat
-            }
-            apportionment::ListDrawingLotsVariant::LargestRemainderResidualSeat => {
-                ListDrawingLotsVariant::LargestRemainderResidualSeat
-            }
-            apportionment::ListDrawingLotsVariant::AbsoluteMajority => {
-                ListDrawingLotsVariant::AbsoluteMajority
-            }
+            apportionment::ListDrawingLotsVariant::HighestAverageResidualSeat(
+                apportionment::HighestAverageResidualSeatDrawingLots {
+                    average,
+                    residual_seat_numbers,
+                    options,
+                },
+            ) => ListDrawingLotsVariant::HighestAverageResidualSeat(
+                HighestAverageResidualSeatDrawingLots {
+                    average: average.into(),
+                    residual_seat_numbers,
+                    options,
+                },
+            ),
+            apportionment::ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                apportionment::LargestRemainderResidualSeatDrawingLots {
+                    remainder,
+                    residual_seat_numbers,
+                    options,
+                },
+            ) => ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                LargestRemainderResidualSeatDrawingLots {
+                    remainder: remainder.into(),
+                    residual_seat_numbers,
+                    options,
+                },
+            ),
+            apportionment::ListDrawingLotsVariant::AbsoluteMajority(
+                apportionment::AbsoluteMajorityDrawingLots { options },
+            ) => ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots { options }),
         }
     }
 }

--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -69,7 +69,7 @@ describe("ApportionmentPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
@@ -65,7 +65,7 @@ describe("AddDeceasedCandidatesPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
@@ -82,7 +82,7 @@ describe("DeceasedCandidatesPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
@@ -61,7 +61,7 @@ describe("IncludeAllCandidatesPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
@@ -40,7 +40,7 @@ describe("ApportionmentFullSeatsPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -66,7 +66,7 @@ describe("ApportionmentListDetailsPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -43,7 +43,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_details: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -399,6 +399,10 @@ export type USER_DELETE_REQUEST_PATH = `/api/users/${UserId}`;
 
 /** TYPES **/
 
+export interface AbsoluteMajorityDrawingLots {
+  options: PGNumber[];
+}
+
 export interface AbsoluteMajorityReassignedSeat {
   list_assigned_seat: PGNumber;
   list_retracted_seat: PGNumber;
@@ -416,7 +420,7 @@ export type ApportionmentState =
   | {
       candidates_drawn: CandidateDrawn[];
       deceased_candidates: DeceasedCandidate[];
-      drawing_lots_details: DrawingLotsDetails;
+      drawing_lots_required: DrawingLotsRequired;
       lists_drawn: ListDrawn[];
       type: "DrawingLots";
     }
@@ -597,8 +601,10 @@ export interface Candidate {
   number: number;
 }
 
-export interface CandidateDrawingLotsRequired {
+export interface CandidateDrawingLotsVariant {
+  /** The list the candidate needs to be drawn from */
   list: PGNumber;
+  /** The candidates that lots are drawn for */
   options: CandidateNumber[];
 }
 
@@ -608,10 +614,8 @@ export interface CandidateDrawingLotsRequired {
 export interface CandidateDrawn {
   /** The candidate that the lot was drawn for */
   drawn: CandidateNumber;
-  /** The list the candidate needs to be drawn from */
-  list: PGNumber;
-  /** The candidates that lots are drawn for */
-  options: CandidateNumber[];
+  /** The type and information for drawing lots */
+  variant: CandidateDrawingLotsVariant;
 }
 
 /**
@@ -845,9 +849,9 @@ export interface DisplayFraction {
   numerator: number;
 }
 
-export type DrawingLotsDetails =
-  | (ListDrawingLotsRequired & { type: "ListDrawingLotsRequired" })
-  | (CandidateDrawingLotsRequired & { type: "CandidateDrawingLotsRequired" });
+export type DrawingLotsRequired =
+  | (ListDrawingLotsVariant & { type: "ListDrawingLotsRequired" })
+  | (CandidateDrawingLotsVariant & { type: "CandidateDrawingLotsRequired" });
 
 /**
  * Election without political groups
@@ -1164,6 +1168,12 @@ export interface HighestAverageAssignedSeat {
   votes_per_seat: DisplayFraction;
 }
 
+export interface HighestAverageResidualSeatDrawingLots {
+  average: DisplayFraction;
+  options: PGNumber[];
+  residual_seat_numbers: number[];
+}
+
 export interface InvestigationConcludedWithNewResults {
   findings: string;
   reason: string;
@@ -1197,6 +1207,12 @@ export interface LargestRemainderAssignedSeat {
   selected_list_number: PGNumber;
 }
 
+export interface LargestRemainderResidualSeatDrawingLots {
+  options: PGNumber[];
+  remainder: DisplayFraction;
+  residual_seat_numbers: number[];
+}
+
 export interface ListCandidateNomination {
   list_name: string;
   list_number: PGNumber;
@@ -1206,17 +1222,10 @@ export interface ListCandidateNomination {
   updated_candidate_ranking: Candidate[];
 }
 
-export interface ListDrawingLotsRequired {
-  options: PGNumber[];
-  variant: ListDrawingLotsVariant;
-}
-
-export const listDrawingLotsVariantValues = [
-  "HighestAverageResidualSeat",
-  "LargestRemainderResidualSeat",
-  "AbsoluteMajority",
-] as const;
-export type ListDrawingLotsVariant = (typeof listDrawingLotsVariantValues)[number];
+export type ListDrawingLotsVariant =
+  | (HighestAverageResidualSeatDrawingLots & { variant: "HighestAverageResidualSeat" })
+  | (LargestRemainderResidualSeatDrawingLots & { variant: "LargestRemainderResidualSeat" })
+  | (AbsoluteMajorityDrawingLots & { variant: "AbsoluteMajority" });
 
 /**
  * The list that has been drawn plus information to assert the correct drawing
@@ -1224,8 +1233,6 @@ export type ListDrawingLotsVariant = (typeof listDrawingLotsVariantValues)[numbe
 export interface ListDrawn {
   /** The list that the lot was drawn for */
   drawn: PGNumber;
-  /** The lists that lots are drawn for */
-  options: PGNumber[];
   /** The type of seat assignment or retraction that lots need to be drawn for */
   variant: ListDrawingLotsVariant;
 }


### PR DESCRIPTION
This PR is to make it possible to send extra information to the frontend when drawing lots is required, to show to the user, and is needed for the "Frontend: drawing lots screens" issues of [Epic: drawing lots in apportionment](https://github.com/kiesraad/abacus/issues/788)

Changes:
- `ListDrawingLotsVariant` and `CandidateDrawingLotsVariant` do not only convey what the variant of the drawing lots it is, but also contain through an "inner struct":
  - extra information to be displayed to the user
  - the `options` (and `list` in case of Candidate) that was previously part of the `ListDrawingLotsRequired` and `CandidateDrawingLotsRequired` types
 - `ListDrawingLotsError` and `CandidateDrawingLotsError` are returned from apportionment functions as the `Err` to also be able to return an error if the variant of a drawn lot is not as expected

For now, the `LargestRemainderResidualSeat` and `HighestAverageResidualSeat` variants have been extended with the information needed, AbsoluteMajority and CandidateDrawingLots will be done in the issues to update the screens.

I recommend starting at `backend/apportionment/src/structs.rs` to see the struct changes in the apportionment crate.