### PR TITLE
Return preliminary results in drawing lots required

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
@@ -12,6 +12,7 @@ fuzz_target!(
     },
     |data: (FuzzedApportionmentInput, Vec::<usize>)| {
     let (data, mut random_order) = data;
+    #[allow(clippy::result_large_err)]
     let (alloc, log1) = run_with_log(|| process(&data));
 
     if random_order.is_empty() {
@@ -41,6 +42,7 @@ fuzz_target!(
         candidates_drawn: Vec::new(),
     };
 
+    #[allow(clippy::result_large_err)]
     let (new_alloc, log2) = run_with_log(|| process(&reordered_input));
 
     if let (Ok(alloc), Ok(new_alloc)) = (alloc, new_alloc) {

--- a/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
@@ -34,6 +34,7 @@ fuzz_target!(
         })
         .collect();
 
+    #[allow(clippy::result_large_err)]
     let (result, log) = run_with_log(|| process(&data));
 
     match result {
@@ -157,7 +158,7 @@ fuzz_target!(
                 }
             }
         }
-        Err(ApportionmentError::ListDrawingLotsRequired(_) | ApportionmentError::CandidateDrawingLotsRequired(_)) => {
+        Err(ApportionmentError::ListDrawingLotsRequired(..) | ApportionmentError::CandidateDrawingLotsRequired(..)) => {
             // Accepted error in this fuzzer
         }
         Err(ApportionmentError::InvalidLotDrawing(message)) => {

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -193,6 +193,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
     let (osv2020_result, osv2020_log) =
         osv2020_apportionment(data.seats.into(), &pg_candidates, &votes);
 
+    #[allow(clippy::result_large_err)]
     let (abacus_result, abacus_log) = run_with_log(|| process(&data));
 
     // Skip cases where there are fewer than 19 seats and both art. P 9 (absolute majority) and art. P 10 (list exhaustion) are applied.
@@ -257,8 +258,8 @@ fn fuzz(data: FuzzedApportionmentInput) {
             }
         }
         Err(
-            e @ ApportionmentError::ListDrawingLotsRequired(_)
-            | e @ ApportionmentError::CandidateDrawingLotsRequired(_),
+            e @ ApportionmentError::ListDrawingLotsRequired(..)
+            | e @ ApportionmentError::CandidateDrawingLotsRequired(..),
         ) => {
             match osv2020_result {
                 Osv2020Result::Allocated(osv2020_seats) => {

--- a/backend/apportionment/fuzz/fuzz_targets/house_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/house_monotonicity.rs
@@ -14,10 +14,12 @@ fuzz_target!(
     let new_seats = seats + u32::from(added_seats);
 
     data.seats = seats;
+    #[allow(clippy::result_large_err)]
     let (alloc, log1) = run_with_log(|| process(&data));
     let alloc = alloc.map(|r| get_total_seats(&r.seat_assignment));
 
     data.seats = new_seats;
+    #[allow(clippy::result_large_err)]
     let (new_alloc, log2) = run_with_log(|| process(&data));
     let new_alloc = new_alloc.map(|r| get_total_seats(&r.seat_assignment));
 

--- a/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
@@ -14,6 +14,8 @@ fuzz_target!(
     },
     |data: (FuzzedApportionmentInput, u16)| {
     let (data, added_votes) = data;
+
+    #[allow(clippy::result_large_err)]
     let (alloc, log1) = run_with_log(|| process(&data));
 
     // Add some votes to the first candidate of the first party
@@ -43,6 +45,7 @@ fuzz_target!(
                 SimpleCandidateVotes::new(first_candidate.number(), first_candidate.votes() + u32::from(added_votes));
         }
 
+    #[allow(clippy::result_large_err)]
     let (new_alloc, log2) = run_with_log(|| process(&new_data));
 
     if let (Ok(alloc), Ok(new_alloc)) = (alloc, new_alloc) {

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -172,7 +172,7 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
     }
 }
 
-pub fn get_total_seats(result: &apportionment::SeatAssignmentResult<SimpleListVotes>) -> Vec<u32> {
+pub fn get_total_seats(result: &apportionment::SeatAssignmentResult<u32>) -> Vec<u32> {
     result
         .final_standing
         .iter()

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::{
     },
     structs::{
         AbsoluteMajorityDrawingLots, ApportionmentError, ApportionmentInput, ApportionmentOutput,
-        CandidateDrawingLotsVariant, CandidateDrawn, CandidateVotes,
+        CandidateDrawingLotsError, CandidateDrawingLotsVariant, CandidateDrawn, CandidateVotes,
         HighestAverageResidualSeatDrawingLots, LargestRemainderResidualSeatDrawingLots,
         ListDrawingLotsError, ListDrawingLotsVariant, ListDrawn, ListVotes,
     },
@@ -33,12 +33,18 @@ pub use self::{
 type ProcessApportionmentError<LV> = ApportionmentError<ListNumber<LV>, CandidateNumber<LV>>;
 
 /// Perform seat assignment and candidate nomination on apportionment input.
+#[allow(clippy::result_large_err)]
 pub fn process<T: ApportionmentInput>(
     input: &T,
 ) -> Result<ApportionmentOutput<'_, T::List>, ProcessApportionmentError<T::List>> {
     let seat_assignment = seat_assignment(input)?;
     let candidate_nomination_input = as_candidate_nomination_input(input, &seat_assignment);
-    let candidate_nomination = candidate_nomination(&candidate_nomination_input)?;
+    let candidate_nomination =
+        candidate_nomination(&candidate_nomination_input).map_err(|err| match err {
+            CandidateDrawingLotsError::DrawingLotsRequired(variant) => {
+                ApportionmentError::CandidateDrawingLotsRequired(variant, seat_assignment.clone())
+            }
+        })?;
 
     Ok(ApportionmentOutput {
         seat_assignment,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -21,11 +21,14 @@ use crate::{
     },
 };
 
+type SeatAssignmentResultType<T> = Result<
+    SeatAssignmentResult<ListNumber<<T as ApportionmentInput>::List>>,
+    ListDrawingLotsError<ListNumber<<T as ApportionmentInput>::List>>,
+>;
+
 /// Seat assignment
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
-pub(crate) fn seat_assignment<T: ApportionmentInput>(
-    input: &T,
-) -> Result<SeatAssignmentResult<T::List>, ListDrawingLotsError<ListNumber<T::List>>> {
+pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmentResultType<T> {
     info!("Seat assignment");
     info!("Seats: {}", input.number_of_seats());
 
@@ -139,9 +142,9 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(
 }
 
 /// Returns the total number of seats each list number received in the apportionment result.
-pub fn get_total_seats_per_list_number_from_apportionment_result<T: ListVotes>(
-    result: &SeatAssignmentResult<T>,
-) -> Vec<(T::ListNumber, u32)> {
+pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy>(
+    result: &SeatAssignmentResult<LN>,
+) -> Vec<(LN, u32)> {
     result
         .final_standing
         .iter()
@@ -153,7 +156,7 @@ pub fn get_total_seats_per_list_number_from_apportionment_result<T: ListVotes>(
 /// and the seat assignment result.
 pub fn as_candidate_nomination_input<'a, T: ApportionmentInput>(
     input: &'a T,
-    seat_assignment: &SeatAssignmentResult<T::List>,
+    seat_assignment: &SeatAssignmentResult<ListNumber<T::List>>,
 ) -> CandidateNominationInputType<'a, T> {
     CandidateNominationInput {
         number_of_seats: input.number_of_seats(),
@@ -349,19 +352,21 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::fmt::Debug;
+
     use test_log::test;
 
     use crate::{
-        ListVotes, SeatAssignmentResult,
+        SeatAssignmentResult,
         fraction::Fraction,
         seat_assignment::{
             ListStanding, get_total_seats_per_list_number_from_apportionment_result, list_numbers,
         },
     };
 
-    fn check_total_seats_per_list<T: ListVotes>(
-        result: &SeatAssignmentResult<T>,
-        expected_total_seats_per_list: &[(T::ListNumber, u32)],
+    fn check_total_seats_per_list<LN: Copy + Debug + PartialEq>(
+        result: &SeatAssignmentResult<LN>,
+        expected_total_seats_per_list: &[(LN, u32)],
     ) {
         let total_seats_per_list_number =
             get_total_seats_per_list_number_from_apportionment_result(result);

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -3,8 +3,9 @@ use std::cmp::Ordering;
 mod residual_seat_assignment;
 mod structs;
 pub use structs::{
-    AbsoluteMajorityReassignedSeat, ApportionmentWarning, HighestAverageAssignedSeat,
-    ListExhaustionRemovedSeat, ListStanding, SeatAssignmentResult, SeatChange, SeatChangeStep,
+    AbsoluteMajorityReassignedSeat, ApportionmentWarning, AssignRemainderDrawingLotsError,
+    HighestAverageAssignedSeat, ListExhaustionRemovedSeat, ListStanding,
+    ResidualSeatDrawingLotsError, SeatAssignmentResult, SeatChange, SeatChangeStep,
 };
 use tracing::info;
 
@@ -27,7 +28,11 @@ type SeatAssignmentResultType<T> = Result<
 >;
 
 /// Seat assignment
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::cognitive_complexity,
+    clippy::result_large_err
+)]
 pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmentResultType<T> {
     info!("Seat assignment");
     info!("Seats: {}", input.number_of_seats());
@@ -71,7 +76,25 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             &[],
             None,
             &mut lists_drawn,
-        )?
+        )
+        .map_err(|err| match err {
+            AssignRemainderDrawingLotsError::DrawingLotsRequired(variant, steps) => {
+                ListDrawingLotsError::DrawingLotsRequired(
+                    variant,
+                    SeatAssignmentResult {
+                        seats: input.number_of_seats(),
+                        full_seats,
+                        residual_seats,
+                        quota,
+                        steps,
+                        final_standing: Vec::new(),
+                    },
+                )
+            }
+            AssignRemainderDrawingLotsError::InvalidLotDrawing(message) => {
+                ListDrawingLotsError::InvalidLotDrawing(message)
+            }
+        })?
     } else {
         info!("All seats have been assigned without any residual seats");
         (vec![], initial_standing)
@@ -85,7 +108,20 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             input.list_votes(),
             &last_step.change.list_assigned(),
             current_standings,
-        )?
+        )
+        .map_err(|err| {
+            ListDrawingLotsError::new(
+                err,
+                SeatAssignmentResult {
+                    seats: input.number_of_seats(),
+                    full_seats,
+                    residual_seats,
+                    quota,
+                    steps: steps.clone(),
+                    final_standing: Vec::new(),
+                },
+            )
+        })?
     } else {
         (current_standings, None)
     };
@@ -118,9 +154,27 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
         input.list_votes(),
         input.deceased_candidates(),
         residual_seats,
-        steps,
+        steps.clone(),
         &mut lists_drawn,
-    )?;
+    )
+    .map_err(|err| match err {
+        AssignRemainderDrawingLotsError::DrawingLotsRequired(variant, steps) => {
+            ListDrawingLotsError::DrawingLotsRequired(
+                variant,
+                SeatAssignmentResult {
+                    seats: input.number_of_seats(),
+                    full_seats,
+                    residual_seats,
+                    quota,
+                    steps: steps.clone(),
+                    final_standing: Vec::new(),
+                },
+            )
+        }
+        AssignRemainderDrawingLotsError::InvalidLotDrawing(message) => {
+            ListDrawingLotsError::InvalidLotDrawing(message)
+        }
+    })?;
 
     let final_full_seats = final_standing
         .iter()
@@ -246,7 +300,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
                 "Drawing of lots is required for lists: {:?} to pick a list which the residual seat gets retracted from",
                 lists_last_residual_seat
             );
-            return Err(ListDrawingLotsError::DrawingLotsRequired(
+            return Err(ResidualSeatDrawingLotsError::DrawingLotsRequired(
                 ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
                     options: lists_last_residual_seat.to_vec(),
                 }),
@@ -286,6 +340,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
 /// If lists got more seats than candidates on their lists,
 /// re-assign those excess seats to other lists without exhausted lists.  
 /// This re-assignment is done according to article P 10 of the Kieswet.
+#[allow(clippy::too_many_arguments, clippy::result_large_err)]
 fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
     previous_standings: Vec<ListStanding<T::ListNumber>>,
     seats: u32,
@@ -623,15 +678,29 @@ pub(crate) mod tests {
                     15,
                     vec![2552, 511, 511, 511, 509, 509],
                 );
-                let result = seat_assignment(&input);
+                let err = seat_assignment(&input).expect_err("should require drawing lots");
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
                 assert_eq!(
-                    result,
-                    Err(ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                            options: vec![2, 3, 4]
-                        })
-                    ))
+                    variant,
+                    ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                        options: vec![2, 3, 4]
+                    }),
                 );
+                assert_eq!(preliminary_result.seats, 15);
+                assert_eq!(preliminary_result.full_seats, 12);
+                assert_eq!(preliminary_result.residual_seats, 3);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 5103,
+                        denominator: 15
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 3);
+                assert_eq!(preliminary_result.final_standing, vec![]);
             }
 
             /// Apportionment with residual seats assigned with largest remainders method
@@ -647,25 +716,34 @@ pub(crate) mod tests {
                     vec![540, 160, 160, 80, 80, 80, 55, 45],
                 );
                 let err = seat_assignment(&input).expect_err("should require drawing lots");
-                assert_eq!(
-                    err,
-                    ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::LargestRemainderResidualSeat(
-                            LargestRemainderResidualSeatDrawingLots {
-                                remainder: Fraction::new(0, 15),
-                                residual_seat_numbers: vec![2],
-                                options: vec![2, 3, 4, 5, 6]
-                            }
-                        )
-                    )
-                );
-
-                // Lot drawn is 6
-
-                let ListDrawingLotsError::DrawingLotsRequired(variant) = err else {
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
                     panic!("should be DrawingLotsRequired");
                 };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            remainder: Fraction::new(0, 1),
+                            residual_seat_numbers: vec![2],
+                            options: vec![2, 3, 4, 5, 6]
+                        }
+                    ),
+                );
+                assert_eq!(preliminary_result.seats, 15);
+                assert_eq!(preliminary_result.full_seats, 13);
+                assert_eq!(preliminary_result.residual_seats, 2);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 80,
+                        denominator: 1
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 1);
+                assert_eq!(preliminary_result.final_standing, vec![]);
 
+                // Lot drawn is 6
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 6 });
                 let result = seat_assignment(&input).expect("should be successful");
 
@@ -706,39 +784,62 @@ pub(crate) mod tests {
                     vec![500, 140, 140, 140, 140, 140],
                 );
                 let err = seat_assignment(&input).expect_err("should require drawing lots");
-                assert_eq!(
-                    err,
-                    ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::LargestRemainderResidualSeat(
-                            LargestRemainderResidualSeatDrawingLots {
-                                remainder: Fraction::new(900, 15),
-                                residual_seat_numbers: vec![1, 2, 3, 4],
-                                options: vec![2, 3, 4, 5, 6]
-                            }
-                        )
-                    )
-                );
-
-                // Drawing lots results in list 4
-
-                let ListDrawingLotsError::DrawingLotsRequired(variant) = err else {
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
                     panic!("should be DrawingLotsRequired");
                 };
-
-                input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
                 assert_eq!(
-                    err,
-                    ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::LargestRemainderResidualSeat(
-                            LargestRemainderResidualSeatDrawingLots {
-                                remainder: Fraction::new(900, 15),
-                                residual_seat_numbers: Vec::new(),
-                                options: vec![2, 3, 5, 6]
-                            }
-                        )
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            remainder: Fraction::new(900, 15),
+                            residual_seat_numbers: vec![1, 2, 3, 4],
+                            options: vec![2, 3, 4, 5, 6]
+                        }
                     )
                 );
+                assert_eq!(preliminary_result.seats, 15);
+                assert_eq!(preliminary_result.full_seats, 11);
+                assert_eq!(preliminary_result.residual_seats, 4);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 80,
+                        denominator: 1
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 0);
+                assert_eq!(preliminary_result.final_standing, vec![]);
+
+                // Drawing lots results in list 4
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
+                let err = seat_assignment(&input).expect_err("should require drawing lots");
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            remainder: Fraction::new(900, 15),
+                            residual_seat_numbers: vec![2, 3, 4],
+                            options: vec![2, 3, 5, 6]
+                        }
+                    ),
+                );
+                assert_eq!(preliminary_result.seats, 15);
+                assert_eq!(preliminary_result.full_seats, 11);
+                assert_eq!(preliminary_result.residual_seats, 4);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 80,
+                        denominator: 1
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 1);
+                assert_eq!(preliminary_result.final_standing, vec![]);
             }
         }
 
@@ -1534,15 +1635,29 @@ pub(crate) mod tests {
                     24,
                     vec![7501, 1249, 1249, 1249, 1249, 1248, 1248, 8],
                 );
-                let result = seat_assignment(&input);
+                let err = seat_assignment(&input).expect_err("should require drawing lots");
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
                 assert_eq!(
-                    result,
-                    Err(ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                            options: vec![6, 7]
-                        })
-                    ))
+                    variant,
+                    ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+                        options: vec![6, 7]
+                    })
                 );
+                assert_eq!(preliminary_result.seats, 24);
+                assert_eq!(preliminary_result.full_seats, 18);
+                assert_eq!(preliminary_result.residual_seats, 6);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 15001,
+                        denominator: 24
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 6);
+                assert_eq!(preliminary_result.final_standing, vec![]);
             }
 
             /// Apportionment with residual seats assigned with highest averages method
@@ -1558,41 +1673,63 @@ pub(crate) mod tests {
                     vec![500, 140, 140, 140, 140, 140],
                 );
                 let err = seat_assignment(&input).expect_err("should require drawing lots");
-
-                assert_eq!(
-                    err,
-                    ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::HighestAverageResidualSeat(
-                            HighestAverageResidualSeatDrawingLots {
-                                average: Fraction::new(140, 3),
-                                residual_seat_numbers: vec![2, 3, 4],
-                                options: vec![2, 3, 4, 5, 6]
-                            }
-                        )
-                    )
-                );
-
-                // Drawing lots results in list 4
-
-                let ListDrawingLotsError::DrawingLotsRequired(variant) = err else {
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
                     panic!("should be DrawingLotsRequired");
                 };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            average: Fraction::new(140, 3),
+                            residual_seat_numbers: vec![2, 3, 4],
+                            options: vec![2, 3, 4, 5, 6]
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.seats, 23);
+                assert_eq!(preliminary_result.full_seats, 19);
+                assert_eq!(preliminary_result.residual_seats, 4);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 1200,
+                        denominator: 23
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 1);
+                assert_eq!(preliminary_result.final_standing, vec![]);
 
+                // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
 
                 let err = seat_assignment(&input).expect_err("should require drawing lots");
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
                 assert_eq!(
-                    err,
-                    ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::HighestAverageResidualSeat(
-                            HighestAverageResidualSeatDrawingLots {
-                                average: Fraction::new(140, 3),
-                                residual_seat_numbers: vec![],
-                                options: vec![2, 3, 5, 6]
-                            }
-                        )
+                    variant,
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            average: Fraction::new(140, 3),
+                            residual_seat_numbers: vec![3, 4],
+                            options: vec![2, 3, 5, 6]
+                        }
                     )
                 );
+                assert_eq!(preliminary_result.seats, 23);
+                assert_eq!(preliminary_result.full_seats, 19);
+                assert_eq!(preliminary_result.residual_seats, 4);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 1200,
+                        denominator: 23
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 2);
+                assert_eq!(preliminary_result.final_standing, vec![]);
             }
 
             /// Apportionment with residual seats assigned with highest averages method
@@ -1608,25 +1745,34 @@ pub(crate) mod tests {
                 );
 
                 let err = seat_assignment(&input).expect_err("should require drawing lots");
-                assert_eq!(
-                    err,
-                    ListDrawingLotsError::DrawingLotsRequired(
-                        ListDrawingLotsVariant::HighestAverageResidualSeat(
-                            HighestAverageResidualSeatDrawingLots {
-                                average: Fraction::new(140, 4),
-                                residual_seat_numbers: vec![],
-                                options: vec![2, 3, 4],
-                            },
-                        )
-                    )
-                );
-
-                // List 3 is drawn, add it to the input's lists_drawn and process again
-
-                let ListDrawingLotsError::DrawingLotsRequired(variant) = err else {
+                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                else {
                     panic!("should be DrawingLotsRequired");
                 };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            average: Fraction::new(140, 4),
+                            residual_seat_numbers: vec![2],
+                            options: vec![2, 3, 4],
+                        },
+                    )
+                );
+                assert_eq!(preliminary_result.seats, 24);
+                assert_eq!(preliminary_result.full_seats, 22);
+                assert_eq!(preliminary_result.residual_seats, 2);
+                assert_eq!(
+                    preliminary_result.quota,
+                    Fraction {
+                        numerator: 920,
+                        denominator: 24
+                    }
+                );
+                assert_eq!(preliminary_result.steps.len(), 1);
+                assert_eq!(preliminary_result.final_standing, vec![]);
 
+                // List 3 is drawn, add it to the input's lists_drawn and process again
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });
                 let result = seat_assignment(&input).expect("should be successful");
 

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -648,7 +648,7 @@ pub(crate) mod tests {
                         ListDrawingLotsVariant::LargestRemainderResidualSeat(
                             LargestRemainderResidualSeatDrawingLots {
                                 remainder: Fraction::new(0, 15),
-                                residual_seat_numbers: vec![],
+                                residual_seat_numbers: vec![2],
                                 options: vec![2, 3, 4, 5, 6]
                             }
                         )
@@ -707,7 +707,7 @@ pub(crate) mod tests {
                         ListDrawingLotsVariant::LargestRemainderResidualSeat(
                             LargestRemainderResidualSeatDrawingLots {
                                 remainder: Fraction::new(900, 15),
-                                residual_seat_numbers: vec![],
+                                residual_seat_numbers: vec![1, 2, 3, 4],
                                 options: vec![2, 3, 4, 5, 6]
                             }
                         )
@@ -1560,7 +1560,7 @@ pub(crate) mod tests {
                         ListDrawingLotsVariant::HighestAverageResidualSeat(
                             HighestAverageResidualSeatDrawingLots {
                                 average: Fraction::new(140, 3),
-                                residual_seat_numbers: vec![],
+                                residual_seat_numbers: vec![2, 3, 4],
                                 options: vec![2, 3, 4, 5, 6]
                             }
                         )

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -278,7 +278,8 @@ fn list_unique_highest_average_assigned_seats<LN: Copy + Eq>(
 /// This function will always return at least one group.
 fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
-    residual_seats: u32,
+    available_residual_seats: u32,
+    residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
 ) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsError<LN>> {
     // We are now going to find the lists that have the highest average
@@ -309,17 +310,18 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
     );
 
     // Check if we can actually assign all these lists a seat, otherwise we would need to draw lots
-    if lists.len() > residual_seats as usize {
+    if lists.len() > available_residual_seats as usize {
         info!(
-            "Drawing of lots is required for lists: {:?}, only {residual_seats} seat(s) available",
+            "Drawing of lots is required for lists: {:?}, only {available_residual_seats} seat(s) available",
             list_numbers(&lists)
         );
 
         let variant = ListDrawingLotsVariant::HighestAverageResidualSeat(
             HighestAverageResidualSeatDrawingLots {
                 average: max_average,
-                // TODO set actual residual_seat_numbers in #1264
-                residual_seat_numbers: Vec::new(),
+                residual_seat_numbers: (residual_seat_number
+                    ..residual_seat_number + available_residual_seats)
+                    .collect(),
                 options: list_numbers(&lists),
             },
         );
@@ -358,7 +360,8 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 /// This function will always return at least one group.
 fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
-    residual_seats: u32,
+    available_residual_seats: u32,
+    residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
 ) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsError<LN>> {
     // We are now going to find the lists that have the largest remainder
@@ -388,17 +391,18 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     );
 
     // Check if we can actually assign all these lists
-    if lists.len() > residual_seats as usize {
+    if lists.len() > available_residual_seats as usize {
         info!(
-            "Drawing of lots is required for lists: {:?}, only {residual_seats} seat(s) available",
+            "Drawing of lots is required for lists: {:?}, only {available_residual_seats} seat(s) available",
             list_numbers(&lists)
         );
 
         let variant = ListDrawingLotsVariant::LargestRemainderResidualSeat(
             LargestRemainderResidualSeatDrawingLots {
                 remainder: max_remainder,
-                // TODO set actual residual_seat_numbers in #1264
-                residual_seat_numbers: Vec::new(),
+                residual_seat_numbers: (residual_seat_number
+                    ..residual_seat_number + available_residual_seats)
+                    .collect(),
                 options: list_numbers(&lists),
             },
         );
@@ -449,6 +453,7 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
             previous_steps,
             exhausted_list_numbers,
             false,
+            residual_seat_number,
             lists_drawn,
         )
     } else {
@@ -458,6 +463,7 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
             residual_seats,
             previous_steps,
             exhausted_list_numbers,
+            residual_seat_number,
             lists_drawn,
         )
     }
@@ -471,6 +477,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
     unique: bool,
+    residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
 ) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
     // Get an iterator that lists all the list standings without exhausted lists
@@ -484,6 +491,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
         let selected_lists = lists_with_highest_average(
             qualifying_for_highest_average,
             residual_seats,
+            residual_seat_number,
             lists_drawn,
         )?;
         let selected_list = selected_lists[0];
@@ -521,6 +529,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     residual_seats: u32,
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
+    residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
 ) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
     // first we check if there are any lists that still qualify for a largest remainder assigned seat
@@ -534,8 +543,12 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     // If there is at least one element in the iterator, we know we can still do a largest remainder assignment
     if qualifying_for_remainder.peek().is_some() {
         debug!("Assign residual seat using largest remainders method");
-        let selected_lists =
-            lists_with_largest_remainder(qualifying_for_remainder, residual_seats, lists_drawn)?;
+        let selected_lists = lists_with_largest_remainder(
+            qualifying_for_remainder,
+            residual_seats,
+            residual_seat_number,
+            lists_drawn,
+        )?;
         let selected_list = selected_lists[0];
         Ok(SeatChange::LargestRemainderAssignment(
             LargestRemainderAssignedSeat {
@@ -568,6 +581,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
                 previous_steps,
                 exhausted_list_numbers,
                 true,
+                residual_seat_number,
                 lists_drawn,
             )
         } else {
@@ -582,6 +596,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
                 previous_steps,
                 exhausted_list_numbers,
                 false,
+                residual_seat_number,
                 lists_drawn,
             )
         }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt::Debug};
 use tracing::{debug, info};
 
 use super::{
-    get_number_of_candidates, list_numbers,
+    AssignRemainderDrawingLotsError, get_number_of_candidates, list_numbers,
     structs::{
         HighestAverageAssignedSeat, LargestRemainderAssignedSeat, ListStanding,
         RemainderAssignmentResult, SeatChange, SeatChangeStep,
@@ -12,16 +12,17 @@ use super::{
 use crate::{
     ListDrawn,
     fraction::Fraction,
+    seat_assignment::structs::ResidualSeatDrawingLotsError,
     structs::{
         DeceasedCandidates, HighestAverageResidualSeatDrawingLots, LARGE_COUNCIL_THRESHOLD,
-        LargestRemainderResidualSeatDrawingLots, ListDrawingLotsError, ListDrawingLotsVariant,
-        ListVotes,
+        LargestRemainderResidualSeatDrawingLots, ListDrawingLotsVariant, ListVotes,
     },
 };
 
 /// This function assigns the residual seats that remain after full seat assignment is finished.
 /// These residual seats are assigned through two different procedures,
 /// depending on how many total seats are available in the election.
+#[allow(clippy::too_many_arguments, clippy::result_large_err)]
 pub fn assign_remainder<'b, T: ListVotes>(
     initial_standings: &[ListStanding<T::ListNumber>],
     seats: u32,
@@ -63,7 +64,8 @@ pub fn assign_remainder<'b, T: ListVotes>(
             &steps,
             &exhausted_list_numbers,
             lists_drawn,
-        )?;
+        )
+        .map_err(|err| AssignRemainderDrawingLotsError::new(err, steps.clone()))?;
 
         let standings = current_standings.clone();
 
@@ -281,7 +283,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
     available_residual_seats: u32,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsError<LN>> {
+) -> Result<Vec<&'a ListStanding<LN>>, ResidualSeatDrawingLotsError<LN>> {
     // We are now going to find the lists that have the highest average
     // votes per seat if we would were to add one additional seat to them
     let (max_average, lists) = standings.fold(
@@ -328,12 +330,12 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 
         // Get a list from the lists_drawn
         let Some(list_drawn) = lists_drawn.next() else {
-            return Err(ListDrawingLotsError::DrawingLotsRequired(variant));
+            return Err(ResidualSeatDrawingLotsError::DrawingLotsRequired(variant));
         };
 
         // Assert the required variant including all data
         if list_drawn.variant() != variant {
-            return Err(ListDrawingLotsError::InvalidLotDrawing(
+            return Err(ResidualSeatDrawingLotsError::InvalidLotDrawing(
                 "Variant mismatch".to_string(),
             ));
         }
@@ -341,7 +343,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
         let list = lists
             .iter()
             .find(|list| list.list_number == *list_drawn.drawn())
-            .ok_or(ListDrawingLotsError::InvalidLotDrawing(
+            .ok_or(ResidualSeatDrawingLotsError::InvalidLotDrawing(
                 "Unknown list number".to_string(),
             ))?;
 
@@ -363,7 +365,7 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     available_residual_seats: u32,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<Vec<&'a ListStanding<LN>>, ListDrawingLotsError<LN>> {
+) -> Result<Vec<&'a ListStanding<LN>>, ResidualSeatDrawingLotsError<LN>> {
     // We are now going to find the lists that have the largest remainder
     let (max_remainder, lists) = standings.fold(
         (Fraction::ZERO, vec![]),
@@ -409,12 +411,12 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 
         // Get a list from the lists_drawn
         let Some(list_drawn) = lists_drawn.next() else {
-            return Err(ListDrawingLotsError::DrawingLotsRequired(variant));
+            return Err(ResidualSeatDrawingLotsError::DrawingLotsRequired(variant));
         };
 
         // Assert the required variant including all data
         if list_drawn.variant() != variant {
-            return Err(ListDrawingLotsError::InvalidLotDrawing(
+            return Err(ResidualSeatDrawingLotsError::InvalidLotDrawing(
                 "Variant mismatch".to_string(),
             ));
         }
@@ -422,7 +424,7 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
         let list = lists
             .iter()
             .find(|list| list.list_number == *list_drawn.drawn())
-            .ok_or(ListDrawingLotsError::InvalidLotDrawing(
+            .ok_or(ResidualSeatDrawingLotsError::InvalidLotDrawing(
                 "Unknown list number".to_string(),
             ))?;
 
@@ -443,7 +445,7 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
+) -> Result<SeatChange<LN>, ResidualSeatDrawingLotsError<LN>> {
     if seats >= LARGE_COUNCIL_THRESHOLD {
         debug!("Assigning residual seat {residual_seat_number} using highest averages method");
         // [Artikel P 7 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP7)
@@ -479,7 +481,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
     unique: bool,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
+) -> Result<SeatChange<LN>, ResidualSeatDrawingLotsError<LN>> {
     // Get an iterator that lists all the list standings without exhausted lists
     // and without lists that have zero votes cast.
     let mut qualifying_for_highest_average = standings
@@ -531,7 +533,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     exhausted_list_numbers: &[LN],
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<SeatChange<LN>, ListDrawingLotsError<LN>> {
+) -> Result<SeatChange<LN>, ResidualSeatDrawingLotsError<LN>> {
     // first we check if there are any lists that still qualify for a largest remainder assigned seat
     let mut qualifying_for_remainder = list_standings_qualifying_for_largest_remainder(
         standings,

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -10,16 +10,16 @@ use crate::{ListVotes, structs::ListDrawingLotsError};
 /// and each of the changes and intermediate standings. The final standing contains the
 /// number of seats per list that was assigned after all seats were assigned.
 #[derive(Debug, PartialEq)]
-pub struct SeatAssignmentResult<T: ListVotes> {
+pub struct SeatAssignmentResult<LN> {
     pub seats: u32,
     pub full_seats: u32,
     pub residual_seats: u32,
     pub quota: Fraction,
-    pub steps: Vec<SeatChangeStep<T::ListNumber>>,
-    pub final_standing: Vec<ListSeatAssignment<T::ListNumber>>,
+    pub steps: Vec<SeatChangeStep<LN>>,
+    pub final_standing: Vec<ListSeatAssignment<LN>>,
 }
 
-impl<T: ListVotes> SeatAssignmentResult<T> {
+impl<LN: Copy> SeatAssignmentResult<LN> {
     pub fn warnings(&self) -> Vec<ApportionmentWarning> {
         let mut warnings = Vec::new();
         let has_p9 = self

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -222,7 +222,7 @@ impl<LN: Copy> SeatChange<LN> {
         }
     }
 
-    /// Get the list of lists with the same average, that have been assigned a seat
+    /// Get the list of lists with the same average or remainder, that have been assigned a seat
     pub fn list_assigned(&self) -> Vec<LN> {
         match self {
             Self::HighestAverageAssignment(highest_average_assigned_seat) => {

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -3,13 +3,13 @@ use std::fmt::Debug;
 use tracing::{debug, info};
 
 use super::Fraction;
-use crate::{ListVotes, structs::ListDrawingLotsError};
+use crate::{ListDrawingLotsVariant, ListVotes};
 
 /// The result of the seat assignment procedure. This contains the number of seats and the quota
 /// that was used. It then contains the initial standing after full seats were assigned,
 /// and each of the changes and intermediate standings. The final standing contains the
 /// number of seats per list that was assigned after all seats were assigned.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SeatAssignmentResult<LN> {
     pub seats: u32,
     pub full_seats: u32,
@@ -51,7 +51,7 @@ pub enum ApportionmentWarning {
 }
 
 /// Contains information about the final assignment of seats for a specific list.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ListSeatAssignment<LN> {
     /// List number for which this assignment applies
     pub list_number: LN,
@@ -312,10 +312,26 @@ pub struct ListExhaustionRemovedSeat<LN> {
     pub full_seat: bool,
 }
 
+/// Used to indicate that drawing lots for a residual seat is needed,
+/// containing all the information needed to do the drawing and the current seat change steps
+#[derive(Debug, PartialEq)]
+pub enum AssignRemainderDrawingLotsError<LN> {
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>, Vec<SeatChangeStep<LN>>),
+    InvalidLotDrawing(String),
+}
+
+/// Used to indicate that drawing lots for a residual seat is needed,
+/// containing all the information needed to do the drawing
+#[derive(Debug, PartialEq)]
+pub enum ResidualSeatDrawingLotsError<LN> {
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
+    InvalidLotDrawing(String),
+}
+
 /// Result type for residual seat (re)assignment: steps taken and final standings.
 pub type RemainderAssignmentResult<LN> =
-    Result<(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>), ListDrawingLotsError<LN>>;
+    Result<(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>), AssignRemainderDrawingLotsError<LN>>;
 
 /// Result type for absolute majority reassignment: updated standings and optional seat change.
 pub type AbsoluteMajorityResult<LN> =
-    Result<(Vec<ListStanding<LN>>, Option<SeatChange<LN>>), ListDrawingLotsError<LN>>;
+    Result<(Vec<ListStanding<LN>>, Option<SeatChange<LN>>), ResidualSeatDrawingLotsError<LN>>;

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -5,8 +5,11 @@ use std::{
 };
 
 use super::{
-    candidate_nomination::CandidateNominationResult, fraction::Fraction,
+    SeatChangeStep, candidate_nomination::CandidateNominationResult, fraction::Fraction,
     seat_assignment::SeatAssignmentResult,
+};
+pub(crate) use crate::seat_assignment::{
+    AssignRemainderDrawingLotsError, ResidualSeatDrawingLotsError,
 };
 
 pub(crate) const LARGE_COUNCIL_THRESHOLD: u32 = 19;
@@ -19,8 +22,11 @@ pub type CandidateNumber<LV> = <<LV as ListVotes>::Cv as CandidateVotes>::Candid
 /// Errors that can occur during apportionment
 #[derive(Debug, PartialEq)]
 pub enum ApportionmentError<LN, CN> {
-    ListDrawingLotsRequired(ListDrawingLotsVariant<LN>),
-    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant<LN, CN>),
+    ListDrawingLotsRequired(ListDrawingLotsVariant<LN>, SeatAssignmentResult<LN>),
+    CandidateDrawingLotsRequired(
+        CandidateDrawingLotsVariant<LN, CN>,
+        SeatAssignmentResult<LN>,
+    ),
     InvalidLotDrawing(String),
 }
 
@@ -28,18 +34,50 @@ pub enum ApportionmentError<LN, CN> {
 /// containing all the information needed to do the drawing
 #[derive(Debug, PartialEq)]
 pub enum ListDrawingLotsError<LN> {
-    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>, SeatAssignmentResult<LN>),
     InvalidLotDrawing(String),
 }
 
 impl<LN, CN> From<ListDrawingLotsError<LN>> for ApportionmentError<LN, CN> {
     fn from(value: ListDrawingLotsError<LN>) -> Self {
         match value {
-            ListDrawingLotsError::DrawingLotsRequired(variant) => {
-                ApportionmentError::ListDrawingLotsRequired(variant)
+            ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) => {
+                ApportionmentError::ListDrawingLotsRequired(variant, preliminary_result)
             }
             ListDrawingLotsError::InvalidLotDrawing(message) => {
                 ApportionmentError::InvalidLotDrawing(message)
+            }
+        }
+    }
+}
+
+impl<LN> ListDrawingLotsError<LN> {
+    pub(crate) fn new(
+        err: ResidualSeatDrawingLotsError<LN>,
+        preliminary_result: SeatAssignmentResult<LN>,
+    ) -> Self {
+        match err {
+            ResidualSeatDrawingLotsError::DrawingLotsRequired(variant) => {
+                ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result)
+            }
+            ResidualSeatDrawingLotsError::InvalidLotDrawing(message) => {
+                ListDrawingLotsError::InvalidLotDrawing(message)
+            }
+        }
+    }
+}
+
+impl<LN> AssignRemainderDrawingLotsError<LN> {
+    pub(crate) fn new(
+        err: ResidualSeatDrawingLotsError<LN>,
+        steps: Vec<SeatChangeStep<LN>>,
+    ) -> Self {
+        match err {
+            ResidualSeatDrawingLotsError::DrawingLotsRequired(variant) => {
+                AssignRemainderDrawingLotsError::DrawingLotsRequired(variant, steps)
+            }
+            ResidualSeatDrawingLotsError::InvalidLotDrawing(message) => {
+                AssignRemainderDrawingLotsError::InvalidLotDrawing(message)
             }
         }
     }
@@ -49,16 +87,6 @@ impl<LN, CN> From<ListDrawingLotsError<LN>> for ApportionmentError<LN, CN> {
 #[derive(Debug, PartialEq)]
 pub enum CandidateDrawingLotsError<LN, CN> {
     DrawingLotsRequired(CandidateDrawingLotsVariant<LN, CN>),
-}
-
-impl<LN, CN> From<CandidateDrawingLotsError<LN, CN>> for ApportionmentError<LN, CN> {
-    fn from(value: CandidateDrawingLotsError<LN, CN>) -> Self {
-        match value {
-            CandidateDrawingLotsError::DrawingLotsRequired(variant) => {
-                ApportionmentError::CandidateDrawingLotsRequired(variant)
-            }
-        }
-    }
 }
 
 /// Different variants of drawing lots for lists, with all the information needed to do the drawing

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -131,7 +131,7 @@ pub trait ApportionmentInput {
 }
 
 pub struct ApportionmentOutput<'a, T: ListVotes> {
-    pub seat_assignment: SeatAssignmentResult<T>,
+    pub seat_assignment: SeatAssignmentResult<ListNumber<T>>,
     pub candidate_nomination: CandidateNominationResult<'a, T>,
 }
 

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -126,9 +126,7 @@ impl CandidateDrawn<u32, u32> for CandidateDrawnMock {
     }
 }
 
-pub fn get_total_seats_from_apportionment_result(
-    result: &SeatAssignmentResult<ListVotesMock>,
-) -> Vec<u32> {
+pub fn get_total_seats_from_apportionment_result(result: &SeatAssignmentResult<u32>) -> Vec<u32> {
     result
         .final_standing
         .iter()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1277,7 +1277,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ElectionApportionmentResponse"
+                  "$ref": "#/components/schemas/ProcessApportionmentResponse"
                 }
               }
             }
@@ -7104,8 +7104,8 @@
         "enum": [
           "AirgapViolation",
           "AlreadyInitialised",
+          "ApportionmentNotCompleted",
           "ApportionmentCommitteeSessionNotCompleted",
-          "ApportionmentDrawingOfLotsRequired",
           "ApportionmentInvalidLotDrawing",
           "CommitteeSessionPaused",
           "DatabaseError",
@@ -8465,6 +8465,53 @@
             "minimum": 0
           }
         }
+      },
+      "ProcessApportionmentResponse": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElectionApportionmentResponse"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "status"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Finalised"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "election_summary",
+              "seat_assignment",
+              "status"
+            ],
+            "properties": {
+              "election_summary": {
+                "$ref": "#/components/schemas/ElectionSummary"
+              },
+              "seat_assignment": {
+                "$ref": "#/components/schemas/SeatAssignment"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "DrawingLotsRequired"
+                ]
+              }
+            }
+          }
+        ]
       },
       "RandomRange": {
         "type": "string"

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -4,15 +4,17 @@ use axum::{
 };
 use serde::Serialize;
 use sqlx::SqlitePool;
+use utoipa::ToSchema;
 
 use crate::{
     APIError, ErrorResponse,
-    api::{
-        apportionment::{ApportionmentApiError, structs::ElectionApportionmentResponse},
-        election::ElectionAuditData,
-    },
+    api::{apportionment::structs::ElectionApportionmentResponse, election::ElectionAuditData},
     audit_log::AuditService,
-    domain::election::{Election, ElectionId},
+    domain::{
+        apportionment::SeatAssignment,
+        election::{Election, ElectionId},
+        summary::ElectionSummary,
+    },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType},
     repository::{election_repo, user_repo::User},
     service,
@@ -26,12 +28,23 @@ impl AsAuditEvent for ApportionmentProcessed {
     const EVENT_LEVEL: AuditEventLevel = AuditEventLevel::Success;
 }
 
+#[derive(Debug, PartialEq, Serialize, ToSchema)]
+#[serde(tag = "status")]
+#[allow(clippy::large_enum_variant)]
+pub enum ProcessApportionmentResponse {
+    Finalised(ElectionApportionmentResponse),
+    DrawingLotsRequired {
+        election_summary: ElectionSummary,
+        seat_assignment: SeatAssignment,
+    },
+}
+
 /// Get the apportionment for an election
 #[utoipa::path(
     post,
     path = "/api/elections/{election_id}/apportionment",
     responses(
-        (status = 200, description = "Election Apportionment", body = ElectionApportionmentResponse),
+        (status = 200, description = "Election Apportionment", body = ProcessApportionmentResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),
@@ -48,17 +61,23 @@ pub async fn process_apportionment(
     State(pool): State<SqlitePool>,
     audit_service: AuditService,
     Path(id): Path<ElectionId>,
-) -> Result<Json<ElectionApportionmentResponse>, APIError> {
+) -> Result<Json<ProcessApportionmentResponse>, APIError> {
+    use ProcessApportionmentResponse::*;
     let mut conn = pool.acquire().await?;
 
     let election = election_repo::get(&mut conn, id).await?;
     user.role().is_authorized(election.committee_category)?;
 
     let apportionment_result = service::process_apportionment(&mut conn, &election).await?;
-    let ApportionmentResult::Ok(apportionment_output) = apportionment_result else {
-        Err(APIError::Delegated(Box::new(
-            ApportionmentApiError::DrawingLotsRequired,
-        )))?
+    let apportionment_output = match apportionment_result {
+        ApportionmentResult::Ok(apportionment_output) => Finalised(apportionment_output),
+        ApportionmentResult::ListDrawingLotsRequired(_, election_summary, seat_assignment)
+        | ApportionmentResult::CandidateDrawingLotsRequired(_, election_summary, seat_assignment) => {
+            DrawingLotsRequired {
+                election_summary,
+                seat_assignment,
+            }
+        }
     };
 
     audit_service

--- a/backend/src/api/apportionment/mapping.rs
+++ b/backend/src/api/apportionment/mapping.rs
@@ -9,9 +9,7 @@ use crate::domain::{
     results::political_group_candidate_votes::PoliticalGroupCandidateVotes,
 };
 
-pub fn map_seat_assignment(
-    sa: &apportionment::SeatAssignmentResult<PoliticalGroupCandidateVotes>,
-) -> SeatAssignment {
+pub fn map_seat_assignment(sa: &apportionment::SeatAssignmentResult<PGNumber>) -> SeatAssignment {
     SeatAssignment {
         seats: sa.seats,
         full_seats: sa.full_seats,

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -1,4 +1,4 @@
-use apportionment::ApportionmentError;
+use apportionment;
 use axum::http::StatusCode;
 use tracing::error;
 use utoipa_axum::{router::OpenApiRouter, routes};
@@ -22,10 +22,11 @@ use crate::{
 };
 
 /// Errors that can occur before apportionment
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ApportionmentApiError {
+    ApportionmentNotCompleted,
     CommitteeSessionNotCompleted,
-    DrawingLotsRequired,
+    InvalidLotDrawing,
 }
 
 impl ApiErrorResponse for ApportionmentApiError {
@@ -35,6 +36,14 @@ impl ApiErrorResponse for ApportionmentApiError {
 
     fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
         match self {
+            ApportionmentApiError::ApportionmentNotCompleted => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                ErrorResponse::new(
+                    "Apportionment not completed",
+                    ErrorReference::ApportionmentNotCompleted,
+                    false,
+                ),
+            ),
             ApportionmentApiError::CommitteeSessionNotCompleted => (
                 StatusCode::PRECONDITION_FAILED,
                 ErrorResponse::new(
@@ -43,27 +52,22 @@ impl ApiErrorResponse for ApportionmentApiError {
                     false,
                 ),
             ),
-            ApportionmentApiError::DrawingLotsRequired => (
-                StatusCode::UNPROCESSABLE_ENTITY,
+            ApportionmentApiError::InvalidLotDrawing => (
+                StatusCode::CONFLICT,
                 ErrorResponse::new(
-                    "Drawing of lots is required",
-                    ErrorReference::ApportionmentDrawingOfLotsRequired,
-                    false,
+                    "Drawn lot is invalid",
+                    ErrorReference::ApportionmentInvalidLotDrawing,
+                    true,
                 ),
             ),
         }
     }
 }
 
-impl From<ApportionmentError<PGNumber, CandidateNumber>> for ApportionmentApiError {
-    fn from(_err: ApportionmentError<PGNumber, CandidateNumber>) -> Self {
-        Self::DrawingLotsRequired
-    }
-}
-
-impl From<ApportionmentError<PGNumber, CandidateNumber>> for APIError {
-    fn from(err: ApportionmentError<PGNumber, CandidateNumber>) -> Self {
-        ApportionmentApiError::from(err).into()
+// Needed for report generation
+impl From<apportionment::ApportionmentError<PGNumber, CandidateNumber>> for APIError {
+    fn from(_err: apportionment::ApportionmentError<PGNumber, CandidateNumber>) -> Self {
+        ApportionmentApiError::ApportionmentNotCompleted.into()
     }
 }
 

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -167,7 +167,7 @@ impl apportionment::CandidateDrawn<PGNumber, CandidateNumber> for CandidateDrawn
     }
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema, PartialEq)]
 pub struct ElectionApportionmentResponse {
     pub seat_assignment: SeatAssignment,
     pub candidate_nomination: CandidateNomination,

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -23,7 +23,7 @@ impl From<apportionment::ApportionmentWarning> for ApportionmentWarning {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq)]
 pub struct SeatAssignment {
     pub seats: u32,
     pub full_seats: u32,
@@ -151,7 +151,7 @@ pub struct ListStanding {
     pub residual_seats: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct ListSeatAssignment {
     pub list_number: PGNumber,
     pub votes_cast: u64,
@@ -162,20 +162,20 @@ pub struct ListSeatAssignment {
     pub total_seats: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct CandidateNomination {
     pub preference_threshold: PreferenceThreshold,
     pub chosen_candidates: Vec<ChosenCandidate>,
     pub list_candidate_nomination: Vec<ListCandidateNomination>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct PreferenceThreshold {
     pub percentage: u64,
     pub number_of_votes: DisplayFraction,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct ListCandidateNomination {
     pub list_number: PGNumber,
     pub list_name: String,
@@ -379,7 +379,6 @@ pub struct CandidateDrawn {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -250,7 +250,7 @@ impl From<&apportionment::SeatChangeStep<PGNumber>> for SeatChangeStep {
 }
 
 /// Fraction with the integer part split out for display purposes
-#[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct DisplayFraction {
     pub integer: u64,
     pub numerator: u64,

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -101,7 +101,7 @@ impl EnrichedSeatAssignment {
                 .iter()
                 .find(|step| step.change.list_number_assigned() == standing.list_number);
             let largest_remainder = LargestRemainder {
-                remainder_votes: standing.remainder_votes.clone(),
+                remainder_votes: standing.remainder_votes,
                 residual_seats: if assigned_seat.is_some() { 1 } else { 0 },
             };
             largest_remainders.push((standing.list_number, largest_remainder));
@@ -119,7 +119,7 @@ impl EnrichedSeatAssignment {
             let assigned_seat = initial_unique_highest_average_steps
                 .iter()
                 .find(|step| step.change.list_number_assigned() == list_number);
-            let average = &initial_unique_highest_average_steps
+            let average = initial_unique_highest_average_steps
                 .first()
                 .expect("There should be at least one step since is_empty is checked")
                 .standings
@@ -133,7 +133,7 @@ impl EnrichedSeatAssignment {
             };
             let unique_highest_average = UniqueHighestAverage {
                 already_assigned_seats,
-                next_votes_per_seat: average.clone(),
+                next_votes_per_seat: average,
                 residual_seats: u32::from(assigned_seat.is_some()),
             };
             Some(unique_highest_average)
@@ -200,7 +200,7 @@ impl EnrichedSeatAssignment {
     ) -> Result<Self, ModelsError> {
         let list_seat_assignments = Self::get_list_seat_assignments(summary, seat_assignment)?;
         Ok(EnrichedSeatAssignment {
-            quota: seat_assignment.quota.clone(),
+            quota: seat_assignment.quota,
             list_seat_assignment: list_seat_assignments.enriched_list_seat_assignments,
             initial_highest_average_steps: if list_seat_assignments
                 .initial_highest_average_steps

--- a/backend/src/domain/summary.rs
+++ b/backend/src/domain/summary.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Contains a summary of the election results, added up from the votes of all polling stations.
-#[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ElectionSummary {
     /// The total number of voters
@@ -193,7 +193,7 @@ impl ElectionSummary {
 }
 
 /// Contains a summary of the differences, containing which polling stations had differences.
-#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct SummaryDifferencesCounts {
     pub more_ballots_count: SumCount,
@@ -224,7 +224,7 @@ impl SummaryDifferencesCounts {
 
 /// Contains a summary count, containing both the count and a list of polling
 /// stations that contributed to it.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct SumCount {
     #[schema(value_type = u32)]
@@ -252,7 +252,7 @@ impl SumCount {
 
 /// Polling stations where results were investigated by the GSB,
 /// as vectors of polling station numbers
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PollingStationInvestigations {
     /// Admitted voters were recounted

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -41,8 +41,8 @@ pub trait ApiErrorResponse: Debug + Any {
 pub enum ErrorReference {
     AirgapViolation,
     AlreadyInitialised,
+    ApportionmentNotCompleted,
     ApportionmentCommitteeSessionNotCompleted,
-    ApportionmentDrawingOfLotsRequired,
     ApportionmentInvalidLotDrawing,
     CommitteeSessionPaused,
     DatabaseError,

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -85,10 +85,10 @@ mod tests {
                         HighestAverageResidualSeatDrawingLots {
                             average: DisplayFraction {
                                 integer: 0,
-                                numerator: 0,
-                                denominator: 0,
+                                numerator: 1,
+                                denominator: 2,
                             },
-                            residual_seat_numbers: vec![],
+                            residual_seat_numbers: vec![1],
                             options: PGNumber::from_values(vec![1, 2, 3]),
                         },
                     ),

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -12,7 +12,7 @@ use crate::{
         apportionment::{
             AbsoluteMajorityDrawingLots, ApportionmentWarning, CandidateDrawingLotsVariant,
             HighestAverageResidualSeatDrawingLots, LargestRemainderResidualSeatDrawingLots,
-            ListDrawingLotsVariant,
+            ListDrawingLotsVariant, SeatAssignment,
         },
         apportionment_state::{ApportionmentState, ApportionmentStateError, DrawingLotsRequired},
         committee_session::CommitteeSessionId,
@@ -103,10 +103,10 @@ pub async fn next_state(
 
     update_state(tx, audit_service, election.id, |state| match result {
         ApportionmentResult::Ok(_) => state.finalise(),
-        ApportionmentResult::ListDrawingLotsRequired(variant) => {
+        ApportionmentResult::ListDrawingLotsRequired(variant, ..) => {
             state.draw_lots(DrawingLotsRequired::ListDrawingLotsRequired(variant))
         }
-        ApportionmentResult::CandidateDrawingLotsRequired(variant) => {
+        ApportionmentResult::CandidateDrawingLotsRequired(variant, ..) => {
             state.draw_lots(DrawingLotsRequired::CandidateDrawingLotsRequired(variant))
         }
     })
@@ -116,8 +116,8 @@ pub async fn next_state(
 #[allow(clippy::large_enum_variant)]
 pub enum ApportionmentResult {
     Ok(ElectionApportionmentResponse),
-    ListDrawingLotsRequired(ListDrawingLotsVariant),
-    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant),
+    ListDrawingLotsRequired(ListDrawingLotsVariant, ElectionSummary, SeatAssignment),
+    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant, ElectionSummary, SeatAssignment),
 }
 
 impl From<apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>>
@@ -171,7 +171,7 @@ type ApportionmentError = apportionment::ApportionmentError<PGNumber, CandidateN
 
 /// - Collect data for the [ApportionmentInputData] from the database and make sure that the
 ///   committee session status is completed.
-/// - Call the apportionment process funtion
+/// - Call the apportionment process function
 /// - Map the Result from the apportionment into an [ApportionmentResult]
 pub async fn process(
     conn: &mut SqliteConnection,
@@ -206,11 +206,19 @@ pub async fn process(
                 .map(ApportionmentWarning::from)
                 .collect(),
         }),
-        Err(ApportionmentError::ListDrawingLotsRequired(r)) => {
-            ApportionmentResult::ListDrawingLotsRequired(r.into())
+        Err(ApportionmentError::ListDrawingLotsRequired(variant, preliminary_seat_assignment)) => {
+            ApportionmentResult::ListDrawingLotsRequired(
+                variant.into(),
+                election_summary.clone(),
+                map_seat_assignment(&preliminary_seat_assignment),
+            )
         }
-        Err(ApportionmentError::CandidateDrawingLotsRequired(r)) => {
-            ApportionmentResult::CandidateDrawingLotsRequired(r.into())
+        Err(ApportionmentError::CandidateDrawingLotsRequired(variant, seat_assignment)) => {
+            ApportionmentResult::CandidateDrawingLotsRequired(
+                variant.into(),
+                election_summary.clone(),
+                map_seat_assignment(&seat_assignment),
+            )
         }
         Err(ApportionmentError::InvalidLotDrawing(message)) => {
             return Err(APIError::Conflict(

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -185,7 +185,7 @@ async fn test_unassigned_seats(pool: SqlitePool) {
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("election_10_csb", "users"))))]
-async fn test_error_drawing_of_lots_required(pool: SqlitePool) {
+async fn test_drawing_of_lots_required(pool: SqlitePool) {
     let addr = serve_api(pool).await;
 
     let request_body = json!({
@@ -229,9 +229,9 @@ async fn test_error_drawing_of_lots_required(pool: SqlitePool) {
         .await;
 
     let response = get_apportionment(&addr, 10).await;
-    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(response.status(), StatusCode::OK);
     let body: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(body["error"], "Drawing of lots is required");
+    assert_eq!(body["status"], "DrawingLotsRequired".to_string());
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]

--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -385,11 +385,11 @@ describe("ApportionmentPage", () => {
       expect(screen.queryByTestId("chosen-candidates-table")).not.toBeInTheDocument();
     });
 
-    test("Not possible because drawing of lots is not implemented yet", async () => {
-      overrideOnce("post", "/api/elections/3/apportionment", 422, {
-        error: "Drawing of lots is required",
+    test("Not possible because committee session is not completed yet", async () => {
+      overrideOnce("post", "/api/elections/3/apportionment", 412, {
+        error: "Committee session not completed",
         fatal: false,
-        reference: "ApportionmentDrawingOfLotsRequired",
+        reference: "ApportionmentCommitteeSessionNotCompleted",
       } satisfies ErrorResponse);
 
       renderApportionmentPage(3, false);
@@ -397,9 +397,9 @@ describe("ApportionmentPage", () => {
       // Wait for the page to be loaded
       expect(await screen.findByRole("heading", { level: 1, name: "Zetelverdeling" })).toBeVisible();
 
-      expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
+      expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
-        await screen.findByText("Loting is noodzakelijk, maar nog niet beschikbaar in deze versie van Abacus"),
+        await screen.findByText("De zetelverdeling kan pas gemaakt worden als de zitting is afgerond"),
       ).toBeVisible();
 
       expect(screen.queryByText("Alle zetels zijn toegewezen")).not.toBeInTheDocument();

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
@@ -216,11 +216,11 @@ describe("ApportionmentFullSeatsPage", () => {
       expect(screen.queryByTestId("residual-seats-calculation-table")).not.toBeInTheDocument();
     });
 
-    test("Not possible because drawing of lots is not implemented yet", async () => {
-      overrideOnce("post", "/api/elections/3/apportionment", 422, {
-        error: "Drawing of lots is required",
+    test("Not possible because committee session is not completed yet", async () => {
+      overrideOnce("post", "/api/elections/3/apportionment", 412, {
+        error: "Committee session not completed",
         fatal: false,
-        reference: "ApportionmentDrawingOfLotsRequired",
+        reference: "ApportionmentCommitteeSessionNotCompleted",
       } satisfies ErrorResponse);
 
       renderApportionmentFullSeatsPage(3);
@@ -228,9 +228,9 @@ describe("ApportionmentFullSeatsPage", () => {
       // Wait for the page to be loaded
       expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de volle zetels" })).toBeVisible();
 
-      expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
+      expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
-        await screen.findByText("Loting is noodzakelijk, maar nog niet beschikbaar in deze versie van Abacus"),
+        await screen.findByText("De zetelverdeling kan pas gemaakt worden als de zitting is afgerond"),
       ).toBeVisible();
 
       expect(screen.queryByTestId("full-seats-table")).not.toBeInTheDocument();

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -344,12 +344,12 @@ describe("ApportionmentListDetailsPage", () => {
       expect(screen.queryByTestId("total-votes-per-candidate-table")).not.toBeInTheDocument();
     });
 
-    test("Not possible because drawing of lots is not implemented yet", async () => {
+    test("Not possible because committee session is not completed yet", async () => {
       vi.spyOn(ReactRouter, "useParams").mockReturnValue({ listNumber: "1" });
-      overrideOnce("post", "/api/elections/3/apportionment", 422, {
-        error: "Drawing of lots is required",
+      overrideOnce("post", "/api/elections/3/apportionment", 412, {
+        error: "Committee session not completed",
         fatal: false,
-        reference: "ApportionmentDrawingOfLotsRequired",
+        reference: "ApportionmentCommitteeSessionNotCompleted",
       } satisfies ErrorResponse);
 
       renderApportionmentListDetailsPage(3);
@@ -357,9 +357,9 @@ describe("ApportionmentListDetailsPage", () => {
       // Wait for the page to be loaded
       expect(await screen.findByRole("heading", { level: 1, name: "Lijst 1 - Political Group A" })).toBeVisible();
 
-      expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
+      expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
-        await screen.findByText("Loting is noodzakelijk, maar nog niet beschikbaar in deze versie van Abacus"),
+        await screen.findByText("De zetelverdeling kan pas gemaakt worden als de zitting is afgerond"),
       ).toBeVisible();
 
       expect(screen.queryByTestId("preferentially-chosen-candidates-table")).not.toBeInTheDocument();

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -517,11 +517,11 @@ describe("ApportionmentResidualSeatsPage", () => {
       expect(screen.queryByTestId("footnotes-list")).not.toBeInTheDocument();
     });
 
-    test("Not possible because drawing of lots is not implemented yet", async () => {
-      overrideOnce("post", "/api/elections/3/apportionment", 422, {
-        error: "Drawing of lots is required",
+    test("Not possible because committee session is not completed yet", async () => {
+      overrideOnce("post", "/api/elections/3/apportionment", 412, {
+        error: "Committee session not completed",
         fatal: false,
-        reference: "ApportionmentDrawingOfLotsRequired",
+        reference: "ApportionmentCommitteeSessionNotCompleted",
       } satisfies ErrorResponse);
 
       renderApportionmentResidualSeatsPage(3);
@@ -529,9 +529,9 @@ describe("ApportionmentResidualSeatsPage", () => {
       // Wait for the page to be loaded
       expect(await screen.findByRole("heading", { level: 1, name: "Verdeling van de restzetels" })).toBeVisible();
 
-      expect(await screen.findByText("Zetelverdeling is niet mogelijk")).toBeVisible();
+      expect(await screen.findByText("Zetelverdeling is nog niet beschikbaar")).toBeVisible();
       expect(
-        await screen.findByText("Loting is noodzakelijk, maar nog niet beschikbaar in deze versie van Abacus"),
+        await screen.findByText("De zetelverdeling kan pas gemaakt worden als de zitting is afgerond"),
       ).toBeVisible();
 
       expect(screen.queryByTestId("highest-averages-table")).not.toBeInTheDocument();

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -7,8 +7,8 @@
   "api_error": {
     "AirgapViolation": "Abacus is niet beschikbaar omdat de applicatie verbonden is met het internet. Abacus is alleen bedoeld voor offline gebruik.",
     "AlreadyInitialised": "De applicatie is al geconfigureerd. Je kan geen nieuwe beheerder aanmaken.",
+    "ApportionmentNotCompleted": "De documenten kunnen pas gedownload worden als de zetelverdeling is afgerond",
     "ApportionmentCommitteeSessionNotCompleted": "De zetelverdeling kan pas gemaakt worden als de zitting is afgerond",
-    "ApportionmentDrawingOfLotsRequired": "Loting is noodzakelijk, maar nog niet beschikbaar in deze versie van Abacus",
     "ApportionmentInvalidLotDrawing": "Loting is ongeldig",
     "CommitteeSessionPaused": "De coördinator heeft het invoeren van stemmen gepauzeerd. Je kan niet meer verder.",
     "DatabaseError": "Er is een fout opgetreden bij het opslaan van de invoer",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1002,8 +1002,8 @@ export interface ElectionWithPoliticalGroups {
 export const errorReferenceValues = [
   "AirgapViolation",
   "AlreadyInitialised",
+  "ApportionmentNotCompleted",
   "ApportionmentCommitteeSessionNotCompleted",
-  "ApportionmentDrawingOfLotsRequired",
   "ApportionmentInvalidLotDrawing",
   "CommitteeSessionPaused",
   "DatabaseError",
@@ -1442,6 +1442,10 @@ export interface PreferenceThreshold {
   number_of_votes: DisplayFraction;
   percentage: number;
 }
+
+export type ProcessApportionmentResponse =
+  | (ElectionApportionmentResponse & { status: "Finalised" })
+  | { election_summary: ElectionSummary; seat_assignment: SeatAssignment; status: "DrawingLotsRequired" };
 
 export type RandomRange = string;
 


### PR DESCRIPTION
## What & why

<!-- What does this change do, and why is it needed? Link the issue(s). -->
This is the extra backend preparation for #1264 in which we need to show the preliminary seat assignment and the alert and page for list drawing lots.

- Added residual seat numbers to highest average and largest remainder variants
- Changed type parameter of SeatAssignmentResult from ListVotes to ListNumber
- Drawing lots situation is now not returned as error from apportionment endpoint and is enriched with election summary and (preliminary) seat assignment

## How to test

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->
Review the updated tests and the apportionment result sent to the frontend instead of the 422 error

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->
Review per commit

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->