### PR TITLE
Return apportionment preliminary standings when drawing lots required

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/anonymity.rs
@@ -46,7 +46,7 @@ fuzz_target!(
     if let (Ok(ApportionmentOutput::Completed(alloc)), Ok(ApportionmentOutput::Completed(new_alloc))) = (alloc, new_alloc) {
         let seats_per_party: Vec<u32> = alloc
             .seat_assignment
-            .final_standing
+            .standings
             .iter()
             .map(|p| p.total_seats)
             .collect();
@@ -59,7 +59,7 @@ fuzz_target!(
 
         let new_seats_per_party: Vec<u32> = new_alloc
             .seat_assignment
-            .final_standing
+            .standings
             .iter()
             .map(|p| p.total_seats)
             .collect();

--- a/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
@@ -48,7 +48,7 @@ fuzz_target!(
             // so the assigned total can be less than seats.
             let seats_per_list: Vec<u32> = result
                 .seat_assignment
-                .final_standing
+                .standings
                 .iter()
                 .map(|standing| standing.total_seats)
                 .collect();

--- a/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/population_monotonicity.rs
@@ -49,13 +49,13 @@ fuzz_target!(
     if let (Ok(ApportionmentOutput::Completed(alloc)), Ok(ApportionmentOutput::Completed(new_alloc))) = (alloc, new_alloc) {
         let seats_per_party: Vec<u32> = alloc
             .seat_assignment
-            .final_standing
+            .standings
             .iter()
             .map(|p| p.total_seats)
             .collect();
         let new_seats_per_party: Vec<u32> = new_alloc
             .seat_assignment
-            .final_standing
+            .standings
             .iter()
             .map(|p| p.total_seats)
             .collect();

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -174,7 +174,7 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
 
 pub fn get_total_seats(result: &apportionment::SeatAssignmentDetails<u32>) -> Vec<u32> {
     result
-        .final_standing
+        .standings
         .iter()
         .map(|p| p.total_seats)
         .collect()

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             &mut lists_drawn,
         )? {
             RemainderAssignment::Completed(steps, current_standings) => (steps, current_standings),
-            RemainderAssignment::DrawingLotsRequired(variant, steps) => {
+            RemainderAssignment::DrawingLotsRequired(variant, steps, standings) => {
                 return Ok(SeatAssignment::DrawingLotsRequired(
                     variant,
                     SeatAssignmentDetails {
@@ -87,7 +87,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                         residual_seats,
                         quota,
                         steps,
-                        standings: Vec::new(),
+                        standings: standings.into_iter().map(Into::into).collect(),
                     },
                 ));
             }
@@ -104,7 +104,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             total_votes_cast,
             input.list_votes(),
             &last_step.change.list_assigned(),
-            current_standings,
+            current_standings.clone(),
         )? {
             AbsoluteMajority::Completed(cumulative_standings, assigned_seat) => {
                 (cumulative_standings, assigned_seat)
@@ -118,7 +118,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                         residual_seats,
                         quota,
                         steps: steps.clone(),
-                        standings: Vec::new(),
+                        standings: current_standings.into_iter().map(Into::into).collect(),
                     },
                 ));
             }
@@ -161,7 +161,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
         RemainderAssignment::Completed(final_steps, final_standing) => {
             (final_steps, final_standing)
         }
-        RemainderAssignment::DrawingLotsRequired(variant, steps) => {
+        RemainderAssignment::DrawingLotsRequired(variant, steps, standings) => {
             return Ok(SeatAssignment::DrawingLotsRequired(
                 variant,
                 SeatAssignmentDetails {
@@ -170,8 +170,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                     residual_seats,
                     quota,
                     steps: steps.clone(),
-                    // TODO preliminary standings
-                    standings: Vec::new(),
+                    standings: standings.into_iter().map(Into::into).collect(),
                 },
             ));
         }
@@ -682,7 +681,8 @@ pub(crate) mod tests {
                     ListDrawingLotsVariant,
                 },
                 test_helpers::{
-                    ListDrawnMock, get_total_seats_from_apportionment_result,
+                    ListDrawnMock, get_standings_residual_seats,
+                    get_total_seats_from_apportionment_result,
                     seat_assignment_fixture_with_default_50_candidates,
                 },
             };
@@ -725,7 +725,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 3);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 1, 1, 0, 0]
+                );
             }
 
             /// Apportionment with residual seats assigned with largest remainders method
@@ -766,7 +769,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![1, 0, 0, 0, 0, 0, 0, 0]
+                );
 
                 // Lot drawn is 6
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 6 });
@@ -776,6 +782,11 @@ pub(crate) mod tests {
 
                 let total_seats = get_total_seats_from_apportionment_result(&result);
                 assert_eq!(total_seats, vec![7, 2, 2, 1, 1, 2, 0, 0]);
+
+                assert_eq!(
+                    get_standings_residual_seats(&result),
+                    vec![1, 0, 0, 0, 0, 1, 0, 0]
+                );
 
                 assert_eq!(result.steps.len(), 2);
                 assert_eq!(
@@ -836,7 +847,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 0);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 0, 0, 0, 0, 0]
+                );
 
                 // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
@@ -866,7 +880,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 0, 0, 1, 0, 0]
+                );
             }
         }
 
@@ -1692,7 +1709,8 @@ pub(crate) mod tests {
                     ListDrawingLotsVariant,
                 },
                 test_helpers::{
-                    ListDrawnMock, get_total_seats_from_apportionment_result,
+                    ListDrawnMock, get_standings_residual_seats,
+                    get_total_seats_from_apportionment_result,
                     seat_assignment_fixture_with_default_50_candidates,
                 },
             };
@@ -1737,7 +1755,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 6);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 1, 1, 1, 1, 1, 0]
+                );
             }
 
             /// Apportionment with residual seats assigned with highest averages method
@@ -1778,7 +1799,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![1, 0, 0, 0, 0, 0]
+                );
 
                 // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
@@ -1809,7 +1833,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 2);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![1, 0, 0, 1, 0, 0]
+                );
             }
 
             /// Apportionment with residual seats assigned with highest averages method
@@ -1850,7 +1877,10 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.standings, vec![]);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![1, 0, 0, 0]
+                );
 
                 // List 3 is drawn, add it to the input's lists_drawn and process again
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -87,7 +87,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                         residual_seats,
                         quota,
                         steps,
-                        final_standing: Vec::new(),
+                        standings: Vec::new(),
                     },
                 ));
             }
@@ -118,7 +118,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                         residual_seats,
                         quota,
                         steps: steps.clone(),
-                        final_standing: Vec::new(),
+                        standings: Vec::new(),
                     },
                 ));
             }
@@ -170,7 +170,8 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
                     residual_seats,
                     quota,
                     steps: steps.clone(),
-                    final_standing: Vec::new(),
+                    // TODO preliminary standings
+                    standings: Vec::new(),
                 },
             ));
         }
@@ -191,7 +192,7 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
         residual_seats: final_residual_seats,
         quota,
         steps: final_steps,
-        final_standing: final_standing.into_iter().map(Into::into).collect(),
+        standings: final_standing.into_iter().map(Into::into).collect(),
     }))
 }
 
@@ -200,7 +201,7 @@ pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy>(
     result: &SeatAssignmentDetails<LN>,
 ) -> Vec<(LN, u32)> {
     result
-        .final_standing
+        .standings
         .iter()
         .map(|p| (p.list_number, p.total_seats))
         .collect::<Vec<_>>()
@@ -724,7 +725,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 3);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
             }
 
             /// Apportionment with residual seats assigned with largest remainders method
@@ -765,7 +766,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
 
                 // Lot drawn is 6
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 6 });
@@ -835,7 +836,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 0);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
 
                 // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
@@ -865,7 +866,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
             }
         }
 
@@ -1736,7 +1737,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 6);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
             }
 
             /// Apportionment with residual seats assigned with highest averages method
@@ -1777,7 +1778,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
 
                 // Drawing lots results in list 4
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
@@ -1808,7 +1809,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 2);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
             }
 
             /// Apportionment with residual seats assigned with highest averages method
@@ -1849,7 +1850,7 @@ pub(crate) mod tests {
                     }
                 );
                 assert_eq!(preliminary_result.steps.len(), 1);
-                assert_eq!(preliminary_result.final_standing, vec![]);
+                assert_eq!(preliminary_result.standings, vec![]);
 
                 // List 3 is drawn, add it to the input's lists_drawn and process again
                 input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -69,6 +69,7 @@ pub fn assign_remainder<'b, T: ListVotes>(
                 return Ok(RemainderAssignment::DrawingLotsRequired(
                     variant,
                     steps.clone(),
+                    current_standings,
                 ));
             }
         };

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -16,7 +16,7 @@ pub struct SeatAssignmentDetails<LN> {
     pub residual_seats: u32,
     pub quota: Fraction,
     pub steps: Vec<SeatChangeStep<LN>>,
-    pub final_standing: Vec<ListSeatAssignment<LN>>,
+    pub standings: Vec<ListSeatAssignment<LN>>,
 }
 
 impl<LN: Copy> SeatAssignmentDetails<LN> {

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -317,7 +317,11 @@ pub type RemainderAssignmentResult<LN> = Result<RemainderAssignment<LN>, Apporti
 
 pub enum RemainderAssignment<LN> {
     Completed(Vec<SeatChangeStep<LN>>, Vec<ListStanding<LN>>),
-    DrawingLotsRequired(ListDrawingLotsVariant<LN>, Vec<SeatChangeStep<LN>>),
+    DrawingLotsRequired(
+        ListDrawingLotsVariant<LN>,
+        Vec<SeatChangeStep<LN>>,
+        Vec<ListStanding<LN>>,
+    ),
 }
 
 /// Result type for absolute majority reassignment: updated standings and optional seat change.

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -127,11 +127,11 @@ impl CandidateDrawn<u32, u32> for CandidateDrawnMock {
 }
 
 pub fn get_total_seats_from_apportionment_result(result: &SeatAssignmentDetails<u32>) -> Vec<u32> {
-    result
-        .standings
-        .iter()
-        .map(|p| p.total_seats)
-        .collect::<Vec<_>>()
+    result.standings.iter().map(|p| p.total_seats).collect()
+}
+
+pub fn get_standings_residual_seats(result: &SeatAssignmentDetails<u32>) -> Vec<u32> {
+    result.standings.iter().map(|p| p.residual_seats).collect()
 }
 
 pub fn check_list_candidate_nomination(

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -128,7 +128,7 @@ impl CandidateDrawn<u32, u32> for CandidateDrawnMock {
 
 pub fn get_total_seats_from_apportionment_result(result: &SeatAssignmentDetails<u32>) -> Vec<u32> {
     result
-        .final_standing
+        .standings
         .iter()
         .map(|p| p.total_seats)
         .collect::<Vec<_>>()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8660,15 +8660,9 @@
           "residual_seats",
           "quota",
           "steps",
-          "final_standing"
+          "standings"
         ],
         "properties": {
-          "final_standing": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ListSeatAssignment"
-            }
-          },
           "full_seats": {
             "type": "integer",
             "format": "int32",
@@ -8686,6 +8680,12 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
+          },
+          "standings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListSeatAssignment"
+            }
           },
           "steps": {
             "type": "array",

--- a/backend/src/api/apportionment/mapping.rs
+++ b/backend/src/api/apportionment/mapping.rs
@@ -16,8 +16,8 @@ pub fn map_seat_assignment(sa: &apportionment::SeatAssignmentDetails<PGNumber>) 
         residual_seats: sa.residual_seats,
         quota: DisplayFraction::from(sa.quota),
         steps: sa.steps.iter().map(Into::into).collect(),
-        final_standing: sa
-            .final_standing
+        standings: sa
+            .standings
             .iter()
             .map(|standing| ListSeatAssignment {
                 list_number: standing.list_number,

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -30,7 +30,7 @@ pub struct SeatAssignment {
     pub residual_seats: u32,
     pub quota: DisplayFraction,
     pub steps: Vec<SeatChangeStep>,
-    pub final_standing: Vec<ListSeatAssignment>,
+    pub standings: Vec<ListSeatAssignment>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -78,7 +78,7 @@ impl EnrichedSeatAssignment {
             // Otherwise take the full seats from the final standing
             // since it will be equal to the initial standing
             seat_assignment
-                .final_standing
+                .standings
                 .iter()
                 .find(|standing| standing.list_number == list_number)
                 .expect("Standing exists for each political group")
@@ -90,13 +90,13 @@ impl EnrichedSeatAssignment {
         seat_assignment: &SeatAssignment,
         initial_largest_remainder_steps: &[&SeatChangeStep],
     ) -> Vec<(PGNumber, LargestRemainder)> {
-        let final_standing_pgs_meeting_threshold: Vec<&ListSeatAssignment> = seat_assignment
-            .final_standing
+        let standings_pgs_meeting_threshold: Vec<&ListSeatAssignment> = seat_assignment
+            .standings
             .iter()
             .filter(|list_seat_assignment| list_seat_assignment.meets_remainder_threshold)
             .collect();
         let mut largest_remainders = Vec::new();
-        for standing in &final_standing_pgs_meeting_threshold {
+        for standing in &standings_pgs_meeting_threshold {
             let assigned_seat = initial_largest_remainder_steps
                 .iter()
                 .find(|step| step.change.list_number_assigned() == standing.list_number);

--- a/backend/tests/apportionment_integration_test.rs
+++ b/backend/tests/apportionment_integration_test.rs
@@ -20,7 +20,7 @@ pub mod shared;
 pub mod utils;
 
 fn get_total_seats_from_seat_assignment(seat_assignment: &serde_json::Value) -> Vec<u64> {
-    seat_assignment["final_standing"]
+    seat_assignment["standings"]
         .as_array()
         .unwrap()
         .iter()
@@ -344,14 +344,14 @@ async fn test_api_output(pool: SqlitePool) {
     );
 
     assert_eq!(
-        body["seat_assignment"]["final_standing"]
+        body["seat_assignment"]["standings"]
             .as_array()
             .unwrap()
             .len(),
         5
     );
     assert_eq!(
-        body["seat_assignment"]["final_standing"][0],
+        body["seat_assignment"]["standings"][0],
         json!({
             "list_number": 1,
             "votes_cast": 1200,

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -158,7 +158,7 @@ export function ApportionmentPage() {
                   <div>
                     <h2 className={cls.tableTitle}>{t("apportionment.title")}</h2>
                     <ApportionmentTable
-                      finalStanding={seatAssignment.final_standing}
+                      standings={seatAssignment.standings}
                       politicalGroups={election.political_groups}
                       fullSeats={seatAssignment.full_seats}
                       residualSeats={seatAssignment.residual_seats}

--- a/frontend/src/features/apportionment/components/ApportionmentTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentTable.stories.tsx
@@ -7,7 +7,7 @@ export const Default: StoryObj = {
   render: () => {
     return (
       <ApportionmentTable
-        finalStanding={gte19Seats.seat_assignment.final_standing}
+        standings={gte19Seats.seat_assignment.standings}
         politicalGroups={gte19Seats.election.political_groups}
         fullSeats={gte19Seats.seat_assignment.full_seats}
         residualSeats={gte19Seats.seat_assignment.residual_seats}

--- a/frontend/src/features/apportionment/components/ApportionmentTable.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentTable.tsx
@@ -6,7 +6,7 @@ import { formatPoliticalGroupName } from "@/utils/politicalGroup";
 import cls from "./Apportionment.module.css";
 
 interface ApportionmentTableProps {
-  finalStanding: ListSeatAssignment[];
+  standings: ListSeatAssignment[];
   politicalGroups: PoliticalGroup[];
   fullSeats: number;
   residualSeats: number;
@@ -21,7 +21,7 @@ function convertZeroToDash(number: number): string {
 }
 
 export function ApportionmentTable({
-  finalStanding,
+  standings,
   politicalGroups,
   fullSeats,
   residualSeats,
@@ -37,7 +37,7 @@ export function ApportionmentTable({
         <Table.HeaderCell className="text-align-r link-cell-padding">{t("apportionment.total_seats")}</Table.HeaderCell>
       </Table.Header>
       <Table.Body>
-        {finalStanding.map((standing: ListSeatAssignment) => (
+        {standings.map((standing: ListSeatAssignment) => (
           <Table.Row key={standing.list_number} id={`list-${standing.list_number}`} to={`./${standing.list_number}`}>
             <Table.Cell className={cn(cls.listNumberColumn, "text-align-r", "font-number")}>
               {standing.list_number}

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.tsx
@@ -50,7 +50,7 @@ export function ApportionmentFullSeatsPage() {
                 <h2 className={cls.tableTitle}>{t("apportionment.how_often_is_quota_met")}</h2>
                 <span className={cls.tableInformation}>{t("apportionment.full_seats_information")}</span>
                 <FullSeatsTable
-                  finalStanding={seatAssignment.final_standing}
+                  standings={seatAssignment.standings}
                   politicalGroups={election.political_groups}
                   quota={seatAssignment.quota}
                   resultChanges={resultChanges}

--- a/frontend/src/features/apportionment/components/full_seats/FullSeatsTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/FullSeatsTable.stories.tsx
@@ -7,7 +7,7 @@ export const Default: StoryObj = {
   render: () => {
     return (
       <FullSeatsTable
-        finalStanding={gte19Seats.seat_assignment.final_standing}
+        standings={gte19Seats.seat_assignment.standings}
         politicalGroups={gte19Seats.election.political_groups}
         quota={gte19Seats.seat_assignment.quota}
         resultChanges={[]}

--- a/frontend/src/features/apportionment/components/full_seats/FullSeatsTable.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/FullSeatsTable.tsx
@@ -7,13 +7,13 @@ import { getFootnotesFromResultChanges, type ResultChange } from "../../utils/se
 import cls from "../Apportionment.module.css";
 
 interface FullSeatsTableProps {
-  finalStanding: ListSeatAssignment[];
+  standings: ListSeatAssignment[];
   politicalGroups: PoliticalGroup[];
   quota: DisplayFraction;
   resultChanges: ResultChange[];
 }
 
-export function FullSeatsTable({ finalStanding, politicalGroups, quota, resultChanges }: FullSeatsTableProps) {
+export function FullSeatsTable({ standings, politicalGroups, quota, resultChanges }: FullSeatsTableProps) {
   return (
     <Table id="full-seats-table" className={cn(cls.table, cls.fullSeatsTable)}>
       <Table.Header>
@@ -28,7 +28,7 @@ export function FullSeatsTable({ finalStanding, politicalGroups, quota, resultCh
         <Table.HeaderCell className="text-align-r">{t("apportionment.full_seats_count")}</Table.HeaderCell>
       </Table.Header>
       <Table.Body>
-        {finalStanding.map((standing: ListSeatAssignment) => {
+        {standings.map((standing: ListSeatAssignment) => {
           const listResultChanges = resultChanges.filter((change) => change.listNumber === standing.list_number);
           return (
             <Table.Row key={standing.list_number}>

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.tsx
@@ -204,7 +204,7 @@ export function ApportionmentListDetailsPage() {
     return <ApportionmentErrorPage sectionTitle={listName} error={error} />;
   }
   if (seatAssignment && candidateNomination && electionSummary) {
-    const listTotalSeats = seatAssignment.final_standing.find(
+    const listTotalSeats = seatAssignment.standings.find(
       (standing) => standing.list_number === list.number,
     )?.total_seats;
     const candidateVotesList = electionSummary.political_group_votes.find(

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.tsx
@@ -63,7 +63,7 @@ function LargeCouncilSection({
         {highestAverageSteps.length > 0 && (
           <HighestAveragesTable
             steps={highestAverageSteps}
-            finalStanding={seatAssignment.final_standing}
+            standings={seatAssignment.standings}
             politicalGroups={politicalGroups}
             resultChanges={resultChanges}
           />
@@ -97,7 +97,7 @@ function LargestRemaindersSection({
         {largestRemainderSteps.length > 0 && (
           <LargestRemaindersTable
             steps={largestRemainderSteps}
-            finalStanding={seatAssignment.final_standing}
+            standings={seatAssignment.standings}
             politicalGroups={politicalGroups}
             resultChanges={resultChanges}
           />
@@ -138,7 +138,7 @@ function HighestAveragesSection({
         <UniqueHighestAveragesTable
           steps={uniqueHighestAverageSteps}
           largestRemainderSteps={largestRemainderSteps}
-          finalStanding={seatAssignment.final_standing}
+          standings={seatAssignment.standings}
           politicalGroups={politicalGroups}
         />
         {highestAverageSteps.length > 0 && (
@@ -152,7 +152,7 @@ function HighestAveragesSection({
             {
               <HighestAveragesTable
                 steps={highestAverageSteps}
-                finalStanding={seatAssignment.final_standing}
+                standings={seatAssignment.standings}
                 politicalGroups={politicalGroups}
                 resultChanges={[]}
               />

--- a/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.stories.tsx
@@ -8,7 +8,7 @@ export const Default: StoryObj = {
     return (
       <HighestAveragesTable
         steps={gte19Seats.steps}
-        finalStanding={gte19Seats.seat_assignment.final_standing}
+        standings={gte19Seats.seat_assignment.standings}
         politicalGroups={gte19Seats.election.political_groups}
         resultChanges={[]}
       />

--- a/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.tsx
@@ -9,17 +9,12 @@ import cls from "../Apportionment.module.css";
 
 interface HighestAveragesTableProps {
   steps: HighestAverageAssignmentStep[];
-  finalStanding: ListSeatAssignment[];
+  standings: ListSeatAssignment[];
   politicalGroups: PoliticalGroup[];
   resultChanges: ResultChange[];
 }
 
-export function HighestAveragesTable({
-  steps,
-  finalStanding,
-  politicalGroups,
-  resultChanges,
-}: HighestAveragesTableProps) {
+export function HighestAveragesTable({ steps, standings, politicalGroups, resultChanges }: HighestAveragesTableProps) {
   return (
     <div className={cls.scrollable}>
       <Table id="highest-averages-table" className={cn(cls.table, cls.highestAveragesTable)}>
@@ -36,7 +31,7 @@ export function HighestAveragesTable({
           </Table.HeaderCell>
         </Table.Header>
         <Table.Body>
-          {finalStanding.map((listSeatAssignment: ListSeatAssignment) => {
+          {standings.map((listSeatAssignment: ListSeatAssignment) => {
             let residualSeats = steps.filter((step) => {
               return step.change.selected_list_number === listSeatAssignment.list_number;
             }).length;

--- a/frontend/src/features/apportionment/components/residual_seats/LargestRemaindersTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/LargestRemaindersTable.stories.tsx
@@ -8,7 +8,7 @@ export const Default: StoryObj = {
     return (
       <LargestRemaindersTable
         steps={lt19Seats.largest_remainder_steps}
-        finalStanding={lt19Seats.seat_assignment.final_standing}
+        standings={lt19Seats.seat_assignment.standings}
         politicalGroups={lt19Seats.election.political_groups}
         resultChanges={[]}
       />

--- a/frontend/src/features/apportionment/components/residual_seats/LargestRemaindersTable.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/LargestRemaindersTable.tsx
@@ -9,18 +9,18 @@ import cls from "../Apportionment.module.css";
 
 interface LargestRemaindersTableProps {
   steps: LargestRemainderAssignmentStep[];
-  finalStanding: ListSeatAssignment[];
+  standings: ListSeatAssignment[];
   politicalGroups: PoliticalGroup[];
   resultChanges: ResultChange[];
 }
 
 export function LargestRemaindersTable({
   steps,
-  finalStanding,
+  standings,
   politicalGroups,
   resultChanges,
 }: LargestRemaindersTableProps) {
-  const finalStandingPgsMeetingThreshold = finalStanding.filter(
+  const standingsPgsMeetingThreshold = standings.filter(
     (listSeatAssignment) => listSeatAssignment.meets_remainder_threshold,
   );
   return (
@@ -35,7 +35,7 @@ export function LargestRemaindersTable({
         <Table.HeaderCell className="text-align-r">{t("apportionment.residual_seats_count")}</Table.HeaderCell>
       </Table.Header>
       <Table.Body>
-        {finalStandingPgsMeetingThreshold.map((listSeatAssignment) => {
+        {standingsPgsMeetingThreshold.map((listSeatAssignment) => {
           let residualSeats = steps.filter((step) => {
             return step.change.selected_list_number === listSeatAssignment.list_number;
           }).length;

--- a/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.stories.tsx
@@ -9,7 +9,7 @@ export const Default: StoryObj = {
       <UniqueHighestAveragesTable
         steps={lt19Seats.highest_average_steps}
         largestRemainderSteps={lt19Seats.largest_remainder_steps}
-        finalStanding={lt19Seats.seat_assignment.final_standing}
+        standings={lt19Seats.seat_assignment.standings}
         politicalGroups={lt19Seats.election.political_groups}
       />
     );

--- a/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/UniqueHighestAveragesTable.tsx
@@ -9,14 +9,14 @@ import cls from "../Apportionment.module.css";
 interface UniqueHighestAveragesTableProps {
   steps: UniqueHighestAverageAssignmentStep[];
   largestRemainderSteps: LargestRemainderAssignmentStep[];
-  finalStanding: ListSeatAssignment[];
+  standings: ListSeatAssignment[];
   politicalGroups: PoliticalGroup[];
 }
 
 export function UniqueHighestAveragesTable({
   steps,
   largestRemainderSteps,
-  finalStanding,
+  standings,
   politicalGroups,
 }: UniqueHighestAveragesTableProps) {
   return (
@@ -31,7 +31,7 @@ export function UniqueHighestAveragesTable({
         <Table.HeaderCell className="text-align-r">{t("apportionment.residual_seats_count")}</Table.HeaderCell>
       </Table.Header>
       <Table.Body>
-        {finalStanding.map((listSeatAssignment) => {
+        {standings.map((listSeatAssignment) => {
           if (steps[0]?.change.list_exhausted.includes(listSeatAssignment.list_number)) {
             return null;
           } else {

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
@@ -1080,7 +1080,7 @@ export const seat_assignment: SeatAssignment = {
       ],
     },
   ],
-  final_standing: [
+  standings: [
     {
       list_number: 1,
       votes_cast: 7501,

--- a/frontend/src/features/apportionment/testing/gte-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats.ts
@@ -428,7 +428,7 @@ export const seat_assignment: SeatAssignment = {
     denominator: 23,
   },
   steps: steps,
-  final_standing: [
+  standings: [
     {
       list_number: 1,
       votes_cast: 600,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
@@ -596,7 +596,7 @@ export const seat_assignment: SeatAssignment = {
       ],
     },
   ],
-  final_standing: [
+  standings: [
     {
       list_number: 1,
       votes_cast: 5,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
@@ -1000,7 +1000,7 @@ export const seat_assignment: SeatAssignment = {
       ],
     },
   ],
-  final_standing: [
+  standings: [
     {
       list_number: 1,
       votes_cast: 2571,

--- a/frontend/src/features/apportionment/testing/lt-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats.ts
@@ -791,7 +791,7 @@ export const seat_assignment: SeatAssignment = {
     denominator: 15,
   },
   steps: (largest_remainder_steps as SeatChangeStep[]).concat(highest_average_steps),
-  final_standing: [
+  standings: [
     {
       list_number: 1,
       votes_cast: 808,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1488,11 +1488,11 @@ export interface SaveDataEntryResponse {
 }
 
 export interface SeatAssignment {
-  final_standing: ListSeatAssignment[];
   full_seats: number;
   quota: DisplayFraction;
   residual_seats: number;
   seats: number;
+  standings: ListSeatAssignment[];
   steps: SeatChangeStep[];
 }
 


### PR DESCRIPTION
## What & why

To be able to show all information necessary to the user when drawing lots is required, the preliminary standings have to be returned. This solves a part of https://github.com/kiesraad/abacus/issues/3408.

We've renamed the `final_standings` to `standings` (first commit) and also return preliminary standings in this field, in case of drawing lots required.

## How to test

Unit tests have been extended with the residual seats from standings, to be able to verify that they match with the residual seat assignment steps.

## Reviewer notes
Review the first commit for the rename, and the second commit for returning standings also in case of drawing lots required.

Please verify that the residual seats in the unit tests are as expected.

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->