### PR TITLE
Generate elections for different drawing lots scenarios

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7381,6 +7381,7 @@
           "voters",
           "seats",
           "generate_p22_2_variants",
+          "generate_drawing_lots",
           "with_data_entry",
           "first_data_entry",
           "second_data_entry",
@@ -7400,9 +7401,17 @@
             "$ref": "#/components/schemas/CommitteeCategory",
             "description": "GSB or CSB"
           },
+          "custom_name": {
+            "type": "string",
+            "description": "Custom election name"
+          },
           "first_data_entry": {
             "$ref": "#/components/schemas/RandomRange",
             "description": "Percentage of the first data entry to complete if data entry is included"
+          },
+          "generate_drawing_lots": {
+            "type": "boolean",
+            "description": "Generate multiple elections, each resulting in drawing lots"
           },
           "generate_p22_2_variants": {
             "type": "boolean",

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<(), AppError> {
     )
     .await?;
 
-    let test_election = create_test_election(args.clone().into(), pool, None).await?;
+    let test_election = create_test_election(&args.clone().into(), &pool, None).await?;
 
     if let Some(export_dir) = args.export_definition {
         // Export the election definition, candidate list and polling stations to a directory

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -25,6 +25,9 @@ use tracing_subscriber::EnvFilter;
 /// Abacus API and asset server
 #[derive(Parser, Debug, Clone)]
 struct Args {
+    /// Custom election name
+    pub custom_name: Option<String>,
+
     /// The committee category
     #[arg(value_enum)]
     committee_category: CommitteeCategory,
@@ -67,6 +70,10 @@ struct Args {
     #[arg(long)]
     generate_p22_2_variants: bool,
 
+    /// Generate multiple elections, each resulting in drawing lots
+    #[arg(long)]
+    generate_drawing_lots: bool,
+
     /// Include (part of) data entry for this election
     #[arg(long)]
     with_data_entry: bool,
@@ -97,6 +104,7 @@ struct Args {
 impl From<Args> for GenerateElectionArgs {
     fn from(args: Args) -> Self {
         GenerateElectionArgs {
+            custom_name: args.custom_name,
             committee_category: args.committee_category,
             political_groups: RandomRange(args.political_groups),
             candidates_per_group: RandomRange(args.candidates_per_group),
@@ -104,6 +112,7 @@ impl From<Args> for GenerateElectionArgs {
             voters: RandomRange(args.voters),
             seats: RandomRange(args.seats),
             generate_p22_2_variants: args.generate_p22_2_variants,
+            generate_drawing_lots: args.generate_drawing_lots,
             with_data_entry: args.with_data_entry,
             first_data_entry: RandomRange(args.first_data_entry),
             second_data_entry: RandomRange(args.second_data_entry),

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -25,9 +25,6 @@ use tracing_subscriber::EnvFilter;
 /// Abacus API and asset server
 #[derive(Parser, Debug, Clone)]
 struct Args {
-    /// Custom election name
-    pub custom_name: Option<String>,
-
     /// The committee category
     #[arg(value_enum)]
     committee_category: CommitteeCategory,
@@ -45,6 +42,10 @@ struct Args {
     #[cfg(feature = "dev-database")]
     #[arg(short, long)]
     reset_database: bool,
+
+    #[arg(long)]
+    /// Custom election name
+    pub custom_name: Option<String>,
 
     /// Number of political groups to create
     #[arg(long, default_value = "20..50", value_parser = parse_range::<u32>)]

--- a/backend/src/test_data_gen/api.rs
+++ b/backend/src/test_data_gen/api.rs
@@ -25,67 +25,124 @@ async fn generate_election_handler(
     State(pool): State<SqlitePool>,
     Json(args): Json<GenerateElectionArgs>,
 ) -> Result<StatusCode, APIError> {
-    if args.generate_p22_2_variants {
-        // 1. Test Election >= 19 seats
-        //    based on test `gte_19_seats::test_with_remainder_seats`
-        let _ = create_test_election_with_votes(
-            &args,
-            &pool,
-            23,
-            default_50_candidates(&[600, 302, 98, 99, 101]),
-        )
-        .await;
-
-        // 2. Test Election >= 19 seats & Absolute Majority Change
-        //    based on test `gte_19_seats::test_with_absolute_majority_of_votes_but_not_seats`
-        let _ = create_test_election_with_votes(
-            &args,
-            &pool,
-            24,
-            default_50_candidates(&[7501, 1249, 1249, 1249, 1249, 1249, 1248, 7]),
-        )
-        .await;
-
-        // 3. Test Election < 19 seats
-        //    based on test `lt_19_seats::test_with_1_list_that_meets_threshold`
-        let _ = create_test_election_with_votes(
-            &args,
-            &pool,
-            15,
-            default_50_candidates(&[808, 59, 58, 57, 56, 55, 54, 53]),
-        )
-        .await;
-
-        // 4. Test Election < 19 seats & Absolute Majority Change & List Exhaustion
-        //    based on test `lt_19_seats::test_with_absolute_majority_of_votes_but_not_seats_and_list_exhaustion`
-        let _ = create_test_election_with_votes(
-            &args,
-            &pool,
-            15,
-            vec![
-                vec![2571, 0, 0, 0, 0, 0, 0],
-                vec![977, 0, 0, 0],
-                vec![567, 0],
-                vec![536, 0],
-                vec![453, 0],
-            ],
-        )
-        .await;
-
-        // 5. Test Election < 19 seats & List Exhaustion
-        //    based on test `lt_19_seats::test_with_list_exhaustion_triggering_2nd_round_highest_average_assignment_with_different_averages`
-        let _ = create_test_election_with_votes(
-            &args,
-            &pool,
-            6,
-            vec![vec![3, 3], vec![2, 2], vec![25, 25]],
-        )
-        .await;
-    } else {
-        let _ = super::create_test_election(args.clone(), pool.clone(), None).await?;
+    match (args.generate_p22_2_variants, args.generate_drawing_lots) {
+        (true, _) => generate_p22_2_variants(args, pool).await,
+        (_, true) => generate_drawing_lots(args, pool).await,
+        (false, false) => _ = super::create_test_election(args, pool, None).await?,
     }
 
     Ok(StatusCode::CREATED)
+}
+
+async fn generate_p22_2_variants(args: GenerateElectionArgs, pool: SqlitePool) {
+    // 1. Test Election >= 19 seats
+    //    based on test `gte_19_seats::test_with_remainder_seats`
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        23,
+        default_50_candidates(&[600, 302, 98, 99, 101]),
+    )
+    .await;
+
+    // 2. Test Election >= 19 seats & Absolute Majority Change
+    //    based on test `gte_19_seats::test_with_absolute_majority_of_votes_but_not_seats`
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        24,
+        default_50_candidates(&[7501, 1249, 1249, 1249, 1249, 1249, 1248, 7]),
+    )
+    .await;
+
+    // 3. Test Election < 19 seats
+    //    based on test `lt_19_seats::test_with_1_list_that_meets_threshold`
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        15,
+        default_50_candidates(&[808, 59, 58, 57, 56, 55, 54, 53]),
+    )
+    .await;
+
+    // 4. Test Election < 19 seats & Absolute Majority Change & List Exhaustion
+    //    based on test `lt_19_seats::test_with_absolute_majority_of_votes_but_not_seats_and_list_exhaustion`
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        15,
+        vec![
+            vec![2571, 0, 0, 0, 0, 0, 0],
+            vec![977, 0, 0, 0],
+            vec![567, 0],
+            vec![536, 0],
+            vec![453, 0],
+        ],
+    )
+    .await;
+
+    // 5. Test Election < 19 seats & List Exhaustion
+    //    based on test `lt_19_seats::test_with_list_exhaustion_triggering_2nd_round_highest_average_assignment_with_different_averages`
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        6,
+        vec![vec![3, 3], vec![2, 2], vec![25, 25]],
+    )
+    .await;
+}
+
+async fn generate_drawing_lots(mut args: GenerateElectionArgs, pool: SqlitePool) {
+    args.custom_name = Some("Drawing lots >= 19 seats, AbsoluteMajority".to_string());
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        24,
+        default_50_candidates(&[7501, 1249, 1249, 1249, 1249, 1248, 1248, 8]),
+    )
+    .await;
+
+    args.custom_name = Some("Drawing lots >= 19 seats, HighestAverageResidualSeat".to_string());
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        23,
+        default_50_candidates(&[500, 140, 140, 140, 140, 140]),
+    )
+    .await;
+
+    args.custom_name = Some("Drawing lots < 19 seats, AbsoluteMajority".to_string());
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        15,
+        default_50_candidates(&[2552, 511, 511, 511, 509, 509]),
+    )
+    .await;
+
+    args.custom_name = Some("Drawing lots < 19 seats, LargestRemainderResidualSeat".to_string());
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        15,
+        default_50_candidates(&[540, 160, 160, 80, 80, 80, 55, 45]),
+    )
+    .await;
+
+    args.custom_name = Some("Drawing lots, Candidate".to_string());
+    let _ = create_test_election_with_votes(
+        &args,
+        &pool,
+        15,
+        vec![
+            vec![500, 500, 500, 500, 500, 500],
+            vec![400, 400, 400, 400, 400, 400],
+            vec![300, 300, 300, 300, 300, 300],
+            vec![200, 200, 200, 200, 200, 200],
+            vec![200, 200, 200, 200, 200, 200],
+        ],
+    )
+    .await;
 }
 
 async fn create_test_election_with_votes(

--- a/backend/src/test_data_gen/api.rs
+++ b/backend/src/test_data_gen/api.rs
@@ -25,21 +25,25 @@ async fn generate_election_handler(
     State(pool): State<SqlitePool>,
     Json(args): Json<GenerateElectionArgs>,
 ) -> Result<StatusCode, APIError> {
-    match (args.generate_p22_2_variants, args.generate_drawing_lots) {
-        (true, _) => generate_p22_2_variants(args, pool).await,
-        (_, true) => generate_drawing_lots(args, pool).await,
-        (false, false) => _ = super::create_test_election(args, pool, None).await?,
+    if args.generate_p22_2_variants {
+        generate_p22_2_variants(&args, &pool).await
+    }
+    if args.generate_drawing_lots {
+        generate_drawing_lots(&args, &pool).await
+    }
+    if !args.generate_p22_2_variants && !args.generate_drawing_lots {
+        _ = super::create_test_election(&args, &pool, None).await?
     }
 
     Ok(StatusCode::CREATED)
 }
 
-async fn generate_p22_2_variants(args: GenerateElectionArgs, pool: SqlitePool) {
+async fn generate_p22_2_variants(args: &GenerateElectionArgs, pool: &SqlitePool) {
     // 1. Test Election >= 19 seats
     //    based on test `gte_19_seats::test_with_remainder_seats`
     let _ = create_test_election_with_votes(
-        &args,
-        &pool,
+        args,
+        pool,
         23,
         default_50_candidates(&[600, 302, 98, 99, 101]),
     )
@@ -48,8 +52,8 @@ async fn generate_p22_2_variants(args: GenerateElectionArgs, pool: SqlitePool) {
     // 2. Test Election >= 19 seats & Absolute Majority Change
     //    based on test `gte_19_seats::test_with_absolute_majority_of_votes_but_not_seats`
     let _ = create_test_election_with_votes(
-        &args,
-        &pool,
+        args,
+        pool,
         24,
         default_50_candidates(&[7501, 1249, 1249, 1249, 1249, 1249, 1248, 7]),
     )
@@ -58,8 +62,8 @@ async fn generate_p22_2_variants(args: GenerateElectionArgs, pool: SqlitePool) {
     // 3. Test Election < 19 seats
     //    based on test `lt_19_seats::test_with_1_list_that_meets_threshold`
     let _ = create_test_election_with_votes(
-        &args,
-        &pool,
+        args,
+        pool,
         15,
         default_50_candidates(&[808, 59, 58, 57, 56, 55, 54, 53]),
     )
@@ -68,8 +72,8 @@ async fn generate_p22_2_variants(args: GenerateElectionArgs, pool: SqlitePool) {
     // 4. Test Election < 19 seats & Absolute Majority Change & List Exhaustion
     //    based on test `lt_19_seats::test_with_absolute_majority_of_votes_but_not_seats_and_list_exhaustion`
     let _ = create_test_election_with_votes(
-        &args,
-        &pool,
+        args,
+        pool,
         15,
         vec![
             vec![2571, 0, 0, 0, 0, 0, 0],
@@ -83,20 +87,18 @@ async fn generate_p22_2_variants(args: GenerateElectionArgs, pool: SqlitePool) {
 
     // 5. Test Election < 19 seats & List Exhaustion
     //    based on test `lt_19_seats::test_with_list_exhaustion_triggering_2nd_round_highest_average_assignment_with_different_averages`
-    let _ = create_test_election_with_votes(
-        &args,
-        &pool,
-        6,
-        vec![vec![3, 3], vec![2, 2], vec![25, 25]],
-    )
-    .await;
+    let _ =
+        create_test_election_with_votes(args, pool, 6, vec![vec![3, 3], vec![2, 2], vec![25, 25]])
+            .await;
 }
 
-async fn generate_drawing_lots(mut args: GenerateElectionArgs, pool: SqlitePool) {
+async fn generate_drawing_lots(args: &GenerateElectionArgs, pool: &SqlitePool) {
+    let mut args = args.clone();
+
     args.custom_name = Some("Drawing lots >= 19 seats, AbsoluteMajority".to_string());
     let _ = create_test_election_with_votes(
         &args,
-        &pool,
+        pool,
         24,
         default_50_candidates(&[7501, 1249, 1249, 1249, 1249, 1248, 1248, 8]),
     )
@@ -105,7 +107,7 @@ async fn generate_drawing_lots(mut args: GenerateElectionArgs, pool: SqlitePool)
     args.custom_name = Some("Drawing lots >= 19 seats, HighestAverageResidualSeat".to_string());
     let _ = create_test_election_with_votes(
         &args,
-        &pool,
+        pool,
         23,
         default_50_candidates(&[500, 140, 140, 140, 140, 140]),
     )
@@ -114,7 +116,7 @@ async fn generate_drawing_lots(mut args: GenerateElectionArgs, pool: SqlitePool)
     args.custom_name = Some("Drawing lots < 19 seats, AbsoluteMajority".to_string());
     let _ = create_test_election_with_votes(
         &args,
-        &pool,
+        pool,
         15,
         default_50_candidates(&[2552, 511, 511, 511, 509, 509]),
     )
@@ -123,7 +125,7 @@ async fn generate_drawing_lots(mut args: GenerateElectionArgs, pool: SqlitePool)
     args.custom_name = Some("Drawing lots < 19 seats, LargestRemainderResidualSeat".to_string());
     let _ = create_test_election_with_votes(
         &args,
-        &pool,
+        pool,
         15,
         default_50_candidates(&[540, 160, 160, 80, 80, 80, 55, 45]),
     )
@@ -132,7 +134,7 @@ async fn generate_drawing_lots(mut args: GenerateElectionArgs, pool: SqlitePool)
     args.custom_name = Some("Drawing lots, Candidate".to_string());
     let _ = create_test_election_with_votes(
         &args,
-        &pool,
+        pool,
         15,
         vec![
             vec![500, 500, 500, 500, 500, 500],
@@ -158,7 +160,7 @@ async fn create_test_election_with_votes(
     args.voters = RandomRange(total_votes..total_votes + 1);
     args.political_groups = RandomRange(political_groups..political_groups + 1);
     args.seats = RandomRange(seats..seats + 1);
-    super::create_test_election(args, pool.clone(), Some(votes)).await
+    super::create_test_election(&args, pool, Some(votes)).await
 }
 
 /// Fill a `Vec` with political groups of 50 candidates. The first candidate gets the specified votes

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -61,7 +61,7 @@ pub struct CreateTestElectionResult {
 async fn generate_gsb_data_entries(
     conn: &mut SqliteConnection,
     rng: &mut StdRng,
-    args: GenerateElectionArgs,
+    args: &GenerateElectionArgs,
     committee_session: &CommitteeSession,
     election: &ElectionWithPoliticalGroups,
     polling_stations: &[(PollingStation, DataEntryId)],
@@ -74,7 +74,7 @@ async fn generate_gsb_data_entries(
     .await?;
 
     let (_, second_entries) =
-        generate_gsb_data_entry(election, polling_stations, rng, conn, &args).await;
+        generate_gsb_data_entry(election, polling_stations, rng, conn, args).await;
     Ok(second_entries == polling_stations.len())
 }
 
@@ -110,11 +110,11 @@ async fn generate_csb_data_entries(
 async fn generate_gsb_election_data(
     rng: &mut StdRng,
     tx: &mut SqliteConnection,
-    args: GenerateElectionArgs,
+    args: &GenerateElectionArgs,
     committee_session: &mut CommitteeSession,
     election: &ElectionWithPoliticalGroups,
 ) -> Result<(Vec<PollingStation>, bool), Box<dyn Error>> {
-    let polling_stations_with_ids = generate_polling_stations(rng, election, tx, &args).await;
+    let polling_stations_with_ids = generate_polling_stations(rng, election, tx, args).await;
 
     if !polling_stations_with_ids.is_empty() {
         *committee_session = committee_session_repo::change_status(
@@ -150,7 +150,7 @@ async fn generate_gsb_election_data(
 async fn generate_csb_election_data(
     rng: &mut StdRng,
     tx: &mut SqliteConnection,
-    args: GenerateElectionArgs,
+    args: &GenerateElectionArgs,
     committee_session: &mut CommitteeSession,
     election: &ElectionWithPoliticalGroups,
     votes: Option<Vec<Vec<u32>>>,
@@ -171,7 +171,7 @@ async fn generate_csb_election_data(
         .map_err(|e| format!("{e:?}"))?;
 
         if args.with_data_entry {
-            generate_csb_data_entries(tx, rng, &args, sub_committee_first_session, election, votes)
+            generate_csb_data_entries(tx, rng, args, sub_committee_first_session, election, votes)
                 .await?
         } else {
             false
@@ -192,8 +192,8 @@ async fn generate_csb_election_data(
 }
 
 pub async fn create_test_election(
-    args: GenerateElectionArgs,
-    pool: SqlitePool,
+    args: &GenerateElectionArgs,
+    pool: &SqlitePool,
     votes: Option<Vec<Vec<u32>>>,
 ) -> Result<CreateTestElectionResult, Box<dyn Error>> {
     let mut rng = StdRng::from_rng(&mut rand::rng());
@@ -202,7 +202,7 @@ pub async fn create_test_election(
 
     // generate and store the election
     let election =
-        election_repo::create(&mut tx, generate_election(&mut rng, &args, votes.as_ref())).await?;
+        election_repo::create(&mut tx, generate_election(&mut rng, args, votes.as_ref())).await?;
 
     // generate the committee session for the election
     let mut committee_session = committee_session_repo::create(
@@ -1004,9 +1004,7 @@ mod tests {
             political_group_distribution_slope: RandomRange(1100..1101),
         };
 
-        create_test_election(args, pool.clone(), None)
-            .await
-            .unwrap();
+        create_test_election(&args, &pool, None).await.unwrap();
 
         let mut conn = pool.acquire().await.unwrap();
         let elections = election_repo::list(&mut conn, None).await.unwrap();

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -292,7 +292,11 @@ fn generate_election(
     let locality = super::data::locality(rng).to_owned();
 
     // use the previous data to generate some identifiers and names
-    let name = format!("Gemeenteraad {locality} {year}");
+    let name: String = args
+        .custom_name
+        .clone()
+        .unwrap_or(format!("Gemeenteraad {locality} {year}"));
+
     let cleaned_up_locality = locality.replace(" ", "_").replace("'", "");
     let election_id = format!("GR{year}_{cleaned_up_locality}");
 
@@ -983,6 +987,7 @@ mod tests {
     #[sqlx::test]
     async fn test_create_test_election(pool: SqlitePool) {
         let args = GenerateElectionArgs {
+            custom_name: None,
             committee_category: CommitteeCategory::GSB,
             political_groups: RandomRange(20..50),
             candidates_per_group: RandomRange(10..50),
@@ -990,6 +995,7 @@ mod tests {
             voters: RandomRange(100_000..200_000),
             seats: RandomRange(9..45),
             generate_p22_2_variants: false,
+            generate_drawing_lots: false,
             with_data_entry: true,
             first_data_entry: RandomRange(100..101),
             second_data_entry: RandomRange(100..101),

--- a/backend/src/test_data_gen/mod.rs
+++ b/backend/src/test_data_gen/mod.rs
@@ -19,6 +19,11 @@ pub struct RandomRange(pub Range<u32>);
 /// Abacus API and asset server
 #[derive(Debug, Deserialize, ToSchema, Clone)]
 pub struct GenerateElectionArgs {
+    /// Custom election name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub custom_name: Option<String>,
+
     /// GSB or CSB
     pub committee_category: CommitteeCategory,
 
@@ -39,6 +44,9 @@ pub struct GenerateElectionArgs {
 
     /// Generate multiple elections, each resulting in a different P 22-2 variant
     pub generate_p22_2_variants: bool,
+
+    /// Generate multiple elections, each resulting in drawing lots
+    pub generate_drawing_lots: bool,
 
     /// Include (part of) data entry for this election
     pub with_data_entry: bool,

--- a/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
+++ b/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
@@ -37,6 +37,7 @@ type RangeFormState = Record<RangeFieldKey, string>;
 interface FormState extends RangeFormState {
   committee_category: CommitteeCategory;
   generate_p22_2_variants: boolean;
+  generate_drawing_lots: boolean;
   with_data_entry: boolean;
 }
 
@@ -49,6 +50,7 @@ const INITIAL_FORM_STATE: FormState = {
   ...INITIAL_RANGE_STATE,
   committee_category: committeeCategoryValues[0],
   generate_p22_2_variants: false,
+  generate_drawing_lots: false,
   with_data_entry: true,
 };
 
@@ -69,7 +71,10 @@ export function GenerateTestElectionForm() {
 
   const submitForm = async (event: SubmitEvent<HTMLFormElement>) => {
     const formData = new StringFormData(event.currentTarget);
-    const committee_category = formState.generate_p22_2_variants ? "CSB" : formData.getString("committee_category");
+    const committee_category =
+      formState.generate_p22_2_variants || formState.generate_drawing_lots
+        ? "CSB"
+        : formData.getString("committee_category");
 
     const payload = RANGE_FIELDS.reduce<Record<string, string | boolean>>(
       (acc, field) =>
@@ -77,6 +82,7 @@ export function GenerateTestElectionForm() {
       {
         committee_category,
         generate_p22_2_variants: formState.generate_p22_2_variants,
+        generate_drawing_lots: formState.generate_drawing_lots,
         with_data_entry: formState.with_data_entry,
       },
     );
@@ -110,7 +116,14 @@ export function GenerateTestElectionForm() {
           checked={formState.generate_p22_2_variants}
           onChange={handleBooleanChange}
         />
-        {formState.generate_p22_2_variants || (
+        <Checkbox
+          id="generate-drawing-lots"
+          name="generate_drawing_lots"
+          label="Genereer meerdere verkiezingen met verschillende vormen van loting"
+          checked={formState.generate_drawing_lots}
+          onChange={handleBooleanChange}
+        />
+        {formState.generate_p22_2_variants || formState.generate_drawing_lots || (
           <>
             <ChoiceList>
               {committeeCategoryValues.map((committeeCategory, index) => (

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1140,8 +1140,12 @@ export interface GenerateElectionArgs {
   candidates_per_group: RandomRange;
   /** GSB or CSB */
   committee_category: CommitteeCategory;
+  /** Custom election name */
+  custom_name?: string;
   /** Percentage of the first data entry to complete if data entry is included */
   first_data_entry: RandomRange;
+  /** Generate multiple elections, each resulting in drawing lots */
+  generate_drawing_lots: boolean;
   /** Generate multiple elections, each resulting in a different P 22-2 variant */
   generate_p22_2_variants: boolean;
   political_group_distribution_slope: RandomRange;


### PR DESCRIPTION
## What & why

To be able to tests the different variants of drawing lots during apportionment, this PR lets you generate multiple elections for different drawing lots scenarios.

## How to test

Go to "Genereer testverkiezing" on the `/dev/` page, select "Genereer meerdere verkiezingen met verschillende vormen van loting" and see as a CSB coordinator that multiple elections have been added. 

If you try and finish apportionment for these elections, you will end up on an empty page (to be implemented in later issues) and you can see in your developer tools that the response from `/apportionment/state` contains the expected `drawing_lots_required`

## Reviewer notes

The test data is copied from unit tests for the specific scenarios.

<img width="754" height="411" alt="image" src="https://github.com/user-attachments/assets/c268ba39-91f2-4172-af43-e2beaf4b4236" />



<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->