### PR TITLE
Serve Abacus using HTTPS

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Install Nextest
         run: cargo binstall cargo-nextest
       - name: Run tests
-        run: cargo --verbose --locked nextest run --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst
+        run: cargo --verbose --locked nextest run --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation
         run: cargo doc --workspace --no-deps --all-features
         env:

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "async_zip",
  "axum",
  "axum-extra",
+ "axum-server",
  "chrono",
  "clap",
  "cookie",
@@ -24,6 +25,7 @@ dependencies = [
  "rand 0.10.1",
  "rcgen",
  "reqwest",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -181,6 +183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,7 +227,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -277,7 +288,7 @@ dependencies = [
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
@@ -310,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
- "untrusted",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -417,6 +428,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "az"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,9 +522,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -607,10 +640,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -751,7 +796,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -771,6 +816,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comemo"
@@ -836,6 +891,16 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1115,7 +1180,7 @@ dependencies = [
  "chrono",
  "quick-xml 0.38.4",
  "regex",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1341,6 +1406,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,8 +1522,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1458,9 +1535,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1576,7 +1655,7 @@ dependencies = [
  "roman-numerals-rs",
  "serde",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
  "unic-langid",
  "unicode-segmentation",
  "unscanny",
@@ -1611,7 +1690,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56204c972d08e844f3db13b1e14be769f846e576699b46d4f4637cc4f8f70102"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "hayro-font",
  "hayro-syntax",
  "kurbo 0.12.0",
@@ -1793,6 +1872,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2202,6 +2296,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,7 +2491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -2385,6 +2523,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2595,6 +2739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,7 +2820,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92a79477295a713c2ed425aa82a8b5d20cec3fdee203706cbe6f3854880c1c81"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2850,7 +3000,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2973,6 +3123,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3204,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -3018,12 +3234,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3082,7 +3317,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3127,15 +3362,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3169,6 +3410,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3248,11 +3503,38 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3261,7 +3543,47 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3276,7 +3598,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -3304,10 +3626,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3613,7 +3967,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml",
@@ -3655,7 +4009,7 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -3666,7 +4020,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3683,7 +4037,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -3695,7 +4049,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -3718,7 +4072,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -3743,7 +4097,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -3904,7 +4258,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
 ]
@@ -3952,11 +4306,31 @@ checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4102,6 +4476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4189,7 +4573,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -4424,7 +4808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e276a5de53020c43efe2111ec236252e54ea4480b5ac18063e663dfbe03d9d1b"
 dependencies = [
  "az",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bumpalo",
  "chinese-number",
  "ciborium",
@@ -4746,6 +5130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5042,7 +5432,7 @@ version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5051,7 +5441,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5065,6 +5455,25 @@ checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5149,11 +5558,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5167,19 +5594,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5189,9 +5637,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5207,9 +5667,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5219,9 +5691,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5296,7 +5780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -5365,7 +5849,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,8 @@ tracing = "0.1.44"
 rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs", "pem", "x509-parser"] }
 rustls-pki-types = "1"
 if-addrs = "0.15"
+rustls = "0.23"
+axum-server = { version = "0.8", default-features = false, features = ["tls-rustls-no-provider"] }
 
 [package]
 name = "abacus"
@@ -56,7 +58,7 @@ pdf-gen-stub = ["pdf_gen/stub"]
 dev-database = []
 airgap-detection = []
 storybook = ["dep:memory-serve"]
-tls = ["dep:rcgen", "dep:rustls-pki-types", "dep:if-addrs"]
+tls = ["dep:rcgen", "dep:rustls-pki-types", "dep:if-addrs", "dep:rustls", "dep:axum-server", "reqwest/rustls"]
 
 [[bin]]
 name = "gen-openapi"
@@ -104,6 +106,8 @@ ttf-parser = "0.25.1"
 rcgen = { workspace = true, optional = true }
 rustls-pki-types = { workspace = true, optional = true }
 if-addrs = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+axum-server = { workspace = true, optional = true }
 
 [dev-dependencies]
 async_zip.workspace = true

--- a/backend/README.md
+++ b/backend/README.md
@@ -98,24 +98,15 @@ Using a binary:
 ```shell
 abacus --airgap-detection
 ```
-### TLS
 
-In production, Abacus must be built with TLS enabled. To do this, enable the feature `tls`:
+### TLS (HTTPS)
+
+In production, Abacus must be built with TLS enabled, which makes Abacus serve
+HTTPS only. To do this, enable the `tls` feature:
 
 ```shell
 cargo build --release --features tls
 ```
-
-On Windows, AWS Libcrypto has some [build requirements](https://aws.github.io/aws-lc-rs/requirements/windows.html):
-- C/C++ Compiler: these build tools have likely been installed during installation of Rust
-- NASM, two options:
-  - Use the installer
-  - Or, use prebuilt NASM objects: `set AWS_LC_SYS_PREBUILT_NASM=1`
-
-### TLS (HTTPS)
-
-Production builds are compiled with the `tls` feature, which makes Abacus serve
-HTTPS only.
 
 On startup Abacus loads (or, on first run, generates) a local certificate
 authority under the directory given by `--tls-dir` (defaults to `tls`). A fresh
@@ -128,6 +119,14 @@ Linux/macOS/Firefox, `ca.cer` (DER) on Windows.
 With the `tls` feature enabled, the default port is 8443 in debug builds and 443
 in release builds. Binding to 443 requires elevated privileges (e.g. the
 `CAP_NET_BIND_SERVICE` capability on Linux).
+
+#### Building with TLS enabled on Windows
+
+On Windows, AWS Libcrypto has some [build requirements](https://aws.github.io/aws-lc-rs/requirements/windows.html):
+- C/C++ Compiler: these build tools have likely been installed during installation of Rust
+- NASM, two options:
+  - Use the installer
+  - Or, use prebuilt NASM objects: `set AWS_LC_SYS_PREBUILT_NASM=1`
 
 ### Building for various platforms
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -99,6 +99,23 @@ Using a binary:
 abacus --airgap-detection
 ```
 
+### TLS (HTTPS)
+
+Production builds are compiled with the `tls` feature, which makes Abacus serve
+HTTPS only.
+
+On startup Abacus loads (or, on first run, generates) a local certificate
+authority under the directory given by `--tls-dir` (defaults to `tls`). A fresh
+server (leaf) certificate is created in memory on every start, signed by the CA
+and covering `localhost`, `abacus.local`, and all routable LAN addresses.
+
+To trust the server, import the CA into the client trust store: `ca.pem` on
+Linux/macOS/Firefox, `ca.cer` (DER) on Windows.
+
+With the `tls` feature enabled, the default port is 8443 in debug builds and 443
+in release builds. Binding to 443 requires elevated privileges (e.g. the
+`CAP_NET_BIND_SERVICE` capability on Linux).
+
 ### Building for various platforms
 
 You can use [`cross`](https://github.com/cross-rs/cross) to compile for different architectures.
@@ -164,6 +181,8 @@ For TLS (HTTPS) support, when the `tls` feature is enabled, the following depend
 - `rcgen`: X.509 certificate/DER generation (`aws-lc-rs` backend)
 - `rustls-pki-types`: shared certificate and private-key types, and PEM decoding.
 - `if-addrs`: enumerating LAN IP addresses for the TLS certificate subject.
+- `rustls`: TLS implementation, on the audited `aws-lc-rs` provider.
+- `axum-server`: HTTPS serving for `axum`, with graceful shutdown.
 
 Additionally, the following development dependencies are used:
 
@@ -228,7 +247,7 @@ Options:
 ```
 
 Note that airgap-detection is forced in our (pre-)releases.
-For release builds the default port number is 80.
+For release builds the default port number is 80, or 443 when TLS is enabled.
 
 A development build also supports the following arguments:
 

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -4,22 +4,21 @@ use std::{
     process,
 };
 
-use abacus::{AppError, create_sqlite_pool, start_server};
+use abacus::{AppError, create_sqlite_pool};
 use clap::Parser;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::TcpListener;
 use tracing::{error, level_filters::LevelFilter};
 use tracing_subscriber::EnvFilter;
 
-/// Get the default port for the server, 8080 in debug builds and 80 for release builds
+/// Default port: with the `tls` feature 8443 (debug) / 443 (release),
+/// without it 8080 (debug) / 80 (release).
 fn get_default_port() -> u16 {
-    #[cfg(debug_assertions)]
-    {
-        8080
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        80
+    match (cfg!(feature = "tls"), cfg!(debug_assertions)) {
+        (true, true) => 8443,
+        (true, false) => 443,
+        (false, true) => 8080,
+        (false, false) => 80,
     }
 }
 
@@ -115,10 +114,13 @@ async fn run() -> Result<(), AppError> {
 
     let listener = TcpListener::from_std(socket.into())?;
 
-    // For TLS: load or generate the local CA and create a leaf certificate
-    // Actual HTTPS serving will be implemented in #3411.
+    // When compiled with the `tls` feature the server always serves HTTPS.
     #[cfg(feature = "tls")]
-    abacus::infra::tls::load_or_generate(&args.tls_dir)?;
-
-    start_server(pool, listener, enable_airgap_detection).await
+    {
+        let certificates = abacus::infra::tls::load_or_generate(&args.tls_dir)?;
+        let tls_config = certificates.server_config()?;
+        abacus::start_server_tls(pool, listener, enable_airgap_detection, tls_config).await
+    }
+    #[cfg(not(feature = "tls"))]
+    abacus::start_server(pool, listener, enable_airgap_detection).await
 }

--- a/backend/src/infra/tls.rs
+++ b/backend/src/infra/tls.rs
@@ -3,7 +3,7 @@
 //! Self-signed certificate authority for serving Abacus over HTTPS.
 //! Certificates are generated with rcgen with the aws-lc-rs backend.
 
-use std::{fs, path::Path};
+use std::{fs, path::Path, sync::Arc};
 
 use chrono::{DateTime, Datelike, Duration, Utc};
 use rcgen::{
@@ -34,6 +34,20 @@ pub struct TlsCertificates {
     pub ca: CaCertificate,
     pub leaf_cert: CertificateDer<'static>,
     pub leaf_key: PrivateKeyDer<'static>,
+}
+
+impl TlsCertificates {
+    /// Build the rustls server config with the leaf certificate.
+    pub fn server_config(&self) -> Result<Arc<rustls::ServerConfig>, AppError> {
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let config = rustls::ServerConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .map_err(tls_err)?
+            .with_no_client_auth()
+            .with_single_cert(vec![self.leaf_cert.clone()], self.leaf_key.clone_key())
+            .map_err(tls_err)?;
+        Ok(Arc::new(config))
+    }
 }
 
 /// Load or generate the CA and create a new leaf certificate
@@ -154,7 +168,7 @@ fn create_leaf(
     let cert = params.signed_by(&leaf_key, issuer).map_err(tls_err)?;
     let cert_der = cert.der().clone();
     tracing::info!(
-        "Created a new server certificate (SHA-256 fingerprint {})",
+        "Created a new server certificate for {subjects:?} (SHA-256 fingerprint {})",
         fingerprint(&cert_der),
     );
     let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(pkcs8));
@@ -249,6 +263,11 @@ mod tests {
             PrivateKeyDer::Pkcs8(_),
             "leaf key should be PKCS#8"
         );
+
+        // the leaf certificate and key build a valid rustls server config
+        first
+            .server_config()
+            .expect("server config should build from the leaf certificate");
 
         // check that ca.cer is equal to the returned DER
         assert_eq!(fs::read(tls_dir.join(CA_CERT_DER)).unwrap(), first.ca.der);

--- a/backend/src/infra/tls.rs
+++ b/backend/src/infra/tls.rs
@@ -17,7 +17,6 @@ use crate::AppError;
 const CA_CERT_PEM: &str = "ca.pem";
 const CA_CERT_DER: &str = "ca.cer";
 const CA_KEY_DER: &str = "ca-key.der";
-const LEAF_CERT_PEM: &str = "leaf.pem";
 
 fn tls_err<E: core::fmt::Debug>(e: E) -> AppError {
     AppError::Tls(format!("{e:?}"))
@@ -47,7 +46,7 @@ pub fn load_or_generate(tls_dir: &Path) -> Result<TlsCertificates, AppError> {
     }
 
     let (issuer, ca) = load_or_generate_ca(tls_dir)?;
-    let (leaf_cert, leaf_key) = create_leaf(tls_dir, &issuer, &get_subjects())?;
+    let (leaf_cert, leaf_key) = create_leaf(&issuer, &get_subjects())?;
     Ok(TlsCertificates {
         ca,
         leaf_cert,
@@ -135,7 +134,6 @@ fn get_ca_params() -> Result<CertificateParams, AppError> {
 
 /// Create a fresh server (leaf) certificate signed by the CA
 fn create_leaf(
-    tls_dir: &Path,
     issuer: &Issuer<'_, KeyPair>,
     subjects: &[String],
 ) -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>), AppError> {
@@ -155,10 +153,6 @@ fn create_leaf(
 
     let cert = params.signed_by(&leaf_key, issuer).map_err(tls_err)?;
     let cert_der = cert.der().clone();
-
-    // TODO: for now persist the leaf to disk so the certificate can be inspected - remove in #3411
-    write_file(&tls_dir.join(LEAF_CERT_PEM), cert.pem().as_bytes(), 0o644)?;
-
     tracing::info!(
         "Created a new server certificate (SHA-256 fingerprint {})",
         fingerprint(&cert_der),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -59,26 +59,40 @@ pub struct AppState {
     airgap_detection: AirgapDetection,
 }
 
+/// Start airgap detection if enabled, logging which path was taken.
+fn setup_airgap_detection(pool: &SqlitePool, enable: bool) -> AirgapDetection {
+    if enable {
+        info!("Airgap detection is enabled, starting airgap detection task...");
+        AirgapDetection::start(pool.clone())
+    } else {
+        warn!("Airgap detection is disabled, this is not allowed in production.");
+        AirgapDetection::nop()
+    }
+}
+
+/// Log startup, start airgap detection, and build the router shared by the
+/// HTTP and HTTPS servers.
+fn build_app(pool: &SqlitePool, enable_airgap_detection: bool) -> Result<axum::Router, AppError> {
+    info!("Starting Abacus (version {})", env!("ABACUS_GIT_VERSION"));
+    let airgap_detection = setup_airgap_detection(pool, enable_airgap_detection);
+    router::create_router(pool.clone(), airgap_detection)
+}
+
+/// Close the database pool (flushing SQLite WAL/shm) and log a clean shutdown.
+async fn close_and_log(pool: SqlitePool) {
+    pool.close().await;
+    info!("Abacus has shut down gracefully.");
+}
+
 /// Start the API server on the given port, using the given database pool.
-#[allow(clippy::cognitive_complexity)]
 pub async fn start_server(
     pool: SqlitePool,
     listener: TcpListener,
     enable_airgap_detection: bool,
 ) -> Result<(), AppError> {
-    info!("Starting Abacus (version {})", env!("ABACUS_GIT_VERSION"));
-    let airgap_detection = if enable_airgap_detection {
-        info!("Airgap detection is enabled, starting airgap detection task...");
+    let app = build_app(&pool, enable_airgap_detection)?;
 
-        AirgapDetection::start(pool.clone())
-    } else {
-        warn!("Airgap detection is disabled, this is not allowed in production.");
-
-        AirgapDetection::nop()
-    };
-
-    let app = router::create_router(pool.clone(), airgap_detection)?;
-
+    warn!("TLS is disabled, serving Abacus over plain HTTP. This is not allowed in production.");
     info!("Starting Abacus on http://{}", listener.local_addr()?);
     let listener = listener.tap_io(|tcp_stream| {
         if let Err(err) = tcp_stream.set_nodelay(true) {
@@ -93,15 +107,55 @@ pub async fn start_server(
     .with_graceful_shutdown(shutdown_signal())
     .await?;
 
-    // close the database, this will flush the shm and wal files for sqlite
-    pool.close().await;
-
-    info!("Abacus has shut down gracefully.");
+    close_and_log(pool).await;
 
     Ok(())
 }
 
-/// Graceful shutdown, useful for Docker containers.
+/// Start the API server over HTTPS using axum-server/rustls.
+#[cfg(feature = "tls")]
+#[allow(clippy::cognitive_complexity)]
+pub async fn start_server_tls(
+    pool: SqlitePool,
+    listener: TcpListener,
+    enable_airgap_detection: bool,
+    tls_config: std::sync::Arc<rustls::ServerConfig>,
+) -> Result<(), AppError> {
+    use std::time::Duration;
+
+    use axum_server::{
+        accept::NoDelayAcceptor,
+        tls_rustls::{RustlsAcceptor, RustlsConfig},
+    };
+
+    let app = build_app(&pool, enable_airgap_detection)?;
+
+    info!("Starting Abacus on https://{}", listener.local_addr()?);
+
+    // Set up graceful shutdown from the existing signal handler
+    let handle = axum_server::Handle::new();
+    let shutdown_handle = handle.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        shutdown_handle.graceful_shutdown(Some(Duration::from_secs(10)));
+    });
+
+    // Serve Abacus using the axum-server/rustls acceptor
+    let acceptor =
+        RustlsAcceptor::new(RustlsConfig::from_config(tls_config)).acceptor(NoDelayAcceptor::new());
+    let std_listener = listener.into_std()?;
+    axum_server::from_tcp(std_listener)?
+        .acceptor(acceptor)
+        .handle(handle)
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+        .await?;
+
+    close_and_log(pool).await;
+
+    Ok(())
+}
+
+/// Graceful shutdown signal handler.
 ///
 /// Copied from the
 /// [axum graceful-shutdown example](https://github.com/tokio-rs/axum/blob/6318b57fda6b524b4d3c7909e07946e2b246ebd2/examples/graceful-shutdown/src/main.rs)
@@ -399,5 +453,130 @@ mod test {
         .await;
 
         assert!(matches!(result, Err(AppError::DatabaseReadOnly(_))));
+    }
+
+    /// TLS tests
+    #[cfg(feature = "tls")]
+    mod tls {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+        use reqwest::StatusCode;
+        use sqlx::SqlitePool;
+        use test_log::test;
+        use tokio::{net::TcpListener, task::JoinHandle};
+
+        use crate::{infra::audit_log, infra::tls::load_or_generate, start_server_tls};
+
+        /// Helper to start an HTTPS server on `bind_addr` with a new CA+leaf certificate
+        async fn spawn_https_server(
+            pool: SqlitePool,
+            bind_addr: &str,
+        ) -> (SocketAddr, String, JoinHandle<()>) {
+            let dir = tempfile::tempdir().unwrap();
+            let certificates = load_or_generate(&dir.path().join("tls")).unwrap();
+            let ca_pem = certificates.ca.pem.clone();
+            let server_config = certificates.server_config().unwrap();
+
+            let listener = TcpListener::bind(bind_addr).await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let task = tokio::spawn(async move {
+                start_server_tls(pool, listener, false, server_config)
+                    .await
+                    .unwrap();
+            });
+            (addr, ca_pem, task)
+        }
+
+        /// A reqwest client that trusts only the given CA (no system roots).
+        fn client_trusting(ca_pem: &str) -> reqwest::Client {
+            let ca = reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap();
+            reqwest::Client::builder()
+                .tls_certs_only([ca])
+                .build()
+                .unwrap()
+        }
+
+        /// Assert that an HTTPS server is reachable and a login succeeds
+        async fn assert_login_works(pool: SqlitePool, bind_addr: &str, expected_ip: IpAddr) {
+            let (addr, ca_pem, task) = spawn_https_server(pool.clone(), bind_addr).await;
+            let base = format!("https://{addr}");
+            let client = client_trusting(&ca_pem);
+
+            // account endpoint can be loaded without TLS error
+            let account = client
+                .get(format!("{base}/api/account"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                account.status(),
+                StatusCode::UNAUTHORIZED,
+                "leaf must chain to the trusted CA"
+            );
+
+            // A valid login over HTTPS succeeds
+            let login = client
+                .post(format!("{base}/api/login"))
+                .json(&serde_json::json!({"username": "admin1", "password": "Admin1Password01"}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                login.status(),
+                StatusCode::OK,
+                "login over HTTPS should succeed"
+            );
+
+            // Login audit event records correct client IP
+            let mut conn = pool.acquire().await.unwrap();
+            let events = audit_log::list_all(&mut conn).await.unwrap();
+            let last = events.last().expect("there should be an audit event");
+            assert_eq!(
+                last.ip(),
+                Some(expected_ip),
+                "the real client IP should reach the audit log"
+            );
+            assert_eq!(last.username(), Some("admin1"));
+
+            task.abort();
+            let _ = task.await;
+        }
+
+        #[test(sqlx::test(fixtures("../fixtures/users.sql")))]
+        async fn test_login_ipv4(pool: SqlitePool) {
+            assert_login_works(pool, "127.0.0.1:0", IpAddr::V4(Ipv4Addr::LOCALHOST)).await;
+        }
+
+        #[test(sqlx::test(fixtures("../fixtures/users.sql")))]
+        async fn test_login_ipv6(pool: SqlitePool) {
+            assert_login_works(pool, "[::1]:0", IpAddr::V6(Ipv6Addr::LOCALHOST)).await;
+        }
+
+        /// A client that has not imported the local CA must fail the TLS handshake.
+        #[test(sqlx::test(fixtures("../fixtures/users.sql")))]
+        async fn test_https_client_fails_without_ca(pool: SqlitePool) {
+            let (addr, _ca_pem, task) = spawn_https_server(pool, "127.0.0.1:0").await;
+
+            // Default client does not trust our local test CA
+            let client = reqwest::Client::new();
+            let err = client
+                .get(format!("https://{addr}/api/account"))
+                .send()
+                .await
+                .expect_err("a client that does not trust the local CA must fail the handshake");
+
+            // Connection should fail during the TLS handshake
+            assert!(
+                err.is_connect(),
+                "expected a connect-phase error, got: {err:?}"
+            );
+            assert!(
+                format!("{err:?}").contains("UnknownIssuer"),
+                "expected an untrusted-issuer certificate error, got: {err:?}"
+            );
+
+            task.abort();
+            let _ = task.await;
+        }
     }
 }


### PR DESCRIPTION
## What & why

Serve Abacus using HTTPS. Resolves #3411.

## How to test

Build frontend, then `cargo run --features memory-serve,tls`.

And in another terminal: `curl --cacert tls/ca.pem https://localhost:8443/`

Or trust `tls/ca.pem` / `tls/ca.cer` and go to https://localhost:8443/ in your browser.

## Reviewer notes

None.