### PR TITLE
Fix PDF diff workflow for PRs from forks

### DIFF
--- a/.github/workflows/pdf-diff.yml
+++ b/.github/workflows/pdf-diff.yml
@@ -6,14 +6,12 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   TZ: "Europe/Amsterdam"
 
 jobs:
   diff:
-    if: "!github.event.pull_request.head.repo.fork"
     name: Diff PDFs
     runs-on: ubuntu-latest
     defaults:
@@ -58,12 +56,8 @@ jobs:
         with:
           name: pdf-diffs
           path: backend/tmp-pdf-gen/diffs/
-      - name: Comment on PR with PDF diff summary and link to artifact
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 #v3.0.4
-        env:
-          DOWNLOAD_LINK: "[Download ZIP file containing PDF files with the visual differences](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload.outputs['artifact-id'] }})"
-        with:
-          message: |
-            ${{ steps.diff_summary.outputs.table }}
-            ${{ steps.artifact-upload.outputs['artifact-id'] && env.DOWNLOAD_LINK }}
+      - name: Add diff download link to job summary
+        if: ${{ steps.diff_summary.outputs.diff_found == '1' }}
+        run: |
+          url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload.outputs.artifact-id }}"
+          echo "[Download ZIP file containing PDF files with the visual differences]($url)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scripts/pdf-diff.js
+++ b/.github/workflows/scripts/pdf-diff.js
@@ -52,6 +52,7 @@ exports.pdfDiff = ({ core }) => {
   };
 
   let diffFound = false;
+  const changedFiles = [];
 
   // Iterate through every PDF present in either ref, run diff-pdf where applicable, and capture the status
   for (const relativePath of allFiles) {
@@ -99,10 +100,35 @@ exports.pdfDiff = ({ core }) => {
     }
 
     rows.push(`| ${relativePath} | ${status} |`);
+    if (status !== statusLabels.identical) {
+      changedFiles.push({ relativePath, status });
+    }
   }
 
   rows.push("");
 
-  core.setOutput("table", rows.join("\n"));
+  // Report the diff table via the workflow job summary
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${rows.join("\n")}\n`);
+  }
+
+  // Add a yellow warning annotation for every changed PDF
+  for (const { relativePath, status } of changedFiles) {
+    const template = path.join(
+      "backend",
+      "templates",
+      `${relativePath.replace(/\.pdf$/i, "")}.typ`,
+    );
+    const annotation = { title: "PDF output changed" };
+    if (fs.existsSync(template)) {
+      annotation.file = template;
+      annotation.startLine = 1;
+    }
+    core.warning(
+      `${relativePath}: ${status}, see the job summary for the visual diff.`,
+      annotation,
+    );
+  }
+
   core.setOutput("diff_found", diffFound ? "1" : "0");
 };


### PR DESCRIPTION
## What & why

Fix PDF diff workflow for PRs from forks by using the workflow summary instead of a PR comment, because PR comments require `pull-requests: write` permissions, which fork PRs do not have. A warning annotation is also added to the Typst template files to make the changes more visible.

This is useful for e.g. #3430.

## How to test

The workflow should run on this PR without finding any PDF differences. It can be tested more thorougly by creating a PR in your own GitHub fork that includes the commit from this branch and some Typst template changes.