### PR TITLE
Change DrawingLotsRequired to be variants of the Ok type instead of the Err type

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use apportionment::{CandidateVotes, process};
+use apportionment::{ApportionmentOutput, CandidateVotes, process};
 use apportionment_fuzz::{FuzzedApportionmentInput, SimpleListVotes, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
 
@@ -12,7 +12,6 @@ fuzz_target!(
     },
     |data: (FuzzedApportionmentInput, Vec::<usize>)| {
     let (data, mut random_order) = data;
-    #[allow(clippy::result_large_err)]
     let (alloc, log1) = run_with_log(|| process(&data));
 
     if random_order.is_empty() {
@@ -42,10 +41,9 @@ fuzz_target!(
         candidates_drawn: Vec::new(),
     };
 
-    #[allow(clippy::result_large_err)]
     let (new_alloc, log2) = run_with_log(|| process(&reordered_input));
 
-    if let (Ok(alloc), Ok(new_alloc)) = (alloc, new_alloc) {
+    if let (Ok(ApportionmentOutput::Completed(alloc)), Ok(ApportionmentOutput::Completed(new_alloc))) = (alloc, new_alloc) {
         let seats_per_party: Vec<u32> = alloc
             .seat_assignment
             .final_standing

--- a/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use apportionment::{ApportionmentError, CandidateVotes, process};
+use apportionment::{ApportionmentError, ApportionmentOutput, CandidateVotes, process};
 use apportionment_fuzz::{
     FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log,
 };
@@ -34,11 +34,10 @@ fuzz_target!(
         })
         .collect();
 
-    #[allow(clippy::result_large_err)]
     let (result, log) = run_with_log(|| process(&data));
 
     match result {
-        Ok(result) => {
+        Ok(ApportionmentOutput::Completed(result)) => {
             let total_seats = data.seats;
 
             // Validate total votes calculation
@@ -158,7 +157,7 @@ fuzz_target!(
                 }
             }
         }
-        Err(ApportionmentError::ListDrawingLotsRequired(..) | ApportionmentError::CandidateDrawingLotsRequired(..)) => {
+        Ok(ApportionmentOutput::ListDrawingLotsRequired(..) | ApportionmentOutput::CandidateDrawingLotsRequired(..)) => {
             // Accepted error in this fuzzer
         }
         Err(ApportionmentError::InvalidLotDrawing(message)) => {

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use apportionment::{ApportionmentError, CandidateVotes, process};
+use apportionment::{ApportionmentError, ApportionmentOutput, CandidateVotes, process};
 use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
@@ -193,7 +193,6 @@ fn fuzz(data: FuzzedApportionmentInput) {
     let (osv2020_result, osv2020_log) =
         osv2020_apportionment(data.seats.into(), &pg_candidates, &votes);
 
-    #[allow(clippy::result_large_err)]
     let (abacus_result, abacus_log) = run_with_log(|| process(&data));
 
     // Skip cases where there are fewer than 19 seats and both art. P 9 (absolute majority) and art. P 10 (list exhaustion) are applied.
@@ -213,7 +212,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
     }
 
     match abacus_result {
-        Ok(ref output) => {
+        Ok(ApportionmentOutput::Completed(ref output)) => {
             let abacus_seats = get_total_seats(&output.seat_assignment);
 
             match osv2020_result {
@@ -257,9 +256,9 @@ fn fuzz(data: FuzzedApportionmentInput) {
                 }
             }
         }
-        Err(
-            e @ ApportionmentError::ListDrawingLotsRequired(..)
-            | e @ ApportionmentError::CandidateDrawingLotsRequired(..),
+        Ok(
+            e @ ApportionmentOutput::ListDrawingLotsRequired(..)
+            | e @ ApportionmentOutput::CandidateDrawingLotsRequired(..),
         ) => {
             match osv2020_result {
                 Osv2020Result::Allocated(osv2020_seats) => {

--- a/backend/apportionment/fuzz/fuzz_targets/house_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/house_monotonicity.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use apportionment::process;
+use apportionment::{ApportionmentOutput, process};
 use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
 
@@ -14,21 +14,23 @@ fuzz_target!(
     let new_seats = seats + u32::from(added_seats);
 
     data.seats = seats;
-    #[allow(clippy::result_large_err)]
     let (alloc, log1) = run_with_log(|| process(&data));
-    let alloc = alloc.map(|r| get_total_seats(&r.seat_assignment));
+    let Ok(ApportionmentOutput::Completed(alloc)) = alloc else {
+        return;
+    };
+    let seats_per_party = get_total_seats(&alloc.seat_assignment);
 
     data.seats = new_seats;
-    #[allow(clippy::result_large_err)]
     let (new_alloc, log2) = run_with_log(|| process(&data));
-    let new_alloc = new_alloc.map(|r| get_total_seats(&r.seat_assignment));
+    let Ok(ApportionmentOutput::Completed(new_alloc)) = new_alloc else {
+        return;
+    };
+    let new_seats_per_party = get_total_seats(&new_alloc.seat_assignment);
 
-    if let (Ok(seats_per_party), Ok(new_seats_per_party)) = (alloc, new_alloc) {
-        // House monotonicity:
-        // The number of seats given to any party will not decrease if the number of seats increases (when votes stay the same)
-        assert!(
-            new_seats_per_party.iter().ge(seats_per_party.iter()),
-            "{new_seats_per_party:?} ({new_seats} seats) is not greater or equal than {seats_per_party:?} ({seats} seats)\n[{seats} seats]\n{log1}\n[{new_seats} seats]\n{log2}",
-        );
-    }
+    // House monotonicity:
+    // The number of seats given to any party will not decrease if the number of seats increases (when votes stay the same)
+    assert!(
+        new_seats_per_party.iter().ge(seats_per_party.iter()),
+        "{new_seats_per_party:?} ({new_seats} seats) is not greater or equal than {seats_per_party:?} ({seats} seats)\n[{seats} seats]\n{log1}\n[{new_seats} seats]\n{log2}",
+    );
 });

--- a/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use apportionment::{CandidateVotes, process};
+use apportionment::{ApportionmentOutput, CandidateVotes, process};
 use apportionment_fuzz::{
     FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log,
 };
@@ -15,7 +15,6 @@ fuzz_target!(
     |data: (FuzzedApportionmentInput, u16)| {
     let (data, added_votes) = data;
 
-    #[allow(clippy::result_large_err)]
     let (alloc, log1) = run_with_log(|| process(&data));
 
     // Add some votes to the first candidate of the first party
@@ -45,10 +44,9 @@ fuzz_target!(
                 SimpleCandidateVotes::new(first_candidate.number(), first_candidate.votes() + u32::from(added_votes));
         }
 
-    #[allow(clippy::result_large_err)]
     let (new_alloc, log2) = run_with_log(|| process(&new_data));
 
-    if let (Ok(alloc), Ok(new_alloc)) = (alloc, new_alloc) {
+    if let (Ok(ApportionmentOutput::Completed(alloc)), Ok(ApportionmentOutput::Completed(new_alloc))) = (alloc, new_alloc) {
         let seats_per_party: Vec<u32> = alloc
             .seat_assignment
             .final_standing

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -172,7 +172,7 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
     }
 }
 
-pub fn get_total_seats(result: &apportionment::SeatAssignmentResult<u32>) -> Vec<u32> {
+pub fn get_total_seats(result: &apportionment::SeatAssignmentDetails<u32>) -> Vec<u32> {
     result
         .final_standing
         .iter()

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -1,27 +1,30 @@
 mod structs;
 
 pub use structs::{
-    Candidate, CandidateNominationResult, ListCandidateNomination, PreferenceThreshold,
+    Candidate, CandidateNominationDetails, ListCandidateNomination, PreferenceThreshold,
 };
 use tracing::{debug, info};
 
 use crate::{
-    CandidateVotes, ListVotes,
+    ApportionmentError, CandidateVotes, ListVotes,
     fraction::Fraction,
     structs::{
-        CandidateDrawingLotsError, CandidateDrawingLotsVariant, CandidateNominationInput,
-        CandidateNumber, DeceasedCandidates, LARGE_COUNCIL_THRESHOLD, ListNumber,
+        CandidateDrawingLotsVariant, CandidateNominationInput, CandidateNumber, DeceasedCandidates,
+        LARGE_COUNCIL_THRESHOLD, ListNumber,
     },
 };
 
-/// Defines a CandidateNominationErr, for more details, check [CandidateDrawingLotsError]
-type CandidateNominationErr<LV> = CandidateDrawingLotsError<ListNumber<LV>, CandidateNumber<LV>>;
+#[derive(Debug, PartialEq)]
+pub enum CandidateNomination<'a, LV: ListVotes> {
+    Completed(CandidateNominationDetails<'a, LV>),
+    DrawingLotsRequired(CandidateDrawingLotsVariant<ListNumber<LV>, CandidateNumber<LV>>),
+}
 
 /// Candidate nomination
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::cognitive_complexity)]
 pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     input: &CandidateNominationInput<'a, L>,
-) -> Result<CandidateNominationResult<'a, L>, CandidateNominationErr<L>> {
+) -> Result<CandidateNomination<'a, L>, ApportionmentError> {
     info!("Candidate nomination");
 
     // [Artikel P 15 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP15)
@@ -38,7 +41,13 @@ pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     );
     info!("Preference threshold: {}", preference_threshold);
 
-    let list_candidate_nomination = candidate_nomination_per_list(input, preference_threshold)?;
+    let list_candidate_nomination =
+        match candidate_nomination_per_list(input, preference_threshold)? {
+            ListCandidateNominations::Completed(list) => list,
+            ListCandidateNominations::DrawingLotsRequired(variant) => {
+                return Ok(CandidateNomination::DrawingLotsRequired(variant));
+            }
+        };
     debug!(
         "List candidate nomination: {:#?}",
         list_candidate_nomination
@@ -48,14 +57,14 @@ pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     let chosen_candidates = all_chosen_candidates(input.list_votes, &list_candidate_nomination);
     debug!("Chosen candidates: {:#?}", chosen_candidates);
 
-    Ok(CandidateNominationResult {
+    Ok(CandidateNomination::Completed(CandidateNominationDetails {
         preference_threshold: PreferenceThreshold {
             percentage: preference_threshold_percentage,
             number_of_votes: preference_threshold,
         },
         chosen_candidates,
         list_candidate_nomination,
-    })
+    }))
 }
 
 /// Collect all chosen candidates via nomination with preferential votes and
@@ -105,14 +114,20 @@ fn filter_out_deceased_candidates<'a, T: ListVotes>(
         .collect()
 }
 
+enum ListCandidateNominations<'a, LV: ListVotes> {
+    Completed(Vec<ListCandidateNomination<'a, LV>>),
+    DrawingLotsRequired(CandidateDrawingLotsVariant<ListNumber<LV>, CandidateNumber<LV>>),
+}
+
 /// This function nominates candidates for the seats each list has been assigned.  
 /// The candidate nomination is first done based on preferential votes and then the other
 /// candidates are nominated.
-fn candidate_nomination_per_list<'a, T: ListVotes>(
-    input: &CandidateNominationInput<'a, T>,
+#[expect(clippy::too_many_lines)]
+fn candidate_nomination_per_list<'a, LV: ListVotes>(
+    input: &CandidateNominationInput<'a, LV>,
     preference_threshold: Fraction,
-) -> Result<Vec<ListCandidateNomination<'a, T>>, CandidateNominationErr<T>> {
-    let mut list_candidate_nomination: Vec<ListCandidateNomination<T>> = vec![];
+) -> Result<ListCandidateNominations<'a, LV>, ApportionmentError> {
+    let mut list_candidate_nomination: Vec<ListCandidateNomination<LV>> = vec![];
     for list in input.list_votes {
         let (list_number, list_seats) = input
             .total_seats_per_list
@@ -131,11 +146,16 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
 
         let candidate_votes_meeting_preference_threshold =
             candidate_votes_meeting_preference_threshold(preference_threshold, candidate_votes);
-        let preferential_candidate_nomination = preferential_candidate_nomination::<T>(
+        let preferential_candidate_nomination = match preferential_candidate_nomination::<LV>(
             list.number(),
             &candidate_votes_meeting_preference_threshold,
             list_seats,
-        )?;
+        )? {
+            PreferentialCandidateNomination::Completed(nomination) => nomination,
+            PreferentialCandidateNomination::DrawingLotsRequired(variant) => {
+                return Ok(ListCandidateNominations::DrawingLotsRequired(variant));
+            }
+        };
         let non_assigned_seats = list_seats as usize - preferential_candidate_nomination.len();
 
         // [Artikel P 17 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP17)
@@ -181,7 +201,9 @@ fn candidate_nomination_per_list<'a, T: ListVotes>(
             updated_candidate_ranking,
         });
     }
-    Ok(list_candidate_nomination)
+    Ok(ListCandidateNominations::Completed(
+        list_candidate_nomination,
+    ))
 }
 
 /// List and sort the candidate votes whose votes meet the preference threshold
@@ -226,12 +248,17 @@ fn other_candidate_nomination<'a, T: CandidateVotes>(
         .collect()
 }
 
+enum PreferentialCandidateNomination<'a, LV: ListVotes> {
+    Completed(Vec<&'a LV::Cv>),
+    DrawingLotsRequired(CandidateDrawingLotsVariant<ListNumber<LV>, CandidateNumber<LV>>),
+}
+
 /// List the candidates nominated with preferential votes
 fn preferential_candidate_nomination<'a, LV: ListVotes>(
     list: LV::ListNumber,
     candidates_meeting_preference_threshold: &[&'a LV::Cv],
     list_seats: u32,
-) -> Result<Vec<&'a LV::Cv>, CandidateNominationErr<LV>> {
+) -> Result<PreferentialCandidateNomination<'a, LV>, ApportionmentError> {
     let mut preferential_candidate_nomination: Vec<&LV::Cv> = vec![];
     if candidates_meeting_preference_threshold.len() <= list_seats as usize {
         preferential_candidate_nomination.extend(candidates_meeting_preference_threshold);
@@ -254,7 +281,7 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
                     "Drawing of lots is required for candidates: {:?}, only {non_assigned_seats} seat(s) available",
                     candidate_votes_numbers(&same_votes_candidates)
                 );
-                return Err(CandidateDrawingLotsError::DrawingLotsRequired(
+                return Ok(PreferentialCandidateNomination::DrawingLotsRequired(
                     CandidateDrawingLotsVariant {
                         list,
                         options: candidate_votes_numbers(&same_votes_candidates),
@@ -267,7 +294,9 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
             }
         }
     }
-    Ok(preferential_candidate_nomination)
+    Ok(PreferentialCandidateNomination::Completed(
+        preferential_candidate_nomination,
+    ))
 }
 
 /// Update the candidate list, moving the candidates meeting the preference threshold
@@ -302,9 +331,9 @@ mod tests {
 
     use crate::{
         ListVotes,
-        candidate_nomination::candidate_nomination,
+        candidate_nomination::{CandidateNomination, candidate_nomination},
         fraction::Fraction,
-        structs::{CandidateDrawingLotsError, CandidateDrawingLotsVariant, DeceasedCandidates},
+        structs::{CandidateDrawingLotsVariant, DeceasedCandidates},
         test_helpers::{
             ListVotesMock,
             candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats,
@@ -373,7 +402,9 @@ mod tests {
             &seat_assignment_input,
             vec![(1, 8), (2, 3), (4, 2), (5, 1), (7, 1)],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -478,7 +509,9 @@ mod tests {
             &seat_assignment_input,
             vec![8, 3, 2, 1, 1],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -560,7 +593,9 @@ mod tests {
             &seat_assignment_input,
             vec![8, 3, 2, 1, 1],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -649,7 +684,9 @@ mod tests {
             &seat_assignment_input,
             vec![1, 1, 1, 1, 1],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -724,7 +761,9 @@ mod tests {
             &seat_assignment_input,
             vec![1, 1, 1, 1, 1],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -800,7 +839,9 @@ mod tests {
             &seat_assignment_input,
             vec![11, 7, 0],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -872,7 +913,9 @@ mod tests {
             &seat_assignment_input,
             vec![6, 6, 5, 2, 0],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 25);
         assert_eq!(
@@ -962,7 +1005,9 @@ mod tests {
             &seat_assignment_input,
             vec![6, 5, 4, 2, 2],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 25);
         assert_eq!(
@@ -1098,7 +1143,9 @@ mod tests {
             &seat_assignment_input,
             vec![2],
         );
-        let result = candidate_nomination(&input).unwrap();
+        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+            panic!("should be completed");
+        };
 
         assert_eq!(result.preference_threshold.percentage, 50);
         assert_eq!(
@@ -1135,7 +1182,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(CandidateDrawingLotsError::DrawingLotsRequired(
+            Ok(CandidateNomination::DrawingLotsRequired(
                 CandidateDrawingLotsVariant {
                     list: 2,
                     options: vec![1, 2, 3, 4, 5, 6]

--- a/backend/apportionment/src/candidate_nomination/structs.rs
+++ b/backend/apportionment/src/candidate_nomination/structs.rs
@@ -34,7 +34,7 @@ pub struct PreferenceThreshold {
 /// It also contains the preferential nomination of candidates, the remaining
 /// nomination of candidates and the final ranking of candidates for each list.
 #[derive(Debug, PartialEq)]
-pub struct CandidateNominationResult<'a, T: ListVotes> {
+pub struct CandidateNominationDetails<'a, T: ListVotes> {
     /// Preference threshold percentage and number of votes
     pub preference_threshold: PreferenceThreshold,
     /// List of chosen candidates

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -16,47 +16,69 @@ use self::{
     seat_assignment::{as_candidate_nomination_input, seat_assignment},
 };
 pub use self::{
-    candidate_nomination::{CandidateNominationResult, PreferenceThreshold},
+    candidate_nomination::{CandidateNomination, CandidateNominationDetails, PreferenceThreshold},
     fraction::Fraction,
     seat_assignment::{
-        ApportionmentWarning, HighestAverageAssignedSeat, SeatAssignmentResult, SeatChange,
-        SeatChangeStep,
+        ApportionmentWarning, HighestAverageAssignedSeat, SeatAssignment, SeatAssignmentDetails,
+        SeatChange, SeatChangeStep,
     },
     structs::{
-        AbsoluteMajorityDrawingLots, ApportionmentError, ApportionmentInput, ApportionmentOutput,
-        CandidateDrawingLotsError, CandidateDrawingLotsVariant, CandidateDrawn, CandidateVotes,
+        AbsoluteMajorityDrawingLots, ApportionmentDetails, ApportionmentError, ApportionmentInput,
+        CandidateDrawingLotsVariant, CandidateDrawn, CandidateVotes,
         HighestAverageResidualSeatDrawingLots, LargestRemainderResidualSeatDrawingLots,
-        ListDrawingLotsError, ListDrawingLotsVariant, ListDrawn, ListVotes,
+        ListDrawingLotsVariant, ListDrawn, ListVotes,
     },
 };
 
-type ProcessApportionmentError<LV> = ApportionmentError<ListNumber<LV>, CandidateNumber<LV>>;
+#[derive(Debug, PartialEq)]
+pub enum ApportionmentOutput<'a, T: ApportionmentInput> {
+    Completed(ApportionmentDetails<'a, T::List>),
+    ListDrawingLotsRequired(
+        ListDrawingLotsVariant<ListNumber<T::List>>,
+        SeatAssignmentDetails<ListNumber<T::List>>,
+    ),
+    CandidateDrawingLotsRequired(
+        CandidateDrawingLotsVariant<ListNumber<T::List>, CandidateNumber<T::List>>,
+        SeatAssignmentDetails<ListNumber<T::List>>,
+    ),
+}
 
 /// Perform seat assignment and candidate nomination on apportionment input.
-#[allow(clippy::result_large_err)]
 pub fn process<T: ApportionmentInput>(
     input: &T,
-) -> Result<ApportionmentOutput<'_, T::List>, ProcessApportionmentError<T::List>> {
-    let seat_assignment = seat_assignment(input)?;
-    let candidate_nomination_input = as_candidate_nomination_input(input, &seat_assignment);
-    let candidate_nomination =
-        candidate_nomination(&candidate_nomination_input).map_err(|err| match err {
-            CandidateDrawingLotsError::DrawingLotsRequired(variant) => {
-                ApportionmentError::CandidateDrawingLotsRequired(variant, seat_assignment.clone())
-            }
-        })?;
+) -> Result<ApportionmentOutput<'_, T>, ApportionmentError> {
+    let seat_assignment = match seat_assignment(input)? {
+        SeatAssignment::Completed(seat_assignment) => seat_assignment,
+        SeatAssignment::DrawingLotsRequired(variant, seat_assignment) => {
+            return Ok(ApportionmentOutput::ListDrawingLotsRequired(
+                variant,
+                seat_assignment,
+            ));
+        }
+    };
 
-    Ok(ApportionmentOutput {
+    let candidate_nomination_input = as_candidate_nomination_input(input, &seat_assignment);
+    let candidate_nomination = match candidate_nomination(&candidate_nomination_input)? {
+        CandidateNomination::Completed(candidate_nomination) => candidate_nomination,
+        CandidateNomination::DrawingLotsRequired(variant) => {
+            return Ok(ApportionmentOutput::CandidateDrawingLotsRequired(
+                variant,
+                seat_assignment,
+            ));
+        }
+    };
+
+    Ok(ApportionmentOutput::Completed(ApportionmentDetails {
         seat_assignment,
         candidate_nomination,
-    })
+    }))
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use super::process;
+    use super::{ApportionmentOutput, process};
     use crate::{
         Fraction,
         test_helpers::{
@@ -68,13 +90,15 @@ mod tests {
     };
 
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn test_apportionment_process() {
         let input = seat_assignment_fixture_with_default_50_candidates(
             15,
             vec![540, 160, 160, 80, 80, 80, 60, 40],
         );
-        let result = process(&input).unwrap();
+        let Ok(ApportionmentOutput::Completed(result)) = process(&input) else {
+            panic!("should be Completed")
+        };
         assert_eq!(result.seat_assignment.full_seats, 13);
         assert_eq!(result.seat_assignment.residual_seats, 2);
         assert_eq!(result.seat_assignment.steps.len(), 2);
@@ -209,7 +233,7 @@ mod tests {
     /// Seat assignment must be unchanged (votes of deceased candidates still count toward
     /// the list total). Only the candidate nomination changes for list 1.
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn test_apportionment_process_with_deceased_candidates() {
         let mut input = seat_assignment_fixture_with_default_50_candidates(
             15,
@@ -217,7 +241,9 @@ mod tests {
         );
         input.deceased_candidates = HashMap::from([(1, HashSet::from([1, 50]))]);
 
-        let result = process(&input).unwrap();
+        let Ok(ApportionmentOutput::Completed(result)) = process(&input) else {
+            panic!("should be Completed")
+        };
 
         // Seat assignment is identical to the `test_apportionment_process` test.
         assert_eq!(result.seat_assignment.full_seats, 13);
@@ -358,6 +384,10 @@ mod tests {
 
             let result =
                 process(&input).unwrap_or_else(|e| panic!("case `{}` failed: {e:?}", case.name));
+
+            let ApportionmentOutput::Completed(result) = result else {
+                panic!("should be Completed for case {}", case.name)
+            };
 
             let total_seats = get_total_seats_from_apportionment_result(&result.seat_assignment);
             assert_eq!(total_seats, case.expected_seats, "case: {}", case.name);

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -324,6 +324,7 @@ mod tests {
     /// List 3: 80 -> 0 full seats, 1 residual (largest remainder = 80, threshold 72)
     /// Initial distribution: [3, 1, 1].
     #[test]
+    #[allow(clippy::too_many_lines, reason = "Written out cases take many lines")]
     fn test_apportionment_process_with_deceased_scenarios() {
         struct Case {
             name: &'static str,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -1897,6 +1897,7 @@ pub(crate) mod tests {
             };
 
             /// Apportionment with no residual seats
+            ///
             /// This test triggers Kieswet Article P 10
             ///
             /// Full seats: [5, 5, 4, 4, 2] - Remainder seats: 0  

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -3,29 +3,29 @@ use std::cmp::Ordering;
 mod residual_seat_assignment;
 mod structs;
 pub use structs::{
-    AbsoluteMajorityReassignedSeat, ApportionmentWarning, AssignRemainderDrawingLotsError,
-    HighestAverageAssignedSeat, ListExhaustionRemovedSeat, ListStanding,
-    ResidualSeatDrawingLotsError, SeatAssignmentResult, SeatChange, SeatChangeStep,
+    AbsoluteMajorityReassignedSeat, ApportionmentWarning, HighestAverageAssignedSeat,
+    ListExhaustionRemovedSeat, ListStanding, SeatAssignmentDetails, SeatChange, SeatChangeStep,
 };
 use tracing::info;
 
-use self::{
-    residual_seat_assignment::assign_remainder,
-    structs::{AbsoluteMajorityResult, RemainderAssignmentResult},
-};
+use self::{residual_seat_assignment::assign_remainder, structs::RemainderAssignmentResult};
 use crate::{
-    ApportionmentInput, ListDrawn, ListVotes,
+    ApportionmentError, ApportionmentInput, ListDrawn, ListVotes,
     fraction::Fraction,
+    seat_assignment::structs::{AbsoluteMajority, AbsoluteMajorityResult, RemainderAssignment},
     structs::{
         AbsoluteMajorityDrawingLots, CandidateNominationInput, CandidateNominationInputType,
-        DeceasedCandidates, ListDrawingLotsError, ListDrawingLotsVariant, ListNumber,
+        DeceasedCandidates, ListDrawingLotsVariant, ListNumber,
     },
 };
 
-type SeatAssignmentResultType<T> = Result<
-    SeatAssignmentResult<ListNumber<<T as ApportionmentInput>::List>>,
-    ListDrawingLotsError<ListNumber<<T as ApportionmentInput>::List>>,
->;
+pub enum SeatAssignment<LN> {
+    Completed(SeatAssignmentDetails<LN>),
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>, SeatAssignmentDetails<LN>),
+}
+
+type SeatAssignmentResult<T> =
+    Result<SeatAssignment<ListNumber<<T as ApportionmentInput>::List>>, ApportionmentError>;
 
 /// Seat assignment
 #[allow(
@@ -33,7 +33,7 @@ type SeatAssignmentResultType<T> = Result<
     clippy::cognitive_complexity,
     clippy::result_large_err
 )]
-pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmentResultType<T> {
+pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmentResult<T> {
     info!("Seat assignment");
     info!("Seats: {}", input.number_of_seats());
 
@@ -68,7 +68,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
     let mut lists_drawn = input.lists_drawn();
 
     let (mut steps, current_standings) = if residual_seats > 0 {
-        assign_remainder::<T::List>(
+        match assign_remainder::<T::List>(
             &initial_standing,
             input.number_of_seats(),
             residual_seats,
@@ -76,12 +76,12 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             &[],
             None,
             &mut lists_drawn,
-        )
-        .map_err(|err| match err {
-            AssignRemainderDrawingLotsError::DrawingLotsRequired(variant, steps) => {
-                ListDrawingLotsError::DrawingLotsRequired(
+        )? {
+            RemainderAssignment::Completed(steps, current_standings) => (steps, current_standings),
+            RemainderAssignment::DrawingLotsRequired(variant, steps) => {
+                return Ok(SeatAssignment::DrawingLotsRequired(
                     variant,
-                    SeatAssignmentResult {
+                    SeatAssignmentDetails {
                         seats: input.number_of_seats(),
                         full_seats,
                         residual_seats,
@@ -89,12 +89,9 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                         steps,
                         final_standing: Vec::new(),
                     },
-                )
+                ));
             }
-            AssignRemainderDrawingLotsError::InvalidLotDrawing(message) => {
-                ListDrawingLotsError::InvalidLotDrawing(message)
-            }
-        })?
+        }
     } else {
         info!("All seats have been assigned without any residual seats");
         (vec![], initial_standing)
@@ -102,26 +99,30 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
 
     // [Artikel P 9 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP9)
     let (cumulative_standings, assigned_seat) = if let Some(last_step) = steps.last() {
-        reassign_residual_seat_for_absolute_majority(
+        match reassign_residual_seat_for_absolute_majority(
             input.number_of_seats(),
             total_votes_cast,
             input.list_votes(),
             &last_step.change.list_assigned(),
             current_standings,
-        )
-        .map_err(|err| {
-            ListDrawingLotsError::new(
-                err,
-                SeatAssignmentResult {
-                    seats: input.number_of_seats(),
-                    full_seats,
-                    residual_seats,
-                    quota,
-                    steps: steps.clone(),
-                    final_standing: Vec::new(),
-                },
-            )
-        })?
+        )? {
+            AbsoluteMajority::Completed(cumulative_standings, assigned_seat) => {
+                (cumulative_standings, assigned_seat)
+            }
+            AbsoluteMajority::DrawingLotsRequired(variant) => {
+                return Ok(SeatAssignment::DrawingLotsRequired(
+                    variant,
+                    SeatAssignmentDetails {
+                        seats: input.number_of_seats(),
+                        full_seats,
+                        residual_seats,
+                        quota,
+                        steps: steps.clone(),
+                        final_standing: Vec::new(),
+                    },
+                ));
+            }
+        }
     } else {
         (current_standings, None)
     };
@@ -148,7 +149,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
     }
 
     // [Artikel P 10 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP10)
-    let (final_steps, final_standing) = reassign_residual_seats_for_exhausted_lists(
+    let (final_steps, final_standing) = match reassign_residual_seats_for_exhausted_lists(
         cumulative_standings,
         input.number_of_seats(),
         input.list_votes(),
@@ -156,12 +157,14 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
         residual_seats,
         steps.clone(),
         &mut lists_drawn,
-    )
-    .map_err(|err| match err {
-        AssignRemainderDrawingLotsError::DrawingLotsRequired(variant, steps) => {
-            ListDrawingLotsError::DrawingLotsRequired(
+    )? {
+        RemainderAssignment::Completed(final_steps, final_standing) => {
+            (final_steps, final_standing)
+        }
+        RemainderAssignment::DrawingLotsRequired(variant, steps) => {
+            return Ok(SeatAssignment::DrawingLotsRequired(
                 variant,
-                SeatAssignmentResult {
+                SeatAssignmentDetails {
                     seats: input.number_of_seats(),
                     full_seats,
                     residual_seats,
@@ -169,12 +172,9 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                     steps: steps.clone(),
                     final_standing: Vec::new(),
                 },
-            )
+            ));
         }
-        AssignRemainderDrawingLotsError::InvalidLotDrawing(message) => {
-            ListDrawingLotsError::InvalidLotDrawing(message)
-        }
-    })?;
+    };
 
     let final_full_seats = final_standing
         .iter()
@@ -185,19 +185,19 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
         .map(|list| list.residual_seats)
         .sum::<u32>();
 
-    Ok(SeatAssignmentResult {
+    Ok(SeatAssignment::Completed(SeatAssignmentDetails {
         seats: input.number_of_seats(),
         full_seats: final_full_seats,
         residual_seats: final_residual_seats,
         quota,
         steps: final_steps,
         final_standing: final_standing.into_iter().map(Into::into).collect(),
-    })
+    }))
 }
 
 /// Returns the total number of seats each list number received in the apportionment result.
 pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy>(
-    result: &SeatAssignmentResult<LN>,
+    result: &SeatAssignmentDetails<LN>,
 ) -> Vec<(LN, u32)> {
     result
         .final_standing
@@ -210,7 +210,7 @@ pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy>(
 /// and the seat assignment result.
 pub fn as_candidate_nomination_input<'a, T: ApportionmentInput>(
     input: &'a T,
-    seat_assignment: &SeatAssignmentResult<ListNumber<T::List>>,
+    seat_assignment: &SeatAssignmentDetails<ListNumber<T::List>>,
 ) -> CandidateNominationInputType<'a, T> {
     CandidateNominationInput {
         number_of_seats: input.number_of_seats(),
@@ -283,7 +283,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
         .iter()
         .find(|list| Fraction::from(list.total_votes()) > half_of_votes_count)
     else {
-        return Ok((standings, None));
+        return Ok(AbsoluteMajority::Completed(standings, None));
     };
 
     let half_of_seats_count = Fraction::from(seats) * Fraction::new(1, 2);
@@ -300,7 +300,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
                 "Drawing of lots is required for lists: {:?} to pick a list which the residual seat gets retracted from",
                 lists_last_residual_seat
             );
-            return Err(ResidualSeatDrawingLotsError::DrawingLotsRequired(
+            return Ok(AbsoluteMajority::DrawingLotsRequired(
                 ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
                     options: lists_last_residual_seat.to_vec(),
                 }),
@@ -323,7 +323,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
             lists_last_residual_seat[0],
             majority_list_votes.number()
         );
-        Ok((
+        Ok(AbsoluteMajority::Completed(
             standing,
             Some(SeatChange::AbsoluteMajorityReassignment(
                 AbsoluteMajorityReassignedSeat {
@@ -333,14 +333,13 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
             )),
         ))
     } else {
-        Ok((standings, None))
+        Ok(AbsoluteMajority::Completed(standings, None))
     }
 }
 
 /// If lists got more seats than candidates on their lists,
 /// re-assign those excess seats to other lists without exhausted lists.  
 /// This re-assignment is done according to article P 10 of the Kieswet.
-#[allow(clippy::too_many_arguments, clippy::result_large_err)]
 fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
     previous_standings: Vec<ListStanding<T::ListNumber>>,
     seats: u32,
@@ -390,7 +389,7 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
         current_steps.extend(list_exhaustion_steps);
 
         // Reassign removed seats to non-exhausted lists
-        (current_steps, current_standings) = assign_remainder(
+        Ok(assign_remainder(
             &current_standings,
             seats,
             assigned_residual_seats + seats_to_reassign,
@@ -398,10 +397,12 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
             &current_steps,
             Some((list_votes, deceased_candidates)),
             lists_drawn,
-        )?;
-        Ok((current_steps, current_standings))
+        )?)
     } else {
-        Ok((previous_steps, previous_standings))
+        Ok(RemainderAssignment::Completed(
+            previous_steps,
+            previous_standings,
+        ))
     }
 }
 
@@ -412,7 +413,7 @@ pub(crate) mod tests {
     use test_log::test;
 
     use crate::{
-        SeatAssignmentResult,
+        SeatAssignmentDetails,
         fraction::Fraction,
         seat_assignment::{
             ListStanding, get_total_seats_per_list_number_from_apportionment_result, list_numbers,
@@ -420,7 +421,7 @@ pub(crate) mod tests {
     };
 
     fn check_total_seats_per_list<LN: Copy + Debug + PartialEq>(
-        result: &SeatAssignmentResult<LN>,
+        result: &SeatAssignmentDetails<LN>,
         expected_total_seats_per_list: &[(LN, u32)],
     ) {
         let total_seats_per_list_number =
@@ -450,7 +451,7 @@ pub(crate) mod tests {
         use test_log::test;
 
         use crate::{
-            seat_assignment::seat_assignment,
+            seat_assignment::{SeatAssignment, seat_assignment},
             test_helpers::{
                 get_total_seats_from_apportionment_result,
                 seat_assignment_fixture_with_default_50_candidates,
@@ -466,7 +467,10 @@ pub(crate) mod tests {
                 15,
                 vec![480, 160, 160, 160, 80, 80, 80],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 15);
             assert_eq!(result.residual_seats, 0);
             assert_eq!(result.steps.len(), 0);
@@ -486,7 +490,10 @@ pub(crate) mod tests {
                 15,
                 vec![540, 160, 160, 80, 80, 80, 60, 40],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 13);
             assert_eq!(result.residual_seats, 2);
             assert_eq!(result.steps.len(), 2);
@@ -512,7 +519,9 @@ pub(crate) mod tests {
                 15,
                 vec![808, 59, 58, 57, 56, 55, 54, 53],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
             assert_eq!(result.full_seats, 10);
             assert_eq!(result.residual_seats, 5);
             assert_eq!(result.steps.len(), 5);
@@ -538,7 +547,10 @@ pub(crate) mod tests {
                 15,
                 vec![480, 240, 240, 55, 50, 45, 45, 45],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 12);
             assert_eq!(result.residual_seats, 3);
             assert_eq!(result.steps.len(), 3);
@@ -563,7 +575,10 @@ pub(crate) mod tests {
                 3,
                 vec![8, 7, 6, 5, 4, 3, 2, 1, 1, 1],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 0);
             assert_eq!(result.residual_seats, 3);
             assert_eq!(result.steps.len(), 3);
@@ -586,7 +601,10 @@ pub(crate) mod tests {
         fn test_1st_round_unique_highest_averages_method_regression() {
             let input =
                 seat_assignment_fixture_with_default_50_candidates(10, vec![0, 3, 5, 6, 7, 79]);
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 7);
             assert_eq!(result.residual_seats, 3);
             assert_eq!(result.steps.len(), 3);
@@ -603,7 +621,10 @@ pub(crate) mod tests {
         #[test]
         fn test_with_0_votes() {
             let input = seat_assignment_fixture_with_default_50_candidates(10, vec![0, 0, 0, 0, 0]);
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.seats, 10);
             assert_eq!(result.full_seats, 0);
             assert_eq!(result.residual_seats, 0);
@@ -627,7 +648,10 @@ pub(crate) mod tests {
                 15,
                 vec![2571, 977, 567, 536, 453],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 12);
             assert_eq!(result.residual_seats, 3);
             assert_eq!(result.steps.len(), 4);
@@ -651,10 +675,10 @@ pub(crate) mod tests {
 
             use crate::{
                 Fraction, SeatChange, seat_assignment,
-                seat_assignment::structs::LargestRemainderAssignedSeat,
+                seat_assignment::{SeatAssignment, structs::LargestRemainderAssignedSeat},
                 structs::{
                     AbsoluteMajorityDrawingLots, LargestRemainderResidualSeatDrawingLots,
-                    ListDrawingLotsError, ListDrawingLotsVariant,
+                    ListDrawingLotsVariant,
                 },
                 test_helpers::{
                     ListDrawnMock, get_total_seats_from_apportionment_result,
@@ -678,8 +702,8 @@ pub(crate) mod tests {
                     15,
                     vec![2552, 511, 511, 511, 509, 509],
                 );
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -715,8 +739,8 @@ pub(crate) mod tests {
                     15,
                     vec![540, 160, 160, 80, 80, 80, 55, 45],
                 );
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -745,7 +769,9 @@ pub(crate) mod tests {
 
                 // Lot drawn is 6
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 6 });
-                let result = seat_assignment(&input).expect("should be successful");
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
 
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![7, 2, 2, 1, 1, 2, 0, 0]);
@@ -783,8 +809,8 @@ pub(crate) mod tests {
                     15,
                     vec![500, 140, 140, 140, 140, 140],
                 );
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -813,8 +839,8 @@ pub(crate) mod tests {
 
                 // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -850,11 +876,13 @@ pub(crate) mod tests {
 
             use super::get_total_seats_from_apportionment_result;
             use crate::{
-                ApportionmentWarning, seat_assignment::seat_assignment,
+                ApportionmentWarning,
+                seat_assignment::{SeatAssignment, seat_assignment},
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
-            /// Apportionment with no residual seats  
+            /// Apportionment with no residual seats
+            ///
             /// This test triggers Kieswet Article P 10
             ///
             /// Full seats: [5, 4, 3, 2, 1] - Remainder seats: 0  
@@ -874,7 +902,10 @@ pub(crate) mod tests {
                         vec![200, 200],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 14);
                 assert_eq!(result.residual_seats, 1);
                 assert_eq!(result.steps.len(), 2);
@@ -923,7 +954,10 @@ pub(crate) mod tests {
                         vec![221, 53, 15, 7, 27, 57],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 11);
                 assert_eq!(result.residual_seats, 6);
                 assert_eq!(result.steps.len(), 8);
@@ -970,7 +1004,10 @@ pub(crate) mod tests {
                         vec![10, 10, 10, 10, 10, 10, 10, 9],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 7);
                 assert_eq!(result.residual_seats, 3);
                 assert_eq!(result.steps.len(), 5);
@@ -1014,7 +1051,10 @@ pub(crate) mod tests {
                     6,
                     vec![vec![3, 2], vec![3, 2], vec![25, 25]],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 2);
                 assert_eq!(result.residual_seats, 4);
                 assert_eq!(result.steps.len(), 9);
@@ -1077,7 +1117,10 @@ pub(crate) mod tests {
                     6,
                     vec![vec![3, 3], vec![2, 2], vec![25, 25]],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 2);
                 assert_eq!(result.residual_seats, 4);
                 assert_eq!(result.steps.len(), 9);
@@ -1138,7 +1181,10 @@ pub(crate) mod tests {
                         vec![453, 0],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 12);
                 assert_eq!(result.residual_seats, 3);
                 assert_eq!(result.steps.len(), 6);
@@ -1188,7 +1234,10 @@ pub(crate) mod tests {
                     8,
                     vec![vec![32, 0, 0, 0, 0], vec![41, 0, 0], vec![7]],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 6);
                 assert_eq!(result.residual_seats, 2);
                 assert_eq!(result.steps.len(), 6);
@@ -1246,7 +1295,10 @@ pub(crate) mod tests {
                     8,
                     vec![vec![537, 0], vec![10], vec![426, 0, 0, 0, 0, 0]],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 5);
                 assert_eq!(result.residual_seats, 3);
                 assert_eq!(result.steps.len(), 8);
@@ -1306,7 +1358,10 @@ pub(crate) mod tests {
                         vec![400],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.seats, 15);
                 assert_eq!(result.full_seats, 14);
                 assert_eq!(result.residual_seats, 0);
@@ -1348,7 +1403,10 @@ pub(crate) mod tests {
                         vec![400],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.seats, 15);
                 assert_eq!(result.full_seats, 13);
                 assert_eq!(result.residual_seats, 1);
@@ -1409,7 +1467,10 @@ pub(crate) mod tests {
                 );
                 input.deceased_candidates = HashMap::from([(1, HashSet::from([6]))]);
 
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 13);
                 assert_eq!(result.residual_seats, 2);
                 assert_eq!(result.steps.len(), 3);
@@ -1438,7 +1499,7 @@ pub(crate) mod tests {
 
         use super::check_total_seats_per_list;
         use crate::{
-            seat_assignment::seat_assignment,
+            seat_assignment::{SeatAssignment, seat_assignment},
             test_helpers::{
                 get_total_seats_from_apportionment_result,
                 seat_assignment_fixture_with_default_50_candidates,
@@ -1455,7 +1516,10 @@ pub(crate) mod tests {
                 25,
                 vec![576, 288, 96, 96, 96, 48],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 25);
             assert_eq!(result.residual_seats, 0);
             assert_eq!(result.steps.len(), 0);
@@ -1482,7 +1546,10 @@ pub(crate) mod tests {
                     (7, vec![51, 50]),
                 ],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 19);
             assert_eq!(result.residual_seats, 4);
             assert_eq!(result.steps.len(), 4);
@@ -1504,7 +1571,10 @@ pub(crate) mod tests {
         fn test_with_remainder_seats() {
             let input =
                 seat_assignment_fixture_with_default_50_candidates(23, vec![600, 302, 98, 99, 101]);
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 19);
             assert_eq!(result.residual_seats, 4);
             assert_eq!(result.steps.len(), 4);
@@ -1532,7 +1602,10 @@ pub(crate) mod tests {
                 19,
                 vec![808, 57, 56, 55, 54, 53, 52, 51, 14],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 12);
             assert_eq!(result.residual_seats, 7);
             assert_eq!(result.steps.len(), 7);
@@ -1553,7 +1626,10 @@ pub(crate) mod tests {
         #[test]
         fn test_with_0_votes() {
             let input = seat_assignment_fixture_with_default_50_candidates(19, vec![0]);
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.seats, 19);
             assert_eq!(result.full_seats, 0);
             assert_eq!(result.residual_seats, 0);
@@ -1579,7 +1655,10 @@ pub(crate) mod tests {
                 24,
                 vec![7501, 1249, 1249, 1249, 1249, 1249, 1248, 7],
             );
-            let result = seat_assignment(&input).unwrap();
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
             assert_eq!(result.full_seats, 18);
             assert_eq!(result.residual_seats, 6);
             assert_eq!(result.steps.len(), 7);
@@ -1606,10 +1685,10 @@ pub(crate) mod tests {
 
             use crate::{
                 Fraction, HighestAverageAssignedSeat, SeatChange,
-                seat_assignment::seat_assignment,
+                seat_assignment::{SeatAssignment, seat_assignment},
                 structs::{
                     AbsoluteMajorityDrawingLots, HighestAverageResidualSeatDrawingLots,
-                    ListDrawingLotsError, ListDrawingLotsVariant,
+                    ListDrawingLotsVariant,
                 },
                 test_helpers::{
                     ListDrawnMock, get_total_seats_from_apportionment_result,
@@ -1635,8 +1714,8 @@ pub(crate) mod tests {
                     24,
                     vec![7501, 1249, 1249, 1249, 1249, 1248, 1248, 8],
                 );
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -1672,8 +1751,8 @@ pub(crate) mod tests {
                     23,
                     vec![500, 140, 140, 140, 140, 140],
                 );
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -1703,8 +1782,8 @@ pub(crate) mod tests {
                 // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
 
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -1744,8 +1823,8 @@ pub(crate) mod tests {
                     vec![500, 140, 140, 140],
                 );
 
-                let err = seat_assignment(&input).expect_err("should require drawing lots");
-                let ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) = err
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
                 else {
                     panic!("should be DrawingLotsRequired");
                 };
@@ -1774,7 +1853,9 @@ pub(crate) mod tests {
 
                 // List 3 is drawn, add it to the input's lists_drawn and process again
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });
-                let result = seat_assignment(&input).expect("should be successful");
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
 
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![14, 3, 4, 3]);
@@ -1810,11 +1891,12 @@ pub(crate) mod tests {
 
             use super::get_total_seats_from_apportionment_result;
             use crate::{
-                ApportionmentWarning, seat_assignment::seat_assignment,
+                ApportionmentWarning,
+                seat_assignment::{SeatAssignment, seat_assignment},
                 test_helpers::seat_assignment_fixture_with_given_candidate_votes,
             };
 
-            /// Apportionment with no residual seats  
+            /// Apportionment with no residual seats
             /// This test triggers Kieswet Article P 10
             ///
             /// Full seats: [5, 5, 4, 4, 2] - Remainder seats: 0  
@@ -1833,7 +1915,10 @@ pub(crate) mod tests {
                         vec![400, 400, 0],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 19);
                 assert_eq!(result.residual_seats, 1);
                 assert_eq!(result.steps.len(), 2);
@@ -1869,7 +1954,10 @@ pub(crate) mod tests {
                         vec![502, 502],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 18);
                 assert_eq!(result.residual_seats, 1);
                 assert_eq!(result.steps.len(), 3);
@@ -1915,7 +2003,10 @@ pub(crate) mod tests {
                         vec![7],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.full_seats, 18);
                 assert_eq!(result.residual_seats, 6);
                 assert_eq!(result.steps.len(), 9);
@@ -1966,7 +2057,10 @@ pub(crate) mod tests {
                         vec![400, 400],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.seats, 20);
                 assert_eq!(result.full_seats, 19);
                 assert_eq!(result.residual_seats, 0);
@@ -2007,7 +2101,10 @@ pub(crate) mod tests {
                         vec![400, 400, 0],
                     ],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.seats, 20);
                 assert_eq!(result.full_seats, 18);
                 assert_eq!(result.residual_seats, 1);
@@ -2046,7 +2143,10 @@ pub(crate) mod tests {
                     10,
                     vec![vec![500, 0, 0, 0, 0], vec![0], vec![0], vec![0], vec![0]],
                 );
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.seats, 10);
                 assert_eq!(result.full_seats, 5);
                 assert_eq!(result.residual_seats, 0);
@@ -2091,7 +2191,10 @@ pub(crate) mod tests {
                 );
                 input.deceased_candidates = HashMap::from([(1, HashSet::from([8]))]);
 
-                let result = seat_assignment(&input).unwrap();
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
                 assert_eq!(result.steps.len(), 3);
                 assert!(
                     result.steps[0]

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -3,16 +3,16 @@ use std::{cmp::Ordering, fmt::Debug};
 use tracing::{debug, info};
 
 use super::{
-    AssignRemainderDrawingLotsError, get_number_of_candidates, list_numbers,
+    get_number_of_candidates, list_numbers,
     structs::{
         HighestAverageAssignedSeat, LargestRemainderAssignedSeat, ListStanding,
         RemainderAssignmentResult, SeatChange, SeatChangeStep,
     },
 };
 use crate::{
-    ListDrawn,
+    ApportionmentError, ListDrawn,
     fraction::Fraction,
-    seat_assignment::structs::ResidualSeatDrawingLotsError,
+    seat_assignment::structs::RemainderAssignment,
     structs::{
         DeceasedCandidates, HighestAverageResidualSeatDrawingLots, LARGE_COUNCIL_THRESHOLD,
         LargestRemainderResidualSeatDrawingLots, ListDrawingLotsVariant, ListVotes,
@@ -22,7 +22,6 @@ use crate::{
 /// This function assigns the residual seats that remain after full seat assignment is finished.
 /// These residual seats are assigned through two different procedures,
 /// depending on how many total seats are available in the election.
-#[allow(clippy::too_many_arguments, clippy::result_large_err)]
 pub fn assign_remainder<'b, T: ListVotes>(
     initial_standings: &[ListStanding<T::ListNumber>],
     seats: u32,
@@ -56,7 +55,7 @@ pub fn assign_remainder<'b, T: ListVotes>(
         let residual_seats = total_residual_seats - residual_seat_number;
         residual_seat_number += 1;
 
-        let change = step_assign_residual_seat(
+        let change = match step_assign_residual_seat(
             &current_standings,
             seats,
             residual_seats,
@@ -64,8 +63,15 @@ pub fn assign_remainder<'b, T: ListVotes>(
             &steps,
             &exhausted_list_numbers,
             lists_drawn,
-        )
-        .map_err(|err| AssignRemainderDrawingLotsError::new(err, steps.clone()))?;
+        )? {
+            ResidualSeat::SeatChange(change) => change,
+            ResidualSeat::DrawingLotsRequired(variant) => {
+                return Ok(RemainderAssignment::DrawingLotsRequired(
+                    variant,
+                    steps.clone(),
+                ));
+            }
+        };
 
         let standings = current_standings.clone();
 
@@ -90,7 +96,7 @@ pub fn assign_remainder<'b, T: ListVotes>(
         });
     }
 
-    Ok((steps, current_standings))
+    Ok(RemainderAssignment::Completed(steps, current_standings))
 }
 
 /// Get a vector with the list number that was assigned the last residual seat.  
@@ -268,6 +274,11 @@ fn list_unique_highest_average_assigned_seats<LN: Copy + Eq>(
         .count()
 }
 
+enum ListStandings<'a, LN> {
+    Completed(Vec<&'a ListStanding<LN>>),
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
+}
+
 /// Compute the lists with the highest average votes per seats.
 ///
 /// This is determined based on seeing what would happen to the average votes
@@ -283,7 +294,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
     available_residual_seats: u32,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<Vec<&'a ListStanding<LN>>, ResidualSeatDrawingLotsError<LN>> {
+) -> Result<ListStandings<'a, LN>, ApportionmentError> {
     // We are now going to find the lists that have the highest average
     // votes per seat if we would were to add one additional seat to them
     let (max_average, lists) = standings.fold(
@@ -330,12 +341,12 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 
         // Get a list from the lists_drawn
         let Some(list_drawn) = lists_drawn.next() else {
-            return Err(ResidualSeatDrawingLotsError::DrawingLotsRequired(variant));
+            return Ok(ListStandings::DrawingLotsRequired(variant));
         };
 
         // Assert the required variant including all data
         if list_drawn.variant() != variant {
-            return Err(ResidualSeatDrawingLotsError::InvalidLotDrawing(
+            return Err(ApportionmentError::InvalidLotDrawing(
                 "Variant mismatch".to_string(),
             ));
         }
@@ -343,13 +354,13 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
         let list = lists
             .iter()
             .find(|list| list.list_number == *list_drawn.drawn())
-            .ok_or(ResidualSeatDrawingLotsError::InvalidLotDrawing(
+            .ok_or(ApportionmentError::InvalidLotDrawing(
                 "Unknown list number".to_string(),
             ))?;
 
-        Ok(vec![list])
+        Ok(ListStandings::Completed(vec![list]))
     } else {
-        Ok(lists)
+        Ok(ListStandings::Completed(lists))
     }
 }
 
@@ -365,7 +376,7 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     available_residual_seats: u32,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<Vec<&'a ListStanding<LN>>, ResidualSeatDrawingLotsError<LN>> {
+) -> Result<ListStandings<'a, LN>, ApportionmentError> {
     // We are now going to find the lists that have the largest remainder
     let (max_remainder, lists) = standings.fold(
         (Fraction::ZERO, vec![]),
@@ -411,12 +422,12 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 
         // Get a list from the lists_drawn
         let Some(list_drawn) = lists_drawn.next() else {
-            return Err(ResidualSeatDrawingLotsError::DrawingLotsRequired(variant));
+            return Ok(ListStandings::DrawingLotsRequired(variant));
         };
 
         // Assert the required variant including all data
         if list_drawn.variant() != variant {
-            return Err(ResidualSeatDrawingLotsError::InvalidLotDrawing(
+            return Err(ApportionmentError::InvalidLotDrawing(
                 "Variant mismatch".to_string(),
             ));
         }
@@ -424,14 +435,19 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
         let list = lists
             .iter()
             .find(|list| list.list_number == *list_drawn.drawn())
-            .ok_or(ResidualSeatDrawingLotsError::InvalidLotDrawing(
+            .ok_or(ApportionmentError::InvalidLotDrawing(
                 "Unknown list number".to_string(),
             ))?;
 
-        Ok(vec![list])
+        Ok(ListStandings::Completed(vec![list]))
     } else {
-        Ok(lists)
+        Ok(ListStandings::Completed(lists))
     }
+}
+
+enum ResidualSeat<LN> {
+    SeatChange(SeatChange<LN>),
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
 }
 
 /// Assign the next residual seat using the procedure for the council size:
@@ -445,7 +461,7 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<SeatChange<LN>, ResidualSeatDrawingLotsError<LN>> {
+) -> Result<ResidualSeat<LN>, ApportionmentError> {
     if seats >= LARGE_COUNCIL_THRESHOLD {
         debug!("Assigning residual seat {residual_seat_number} using highest averages method");
         // [Artikel P 7 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP7)
@@ -471,7 +487,8 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
     }
 }
 
-/// Assign the next residual seat, and return which group that seat was assigned to.  
+/// Assign the next residual seat, and return which group that seat was assigned to.
+///
 /// This assignment is done according to the rules for elections with 19 seats or more.
 fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 'a>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
@@ -481,7 +498,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
     unique: bool,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<SeatChange<LN>, ResidualSeatDrawingLotsError<LN>> {
+) -> Result<ResidualSeat<LN>, ApportionmentError> {
     // Get an iterator that lists all the list standings without exhausted lists
     // and without lists that have zero votes cast.
     let mut qualifying_for_highest_average = standings
@@ -490,12 +507,18 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
         .peekable();
 
     if qualifying_for_highest_average.peek().is_some() {
-        let selected_lists = lists_with_highest_average(
+        let selected_lists = match lists_with_highest_average(
             qualifying_for_highest_average,
             residual_seats,
             residual_seat_number,
             lists_drawn,
-        )?;
+        )? {
+            ListStandings::Completed(lists) => lists,
+            ListStandings::DrawingLotsRequired(variant) => {
+                return Ok(ResidualSeat::DrawingLotsRequired(variant));
+            }
+        };
+
         let selected_list = selected_lists[0];
         let assigned_seat = HighestAverageAssignedSeat {
             selected_list_number: selected_list.list_number,
@@ -513,9 +536,13 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
             votes_per_seat: selected_list.next_votes_per_seat,
         };
         if unique {
-            Ok(SeatChange::UniqueHighestAverageAssignment(assigned_seat))
+            Ok(ResidualSeat::SeatChange(
+                SeatChange::UniqueHighestAverageAssignment(assigned_seat),
+            ))
         } else {
-            Ok(SeatChange::HighestAverageAssignment(assigned_seat))
+            Ok(ResidualSeat::SeatChange(
+                SeatChange::HighestAverageAssignment(assigned_seat),
+            ))
         }
     } else {
         // Unreachable: `assign_remainder` breaks the loop before this can be reached
@@ -525,7 +552,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
 
 /// Assign the next residual seat, and return which group that seat was assigned to.  
 /// This assignment is done according to the rules for elections with less than 19 seats.
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::cognitive_complexity, clippy::too_many_lines)]
 fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     standings: &'a [ListStanding<LN>],
     residual_seats: u32,
@@ -533,7 +560,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     exhausted_list_numbers: &[LN],
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
-) -> Result<SeatChange<LN>, ResidualSeatDrawingLotsError<LN>> {
+) -> Result<ResidualSeat<LN>, ApportionmentError> {
     // first we check if there are any lists that still qualify for a largest remainder assigned seat
     let mut qualifying_for_remainder = list_standings_qualifying_for_largest_remainder(
         standings,
@@ -545,15 +572,21 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     // If there is at least one element in the iterator, we know we can still do a largest remainder assignment
     if qualifying_for_remainder.peek().is_some() {
         debug!("Assign residual seat using largest remainders method");
-        let selected_lists = lists_with_largest_remainder(
+        let selected_lists = match lists_with_largest_remainder(
             qualifying_for_remainder,
             residual_seats,
             residual_seat_number,
             lists_drawn,
-        )?;
+        )? {
+            ListStandings::Completed(lists) => lists,
+            ListStandings::DrawingLotsRequired(variant) => {
+                return Ok(ResidualSeat::DrawingLotsRequired(variant));
+            }
+        };
+
         let selected_list = selected_lists[0];
-        Ok(SeatChange::LargestRemainderAssignment(
-            LargestRemainderAssignedSeat {
+        Ok(ResidualSeat::SeatChange(
+            SeatChange::LargestRemainderAssignment(LargestRemainderAssignedSeat {
                 selected_list_number: selected_list.list_number,
                 list_assigned: list_assigned_from_previous_step(
                     selected_list,
@@ -562,7 +595,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
                 ),
                 list_options: selected_lists.iter().map(|list| list.list_number).collect(),
                 remainder_votes: selected_list.remainder_votes,
-            },
+            }),
         ))
     } else {
         // We've now exhausted the largest remainder seats, we now do unique highest average instead:

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -3,14 +3,14 @@ use std::fmt::Debug;
 use tracing::{debug, info};
 
 use super::Fraction;
-use crate::{ListDrawingLotsVariant, ListVotes};
+use crate::{ApportionmentError, ListDrawingLotsVariant, ListVotes};
 
 /// The result of the seat assignment procedure. This contains the number of seats and the quota
 /// that was used. It then contains the initial standing after full seats were assigned,
 /// and each of the changes and intermediate standings. The final standing contains the
 /// number of seats per list that was assigned after all seats were assigned.
-#[derive(Clone, Debug, PartialEq)]
-pub struct SeatAssignmentResult<LN> {
+#[derive(Debug, PartialEq)]
+pub struct SeatAssignmentDetails<LN> {
     pub seats: u32,
     pub full_seats: u32,
     pub residual_seats: u32,
@@ -19,7 +19,7 @@ pub struct SeatAssignmentResult<LN> {
     pub final_standing: Vec<ListSeatAssignment<LN>>,
 }
 
-impl<LN: Copy> SeatAssignmentResult<LN> {
+impl<LN: Copy> SeatAssignmentDetails<LN> {
     pub fn warnings(&self) -> Vec<ApportionmentWarning> {
         let mut warnings = Vec::new();
         let has_p9 = self
@@ -51,21 +51,21 @@ pub enum ApportionmentWarning {
 }
 
 /// Contains information about the final assignment of seats for a specific list.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct ListSeatAssignment<LN> {
     /// List number for which this assignment applies
     pub list_number: LN,
-    /// The number of votes cast for this group
+    /// The number of votes cast for this list
     pub votes_cast: u64,
     /// The remainder votes that were not used to get full seats assigned to this list
     pub remainder_votes: Fraction,
-    /// Whether this group met the threshold for largest remainder seat assignment
+    /// Whether this list met the threshold for largest remainder seat assignment
     pub meets_remainder_threshold: bool,
-    /// The number of full seats assigned to this group
+    /// The number of full seats assigned to this list
     pub full_seats: u32,
-    /// The number of residual seats assigned to this group
+    /// The number of residual seats assigned to this list
     pub residual_seats: u32,
-    /// The total number of seats assigned to this group
+    /// The total number of seats assigned to this list
     pub total_seats: u32,
 }
 
@@ -90,7 +90,7 @@ impl<LN: Copy + Debug> From<ListStanding<LN>> for ListSeatAssignment<LN> {
 pub struct ListStanding<LN> {
     /// List number for which this standing applies
     pub list_number: LN,
-    /// The number of votes cast for this group
+    /// The number of votes cast for this list
     pub votes_cast: u64,
     /// The remainder of votes that was not used to get full seats (does not have to be a whole number of votes)
     pub remainder_votes: Fraction,
@@ -312,26 +312,18 @@ pub struct ListExhaustionRemovedSeat<LN> {
     pub full_seat: bool,
 }
 
-/// Used to indicate that drawing lots for a residual seat is needed,
-/// containing all the information needed to do the drawing and the current seat change steps
-#[derive(Debug, PartialEq)]
-pub enum AssignRemainderDrawingLotsError<LN> {
-    DrawingLotsRequired(ListDrawingLotsVariant<LN>, Vec<SeatChangeStep<LN>>),
-    InvalidLotDrawing(String),
-}
-
-/// Used to indicate that drawing lots for a residual seat is needed,
-/// containing all the information needed to do the drawing
-#[derive(Debug, PartialEq)]
-pub enum ResidualSeatDrawingLotsError<LN> {
-    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
-    InvalidLotDrawing(String),
-}
-
 /// Result type for residual seat (re)assignment: steps taken and final standings.
-pub type RemainderAssignmentResult<LN> =
-    Result<(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>), AssignRemainderDrawingLotsError<LN>>;
+pub type RemainderAssignmentResult<LN> = Result<RemainderAssignment<LN>, ApportionmentError>;
+
+pub enum RemainderAssignment<LN> {
+    Completed(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>),
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>, Vec<SeatChangeStep<LN>>),
+}
 
 /// Result type for absolute majority reassignment: updated standings and optional seat change.
-pub type AbsoluteMajorityResult<LN> =
-    Result<(Vec<ListStanding<LN>>, Option<SeatChange<LN>>), ResidualSeatDrawingLotsError<LN>>;
+pub type AbsoluteMajorityResult<LN> = Result<AbsoluteMajority<LN>, ApportionmentError>;
+
+pub enum AbsoluteMajority<LN> {
+    Completed(Vec<ListStanding<LN>>, Option<SeatChange<LN>>),
+    DrawingLotsRequired(ListDrawingLotsVariant<LN>),
+}

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -5,11 +5,8 @@ use std::{
 };
 
 use super::{
-    SeatChangeStep, candidate_nomination::CandidateNominationResult, fraction::Fraction,
-    seat_assignment::SeatAssignmentResult,
-};
-pub(crate) use crate::seat_assignment::{
-    AssignRemainderDrawingLotsError, ResidualSeatDrawingLotsError,
+    candidate_nomination::CandidateNominationDetails, fraction::Fraction,
+    seat_assignment::SeatAssignmentDetails,
 };
 
 pub(crate) const LARGE_COUNCIL_THRESHOLD: u32 = 19;
@@ -21,72 +18,8 @@ pub type CandidateNumber<LV> = <<LV as ListVotes>::Cv as CandidateVotes>::Candid
 
 /// Errors that can occur during apportionment
 #[derive(Debug, PartialEq)]
-pub enum ApportionmentError<LN, CN> {
-    ListDrawingLotsRequired(ListDrawingLotsVariant<LN>, SeatAssignmentResult<LN>),
-    CandidateDrawingLotsRequired(
-        CandidateDrawingLotsVariant<LN, CN>,
-        SeatAssignmentResult<LN>,
-    ),
+pub enum ApportionmentError {
     InvalidLotDrawing(String),
-}
-
-/// Used in [ApportionmentError] to indicate that drawing lots for a list is needed,
-/// containing all the information needed to do the drawing
-#[derive(Debug, PartialEq)]
-pub enum ListDrawingLotsError<LN> {
-    DrawingLotsRequired(ListDrawingLotsVariant<LN>, SeatAssignmentResult<LN>),
-    InvalidLotDrawing(String),
-}
-
-impl<LN, CN> From<ListDrawingLotsError<LN>> for ApportionmentError<LN, CN> {
-    fn from(value: ListDrawingLotsError<LN>) -> Self {
-        match value {
-            ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result) => {
-                ApportionmentError::ListDrawingLotsRequired(variant, preliminary_result)
-            }
-            ListDrawingLotsError::InvalidLotDrawing(message) => {
-                ApportionmentError::InvalidLotDrawing(message)
-            }
-        }
-    }
-}
-
-impl<LN> ListDrawingLotsError<LN> {
-    pub(crate) fn new(
-        err: ResidualSeatDrawingLotsError<LN>,
-        preliminary_result: SeatAssignmentResult<LN>,
-    ) -> Self {
-        match err {
-            ResidualSeatDrawingLotsError::DrawingLotsRequired(variant) => {
-                ListDrawingLotsError::DrawingLotsRequired(variant, preliminary_result)
-            }
-            ResidualSeatDrawingLotsError::InvalidLotDrawing(message) => {
-                ListDrawingLotsError::InvalidLotDrawing(message)
-            }
-        }
-    }
-}
-
-impl<LN> AssignRemainderDrawingLotsError<LN> {
-    pub(crate) fn new(
-        err: ResidualSeatDrawingLotsError<LN>,
-        steps: Vec<SeatChangeStep<LN>>,
-    ) -> Self {
-        match err {
-            ResidualSeatDrawingLotsError::DrawingLotsRequired(variant) => {
-                AssignRemainderDrawingLotsError::DrawingLotsRequired(variant, steps)
-            }
-            ResidualSeatDrawingLotsError::InvalidLotDrawing(message) => {
-                AssignRemainderDrawingLotsError::InvalidLotDrawing(message)
-            }
-        }
-    }
-}
-
-/// Errors that can occur when drawing lots for a candidate  is needed during apportionment
-#[derive(Debug, PartialEq)]
-pub enum CandidateDrawingLotsError<LN, CN> {
-    DrawingLotsRequired(CandidateDrawingLotsVariant<LN, CN>),
 }
 
 /// Different variants of drawing lots for lists, with all the information needed to do the drawing
@@ -158,9 +91,10 @@ pub trait ApportionmentInput {
     fn candidates_drawn(&self) -> impl Iterator<Item = &Self::CandidateDrawn>;
 }
 
-pub struct ApportionmentOutput<'a, T: ListVotes> {
-    pub seat_assignment: SeatAssignmentResult<ListNumber<T>>,
-    pub candidate_nomination: CandidateNominationResult<'a, T>,
+#[derive(Debug, PartialEq)]
+pub struct ApportionmentDetails<'a, T: ListVotes> {
+    pub seat_assignment: SeatAssignmentDetails<ListNumber<T>>,
+    pub candidate_nomination: CandidateNominationDetails<'a, T>,
 }
 
 pub trait ListVotes: PartialEq + Debug {

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -4,7 +4,7 @@ use super::{
     CandidateDrawingLotsVariant, ListVotes, fraction::Fraction, structs::CandidateNominationInput,
 };
 use crate::{
-    ApportionmentInput, CandidateVotes, SeatAssignmentResult,
+    ApportionmentInput, CandidateVotes, SeatAssignmentDetails,
     candidate_nomination::{Candidate, ListCandidateNomination, candidate_votes_numbers},
     structs::{CandidateDrawn, ListDrawingLotsVariant, ListDrawn},
 };
@@ -126,7 +126,7 @@ impl CandidateDrawn<u32, u32> for CandidateDrawnMock {
     }
 }
 
-pub fn get_total_seats_from_apportionment_result(result: &SeatAssignmentResult<u32>) -> Vec<u32> {
+pub fn get_total_seats_from_apportionment_result(result: &SeatAssignmentDetails<u32>) -> Vec<u32> {
     result
         .final_standing
         .iter()

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "hyper",
  "pdf_gen",
  "quick-xml 0.39.2",
- "rand 0.10.1",
+ "rand",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -400,6 +400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,12 +429,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -530,14 +530,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
+ "cmov",
 ]
 
 [[package]]
@@ -567,7 +565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -579,8 +576,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -635,18 +633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -684,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -704,6 +701,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -870,9 +873,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -880,14 +881,19 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -902,7 +908,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -928,29 +934,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1220,9 +1217,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -1244,24 +1238,6 @@ checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1313,12 +1289,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1351,7 +1327,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1360,23 +1336,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1386,33 +1346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1445,7 +1384,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1490,15 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,37 +1461,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1577,15 +1480,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "prettyplease"
@@ -1642,17 +1536,6 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -1660,16 +1543,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.1",
  "rand_core 0.10.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1692,15 +1565,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
@@ -1733,26 +1597,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "rustversion"
@@ -1846,6 +1690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +1719,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1916,16 +1780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1966,20 +1820,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -1990,12 +1834,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -2005,12 +1850,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -2019,15 +1863,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2038,15 +1883,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -2057,58 +1902,43 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
+ "thiserror",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.2",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.5",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -2124,16 +1954,14 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "home",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2144,13 +1972,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2160,7 +1989,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror",
  "tracing",
@@ -2338,7 +2166,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2376,6 +2204,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2641,12 +2510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,13 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "windows-core"
@@ -2796,15 +2655,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2813,61 +2663,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "memchr",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "wit-bindgen"
@@ -2987,26 +2789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "zerofrom"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,12 +2808,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/backend/src/api/apportionment/mapping.rs
+++ b/backend/src/api/apportionment/mapping.rs
@@ -9,7 +9,7 @@ use crate::domain::{
     results::political_group_candidate_votes::PoliticalGroupCandidateVotes,
 };
 
-pub fn map_seat_assignment(sa: &apportionment::SeatAssignmentResult<PGNumber>) -> SeatAssignment {
+pub fn map_seat_assignment(sa: &apportionment::SeatAssignmentDetails<PGNumber>) -> SeatAssignment {
     SeatAssignment {
         seats: sa.seats,
         full_seats: sa.full_seats,
@@ -42,7 +42,7 @@ fn sort_candidates_alphabetically(mut candidates: Vec<ChosenCandidate>) -> Vec<C
 }
 
 pub fn map_candidate_nomination(
-    cn: &apportionment::CandidateNominationResult<'_, PoliticalGroupCandidateVotes>,
+    cn: &apportionment::CandidateNominationDetails<'_, PoliticalGroupCandidateVotes>,
     political_groups: &[PoliticalGroup],
 ) -> CandidateNomination {
     let mut list_names: HashMap<PGNumber, String> = HashMap::new();

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -14,10 +14,7 @@ pub use self::{
 use crate::{
     APIError, AppState,
     api::middleware::authentication::RouteAuthorization,
-    domain::{
-        election::{CandidateNumber, PGNumber},
-        role::Role,
-    },
+    domain::role::Role,
     error::{ApiErrorResponse, ErrorReference, ErrorResponse},
 };
 
@@ -64,10 +61,9 @@ impl ApiErrorResponse for ApportionmentApiError {
     }
 }
 
-// Needed for report generation
-impl From<apportionment::ApportionmentError<PGNumber, CandidateNumber>> for APIError {
-    fn from(_err: apportionment::ApportionmentError<PGNumber, CandidateNumber>) -> Self {
-        ApportionmentApiError::ApportionmentNotCompleted.into()
+impl From<apportionment::ApportionmentError> for APIError {
+    fn from(_err: apportionment::ApportionmentError) -> Self {
+        ApportionmentApiError::InvalidLotDrawing.into()
     }
 }
 

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -123,6 +123,7 @@ pub struct FootnotePoliticalGroup {
 
 #[cfg(test)]
 mod tests {
+    use apportionment::ApportionmentOutput;
     use test_log::test;
 
     use crate::{
@@ -155,9 +156,12 @@ mod tests {
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
             ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
-        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
+        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result = ApportionmentFootnotes::new(&election.political_groups, &seat_assignment)
             .expect("ApportionmentFootnotes::new should succeed");
         assert!(result.is_none());
@@ -186,9 +190,12 @@ mod tests {
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
             ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
-        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
+        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result = ApportionmentFootnotes::new(&election.political_groups, &seat_assignment)
             .expect("ApportionmentFootnotes::new should succeed");
         assert!(result.is_some());
@@ -224,9 +231,12 @@ mod tests {
             create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
         let apportionment_input =
             ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
-        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
+        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result = ApportionmentFootnotes::new(&election.political_groups, &seat_assignment)
             .expect("ApportionmentFootnotes::new should succeed");
         assert!(result.is_some());

--- a/backend/src/domain/models/enriched_candidate_nomination.rs
+++ b/backend/src/domain/models/enriched_candidate_nomination.rs
@@ -122,6 +122,7 @@ pub struct CandidateWithSeatTableColumn {
 
 #[cfg(test)]
 mod tests {
+    use apportionment::ApportionmentOutput;
     use test_log::test;
 
     use crate::{
@@ -154,10 +155,13 @@ mod tests {
         let list_votes = create_political_group_candidate_votes(political_groups, &candidate_votes);
         let apportionment_input =
             ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
         let candidate_nomination =
-            map_candidate_nomination(&apportionment_result.candidate_nomination, political_groups);
+            map_candidate_nomination(&apportionment.candidate_nomination, political_groups);
         let result = EnrichedCandidateNomination::new(&election, &candidate_nomination)
             .expect("EnrichedCandidateNomination::new should succeed");
         assert_eq!(

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -255,6 +255,7 @@ pub struct UniqueHighestAverage {
 
 #[cfg(test)]
 mod tests {
+    use apportionment::ApportionmentOutput;
     use test_log::test;
 
     use crate::{
@@ -339,9 +340,12 @@ mod tests {
             &[],
             &[],
         );
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
-        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
+        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result =
             EnrichedSeatAssignment::new(election.number_of_seats, &summary_csb, &seat_assignment)
                 .expect("EnrichedSeatAssignment::new should succeed");
@@ -459,9 +463,12 @@ mod tests {
             &[],
             &[],
         );
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
-        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
+        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result =
             EnrichedSeatAssignment::new(election.number_of_seats, &summary_csb, &seat_assignment)
                 .expect("EnrichedSeatAssignment::new should succeed");
@@ -547,9 +554,12 @@ mod tests {
             &[],
             &[],
         );
-        let apportionment_result =
-            apportionment::process(&apportionment_input).expect("apportionment failed");
-        let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+        let apportionment_result = apportionment::process(&apportionment_input);
+        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+            panic!("should be Completed");
+        };
+
+        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result =
             EnrichedSeatAssignment::new(election.number_of_seats, &summary_csb, &seat_assignment)
                 .expect("EnrichedSeatAssignment::new should succeed");

--- a/backend/src/domain/report/files.rs
+++ b/backend/src/domain/report/files.rs
@@ -1,9 +1,13 @@
+use apportionment::ApportionmentOutput;
 use chrono::{Local, Utc};
 use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::{
     APIError, SqlitePoolExt,
-    api::{apportionment::ApportionmentInputData, report::ReportApiError},
+    api::{
+        apportionment::{ApportionmentApiError, ApportionmentInputData},
+        report::ReportApiError,
+    },
     domain::{
         committee_session::{CommitteeSession, CommitteeSessionError, CommitteeSessionId},
         committee_session_status::CommitteeSessionStatus,
@@ -112,7 +116,11 @@ async fn generate_and_save_files_csb_election(
         state.get_lists_drawn(),
         state.get_candidates_drawn(),
     );
-    let apportionment_result = apportionment::process(&apportionment_input)?;
+    let ApportionmentOutput::Completed(apportionment_result) =
+        apportionment::process(&apportionment_input)?
+    else {
+        return Err(ApportionmentApiError::ApportionmentNotCompleted.into());
+    };
 
     let generated_files = csb_input.generate_csb_files(&apportionment_result).await?;
 

--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -1,4 +1,4 @@
-use apportionment::ApportionmentOutput;
+use apportionment::ApportionmentDetails;
 use chrono::{DateTime, Datelike, Local, Utc};
 use eml_nl::{EMLError, documents::election_count::ElectionCount, io::EMLWrite};
 use pdf_gen::{generate_pdf, zip::slugify_filename};
@@ -285,7 +285,7 @@ impl ResultsInputCSB {
 
     pub async fn generate_csb_files(
         &self,
-        apportionment_result: &ApportionmentOutput<'_, PoliticalGroupCandidateVotes>,
+        apportionment_result: &ApportionmentDetails<'_, PoliticalGroupCandidateVotes>,
     ) -> Result<CsbGeneratedFiles, APIError> {
         let data = &self.data;
         let creation_date_time = data.created_at.format(DEFAULT_DATE_TIME_FORMAT).to_string();
@@ -343,7 +343,7 @@ impl ResultsInputCSB {
 
     fn get_p22_2_pdf_file(
         &self,
-        apportionment_result: &ApportionmentOutput<'_, PoliticalGroupCandidateVotes>,
+        apportionment_result: &ApportionmentDetails<'_, PoliticalGroupCandidateVotes>,
         hash: String,
         creation_date_time: String,
         filename: String,

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -3,7 +3,7 @@ use std::{num::NonZeroU64, str::FromStr as _};
 mod error;
 pub mod hash;
 
-use apportionment::CandidateNominationResult;
+use apportionment::CandidateNominationDetails;
 use chrono::{DateTime, Local, Utc};
 use eml_nl::{
     EMLError,
@@ -693,7 +693,7 @@ impl ElectionWithPoliticalGroups {
         &self,
         transaction_id: Option<u64>,
         timestamp: DateTime<Utc>,
-        nominations: &CandidateNominationResult<PoliticalGroupCandidateVotes>,
+        nominations: &CandidateNominationDetails<PoliticalGroupCandidateVotes>,
     ) -> Result<ElectionResult, EMLError> {
         ElectionResult::builder()
             .transaction_id(transaction_id.unwrap_or(1))
@@ -712,7 +712,7 @@ impl ElectionWithPoliticalGroups {
 
     fn as_eml_result_contest(
         &self,
-        nominations: &CandidateNominationResult<PoliticalGroupCandidateVotes>,
+        nominations: &CandidateNominationDetails<PoliticalGroupCandidateVotes>,
     ) -> Result<ElectionResultContest, EMLError> {
         let mut selections = vec![];
         for pg in &self.political_groups {

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -4,6 +4,7 @@
 /// The generated PDFs are checked to a minimum size to ensure that the generation was successful.
 /// The tests cover various edge cases by varying the number of parties, candidates,
 /// string lengths, and the presence of optional fields.
+use apportionment::ApportionmentOutput;
 use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, Utc};
 use pdf_gen::generate_pdf;
 use rand::{RngExt, seq::IndexedRandom};
@@ -763,13 +764,16 @@ async fn test_p_22_2() {
         &[],
         &[],
     );
-    let apportionment_result =
-        apportionment::process(&apportionment_input).expect("apportionment failed");
-    let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
+    let apportionment_result = apportionment::process(&apportionment_input);
+    let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+        panic!("should be Completed");
+    };
+
+    let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
     let enriched_seat_assignment =
         EnrichedSeatAssignment::new(election.number_of_seats, &summary, &seat_assignment).unwrap();
     let candidate_nomination = map_candidate_nomination(
-        &apportionment_result.candidate_nomination,
+        &apportionment.candidate_nomination,
         &election.political_groups,
     );
     let enriched_candidate_nomination =

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -1,4 +1,4 @@
-use apportionment;
+use apportionment::{self, ApportionmentOutput};
 use serde::Serialize;
 use sqlx::SqliteConnection;
 
@@ -20,7 +20,6 @@ use crate::{
         election::{CandidateNumber, ElectionId, ElectionWithPoliticalGroups, PGNumber},
         summary::ElectionSummary,
     },
-    error::ErrorReference,
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
     repository::{apportionment_state_repo, committee_session_repo, data_entry_repo},
     service,
@@ -167,8 +166,6 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
     }
 }
 
-type ApportionmentError = apportionment::ApportionmentError<PGNumber, CandidateNumber>;
-
 /// - Collect data for the [ApportionmentInputData] from the database and make sure that the
 ///   committee session status is completed.
 /// - Call the apportionment process function
@@ -191,40 +188,36 @@ pub async fn process(
         state.get_candidates_drawn(),
     );
 
-    let apportionment_result = match apportionment::process(&input) {
-        Ok(output) => ApportionmentResult::Ok(ElectionApportionmentResponse {
-            seat_assignment: map_seat_assignment(&output.seat_assignment),
-            candidate_nomination: map_candidate_nomination(
-                &output.candidate_nomination,
-                &election.political_groups,
-            ),
-            election_summary: election_summary.clone(),
-            warnings: output
-                .seat_assignment
-                .warnings()
-                .into_iter()
-                .map(ApportionmentWarning::from)
-                .collect(),
-        }),
-        Err(ApportionmentError::ListDrawingLotsRequired(variant, preliminary_seat_assignment)) => {
+    let apportionment_result = match apportionment::process(&input)? {
+        ApportionmentOutput::Completed(output) => {
+            ApportionmentResult::Ok(ElectionApportionmentResponse {
+                seat_assignment: map_seat_assignment(&output.seat_assignment),
+                candidate_nomination: map_candidate_nomination(
+                    &output.candidate_nomination,
+                    &election.political_groups,
+                ),
+                election_summary: election_summary.clone(),
+                warnings: output
+                    .seat_assignment
+                    .warnings()
+                    .into_iter()
+                    .map(ApportionmentWarning::from)
+                    .collect(),
+            })
+        }
+        ApportionmentOutput::ListDrawingLotsRequired(variant, preliminary_seat_assignment) => {
             ApportionmentResult::ListDrawingLotsRequired(
                 variant.into(),
                 election_summary.clone(),
                 map_seat_assignment(&preliminary_seat_assignment),
             )
         }
-        Err(ApportionmentError::CandidateDrawingLotsRequired(variant, seat_assignment)) => {
+        ApportionmentOutput::CandidateDrawingLotsRequired(variant, seat_assignment) => {
             ApportionmentResult::CandidateDrawingLotsRequired(
                 variant.into(),
                 election_summary.clone(),
                 map_seat_assignment(&seat_assignment),
             )
-        }
-        Err(ApportionmentError::InvalidLotDrawing(message)) => {
-            return Err(APIError::Conflict(
-                message,
-                ErrorReference::ApportionmentInvalidLotDrawing,
-            ));
         }
     };
 


### PR DESCRIPTION
## What & why

Using the "error path" to indicate that drawing lots is required resulted in clippy warnings and bloated error types and mappings. This PR changes that to use new Ok enum types to indicate that an apportionment step was completed or that drawing lots is required.

Typically, this means going from a signature like 

```rust
pub enum CandidateDrawingLotsError<LN, CN> {
    DrawingLotsRequired(CandidateDrawingLotsVariant<LN, CN>),
}

pub(crate) fn candidate_nomination<'a, L: ListVotes>(
    input: &CandidateNominationInput<'a, L>,
) -> Result<CandidateNominationResult<'a, L>, CandidateDrawingLotsError<ListNumber<LV>, CandidateNumber<LV>>> {
```

to 

```rust
pub enum CandidateNomination<'a, LV: ListVotes> {
    Completed(CandidateNominationDetails<'a, LV>),
    DrawingLotsRequired(CandidateDrawingLotsVariant<ListNumber<LV>, CandidateNumber<LV>>),
}

pub(crate) fn candidate_nomination<'a, L: ListVotes>(
    input: &CandidateNominationInput<'a, L>,
) -> Result<CandidateNomination<'a, L>, ApportionmentError> {
```


## How to test

Unit tests are changed accordingly and still succeed, the feature can be fully tested after the frontend has been done.

## Reviewer notes

Unfortunately this was a bit all or nothing. You can leave the fuzz tests for last.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->