### PR TITLE
Model P 22-2 thousands separation 

### DIFF
--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -757,9 +757,9 @@
             let value = if not step.change.list_exhausted.contains(list_seat_assignment.number) { format_fraction(average) } else { "" }
             table.cell({
               if step.change.selected_list_number == list_seat_assignment.number {
-                text(weight: "semibold")[#value]
+                text(weight: "semibold")[fmt-number(value, zero: "0")]
               } else {
-                value
+                fmt-number(value, zero: "0")
               }
             })
           }),

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -332,8 +332,12 @@
   " uur"
 }
 
-#let format_fraction(fraction) = {
-  str(fraction.integer)
+#let format_fraction(fraction, format_integer: true) = {
+  if format_integer {
+    fmt-number(fraction.integer, zero: "0")
+  } else {
+    str(fraction.integer)
+  }
   if fraction.numerator > 0 {
     " " + super[#fraction.numerator] + "⁄" + sub[#fraction.denominator]
   }

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -700,7 +700,7 @@
         table.cell(align: right, [#column.list_seat_number]),
         table.cell([#candidate_name(column.candidate)]),
         table.cell([#candidate_location(column.candidate)]),
-        if showVotes { table.cell(align: right, [#column.votes])}
+        if showVotes { table.cell(align: right, fmt-number(column.votes, zero: "0"))}
         else if showPosition { table.cell(align: right, [#column.candidate.number])},
       )
     }).flatten(),

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -147,17 +147,30 @@
   items.map(str).join(", ")
 }
 
-/// Format a number with thousands separator
-#let fmt-number(
+/// Format a number with thousands separator, return as str
+#let fmt-number-str(
   integer,
   thousands-sep: ".",
-  zero: "-",
+  zero: "0"
 ) = {
   if (integer == 0 or integer == none) {
     return zero
   }
 
-  let formatted = str(integer).clusters().rev().chunks(3).map(c => c.join("")).join(thousands-sep).rev()
+  str(integer).clusters().rev().chunks(3).map(c => c.join("")).join(thousands-sep).rev()
+}
+
+/// Format a number with thousands separator, return as text object
+#let fmt-number(
+  integer,
+  thousands-sep: ".",
+  zero: "-",
+) = {
+  let formatted = fmt-number-str(integer, thousands-sep: thousands-sep, zero: zero)
+
+  if formatted == zero {
+    return zero
+  }
 
   text(
     number-width: "tabular",
@@ -334,7 +347,7 @@
 
 #let format_fraction(fraction, format_integer: true) = {
   if format_integer {
-    fmt-number(fraction.integer, zero: "0")
+    fmt-number-str(fraction.integer)
   } else {
     str(fraction.integer)
   }
@@ -384,7 +397,7 @@
   }
 
   name += election_candidate.last_name + ", " + election_candidate.initials + " "
-  
+
   if "first_name" in election_candidate and with_first_name {
     name += "(" + election_candidate.first_name + ") "
   }
@@ -700,7 +713,7 @@
         table.cell(align: right, [#column.list_seat_number]),
         table.cell([#candidate_name(column.candidate)]),
         table.cell([#candidate_location(column.candidate)]),
-        if showVotes { table.cell(align: right, fmt-number(column.votes, zero: "0"))}
+        if showVotes { table.cell(align: right, fmt-number-str(column.votes))}
         else if showPosition { table.cell(align: right, [#column.candidate.number])},
       )
     }).flatten(),
@@ -757,9 +770,9 @@
             let value = if not step.change.list_exhausted.contains(list_seat_assignment.number) { format_fraction(average) } else { "" }
             table.cell({
               if step.change.selected_list_number == list_seat_assignment.number {
-                text(weight: "semibold")[fmt-number(value, zero: "0")]
+                text(weight: "semibold")[fmt-number-str(value)]
               } else {
-                [fmt-number(value, zero: "0")]
+                [fmt-number-str(value)]
               }
             })
           }),

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -759,7 +759,7 @@
               if step.change.selected_list_number == list_seat_assignment.number {
                 text(weight: "semibold")[fmt-number(value, zero: "0")]
               } else {
-                fmt-number(value, zero: "0")
+                [fmt-number(value, zero: "0")]
               }
             })
           }),

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -345,12 +345,8 @@
   " uur"
 }
 
-#let format_fraction(fraction, format_integer: true) = {
-  if format_integer {
-    fmt-number-str(fraction.integer)
-  } else {
-    str(fraction.integer)
-  }
+#let format_fraction(fraction) = {
+  fmt-number-str(fraction.integer)
   if fraction.numerator > 0 {
     " " + super[#fraction.numerator] + "⁄" + sub[#fraction.denominator]
   }

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -222,7 +222,7 @@ Met de kiesdeler wordt de zetelverdeling bepaald. De kiesdeler is het aantal ste
     table.cell(header_text([Kiesdeler])),
   ),
   table.hline(stroke: 1pt + black),
-  table.cell(align: right, [#input.summary.votes_counts.total_votes_candidates_count]),
+  table.cell(align: right, fmt-number(input.summary.votes_counts.total_votes_candidates_count, zero: "0")),
   table.cell(align: center, [÷]),
   table.cell(align: center, [#input.election.number_of_seats]),
   table.cell(align: center, [=]),

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -160,19 +160,19 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter of lid
   ..for pg_votes in input.summary.votes_counts.political_group_total_votes {
     (
       table.cell(format_political_group_name(pg_votes.number, pg_votes.name, with_prefix: "only_list_number")),
-      table.cell(align: right, fmt-number(pg_votes.total, zero: "0"))
+      table.cell(align: right, fmt-number-str(pg_votes.total))
     )
   }.flatten(),
   table.hline(stroke: 1pt + black),
   table.cell(header_text([Stemmen op kandidaten])),
-  table.cell(align: right, header_text(fmt-number(input.summary.votes_counts.total_votes_candidates_count, zero: "0"))),
+  table.cell(align: right, header_text(fmt-number-str(input.summary.votes_counts.total_votes_candidates_count))),
   table.cell(fill: luma(245), [Blanco stemmen]),
-  table.cell(fill: luma(245), align: right, fmt-number(input.summary.votes_counts.blank_votes_count, zero: "0")),
+  table.cell(fill: luma(245), align: right, fmt-number-str(input.summary.votes_counts.blank_votes_count)),
   table.cell([Ongeldige stemmen]),
-  table.cell(align: right, fmt-number(input.summary.votes_counts.invalid_votes_count, zero: "0")),
+  table.cell(align: right, fmt-number-str(input.summary.votes_counts.invalid_votes_count)),
   table.hline(stroke: 1pt + black),
   table.cell(header_text([Totaal uitgebrachte stemmen])),
-  table.cell(align: right, header_text(fmt-number(input.summary.votes_counts.total_votes_cast_count, zero: "0"))),
+  table.cell(align: right, header_text(fmt-number-str(input.summary.votes_counts.total_votes_cast_count))),
 )
 
 #pagebreak(weak: true)
@@ -222,7 +222,7 @@ Met de kiesdeler wordt de zetelverdeling bepaald. De kiesdeler is het aantal ste
     table.cell(header_text([Kiesdeler])),
   ),
   table.hline(stroke: 1pt + black),
-  table.cell(align: right, fmt-number(input.summary.votes_counts.total_votes_candidates_count, zero: "0")),
+  table.cell(align: right, fmt-number-str(input.summary.votes_counts.total_votes_candidates_count)),
   table.cell(align: center, [÷]),
   table.cell(align: center, [#input.election.number_of_seats]),
   table.cell(align: center, [=]),
@@ -253,14 +253,14 @@ Hieronder is berekend hoe vaak elke lijst qua stemmenaantal de kiesdeler heeft g
   ..for column in input.seat_assignment.list_seat_assignment {
     (
       table.cell(format_political_group_name(column.number, column.name, with_prefix: "only_list_number")),
-      table.cell(align: right, fmt-number(column.total, zero: "0")),
+      table.cell(align: right, fmt-number-str(column.total)),
       table.cell(align: center, [÷ #format_fraction(input.seat_assignment.quota) =]),
       table.cell(align: right, [#column.initial_full_seats])
     )
   }.flatten(),
   table.hline(stroke: 1pt + black),
   table.cell(header_text([Totaal])),
-  table.cell(align: right, header_text(fmt-number(input.summary.votes_counts.total_votes_candidates_count, zero: "0"))),
+  table.cell(align: right, header_text(fmt-number-str(input.summary.votes_counts.total_votes_candidates_count))),
   table.cell(stroke: none, []),
   table.cell(stroke: none, align: right, header_text([#input.seat_assignment.initial_total_full_seats])),
 )

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -253,14 +253,14 @@ Hieronder is berekend hoe vaak elke lijst qua stemmenaantal de kiesdeler heeft g
   ..for column in input.seat_assignment.list_seat_assignment {
     (
       table.cell(format_political_group_name(column.number, column.name, with_prefix: "only_list_number")),
-      table.cell(align: right, [#column.total]),
+      table.cell(align: right, fmt-number(column.total, zero: "0")),
       table.cell(align: center, [÷ #format_fraction(input.seat_assignment.quota) =]),
       table.cell(align: right, [#column.initial_full_seats])
     )
   }.flatten(),
   table.hline(stroke: 1pt + black),
   table.cell(header_text([Totaal])),
-  table.cell(align: right, header_text([#input.summary.votes_counts.total_votes_candidates_count])),
+  table.cell(align: right, header_text(fmt-number(input.summary.votes_counts.total_votes_candidates_count, zero: "0"))),
   table.cell(stroke: none, []),
   table.cell(stroke: none, align: right, header_text([#input.seat_assignment.initial_total_full_seats])),
 )

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -160,19 +160,19 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter of lid
   ..for pg_votes in input.summary.votes_counts.political_group_total_votes {
     (
       table.cell(format_political_group_name(pg_votes.number, pg_votes.name, with_prefix: "only_list_number")),
-      table.cell(align: right, [#pg_votes.total])
+      table.cell(align: right, fmt-number(pg_votes.total, zero: "0"))
     )
   }.flatten(),
   table.hline(stroke: 1pt + black),
   table.cell(header_text([Stemmen op kandidaten])),
-  table.cell(align: right, header_text([#input.summary.votes_counts.total_votes_candidates_count])),
+  table.cell(align: right, header_text(fmt-number(input.summary.votes_counts.total_votes_candidates_count, zero: "0"))),
   table.cell(fill: luma(245), [Blanco stemmen]),
-  table.cell(fill: luma(245), align: right, [#input.summary.votes_counts.blank_votes_count]),
+  table.cell(fill: luma(245), align: right, fmt-number(input.summary.votes_counts.blank_votes_count, zero: "0")),
   table.cell([Ongeldige stemmen]),
-  table.cell(align: right, [#input.summary.votes_counts.invalid_votes_count]),
+  table.cell(align: right, fmt-number(input.summary.votes_counts.invalid_votes_count, zero: "0")),
   table.hline(stroke: 1pt + black),
   table.cell(header_text([Totaal uitgebrachte stemmen])),
-  table.cell(align: right, header_text([#input.summary.votes_counts.total_votes_cast_count])),
+  table.cell(align: right, header_text(fmt-number(input.summary.votes_counts.total_votes_cast_count, zero: "0"))),
 )
 
 #pagebreak(weak: true)


### PR DESCRIPTION
## What & why

This fixes thousands-separation in model P 22-2.
Resolves #3425 

## How to test

Using "backend/templates/visual-diff.sh" you can visually review the output difference between model-p-22-2-old.pdf and model-p-22-2-new.pdf

Aside from the typesetting using that script, `cargo test infra::pdf_gen` will expose potential impact on the backend side as well.

## Reviewer notes

This is my first time working on larger Typst templates, if I've missed anything, please let me know.