### PR TITLE
format number of candidates in ElectionSummarytable

### DIFF
--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.tsx
@@ -115,9 +115,12 @@ export function ElectionSummaryTable({
             {t("apportionment.candidates_for_apportionment")}
           </Table.HeaderCell>
           <Table.NumberCell>
-            {deceasedCandidatesInfo.numberOfCandidates} - {deceasedCandidatesInfo.numberOfDeceasedCandidates}
+            {formatNumber(deceasedCandidatesInfo.numberOfCandidates)} -{" "}
+            {deceasedCandidatesInfo.numberOfDeceasedCandidates}
             <span className="superscript">&nbsp;&dagger;</span> ={" "}
-            {deceasedCandidatesInfo.numberOfCandidates - deceasedCandidatesInfo.numberOfDeceasedCandidates}
+            {formatNumber(
+              deceasedCandidatesInfo.numberOfCandidates - deceasedCandidatesInfo.numberOfDeceasedCandidates,
+            )}
           </Table.NumberCell>
           <Table.Cell className="fs-sm">
             <Button.Link variant="underlined" size="md" to={deceasedCandidatesInfo.deceasedCandidatesLink}>


### PR DESCRIPTION
## What & why

While generating a test election with large numbers I noticed we don't have thousands separators in "Kengetallen" - "Kandidaten voor zetelverdeling". While it's unlikely for a municipal election (our current scope) to have 1.000 candidates or more (Amsterdam had slightly over 600 this year), a parlimentary election is likely to have more than a 1.000 candidates (there were 1166 candidates in 2025).

So I added a `formatNumber()` to the total number of candidates and to the result of number of candidates minus number of deceased candidates. I did not add the formatting to the number of deceased candidates, because our `formatNumber()` transforms a `0` to an empty string. (And if the number of deceased candidates is >= 1.000, a missing thousands separator is the least of your concerns.)

## How to test
Test by generating an election with a large number of candidates or use `ElectionSummaryTable.stories.tsx`.

<img width="947" height="92" alt="image" src="https://github.com/user-attachments/assets/d5416dba-a9ee-439f-aebf-73917b8189c4" />

<img width="944" height="90" alt="image" src="https://github.com/user-attachments/assets/94fc9b52-5d5b-4966-9569-8b208af72f97" />

<img width="937" height="91" alt="image" src="https://github.com/user-attachments/assets/616ba0f9-fd88-4a6c-ab84-8161eef3cf60" />

<img width="950" height="91" alt="image" src="https://github.com/user-attachments/assets/bc6e00f3-4d96-4258-9944-db7d1f8c7b79" />

## Reviewer notes

no notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [x] Description explains how to test
