### PR TITLE
Write Sigrid PR feedback to job summary

### DIFF
--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -28,4 +28,8 @@ jobs:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
       - name: "Sigrid feedback to job summary"
         if: always()
-        run: cat sigrid-ci-output/*feedback.md >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          for feedback in sigrid-ci-output/*feedback.md; do
+            cat "$feedback" >> "$GITHUB_STEP_SUMMARY"
+            echo >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -7,14 +7,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   sigridci:
     if: "!github.event.pull_request.head.repo.fork"
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.3
@@ -29,9 +26,6 @@ jobs:
           capability: maintainability,osh,security
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
-      - name: "Sigrid PR feedback"
-        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
+      - name: "Sigrid feedback to job summary"
         if: always()
-        with:
-          message-id: sigrid
-          message-path: sigrid-ci-output/*feedback.md
+        run: cat sigrid-ci-output/*feedback.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What & why

Instead of creating a noisy PR comment, write the feedback to the job summary so it can be seen on the Checks tab.

## How to test

See the Checks tab on this PR.

## Reviewer notes

Do we prefer this approach or the comment? I personally do not like getting three automated comments on every PR, this adds a lot of notification noise. The PDF diff workflow is changed in #3449 and Codecov already reports a job summary, so we can [disable comments](https://docs.codecov.com/docs/pull-request-comments#disable-comment).