### PR TITLE
Fix bug incorrect list standings in SeatChangeStep for absolute majority reassignment

### DIFF
--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -61,7 +61,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
 
     let full_seats = initial_standing
         .iter()
-        .map(|list| list.full_seats)
+        .map(|list| list.full_seats())
         .sum::<u32>();
     let residual_seats = input.number_of_seats() - full_seats;
 
@@ -104,7 +104,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             total_votes_cast,
             input.list_votes(),
             &last_step.change.list_assigned(),
-            current_standings,
+            current_standings.clone(),
         )? {
             AbsoluteMajority::Completed(cumulative_standings, assigned_seat) => {
                 (cumulative_standings, assigned_seat)
@@ -124,12 +124,12 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             }
         }
     } else {
-        (current_standings, None)
+        (current_standings.clone(), None)
     };
     if let Some(assigned_seat) = assigned_seat {
         // add the absolute majority change to the remainder assignment steps
         steps.push(SeatChangeStep {
-            standings: cumulative_standings.clone(),
+            standings: current_standings,
             residual_seat_number: None,
             change: assigned_seat,
         });
@@ -178,11 +178,11 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
 
     let final_full_seats = final_standing
         .iter()
-        .map(|list| list.full_seats)
+        .map(|list| list.full_seats())
         .sum::<u32>();
     let final_residual_seats = final_standing
         .iter()
-        .map(|list| list.residual_seats)
+        .map(|list| list.residual_seats())
         .sum::<u32>();
 
     Ok(SeatAssignment::Completed(SeatAssignmentDetails {
@@ -225,7 +225,7 @@ pub fn as_candidate_nomination_input<'a, T: ApportionmentInput>(
 
 /// Returns a vector containing just the list numbers from an iterator of the current standing
 fn list_numbers<LN: Copy>(standing: &[&ListStanding<LN>]) -> Vec<LN> {
-    standing.iter().map(|s| s.list_number).collect()
+    standing.iter().map(|s| s.list_number()).collect()
 }
 
 /// Returns the number of candidates of a list.
@@ -255,10 +255,10 @@ fn list_numbers_with_exhausted_seats<T: ListVotes>(
         .iter()
         .fold(vec![], |mut exhausted_list_numbers_and_seats, s| {
             let number_of_candidates =
-                get_number_of_candidates(input_list_votes, s.list_number, deceased_candidates);
+                get_number_of_candidates(input_list_votes, s.list_number(), deceased_candidates);
             if number_of_candidates.cmp(&s.total_seats()) == Ordering::Less {
                 exhausted_list_numbers_and_seats.push((
-                    s.list_number,
+                    s.list_number(),
                     number_of_candidates.abs_diff(s.total_seats()),
                 ))
             }
@@ -274,7 +274,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
     total_votes_cast: u32,
     list_votes: &[T],
     lists_last_residual_seat: &[T::ListNumber],
-    standings: Vec<ListStanding<T::ListNumber>>,
+    previous_standings: Vec<ListStanding<T::ListNumber>>,
 ) -> AbsoluteMajorityResult<T::ListNumber> {
     let half_of_votes_count = Fraction::from(total_votes_cast) * Fraction::new(1, 2);
 
@@ -283,13 +283,13 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
         .iter()
         .find(|list| Fraction::from(list.total_votes()) > half_of_votes_count)
     else {
-        return Ok(AbsoluteMajority::Completed(standings, None));
+        return Ok(AbsoluteMajority::Completed(previous_standings, None));
     };
 
     let half_of_seats_count = Fraction::from(seats) * Fraction::new(1, 2);
-    let standing_of_list_with_majority_votes = standings
+    let standing_of_list_with_majority_votes = previous_standings
         .iter()
-        .find(|list_standing| list_standing.list_number == majority_list_votes.number())
+        .find(|list_standing| list_standing.list_number() == majority_list_votes.number())
         .expect("Standing exists");
 
     let list_seats = Fraction::from(standing_of_list_with_majority_votes.total_seats());
@@ -308,15 +308,19 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
         }
 
         // Reassign the seat
-        let mut standing = standings.clone();
-        for list_standing in &mut standing {
-            if list_standing.list_number == lists_last_residual_seat[0] {
-                list_standing.residual_seats -= 1
-            }
-            if list_standing.list_number == majority_list_votes.number() {
-                list_standing.residual_seats += 1
-            }
-        }
+        let mut current_standings = previous_standings.clone();
+
+        let from_list_standing = current_standings
+            .iter_mut()
+            .find(|list_standing| list_standing.list_number() == lists_last_residual_seat[0])
+            .expect("standing to remove residual seat from should exist");
+        from_list_standing.remove_residual_seat();
+
+        let to_list_standing = current_standings
+            .iter_mut()
+            .find(|list_standing| list_standing.list_number() == majority_list_votes.number())
+            .expect("standing to add residual seat to should exist");
+        to_list_standing.add_residual_seat();
 
         info!(
             "Seat first assigned to list {:?} has been reassigned to list {:?} in accordance with Article P 9 Kieswet",
@@ -324,7 +328,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
             majority_list_votes.number()
         );
         Ok(AbsoluteMajority::Completed(
-            standing,
+            current_standings,
             Some(SeatChange::AbsoluteMajorityReassignment(
                 AbsoluteMajorityReassignedSeat {
                     list_retracted_seat: lists_last_residual_seat[0],
@@ -333,7 +337,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
             )),
         ))
     } else {
-        Ok(AbsoluteMajority::Completed(standings, None))
+        Ok(AbsoluteMajority::Completed(previous_standings, None))
     }
 }
 
@@ -361,16 +365,18 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
             seats_to_reassign += seats;
             let mut full_seat: bool = false;
             for _ in 1..=seats {
-                for list_standing in &mut current_standings {
-                    if list_standing.list_number == list_number {
-                        if list_standing.residual_seats > 0 {
-                            list_standing.residual_seats -= 1;
-                        } else {
-                            list_standing.full_seats -= 1;
-                            full_seat = true;
-                        }
-                    }
+                let list_standing = current_standings
+                    .iter_mut()
+                    .find(|list_standing| list_standing.list_number() == list_number)
+                    .expect("list standing should exist");
+
+                if list_standing.residual_seats() > 0 {
+                    list_standing.remove_residual_seat();
+                } else {
+                    list_standing.remove_full_seat();
+                    full_seat = true;
                 }
+
                 info!(
                     "Seat first assigned to list {:?} has been removed and will be assigned to another list in accordance with Article P 10 Kieswet",
                     list_number
@@ -418,6 +424,7 @@ pub(crate) mod tests {
         seat_assignment::{
             ListStanding, get_total_seats_per_list_number_from_apportionment_result, list_numbers,
         },
+        test_helpers::{CandidateVotesMock, ListVotesMock},
     };
 
     fn check_total_seats_per_list<LN: Copy + Debug + PartialEq>(
@@ -432,14 +439,17 @@ pub(crate) mod tests {
     #[test]
     fn test_list_numbers() {
         let standings: Vec<ListStanding<u32>> = (2..=6)
-            .map(|n| ListStanding {
-                list_number: n,
-                votes_cast: 1249,
-                remainder_votes: Fraction::new(14975, 24),
-                meets_remainder_threshold: true,
-                next_votes_per_seat: Fraction::new(1249, 2),
-                full_seats: 1,
-                residual_seats: 0,
+            .map(|n| {
+                ListStanding::new(
+                    &ListVotesMock {
+                        number: n,
+                        candidate_votes: vec![CandidateVotesMock {
+                            number: 1,
+                            votes: 1249,
+                        }],
+                    },
+                    Fraction::new(100, 1),
+                )
             })
             .collect();
         let standing: Vec<_> = standings.iter().collect();

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -43,7 +43,7 @@ pub fn assign_remainder<'b, T: ListVotes>(
         // votes or every list is exhausted. Any remaining seats will be reported as unassigned.
         let any_eligible = current_standings
             .iter()
-            .any(|s| s.votes_cast > 0 && !exhausted_list_numbers.contains(&s.list_number));
+            .any(|s| s.votes_cast() > 0 && !exhausted_list_numbers.contains(&s.list_number()));
         if !any_eligible {
             info!(
                 "No eligible lists remain, {} seat(s) left unassigned",
@@ -77,16 +77,12 @@ pub fn assign_remainder<'b, T: ListVotes>(
 
         // update the current standing by finding the selected group and
         // adding the residual seat to their tally
-        current_standings = current_standings
-            .into_iter()
-            .map(|s| {
-                if s.list_number == change.list_number_assigned() {
-                    s.add_residual_seat()
-                } else {
-                    s
-                }
-            })
-            .collect();
+        let list_standing = current_standings
+            .iter_mut()
+            .find(|s| s.list_number() == change.list_number_assigned())
+            .expect("should be able to find list standing");
+
+        list_standing.add_residual_seat();
 
         // add the update to the remainder assignment steps
         steps.push(SeatChangeStep {
@@ -114,11 +110,11 @@ fn list_assigned_from_previous_step<LN: Copy + Eq>(
         && previous_step
             .change
             .list_options()
-            .contains(&selected_list.list_number)
+            .contains(&selected_list.list_number())
     {
         list_assigned = previous_step.change.list_assigned()
     }
-    list_assigned.push(selected_list.list_number);
+    list_assigned.push(selected_list.list_number());
     list_assigned
 }
 
@@ -148,9 +144,9 @@ where
 {
     standings.fold(vec![], |mut list_numbers_without_empty_seats, s| {
         let number_of_candidates =
-            get_number_of_candidates(input_list_votes, s.list_number, deceased_candidates);
+            get_number_of_candidates(input_list_votes, s.list_number(), deceased_candidates);
         if number_of_candidates.cmp(&s.total_seats()) == Ordering::Equal {
-            list_numbers_without_empty_seats.push(s.list_number)
+            list_numbers_without_empty_seats.push(s.list_number())
         }
         list_numbers_without_empty_seats
     })
@@ -223,14 +219,14 @@ fn list_standings_qualifying_for_largest_remainder<'a, LN: Copy + Eq>(
     exhausted_list_numbers: &[LN],
 ) -> impl Iterator<Item = &'a ListStanding<LN>> {
     standings.iter().filter(|&s| {
-        s.votes_cast > 0
-            && s.meets_remainder_threshold
-            && !exhausted_list_numbers.contains(&s.list_number)
+        s.votes_cast() > 0
+            && s.meets_remainder_threshold()
+            && !exhausted_list_numbers.contains(&s.list_number())
             && list_qualifies_for_extra_seat(
-                list_largest_remainder_assigned_seats(previous_steps, s.list_number),
+                list_largest_remainder_assigned_seats(previous_steps, s.list_number()),
                 None,
                 previous_steps,
-                s.list_number,
+                s.list_number(),
             )
     })
 }
@@ -245,16 +241,16 @@ fn list_standings_qualifying_for_unique_highest_average<'a, LN: Copy + Eq>(
     exhausted_list_numbers: &[LN],
 ) -> impl Iterator<Item = &'a ListStanding<LN>> {
     standings.iter().filter(|&s| {
-        s.votes_cast > 0
-            && !exhausted_list_numbers.contains(&s.list_number)
+        s.votes_cast() > 0
+            && !exhausted_list_numbers.contains(&s.list_number())
             && list_qualifies_for_extra_seat(
-                list_largest_remainder_assigned_seats(previous_steps, s.list_number),
+                list_largest_remainder_assigned_seats(previous_steps, s.list_number()),
                 Some(list_unique_highest_average_assigned_seats(
                     previous_steps,
-                    s.list_number,
+                    s.list_number(),
                 )),
                 previous_steps,
-                s.list_number,
+                s.list_number(),
             )
     })
 }
@@ -301,12 +297,12 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
         (Fraction::ZERO, vec![]),
         |(current_max, mut max_groups), s| {
             // If this average is higher than any previously seen, we reset the list of groups matching
-            if s.next_votes_per_seat > current_max {
-                (s.next_votes_per_seat, vec![s])
+            if s.next_votes_per_seat() > current_max {
+                (s.next_votes_per_seat(), vec![s])
             } else {
                 // If the next average seats for this list is the same as the
                 // max we add it to the list of groups that have that current maximum
-                if s.next_votes_per_seat == current_max {
+                if s.next_votes_per_seat() == current_max {
                     max_groups.push(s);
                 }
                 (current_max, max_groups)
@@ -353,7 +349,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 
         let list = lists
             .iter()
-            .find(|list| list.list_number == *list_drawn.drawn())
+            .find(|list| list.list_number() == *list_drawn.drawn())
             .ok_or(ApportionmentError::InvalidLotDrawing(
                 "Unknown list number".to_string(),
             ))?;
@@ -382,12 +378,12 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
         (Fraction::ZERO, vec![]),
         |(current_max, mut max_groups), s| {
             // If this remainder is higher than any previously seen, we reset the list of groups matching
-            if s.remainder_votes > current_max {
-                (s.remainder_votes, vec![s])
+            if s.remainder_votes() > current_max {
+                (s.remainder_votes(), vec![s])
             } else {
                 // If the remainder for this list is the same as the
                 // max we add it to the list of groups that have that current maximum
-                if s.remainder_votes == current_max {
+                if s.remainder_votes() == current_max {
                     max_groups.push(s);
                 }
                 (current_max, max_groups)
@@ -434,7 +430,7 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 
         let list = lists
             .iter()
-            .find(|list| list.list_number == *list_drawn.drawn())
+            .find(|list| list.list_number() == *list_drawn.drawn())
             .ok_or(ApportionmentError::InvalidLotDrawing(
                 "Unknown list number".to_string(),
             ))?;
@@ -503,7 +499,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
     // and without lists that have zero votes cast.
     let mut qualifying_for_highest_average = standings
         .into_iter()
-        .filter(|&s| s.votes_cast > 0 && !exhausted_list_numbers.contains(&s.list_number))
+        .filter(|&s| s.votes_cast() > 0 && !exhausted_list_numbers.contains(&s.list_number()))
         .peekable();
 
     if qualifying_for_highest_average.peek().is_some() {
@@ -521,7 +517,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
 
         let selected_list = selected_lists[0];
         let assigned_seat = HighestAverageAssignedSeat {
-            selected_list_number: selected_list.list_number,
+            selected_list_number: selected_list.list_number(),
             list_assigned: list_assigned_from_previous_step(
                 selected_list,
                 previous_steps,
@@ -531,9 +527,12 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
                     SeatChange::is_changed_by_highest_average_assignment
                 },
             ),
-            list_options: selected_lists.iter().map(|list| list.list_number).collect(),
+            list_options: selected_lists
+                .iter()
+                .map(|list| list.list_number())
+                .collect(),
             list_exhausted: exhausted_list_numbers.to_vec(),
-            votes_per_seat: selected_list.next_votes_per_seat,
+            votes_per_seat: selected_list.next_votes_per_seat(),
         };
         if unique {
             Ok(ResidualSeat::SeatChange(
@@ -587,14 +586,17 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
         let selected_list = selected_lists[0];
         Ok(ResidualSeat::SeatChange(
             SeatChange::LargestRemainderAssignment(LargestRemainderAssignedSeat {
-                selected_list_number: selected_list.list_number,
+                selected_list_number: selected_list.list_number(),
                 list_assigned: list_assigned_from_previous_step(
                     selected_list,
                     previous_steps,
                     SeatChange::is_changed_by_largest_remainder_assignment,
                 ),
-                list_options: selected_lists.iter().map(|list| list.list_number).collect(),
-                remainder_votes: selected_list.remainder_votes,
+                list_options: selected_lists
+                    .iter()
+                    .map(|list| list.list_number())
+                    .collect(),
+                remainder_votes: selected_list.remainder_votes(),
             }),
         ))
     } else {

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -89,17 +89,17 @@ impl<LN: Copy + Debug> From<ListStanding<LN>> for ListSeatAssignment<LN> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ListStanding<LN> {
     /// List number for which this standing applies
-    pub list_number: LN,
+    list_number: LN,
     /// The number of votes cast for this list
-    pub votes_cast: u64,
+    votes_cast: u64,
     /// The remainder of votes that was not used to get full seats (does not have to be a whole number of votes)
-    pub remainder_votes: Fraction,
+    remainder_votes: Fraction,
     /// Whether the remainder votes meet the threshold to be applicable for largest remainder seat assignment
-    pub meets_remainder_threshold: bool,
+    meets_remainder_threshold: bool,
     /// The number of votes per seat if a new seat would be added to the current residual seats
-    pub next_votes_per_seat: Fraction,
+    next_votes_per_seat: Fraction,
     /// The number of full seats this list got assigned
-    pub full_seats: u32,
+    full_seats: u32,
     /// The current number of residual seats this list got assigned
     pub residual_seats: u32,
 }
@@ -133,20 +133,60 @@ impl<LN: Debug> ListStanding<LN> {
         }
     }
 
-    /// Add a residual seat to the list and return the updated instance
-    pub fn add_residual_seat(self) -> Self {
+    /// Remove a full seat to the list
+    pub fn remove_full_seat(&mut self) {
+        assert!(self.full_seats > 0);
+        info!("Removing full seat to list {:?}", self.list_number);
+        self.full_seats -= 1;
+        self.next_votes_per_seat =
+            Fraction::from(self.votes_cast) / Fraction::from(self.total_seats() + 1);
+        // NB: remainder_votes is not updated!
+    }
+
+    /// Add a residual seat to the list
+    pub fn add_residual_seat(&mut self) {
         info!("Adding residual seat to list {:?}", self.list_number);
-        ListStanding {
-            residual_seats: self.residual_seats + 1,
-            next_votes_per_seat: Fraction::from(self.votes_cast)
-                / Fraction::from(self.total_seats() + 2),
-            ..self
-        }
+        self.residual_seats += 1;
+        self.next_votes_per_seat =
+            Fraction::from(self.votes_cast) / Fraction::from(self.total_seats() + 1);
+    }
+
+    /// Remove a residual seat to the list
+    pub fn remove_residual_seat(&mut self) {
+        assert!(self.residual_seats > 0);
+        info!("Removing residual seat to list {:?}", self.list_number);
+        self.residual_seats -= 1;
+        self.next_votes_per_seat =
+            Fraction::from(self.votes_cast) / Fraction::from(self.total_seats() + 1);
     }
 
     /// Returns the total number of seats assigned to this list
     pub fn total_seats(&self) -> u32 {
         self.full_seats + self.residual_seats
+    }
+}
+
+impl<LN> ListStanding<LN> {
+    pub fn list_number(self) -> LN {
+        self.list_number
+    }
+    pub fn votes_cast(self) -> u64 {
+        self.votes_cast
+    }
+    pub fn remainder_votes(self) -> Fraction {
+        self.remainder_votes
+    }
+    pub fn meets_remainder_threshold(self) -> bool {
+        self.meets_remainder_threshold
+    }
+    pub fn next_votes_per_seat(self) -> Fraction {
+        self.next_votes_per_seat
+    }
+    pub fn full_seats(self) -> u32 {
+        self.full_seats
+    }
+    pub fn residual_seats(self) -> u32 {
+        self.residual_seats
     }
 }
 

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -133,10 +133,10 @@ impl<LN: Debug> ListStanding<LN> {
         }
     }
 
-    /// Remove a full seat to the list
+    /// Remove a full seat from the list
     pub fn remove_full_seat(&mut self) {
         assert!(self.full_seats > 0);
-        info!("Removing full seat to list {:?}", self.list_number);
+        info!("Removing full seat from list {:?}", self.list_number);
         self.full_seats -= 1;
         self.next_votes_per_seat =
             Fraction::from(self.votes_cast) / Fraction::from(self.total_seats() + 1);
@@ -151,10 +151,10 @@ impl<LN: Debug> ListStanding<LN> {
             Fraction::from(self.votes_cast) / Fraction::from(self.total_seats() + 1);
     }
 
-    /// Remove a residual seat to the list
+    /// Remove a residual seat from the list
     pub fn remove_residual_seat(&mut self) {
         assert!(self.residual_seats > 0);
-        info!("Removing residual seat to list {:?}", self.list_number);
+        info!("Removing residual seat from list {:?}", self.list_number);
         self.residual_seats -= 1;
         self.next_votes_per_seat =
             Fraction::from(self.votes_cast) / Fraction::from(self.total_seats() + 1);

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -101,7 +101,7 @@ pub struct ListStanding<LN> {
     /// The number of full seats this list got assigned
     full_seats: u32,
     /// The current number of residual seats this list got assigned
-    pub residual_seats: u32,
+    residual_seats: u32,
 }
 
 impl<LN: Debug> ListStanding<LN> {

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -236,13 +236,13 @@ impl From<&apportionment::SeatChangeStep<PGNumber>> for SeatChangeStep {
                 .standings
                 .iter()
                 .map(|standing| ListStanding {
-                    list_number: standing.list_number,
-                    votes_cast: standing.votes_cast,
-                    remainder_votes: DisplayFraction::from(standing.remainder_votes),
-                    meets_remainder_threshold: standing.meets_remainder_threshold,
-                    next_votes_per_seat: DisplayFraction::from(standing.next_votes_per_seat),
-                    full_seats: standing.full_seats,
-                    residual_seats: standing.residual_seats,
+                    list_number: standing.list_number(),
+                    votes_cast: standing.votes_cast(),
+                    remainder_votes: DisplayFraction::from(standing.remainder_votes()),
+                    meets_remainder_threshold: standing.meets_remainder_threshold(),
+                    next_votes_per_seat: DisplayFraction::from(standing.next_votes_per_seat()),
+                    full_seats: standing.full_seats(),
+                    residual_seats: standing.residual_seats(),
                 })
                 .collect(),
         }


### PR DESCRIPTION
## What & why

The SeatChangeStep for absolute majority reassignment contained updated list standings instead of the previous list standings.

Two other improvements were made to prevent other issues:
- Make ListStanding fields read-only, use add/remove seat methods instead, to keep next_votes_per_seat up to date
- Assert that a list standing is found when looking one up by its number

## How to test

Unit tests are still working.

<!-- ## Reviewer notes -->

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->