### PR TITLE
Drawing of lots include list of averages/remainders

### DIFF
--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -777,15 +777,16 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(
                         LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(0, 1),
                             residual_seat_numbers: vec![2],
                             options: vec![2, 3, 4, 5, 6],
                             list_remainders: vec![
                                 (1, Fraction::new(60, 1)),
-                                (2, Fraction::new(0, 15)),
-                                (3, Fraction::new(0, 15)),
-                                (4, Fraction::new(0, 15)),
-                                (5, Fraction::new(0, 15)),
-                                (6, Fraction::new(0, 15)),
+                                (2, Fraction::new(0, 1)),
+                                (3, Fraction::new(0, 1)),
+                                (4, Fraction::new(0, 1)),
+                                (5, Fraction::new(0, 1)),
+                                (6, Fraction::new(0, 1)),
                                 (7, Fraction::new(55, 1)),
                                 (8, Fraction::new(45, 1)),
                             ],
@@ -864,6 +865,7 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(
                         LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(420, 7),
                             residual_seat_numbers: vec![1, 2, 3, 4],
                             options: vec![2, 3, 4, 5, 6],
                             list_remainders: vec![
@@ -904,6 +906,7 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(
                         LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(420, 7),
                             residual_seat_numbers: vec![2, 3, 4],
                             options: vec![2, 3, 5, 6],
                             list_remainders: vec![
@@ -1830,6 +1833,7 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
+                            max_average: Fraction::new(140, 3),
                             residual_seat_numbers: vec![2, 3, 4],
                             options: vec![2, 3, 4, 5, 6],
                             list_averages: vec![
@@ -1871,6 +1875,7 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
+                            max_average: Fraction::new(140, 3),
                             residual_seat_numbers: vec![3, 4],
                             options: vec![2, 3, 5, 6],
                             list_averages: vec![
@@ -1922,6 +1927,7 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
+                            max_average: Fraction::new(140, 4),
                             residual_seat_numbers: vec![2],
                             options: vec![2, 3, 4],
                             list_averages: vec![

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -779,7 +779,7 @@ pub(crate) mod tests {
                         LargestRemainderResidualSeatDrawingLots {
                             remainder: Fraction::new(0, 1),
                             residual_seat_numbers: vec![2],
-                            options: vec![2, 3, 4, 5, 6]
+                            options: vec![2, 3, 4, 5, 6],
                         }
                     ),
                 );

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -763,7 +763,7 @@ pub(crate) mod tests {
             /// 1 - largest remainder: seat assigned to list 1
             /// 2 - Drawing of lots is required for lists: [2, 3, 4, 5, 6], only 1 seat available
             #[test]
-            fn test_with_0_remainders_drawing_of_lots_error() {
+            fn test_with_0_remainders_drawing_of_lots_required() {
                 let mut input = seat_assignment_fixture_with_default_50_candidates(
                     15,
                     vec![540, 160, 160, 80, 80, 80, 55, 45],
@@ -777,9 +777,18 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(
                         LargestRemainderResidualSeatDrawingLots {
-                            remainder: Fraction::new(0, 1),
                             residual_seat_numbers: vec![2],
                             options: vec![2, 3, 4, 5, 6],
+                            list_remainders: vec![
+                                (1, Fraction::new(60, 1)),
+                                (2, Fraction::new(0, 15)),
+                                (3, Fraction::new(0, 15)),
+                                (4, Fraction::new(0, 15)),
+                                (5, Fraction::new(0, 15)),
+                                (6, Fraction::new(0, 15)),
+                                (7, Fraction::new(55, 1)),
+                                (8, Fraction::new(45, 1)),
+                            ],
                         }
                     ),
                 );
@@ -841,7 +850,7 @@ pub(crate) mod tests {
             /// 1 - Drawing of lots is required for lists: [2, 3, 4, 5, 6], only 4 seats available
             /// 2 - Drawing of lots is required for lists: [2, 3, 5, 6], only 3 seats available
             #[test]
-            fn test_with_drawing_of_lots_error() {
+            fn test_with_drawing_of_lots_required() {
                 let mut input = seat_assignment_fixture_with_default_50_candidates(
                     15,
                     vec![500, 140, 140, 140, 140, 140],
@@ -855,9 +864,16 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(
                         LargestRemainderResidualSeatDrawingLots {
-                            remainder: Fraction::new(900, 15),
                             residual_seat_numbers: vec![1, 2, 3, 4],
-                            options: vec![2, 3, 4, 5, 6]
+                            options: vec![2, 3, 4, 5, 6],
+                            list_remainders: vec![
+                                (1, Fraction::new(500, 25)),
+                                (2, Fraction::new(420, 7)),
+                                (3, Fraction::new(420, 7)),
+                                (4, Fraction::new(420, 7)),
+                                (5, Fraction::new(420, 7)),
+                                (6, Fraction::new(420, 7)),
+                            ],
                         }
                     )
                 );
@@ -888,9 +904,16 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(
                         LargestRemainderResidualSeatDrawingLots {
-                            remainder: Fraction::new(900, 15),
                             residual_seat_numbers: vec![2, 3, 4],
-                            options: vec![2, 3, 5, 6]
+                            options: vec![2, 3, 5, 6],
+                            list_remainders: vec![
+                                (1, Fraction::new(500, 25)),
+                                (2, Fraction::new(420, 7)),
+                                (3, Fraction::new(420, 7)),
+                                (4, Fraction::new(420, 7)),
+                                (5, Fraction::new(420, 7)),
+                                (6, Fraction::new(420, 7)),
+                            ],
                         }
                     ),
                 );
@@ -1807,9 +1830,16 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
-                            average: Fraction::new(140, 3),
                             residual_seat_numbers: vec![2, 3, 4],
-                            options: vec![2, 3, 4, 5, 6]
+                            options: vec![2, 3, 4, 5, 6],
+                            list_averages: vec![
+                                (1, Fraction::new(500, 11)),
+                                (2, Fraction::new(140, 3)),
+                                (3, Fraction::new(140, 3)),
+                                (4, Fraction::new(140, 3)),
+                                (5, Fraction::new(140, 3)),
+                                (6, Fraction::new(140, 3)),
+                            ]
                         }
                     )
                 );
@@ -1841,9 +1871,16 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
-                            average: Fraction::new(140, 3),
                             residual_seat_numbers: vec![3, 4],
-                            options: vec![2, 3, 5, 6]
+                            options: vec![2, 3, 5, 6],
+                            list_averages: vec![
+                                (1, Fraction::new(500, 11)),
+                                (2, Fraction::new(140, 3)),
+                                (3, Fraction::new(140, 3)),
+                                (4, Fraction::new(140, 4)),
+                                (5, Fraction::new(140, 3)),
+                                (6, Fraction::new(140, 3)),
+                            ]
                         }
                     )
                 );
@@ -1885,9 +1922,14 @@ pub(crate) mod tests {
                     variant,
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
-                            average: Fraction::new(140, 4),
                             residual_seat_numbers: vec![2],
                             options: vec![2, 3, 4],
+                            list_averages: vec![
+                                (1, Fraction::new(500, 15)),
+                                (2, Fraction::new(140, 4)),
+                                (3, Fraction::new(140, 4)),
+                                (4, Fraction::new(140, 4)),
+                            ]
                         },
                     )
                 );

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -290,6 +290,7 @@ enum ListStandings<'a, LN> {
 #[expect(clippy::cognitive_complexity)]
 fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
+    list_averages: Vec<(LN, Fraction)>,
     available_residual_seats: u32,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
@@ -330,11 +331,11 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 
         let variant = ListDrawingLotsVariant::HighestAverageResidualSeat(
             HighestAverageResidualSeatDrawingLots {
-                average: max_average,
                 residual_seat_numbers: (residual_seat_number
                     ..residual_seat_number + available_residual_seats)
                     .collect(),
                 options: list_numbers(&lists),
+                list_averages,
             },
         );
 
@@ -378,6 +379,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 #[expect(clippy::cognitive_complexity)]
 fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     standings: impl Iterator<Item = &'a ListStanding<LN>>,
+    list_remainders: Vec<(LN, Fraction)>,
     available_residual_seats: u32,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
@@ -417,11 +419,11 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 
         let variant = ListDrawingLotsVariant::LargestRemainderResidualSeat(
             LargestRemainderResidualSeatDrawingLots {
-                remainder: max_remainder,
                 residual_seat_numbers: (residual_seat_number
                     ..residual_seat_number + available_residual_seats)
                     .collect(),
                 options: list_numbers(&lists),
+                list_remainders,
             },
         );
 
@@ -476,7 +478,7 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
         debug!("Assigning residual seat {residual_seat_number} using highest averages method");
         // [Artikel P 7 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf2_ArtikelP7)
         step_assign_remainder_using_highest_averages(
-            standings.iter(),
+            standings,
             residual_seats,
             previous_steps,
             exhausted_list_numbers,
@@ -497,81 +499,120 @@ fn step_assign_residual_seat<'a, 'b, LN: Copy + Debug + Eq>(
     }
 }
 
+/// Select the lists that qualify for the next highest averages residual seat.
+///
+/// When check_for_unique is true, every list that did not yet get a residual seat qualifies.
+/// If none qualify (or check_for_unique is false), falls back to every non-exhausted list with votes.
+/// The returned boolean indicates whether unique highest average assignment is used
+fn lists_qualifying_for_highest_average<'a, LN: Copy + Debug + Eq>(
+    standings: &'a [ListStanding<LN>],
+    previous_steps: &'a [SeatChangeStep<LN>],
+    exhausted_list_numbers: &[LN],
+    check_for_unique: bool,
+) -> (bool, Vec<&'a ListStanding<LN>>) {
+    let unique_qualifying_standings = if check_for_unique {
+        list_standings_qualifying_for_unique_highest_average(
+            standings,
+            previous_steps,
+            exhausted_list_numbers,
+        )
+        .collect()
+    } else {
+        vec![]
+    };
+
+    if !unique_qualifying_standings.is_empty() {
+        debug!("Assign residual seat using unique highest averages method");
+        (true, unique_qualifying_standings)
+    } else {
+        debug!("Assign residual seat using highest averages method");
+        let qualifying_standings = standings
+            .iter()
+            .filter(|&s| s.votes_cast() > 0 && !exhausted_list_numbers.contains(&s.list_number()))
+            .collect();
+        (false, qualifying_standings)
+    }
+}
+
 /// Assign the next residual seat, and return which group that seat was assigned to.
 ///
 /// This assignment is done according to the rules for elections with 19 seats or more.
 fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 'a>(
-    standings: impl Iterator<Item = &'a ListStanding<LN>>,
+    standings: &'a [ListStanding<LN>],
     residual_seats: u32,
     previous_steps: &[SeatChangeStep<LN>],
     exhausted_list_numbers: &[LN],
-    unique: bool,
+    check_for_unique: bool,
     residual_seat_number: u32,
     lists_drawn: &mut impl Iterator<Item = &'b (impl ListDrawn<LN> + 'b)>,
 ) -> Result<ResidualSeat<LN>, ApportionmentError> {
-    // Get an iterator that lists all the list standings without exhausted lists
-    // and without lists that have zero votes cast.
-    let mut qualifying_for_highest_average = standings
-        .into_iter()
-        .filter(|&s| s.votes_cast() > 0 && !exhausted_list_numbers.contains(&s.list_number()))
-        .peekable();
+    let (unique, qualifying) = lists_qualifying_for_highest_average(
+        standings,
+        previous_steps,
+        exhausted_list_numbers,
+        check_for_unique,
+    );
 
-    if qualifying_for_highest_average.peek().is_some() {
-        let (selected_list, list_options) = match lists_with_highest_average(
-            qualifying_for_highest_average,
-            residual_seats,
-            residual_seat_number,
-            lists_drawn,
-        )? {
-            ListStandings::Completed(lists) => {
-                let list_options = lists.iter().map(|list| list.list_number()).collect();
-                (lists[0], list_options)
-            }
-            ListStandings::CompletedWithDrawingLots(lists, variant) => {
-                let list_options = match variant {
-                    ListDrawingLotsVariant::HighestAverageResidualSeat(variant) => variant.options,
-                    _ => unreachable!("unexpected list drawing lots variant for highest average"),
-                };
-                (lists[0], list_options)
-            }
-            ListStandings::DrawingLotsRequired(variant) => {
-                return Ok(ResidualSeat::DrawingLotsRequired(variant));
-            }
-        };
-
-        let assigned_seat = HighestAverageAssignedSeat {
-            selected_list_number: selected_list.list_number(),
-            list_assigned: list_assigned_from_previous_step(
-                selected_list,
-                previous_steps,
-                if unique {
-                    SeatChange::is_changed_by_unique_highest_average_assignment
-                } else {
-                    SeatChange::is_changed_by_highest_average_assignment
-                },
-            ),
-            list_options,
-            list_exhausted: exhausted_list_numbers.to_vec(),
-            votes_per_seat: selected_list.next_votes_per_seat(),
-        };
-        if unique {
-            Ok(ResidualSeat::SeatChange(
-                SeatChange::UniqueHighestAverageAssignment(assigned_seat),
-            ))
-        } else {
-            Ok(ResidualSeat::SeatChange(
-                SeatChange::HighestAverageAssignment(assigned_seat),
-            ))
-        }
-    } else {
+    let mut qualifying_for_highest_average = qualifying.into_iter().peekable();
+    if qualifying_for_highest_average.peek().is_none() {
         // Unreachable: `assign_remainder` breaks the loop before this can be reached
         unreachable!("step_assign_remainder_using_highest_averages called with no eligible lists")
     }
+
+    // List averages of all standings
+    let list_averages = standings
+        .iter()
+        .map(|s| (s.list_number(), s.next_votes_per_seat()))
+        .collect();
+    let (selected_list, list_options) = match lists_with_highest_average(
+        qualifying_for_highest_average,
+        list_averages,
+        residual_seats,
+        residual_seat_number,
+        lists_drawn,
+    )? {
+        ListStandings::Completed(lists) => {
+            let list_options = lists.iter().map(|list| list.list_number()).collect();
+            (lists[0], list_options)
+        }
+        ListStandings::CompletedWithDrawingLots(lists, variant) => {
+            let list_options = match variant {
+                ListDrawingLotsVariant::HighestAverageResidualSeat(variant) => variant.options,
+                _ => unreachable!("unexpected list drawing lots variant for highest average"),
+            };
+            (lists[0], list_options)
+        }
+        ListStandings::DrawingLotsRequired(variant) => {
+            return Ok(ResidualSeat::DrawingLotsRequired(variant));
+        }
+    };
+
+    let assigned_seat = HighestAverageAssignedSeat {
+        selected_list_number: selected_list.list_number(),
+        list_assigned: list_assigned_from_previous_step(
+            selected_list,
+            previous_steps,
+            if unique {
+                SeatChange::is_changed_by_unique_highest_average_assignment
+            } else {
+                SeatChange::is_changed_by_highest_average_assignment
+            },
+        ),
+        list_options,
+        list_exhausted: exhausted_list_numbers.to_vec(),
+        votes_per_seat: selected_list.next_votes_per_seat(),
+    };
+
+    let change = if unique {
+        SeatChange::UniqueHighestAverageAssignment(assigned_seat)
+    } else {
+        SeatChange::HighestAverageAssignment(assigned_seat)
+    };
+    Ok(ResidualSeat::SeatChange(change))
 }
 
 /// Assign the next residual seat, and return which group that seat was assigned to.  
 /// This assignment is done according to the rules for elections with less than 19 seats.
-#[expect(clippy::cognitive_complexity, clippy::too_many_lines)]
 fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     standings: &'a [ListStanding<LN>],
     residual_seats: u32,
@@ -591,14 +632,20 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
     // If there is at least one element in the iterator, we know we can still do a largest remainder assignment
     if qualifying_for_remainder.peek().is_some() {
         debug!("Assign residual seat using largest remainders method");
+        // List remainders of all standings
+        let list_remainders = standings
+            .iter()
+            .map(|s| (s.list_number(), s.remainder_votes()))
+            .collect();
         let (selected_list, list_options) = match lists_with_largest_remainder(
             qualifying_for_remainder,
+            list_remainders,
             residual_seats,
             residual_seat_number,
             lists_drawn,
         )? {
             ListStandings::Completed(lists) => {
-                let list_options = lists.iter().map(|list| list.list_number()).collect();
+                let list_options = list_numbers(&lists);
                 (lists[0], list_options)
             }
             ListStandings::CompletedWithDrawingLots(lists, variant) => {
@@ -628,42 +675,19 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
             }),
         ))
     } else {
-        // We've now exhausted the largest remainder seats, we now do unique highest average instead:
-        // we allow every group to get a seat, not allowing any group to get a second residual seat
-        // while there are still lists that did not get a residual seat.
-        let mut qualifying_for_unique_highest_average =
-            list_standings_qualifying_for_unique_highest_average(
-                standings,
-                previous_steps,
-                exhausted_list_numbers,
-            )
-            .peekable();
-        if qualifying_for_unique_highest_average.peek().is_some() {
-            debug!("Assign residual seat using unique highest averages method");
-            step_assign_remainder_using_highest_averages(
-                qualifying_for_unique_highest_average,
-                residual_seats,
-                previous_steps,
-                exhausted_list_numbers,
-                true,
-                residual_seat_number,
-                lists_drawn,
-            )
-        } else {
-            // We've now even exhausted unique highest average seats: every group that qualified
-            // got a largest remainder seat, and every group also had at least a single residual seat
-            // assigned to them. We now allow any residual seats to be assigned using the highest
-            // averages procedure
-            debug!("Assign residual seat using highest averages method");
-            step_assign_remainder_using_highest_averages(
-                standings.iter(),
-                residual_seats,
-                previous_steps,
-                exhausted_list_numbers,
-                false,
-                residual_seat_number,
-                lists_drawn,
-            )
-        }
+        // We've now exhausted the largest remainder seats, we now do unique highest average instead
+        // Param check_for_unique is enabled, so we first assign seats to lists that did not yet
+        // get a residual seat assigned, and only if there are no such lists left, we assign seats
+        // to lists that already got a residual seat assigned.
+        debug!("Assign residual seat using unique highest averages method");
+        step_assign_remainder_using_highest_averages(
+            standings,
+            residual_seats,
+            previous_steps,
+            exhausted_list_numbers,
+            true,
+            residual_seat_number,
+            lists_drawn,
+        )
     }
 }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -571,10 +571,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
         residual_seat_number,
         lists_drawn,
     )? {
-        ListStandings::Completed(lists) => {
-            let list_options = lists.iter().map(|list| list.list_number()).collect();
-            (lists[0], list_options)
-        }
+        ListStandings::Completed(lists) => (lists[0], list_numbers(&lists)),
         ListStandings::CompletedWithDrawingLots(lists, variant) => {
             let list_options = match variant {
                 ListDrawingLotsVariant::HighestAverageResidualSeat(variant) => variant.options,
@@ -644,10 +641,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
             residual_seat_number,
             lists_drawn,
         )? {
-            ListStandings::Completed(lists) => {
-                let list_options = list_numbers(&lists);
-                (lists[0], list_options)
-            }
+            ListStandings::Completed(lists) => (lists[0], list_numbers(&lists)),
             ListStandings::CompletedWithDrawingLots(lists, variant) => {
                 let list_options = match variant {
                     ListDrawingLotsVariant::LargestRemainderResidualSeat(variant) => {

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -691,3 +691,133 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{CandidateVotesMock, ListVotesMock};
+
+    use super::*;
+
+    fn standing(list_number: u32, votes_cast: u32) -> ListStanding<u32> {
+        ListStanding::new(
+            &ListVotesMock {
+                number: list_number,
+                candidate_votes: vec![CandidateVotesMock {
+                    number: 1,
+                    votes: votes_cast,
+                }],
+            },
+            Fraction::new(100, 1),
+        )
+    }
+
+    fn unique_highest_average_step(list_number: u32) -> SeatChangeStep<u32> {
+        SeatChangeStep {
+            residual_seat_number: None,
+            standings: vec![],
+            change: SeatChange::UniqueHighestAverageAssignment(HighestAverageAssignedSeat {
+                selected_list_number: list_number,
+                list_options: vec![list_number],
+                list_assigned: vec![list_number],
+                list_exhausted: vec![],
+                votes_per_seat: Fraction::ZERO,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_lists_qualifying_for_highest_average() {
+        // Lists 1-3 have votes, list 4 has none (and should never qualify).
+        let standings = [
+            standing(1, 100),
+            standing(2, 80),
+            standing(3, 80),
+            standing(4, 0),
+        ];
+
+        struct Case {
+            description: &'static str,
+            check_for_unique: bool,
+            exhausted: Vec<u32>,
+            previous_steps: Vec<SeatChangeStep<u32>>,
+            expected_unique: bool,
+            expected_lists: Vec<u32>,
+        }
+
+        let cases = vec![
+            Case {
+                description: "regular method qualifies every list with votes",
+                check_for_unique: false,
+                exhausted: vec![],
+                previous_steps: vec![],
+                expected_unique: false,
+                expected_lists: vec![1, 2, 3],
+            },
+            Case {
+                description: "regular method excludes exhausted lists",
+                check_for_unique: false,
+                exhausted: vec![2],
+                previous_steps: vec![],
+                expected_unique: false,
+                expected_lists: vec![1, 3],
+            },
+            Case {
+                description: "unique method qualifies every list with votes when none got a seat",
+                check_for_unique: true,
+                exhausted: vec![],
+                previous_steps: vec![],
+                expected_unique: true,
+                expected_lists: vec![1, 2, 3],
+            },
+            Case {
+                description: "unique method excludes lists that already got a unique seat",
+                check_for_unique: true,
+                exhausted: vec![],
+                previous_steps: vec![unique_highest_average_step(1)],
+                expected_unique: true,
+                expected_lists: vec![2, 3],
+            },
+            Case {
+                description: "unique method also excludes exhausted lists",
+                check_for_unique: true,
+                exhausted: vec![3],
+                previous_steps: vec![unique_highest_average_step(1)],
+                expected_unique: true,
+                expected_lists: vec![2],
+            },
+            Case {
+                description: "falls back to regular method when every list got a unique seat",
+                check_for_unique: true,
+                exhausted: vec![],
+                previous_steps: vec![
+                    unique_highest_average_step(1),
+                    unique_highest_average_step(2),
+                    unique_highest_average_step(3),
+                ],
+                expected_unique: false,
+                expected_lists: vec![1, 2, 3],
+            },
+        ];
+
+        for case in cases {
+            let (unique, qualifying) = lists_qualifying_for_highest_average(
+                &standings,
+                &case.previous_steps,
+                &case.exhausted,
+                case.check_for_unique,
+            );
+
+            assert_eq!(
+                unique, case.expected_unique,
+                "unique flag: {}",
+                case.description
+            );
+            assert_eq!(
+                list_numbers(&qualifying),
+                case.expected_lists,
+                "qualifying lists: {}",
+                case.description
+            );
+        }
+    }
+}

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -331,6 +331,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
 
         let variant = ListDrawingLotsVariant::HighestAverageResidualSeat(
             HighestAverageResidualSeatDrawingLots {
+                max_average,
                 residual_seat_numbers: (residual_seat_number
                     ..residual_seat_number + available_residual_seats)
                     .collect(),
@@ -419,6 +420,7 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 
         let variant = ListDrawingLotsVariant::LargestRemainderResidualSeat(
             LargestRemainderResidualSeatDrawingLots {
+                max_remainder,
                 residual_seat_numbers: (residual_seat_number
                     ..residual_seat_number + available_residual_seats)
                     .collect(),
@@ -720,6 +722,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::too_many_lines)]
     fn test_lists_qualifying_for_highest_average() {
         // Lists 1-3 have votes, list 4 has none (and should never qualify).
         let standings = [

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -35,16 +35,16 @@ pub enum ListDrawingLotsVariant<LN> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HighestAverageResidualSeatDrawingLots<LN> {
-    pub average: Fraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<LN>,
+    pub list_averages: Vec<(LN, Fraction)>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LargestRemainderResidualSeatDrawingLots<LN> {
-    pub remainder: Fraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<LN>,
+    pub list_remainders: Vec<(LN, Fraction)>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -35,6 +35,7 @@ pub enum ListDrawingLotsVariant<LN> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HighestAverageResidualSeatDrawingLots<LN> {
+    pub max_average: Fraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<LN>,
     pub list_averages: Vec<(LN, Fraction)>,
@@ -42,6 +43,7 @@ pub struct HighestAverageResidualSeatDrawingLots<LN> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LargestRemainderResidualSeatDrawingLots<LN> {
+    pub max_remainder: Fraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<LN>,
     pub list_remainders: Vec<(LN, Fraction)>,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7489,13 +7489,50 @@
       "HighestAverageResidualSeatDrawingLots": {
         "type": "object",
         "required": [
-          "average",
           "residual_seat_numbers",
-          "options"
+          "options",
+          "list_averages"
         ],
         "properties": {
-          "average": {
-            "$ref": "#/components/schemas/DisplayFraction"
+          "list_averages": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                },
+                {
+                  "type": "object",
+                  "description": "Fraction with the integer part split out for display purposes",
+                  "required": [
+                    "integer",
+                    "numerator",
+                    "denominator"
+                  ],
+                  "properties": {
+                    "denominator": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    },
+                    "integer": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    },
+                    "numerator": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    }
+                  }
+                }
+              ]
+            }
           },
           "options": {
             "type": "array",
@@ -7663,19 +7700,56 @@
       "LargestRemainderResidualSeatDrawingLots": {
         "type": "object",
         "required": [
-          "remainder",
           "residual_seat_numbers",
-          "options"
+          "options",
+          "list_remainders"
         ],
         "properties": {
+          "list_remainders": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                },
+                {
+                  "type": "object",
+                  "description": "Fraction with the integer part split out for display purposes",
+                  "required": [
+                    "integer",
+                    "numerator",
+                    "denominator"
+                  ],
+                  "properties": {
+                    "denominator": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    },
+                    "integer": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    },
+                    "numerator": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    }
+                  }
+                }
+              ]
+            }
+          },
           "options": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PGNumber"
             }
-          },
-          "remainder": {
-            "$ref": "#/components/schemas/DisplayFraction"
           },
           "residual_seat_numbers": {
             "type": "array",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7489,6 +7489,7 @@
       "HighestAverageResidualSeatDrawingLots": {
         "type": "object",
         "required": [
+          "max_average",
           "residual_seat_numbers",
           "options",
           "list_averages"
@@ -7499,6 +7500,9 @@
             "items": {
               "$ref": "#/components/schemas/ListAverage"
             }
+          },
+          "max_average": {
+            "$ref": "#/components/schemas/DisplayFraction"
           },
           "options": {
             "type": "array",
@@ -7666,6 +7670,7 @@
       "LargestRemainderResidualSeatDrawingLots": {
         "type": "object",
         "required": [
+          "max_remainder",
           "residual_seat_numbers",
           "options",
           "list_remainders"
@@ -7676,6 +7681,9 @@
             "items": {
               "$ref": "#/components/schemas/ListRemainder"
             }
+          },
+          "max_remainder": {
+            "$ref": "#/components/schemas/DisplayFraction"
           },
           "options": {
             "type": "array",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7497,41 +7497,7 @@
           "list_averages": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": false,
-              "prefixItems": [
-                {
-                  "type": "integer",
-                  "format": "int32",
-                  "minimum": 0
-                },
-                {
-                  "type": "object",
-                  "description": "Fraction with the integer part split out for display purposes",
-                  "required": [
-                    "integer",
-                    "numerator",
-                    "denominator"
-                  ],
-                  "properties": {
-                    "denominator": {
-                      "type": "integer",
-                      "format": "int64",
-                      "minimum": 0
-                    },
-                    "integer": {
-                      "type": "integer",
-                      "format": "int64",
-                      "minimum": 0
-                    },
-                    "numerator": {
-                      "type": "integer",
-                      "format": "int64",
-                      "minimum": 0
-                    }
-                  }
-                }
-              ]
+              "$ref": "#/components/schemas/ListAverage"
             }
           },
           "options": {
@@ -7708,41 +7674,7 @@
           "list_remainders": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": false,
-              "prefixItems": [
-                {
-                  "type": "integer",
-                  "format": "int32",
-                  "minimum": 0
-                },
-                {
-                  "type": "object",
-                  "description": "Fraction with the integer part split out for display purposes",
-                  "required": [
-                    "integer",
-                    "numerator",
-                    "denominator"
-                  ],
-                  "properties": {
-                    "denominator": {
-                      "type": "integer",
-                      "format": "int64",
-                      "minimum": 0
-                    },
-                    "integer": {
-                      "type": "integer",
-                      "format": "int64",
-                      "minimum": 0
-                    },
-                    "numerator": {
-                      "type": "integer",
-                      "format": "int64",
-                      "minimum": 0
-                    }
-                  }
-                }
-              ]
+              "$ref": "#/components/schemas/ListRemainder"
             }
           },
           "options": {
@@ -7758,6 +7690,21 @@
               "format": "int32",
               "minimum": 0
             }
+          }
+        }
+      },
+      "ListAverage": {
+        "type": "object",
+        "required": [
+          "pg_number",
+          "average"
+        ],
+        "properties": {
+          "average": {
+            "$ref": "#/components/schemas/DisplayFraction"
+          },
+          "pg_number": {
+            "$ref": "#/components/schemas/PGNumber"
           }
         }
       },
@@ -7906,6 +7853,21 @@
           },
           "list_retracted_seat": {
             "$ref": "#/components/schemas/PGNumber"
+          }
+        }
+      },
+      "ListRemainder": {
+        "type": "object",
+        "required": [
+          "pg_number",
+          "remainder"
+        ],
+        "properties": {
+          "pg_number": {
+            "$ref": "#/components/schemas/PGNumber"
+          },
+          "remainder": {
+            "$ref": "#/components/schemas/DisplayFraction"
           }
         }
       },

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -108,28 +108,34 @@ impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNu
         match value {
             ListDrawingLotsVariant::HighestAverageResidualSeat(
                 HighestAverageResidualSeatDrawingLots {
-                    average,
                     residual_seat_numbers,
                     options,
+                    list_averages,
                 },
             ) => Self::HighestAverageResidualSeat(
                 apportionment::HighestAverageResidualSeatDrawingLots {
-                    average: average.into(),
                     residual_seat_numbers,
                     options,
+                    list_averages: list_averages
+                        .into_iter()
+                        .map(|(ln, avg)| (ln, avg.into()))
+                        .collect(),
                 },
             ),
             ListDrawingLotsVariant::LargestRemainderResidualSeat(
                 LargestRemainderResidualSeatDrawingLots {
-                    remainder,
                     residual_seat_numbers,
                     options,
+                    list_remainders,
                 },
             ) => Self::LargestRemainderResidualSeat(
                 apportionment::LargestRemainderResidualSeatDrawingLots {
-                    remainder: remainder.into(),
                     residual_seat_numbers,
                     options,
+                    list_remainders: list_remainders
+                        .into_iter()
+                        .map(|(ln, rem)| (ln, rem.into()))
+                        .collect(),
                 },
             ),
             ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots { options }) => {

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -8,7 +8,8 @@ use crate::domain::{
     apportionment::{
         AbsoluteMajorityDrawingLots, ApportionmentWarning, CandidateDrawingLotsVariant,
         CandidateDrawn, CandidateNomination, HighestAverageResidualSeatDrawingLots,
-        LargestRemainderResidualSeatDrawingLots, ListDrawingLotsVariant, ListDrawn, SeatAssignment,
+        LargestRemainderResidualSeatDrawingLots, ListAverage, ListDrawingLotsVariant, ListDrawn,
+        ListRemainder, SeatAssignment,
     },
     apportionment_state::DeceasedCandidate,
     election::{CandidateNumber, PGNumber},
@@ -118,7 +119,7 @@ impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNu
                     options,
                     list_averages: list_averages
                         .into_iter()
-                        .map(|(ln, avg)| (ln, avg.into()))
+                        .map(|ListAverage { pg_number, average }| (pg_number, average.into()))
                         .collect(),
                 },
             ),
@@ -134,7 +135,12 @@ impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNu
                     options,
                     list_remainders: list_remainders
                         .into_iter()
-                        .map(|(ln, rem)| (ln, rem.into()))
+                        .map(
+                            |ListRemainder {
+                                 pg_number,
+                                 remainder,
+                             }| (pg_number, remainder.into()),
+                        )
                         .collect(),
                 },
             ),

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -109,12 +109,14 @@ impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNu
         match value {
             ListDrawingLotsVariant::HighestAverageResidualSeat(
                 HighestAverageResidualSeatDrawingLots {
+                    max_average,
                     residual_seat_numbers,
                     options,
                     list_averages,
                 },
             ) => Self::HighestAverageResidualSeat(
                 apportionment::HighestAverageResidualSeatDrawingLots {
+                    max_average: max_average.into(),
                     residual_seat_numbers,
                     options,
                     list_averages: list_averages
@@ -125,12 +127,14 @@ impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNu
             ),
             ListDrawingLotsVariant::LargestRemainderResidualSeat(
                 LargestRemainderResidualSeatDrawingLots {
+                    max_remainder,
                     residual_seat_numbers,
                     options,
                     list_remainders,
                 },
             ) => Self::LargestRemainderResidualSeat(
                 apportionment::LargestRemainderResidualSeatDrawingLots {
+                    max_remainder: max_remainder.into(),
                     residual_seat_numbers,
                     options,
                     list_remainders: list_remainders

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -334,6 +334,7 @@ pub enum ListDrawingLotsVariant {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct HighestAverageResidualSeatDrawingLots {
+    pub max_average: DisplayFraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<PGNumber>,
     pub list_averages: Vec<ListAverage>,
@@ -347,6 +348,7 @@ pub struct ListAverage {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct LargestRemainderResidualSeatDrawingLots {
+    pub max_remainder: DisplayFraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<PGNumber>,
     pub list_remainders: Vec<ListRemainder>,

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -336,14 +336,26 @@ pub enum ListDrawingLotsVariant {
 pub struct HighestAverageResidualSeatDrawingLots {
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<PGNumber>,
-    pub list_averages: Vec<(PGNumber, DisplayFraction)>,
+    pub list_averages: Vec<ListAverage>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+pub struct ListAverage {
+    pub pg_number: PGNumber,
+    pub average: DisplayFraction,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct LargestRemainderResidualSeatDrawingLots {
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<PGNumber>,
-    pub list_remainders: Vec<(PGNumber, DisplayFraction)>,
+    pub list_remainders: Vec<ListRemainder>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+pub struct ListRemainder {
+    pub pg_number: PGNumber,
+    pub remainder: DisplayFraction,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -334,16 +334,16 @@ pub enum ListDrawingLotsVariant {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct HighestAverageResidualSeatDrawingLots {
-    pub average: DisplayFraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<PGNumber>,
+    pub list_averages: Vec<(PGNumber, DisplayFraction)>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct LargestRemainderResidualSeatDrawingLots {
-    pub remainder: DisplayFraction,
     pub residual_seat_numbers: Vec<u32>,
     pub options: Vec<PGNumber>,
+    pub list_remainders: Vec<(PGNumber, DisplayFraction)>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -56,8 +56,7 @@ mod tests {
     use crate::domain::{
         apportionment::{
             AbsoluteMajorityDrawingLots, CandidateDrawingLotsVariant, CandidateDrawn,
-            DisplayFraction, HighestAverageResidualSeatDrawingLots, ListDrawingLotsVariant,
-            ListDrawn,
+            HighestAverageResidualSeatDrawingLots, ListDrawingLotsVariant, ListDrawn,
         },
         apportionment_state::{DeceasedCandidate, DrawingLotsRequired},
         election::{CandidateNumber, PGNumber},
@@ -83,13 +82,9 @@ mod tests {
                 drawing_lots_required: DrawingLotsRequired::ListDrawingLotsRequired(
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
-                            average: DisplayFraction {
-                                integer: 0,
-                                numerator: 1,
-                                denominator: 2,
-                            },
                             residual_seat_numbers: vec![1],
                             options: PGNumber::from_values(vec![1, 2, 3]),
+                            list_averages: vec![],
                         },
                     ),
                 ),

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -56,7 +56,8 @@ mod tests {
     use crate::domain::{
         apportionment::{
             AbsoluteMajorityDrawingLots, CandidateDrawingLotsVariant, CandidateDrawn,
-            HighestAverageResidualSeatDrawingLots, ListDrawingLotsVariant, ListDrawn,
+            DisplayFraction, HighestAverageResidualSeatDrawingLots, ListDrawingLotsVariant,
+            ListDrawn,
         },
         apportionment_state::{DeceasedCandidate, DrawingLotsRequired},
         election::{CandidateNumber, PGNumber},
@@ -82,6 +83,11 @@ mod tests {
                 drawing_lots_required: DrawingLotsRequired::ListDrawingLotsRequired(
                     ListDrawingLotsVariant::HighestAverageResidualSeat(
                         HighestAverageResidualSeatDrawingLots {
+                            max_average: DisplayFraction {
+                                integer: 0,
+                                numerator: 1,
+                                denominator: 2,
+                            },
                             residual_seat_numbers: vec![1],
                             options: PGNumber::from_values(vec![1, 2, 3]),
                             list_averages: vec![],

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -135,12 +135,14 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
         match value {
             apportionment::ListDrawingLotsVariant::HighestAverageResidualSeat(
                 apportionment::HighestAverageResidualSeatDrawingLots {
+                    max_average,
                     residual_seat_numbers,
                     options,
                     list_averages,
                 },
             ) => ListDrawingLotsVariant::HighestAverageResidualSeat(
                 HighestAverageResidualSeatDrawingLots {
+                    max_average: max_average.into(),
                     residual_seat_numbers,
                     options,
                     list_averages: list_averages
@@ -154,12 +156,14 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
             ),
             apportionment::ListDrawingLotsVariant::LargestRemainderResidualSeat(
                 apportionment::LargestRemainderResidualSeatDrawingLots {
+                    max_remainder,
                     residual_seat_numbers,
                     options,
                     list_remainders,
                 },
             ) => ListDrawingLotsVariant::LargestRemainderResidualSeat(
                 LargestRemainderResidualSeatDrawingLots {
+                    max_remainder: max_remainder.into(),
                     residual_seat_numbers,
                     options,
                     list_remainders: list_remainders

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -12,7 +12,7 @@ use crate::{
         apportionment::{
             AbsoluteMajorityDrawingLots, ApportionmentWarning, CandidateDrawingLotsVariant,
             HighestAverageResidualSeatDrawingLots, LargestRemainderResidualSeatDrawingLots,
-            ListDrawingLotsVariant, SeatAssignment,
+            ListAverage, ListDrawingLotsVariant, ListRemainder, SeatAssignment,
         },
         apportionment_state::{ApportionmentState, ApportionmentStateError, DrawingLotsRequired},
         committee_session::CommitteeSessionId,
@@ -145,7 +145,10 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
                     options,
                     list_averages: list_averages
                         .into_iter()
-                        .map(|(ln, avg)| (ln, avg.into()))
+                        .map(|(ln, avg)| ListAverage {
+                            pg_number: ln,
+                            average: avg.into(),
+                        })
                         .collect(),
                 },
             ),
@@ -161,7 +164,10 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
                     options,
                     list_remainders: list_remainders
                         .into_iter()
-                        .map(|(ln, rem)| (ln, rem.into()))
+                        .map(|(ln, rem)| ListRemainder {
+                            pg_number: ln,
+                            remainder: rem.into(),
+                        })
                         .collect(),
                 },
             ),

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -135,28 +135,34 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
         match value {
             apportionment::ListDrawingLotsVariant::HighestAverageResidualSeat(
                 apportionment::HighestAverageResidualSeatDrawingLots {
-                    average,
                     residual_seat_numbers,
                     options,
+                    list_averages,
                 },
             ) => ListDrawingLotsVariant::HighestAverageResidualSeat(
                 HighestAverageResidualSeatDrawingLots {
-                    average: average.into(),
                     residual_seat_numbers,
                     options,
+                    list_averages: list_averages
+                        .into_iter()
+                        .map(|(ln, avg)| (ln, avg.into()))
+                        .collect(),
                 },
             ),
             apportionment::ListDrawingLotsVariant::LargestRemainderResidualSeat(
                 apportionment::LargestRemainderResidualSeatDrawingLots {
-                    remainder,
                     residual_seat_numbers,
                     options,
+                    list_remainders,
                 },
             ) => ListDrawingLotsVariant::LargestRemainderResidualSeat(
                 LargestRemainderResidualSeatDrawingLots {
-                    remainder: remainder.into(),
                     residual_seat_numbers,
                     options,
+                    list_remainders: list_remainders
+                        .into_iter()
+                        .map(|(ln, rem)| (ln, rem.into()))
+                        .collect(),
                 },
             ),
             apportionment::ListDrawingLotsVariant::AbsoluteMajority(

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1175,6 +1175,7 @@ export interface HighestAverageAssignedSeat {
 
 export interface HighestAverageResidualSeatDrawingLots {
   list_averages: ListAverage[];
+  max_average: DisplayFraction;
   options: PGNumber[];
   residual_seat_numbers: number[];
 }
@@ -1214,6 +1215,7 @@ export interface LargestRemainderAssignedSeat {
 
 export interface LargestRemainderResidualSeatDrawingLots {
   list_remainders: ListRemainder[];
+  max_remainder: DisplayFraction;
   options: PGNumber[];
   residual_seat_numbers: number[];
 }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1174,7 +1174,7 @@ export interface HighestAverageAssignedSeat {
 }
 
 export interface HighestAverageResidualSeatDrawingLots {
-  list_averages: unknown[][];
+  list_averages: ListAverage[];
   options: PGNumber[];
   residual_seat_numbers: number[];
 }
@@ -1213,9 +1213,14 @@ export interface LargestRemainderAssignedSeat {
 }
 
 export interface LargestRemainderResidualSeatDrawingLots {
-  list_remainders: unknown[][];
+  list_remainders: ListRemainder[];
   options: PGNumber[];
   residual_seat_numbers: number[];
+}
+
+export interface ListAverage {
+  average: DisplayFraction;
+  pg_number: PGNumber;
 }
 
 export interface ListCandidateNomination {
@@ -1245,6 +1250,11 @@ export interface ListDrawn {
 export interface ListExhaustionRemovedSeat {
   full_seat: boolean;
   list_retracted_seat: PGNumber;
+}
+
+export interface ListRemainder {
+  pg_number: PGNumber;
+  remainder: DisplayFraction;
 }
 
 export interface ListSeatAssignment {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1174,7 +1174,7 @@ export interface HighestAverageAssignedSeat {
 }
 
 export interface HighestAverageResidualSeatDrawingLots {
-  average: DisplayFraction;
+  list_averages: unknown[][];
   options: PGNumber[];
   residual_seat_numbers: number[];
 }
@@ -1213,8 +1213,8 @@ export interface LargestRemainderAssignedSeat {
 }
 
 export interface LargestRemainderResidualSeatDrawingLots {
+  list_remainders: unknown[][];
   options: PGNumber[];
-  remainder: DisplayFraction;
   residual_seat_numbers: number[];
 }
 


### PR DESCRIPTION
## What & why

Related issue https://github.com/kiesraad/abacus/issues/3408

Changes:
- `HighestAverageResidualSeatDrawingLots`: 
  - Field `average` renamed to `max_average`.  
  - Field `list_averages` added with the `next_votes_per_seat` value for every list. 
- `LargestRemainderResidualSeatDrawingLots`: 
  - Field `remainder` renamed to `max_remainder`.
  - Field `list_remainders` added with the `remainder_votes` value for every list.

Since `list_standings_qualifying_for_unique_highest_average` in some cases only received qualified standings, the filter logic to do this has been moved inside the function. This way we full list of standings can be used to compile `list_averages`. 

The logic whether to qualify for unique highest averages or regular highest averages has been extracted to a separate function called `lists_qualifying_for_highest_average`. This method now also has its own testcases.

## How to test

Testcases should cover this change, however you can manually see the added `list_averages`/`list_remainders`:
1. Generating test elections through `Genereer meerdere verkiezingen met verschillende vormen van loting`
2. Login as `Coordinator CSB` and choose a variant, click on `Zetelverdeling`
3. Mark no deceased candidates and continue
4. Check the apportionment state response in your webdev toolbar, `drawing_lots_required` should contain `list_averages`/`list_remainders`.

## Reviewer notes

Review per commit.