### PR TITLE
Process apportionment anew after adding drawn lots

### DIFF
--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     infra::audit_log::AuditService,
     repository::{election_repo, user_repo::User},
-    service::update_apportionment_state,
+    service::{next_apportionment_state, update_apportionment_state},
 };
 
 /// Add candidate to drawing lots
@@ -44,10 +44,12 @@ pub async fn add_candidate_drawn(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+    update_apportionment_state(&mut tx, &audit_service, election_id, |state| {
         state.add_candidate_drawn(candidate_drawn)
     })
     .await?;
+
+    let state = next_apportionment_state(&mut tx, &audit_service, &election).await?;
 
     tx.commit().await?;
     Ok(Json(state))
@@ -67,6 +69,7 @@ mod tests {
             election::{CandidateNumber, PGNumber},
             role::Role,
         },
+        infra::audit_log::list_event_names,
         repository::{apportionment_state_repo, committee_session_repo, user_repo::UserId},
     };
 
@@ -123,12 +126,16 @@ mod tests {
 
         assert_eq!(
             state.0,
-            ApportionmentState::DrawingLots {
-                drawing_lots_required,
+            ApportionmentState::Finalised {
                 deceased_candidates: vec![],
                 lists_drawn: vec![],
                 candidates_drawn: vec![candidate_drawn],
             }
+        );
+
+        assert_eq!(
+            list_event_names(&mut conn).await.unwrap(),
+            ["ApportionmentStateUpdated", "ApportionmentStateUpdated"]
         );
     }
 }

--- a/backend/src/api/apportionment/handlers/add_deceased_candidate.rs
+++ b/backend/src/api/apportionment/handlers/add_deceased_candidate.rs
@@ -44,7 +44,7 @@ pub async fn add_deceased_candidate(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+    let state = update_apportionment_state(&mut tx, &audit_service, election_id, |state| {
         state.add_deceased_candidate(candidate)
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/add_list_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_list_drawn.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     infra::audit_log::AuditService,
     repository::{election_repo, user_repo::User},
-    service::update_apportionment_state,
+    service::{next_apportionment_state, update_apportionment_state},
 };
 
 /// Add list to drawing lots
@@ -43,10 +43,12 @@ pub async fn add_list_drawn(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+    update_apportionment_state(&mut tx, &audit_service, election_id, |state| {
         state.add_list_drawn(list_drawn)
     })
     .await?;
+
+    let state = next_apportionment_state(&mut tx, &audit_service, &election).await?;
 
     tx.commit().await?;
     Ok(Json(state))
@@ -66,6 +68,7 @@ mod tests {
             election::PGNumber,
             role::Role,
         },
+        infra::audit_log::list_event_names,
         repository::{apportionment_state_repo, committee_session_repo, user_repo::UserId},
     };
 
@@ -121,12 +124,16 @@ mod tests {
 
         assert_eq!(
             state.0,
-            ApportionmentState::DrawingLots {
-                drawing_lots_required,
+            ApportionmentState::Finalised {
                 deceased_candidates: vec![],
                 lists_drawn: vec![list_drawn],
                 candidates_drawn: vec![],
             }
+        );
+
+        assert_eq!(
+            list_event_names(&mut conn).await.unwrap(),
+            ["ApportionmentStateUpdated", "ApportionmentStateUpdated"]
         );
     }
 }

--- a/backend/src/api/apportionment/handlers/delete_deceased_candidate.rs
+++ b/backend/src/api/apportionment/handlers/delete_deceased_candidate.rs
@@ -44,7 +44,7 @@ pub async fn delete_deceased_candidate(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+    let state = update_apportionment_state(&mut tx, &audit_service, election_id, |state| {
         state.delete_deceased_candidate(candidate)
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/finalise_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/finalise_deceased_candidates.rs
@@ -39,7 +39,7 @@ pub async fn finalise_deceased_candidates(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = next_apportionment_state(&mut tx, audit_service, &election).await?;
+    let state = next_apportionment_state(&mut tx, &audit_service, &election).await?;
 
     tx.commit().await?;
     Ok(Json(state))

--- a/backend/src/api/apportionment/handlers/register_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/register_deceased_candidates.rs
@@ -39,7 +39,7 @@ pub async fn register_deceased_candidates(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = update_apportionment_state(&mut tx, audit_service, election_id, |state| {
+    let state = update_apportionment_state(&mut tx, &audit_service, election_id, |state| {
         state.register_deceased_candidates()
     })
     .await?;

--- a/backend/src/api/apportionment/handlers/reset_apportionment_state.rs
+++ b/backend/src/api/apportionment/handlers/reset_apportionment_state.rs
@@ -40,7 +40,7 @@ pub async fn reset_apportionment_state(
     user.role().is_authorized(election.committee_category)?;
 
     let state =
-        update_apportionment_state(&mut tx, audit_service, election_id, |state| state.reset())
+        update_apportionment_state(&mut tx, &audit_service, election_id, |state| state.reset())
             .await?;
 
     tx.commit().await?;

--- a/backend/src/api/apportionment/handlers/skip_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/skip_deceased_candidates.rs
@@ -39,7 +39,7 @@ pub async fn skip_deceased_candidates(
     let election = election_repo::get(&mut tx, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    let state = next_apportionment_state(&mut tx, audit_service, &election).await?;
+    let state = next_apportionment_state(&mut tx, &audit_service, &election).await?;
 
     tx.commit().await?;
     Ok(Json(state))

--- a/backend/src/domain/report/files.rs
+++ b/backend/src/domain/report/files.rs
@@ -441,12 +441,9 @@ mod tests {
         assert_delegated(error, &ReportApiError::ApportionmentStateNotFinalised);
 
         // Finalise apportionment state
-        update_apportionment_state(
-            &mut conn,
-            audit_service.clone(),
-            ElectionId::from(8),
-            |state| state.finalise(),
-        )
+        update_apportionment_state(&mut conn, &audit_service, ElectionId::from(8), |state| {
+            state.finalise()
+        })
         .await
         .unwrap();
 
@@ -484,12 +481,9 @@ mod tests {
         .unwrap();
 
         // Finalise apportionment state
-        update_apportionment_state(
-            &mut conn,
-            audit_service.clone(),
-            ElectionId::from(8),
-            |state| state.finalise(),
-        )
+        update_apportionment_state(&mut conn, &audit_service, ElectionId::from(8), |state| {
+            state.finalise()
+        })
         .await
         .unwrap();
 

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -66,7 +66,7 @@ pub async fn get_state(
 /// - log new state to audit log
 pub async fn update_state(
     conn: &mut SqliteConnection,
-    audit_service: AuditService,
+    audit_service: &AuditService,
     election_id: ElectionId,
     update_fn: impl FnOnce(ApportionmentState) -> Result<ApportionmentState, ApportionmentStateError>,
 ) -> Result<ApportionmentState, APIError> {
@@ -95,7 +95,7 @@ pub async fn update_state(
 /// - use [update_state] to go to the appropriate state and persist that
 pub async fn next_state(
     tx: &mut SqliteConnection,
-    audit_service: AuditService,
+    audit_service: &AuditService,
     election: &ElectionWithPoliticalGroups,
 ) -> Result<ApportionmentState, APIError> {
     let result = process(tx, election).await?;
@@ -257,7 +257,7 @@ mod tests {
 
         let result = update_state(
             &mut conn,
-            AuditService::new(None, None),
+            &AuditService::new(None, None),
             unknown_election,
             |_| panic!("should not call callback"),
         )
@@ -277,7 +277,7 @@ mod tests {
 
         let err = update_state(
             &mut conn,
-            AuditService::new(None, None),
+            &AuditService::new(None, None),
             ElectionId::from(ELECTION_ID),
             |_| panic!("should not call callback"),
         )
@@ -313,7 +313,7 @@ mod tests {
         // Creates a new entry in the database
         update_state(
             &mut conn,
-            AuditService::new(None, None),
+            &AuditService::new(None, None),
             ElectionId::from(ELECTION_ID),
             Ok,
         )
@@ -343,7 +343,7 @@ mod tests {
 
         let returned_state = update_state(
             &mut conn,
-            AuditService::new(None, None),
+            &AuditService::new(None, None),
             ElectionId::from(ELECTION_ID),
             |state| {
                 assert_eq!(state, ApportionmentState::Uninitialised);

--- a/backend/src/service/change_committee_session_status.rs
+++ b/backend/src/service/change_committee_session_status.rs
@@ -115,7 +115,7 @@ pub async fn change_committee_session_status(
             .await?;
         update_apportionment_state(
             &mut tx,
-            audit_service.clone(),
+            &audit_service,
             committee_session.election_id,
             |state| state.reset(),
         )
@@ -292,12 +292,9 @@ mod tests {
         .await?;
 
         // Finalise apportionment state
-        update_apportionment_state(
-            &mut conn,
-            audit_service.clone(),
-            ElectionId::from(5),
-            |state| state.finalise(),
-        )
+        update_apportionment_state(&mut conn, &audit_service, ElectionId::from(5), |state| {
+            state.finalise()
+        })
         .await?;
         let (_, state) = get_apportionment_state(&mut conn, ElectionId::from(5)).await?;
         assert!(state.is_finalised());


### PR DESCRIPTION
## What & why

When the result of drawing lots has been added to the apportionment state, the new state has to be determined as well. This PR adds this step for the `add_list_drawn` and `add_candidate_drawn` endpoints.

I've also changed the `audit_log` argument for `update_apportionment_state` and `next_apportionment_state` to be a reference, because there is no need for ownership.

## How to test

You can see in the changed unit test that the state is now `Finalised` instead of the old `DrawingLots`, and that two times `ApportionmentStateUpdated` is logged to the audit log.



<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->