### PR TITLE
Resolve mutation in list_qualifies_for_extra_seat

### DIFF
--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -806,7 +806,6 @@ mod tests {
                 "qualifying lists: {}",
                 case.description
             );
-            
         }
     }
     use crate::seat_assignment::AbsoluteMajorityReassignedSeat;

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -806,13 +806,9 @@ mod tests {
                 "qualifying lists: {}",
                 case.description
             );
+            
         }
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
     use crate::seat_assignment::AbsoluteMajorityReassignedSeat;
 
     /// A list whose seat was retracted via absolute majority reassignment should still qualify for reassignment.
@@ -826,6 +822,7 @@ mod tests {
             change: SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
                 list_retracted_seat: RETRACTED_LIST,
                 list_assigned_seat: ASSIGNED_LIST,
+                drawing_lots: None,
             }),
             standings: vec![],
         };

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -667,3 +667,25 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_qualifies_for_extra_seat() {
+        use crate::seat_assignment::AbsoluteMajorityReassignedSeat;
+
+        let previous_steps = SeatChangeStep {
+            residual_seat_number: None,
+            change: SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                list_retracted_seat: 1,
+                list_assigned_seat: 2,
+            }),
+            standings: vec![],
+        };
+
+        let boolean = list_qualifies_for_extra_seat(0, Some(1), &[previous_steps], 1u32);
+        assert_eq!(boolean, true);
+    }
+}

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -671,20 +671,28 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::seat_assignment::AbsoluteMajorityReassignedSeat;
 
+    /// A list whose seat was retracted via absolute majority reassignment should still qualify for reassignment.
     #[test]
-    fn test_list_qualifies_for_extra_seat() {
-        use crate::seat_assignment::AbsoluteMajorityReassignedSeat;
+    fn test_reassignment_allowed_after_seat_was_retracted() {
+        const LIST_UNDER_TEST: u32 = 1;
+        const OTHER_LIST: u32 = 2;
 
         let previous_steps = SeatChangeStep {
             residual_seat_number: None,
             change: SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
-                list_retracted_seat: 1,
-                list_assigned_seat: 2,
+                list_retracted_seat: LIST_UNDER_TEST,
+                list_assigned_seat: OTHER_LIST,
             }),
             standings: vec![],
         };
 
-        assert!(list_qualifies_for_extra_seat(0, Some(1), &[previous_steps], 1u32));
+        assert!(list_qualifies_for_extra_seat(
+            0,
+            Some(1),
+            &[previous_steps],
+            1u32
+        ))
     }
 }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -685,7 +685,6 @@ mod tests {
             standings: vec![],
         };
 
-        let boolean = list_qualifies_for_extra_seat(0, Some(1), &[previous_steps], 1u32);
-        assert_eq!(boolean, true);
+        assert!(list_qualifies_for_extra_seat(0, Some(1), &[previous_steps], 1u32));
     }
 }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -676,14 +676,14 @@ mod tests {
     /// A list whose seat was retracted via absolute majority reassignment should still qualify for reassignment.
     #[test]
     fn test_reassignment_allowed_after_seat_was_retracted() {
-        const LIST_UNDER_TEST: u32 = 1;
-        const OTHER_LIST: u32 = 2;
+        const RETRACTED_LIST: u32 = 1;
+        const ASSIGNED_LIST: u32 = 2;
 
         let previous_steps = SeatChangeStep {
             residual_seat_number: None,
             change: SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
-                list_retracted_seat: LIST_UNDER_TEST,
-                list_assigned_seat: OTHER_LIST,
+                list_retracted_seat: RETRACTED_LIST,
+                list_assigned_seat: ASSIGNED_LIST,
             }),
             standings: vec![],
         };

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -692,7 +692,7 @@ mod tests {
             0,
             Some(1),
             &[previous_steps],
-            1u32
+            RETRACTED_LIST
         ))
     }
 }


### PR DESCRIPTION
## What & why

Kills a surviving mutation on `list_qualifies_for_extra_seat` The mutant changes `==` to `!=` on line 202 of `backend/apportionment/src/seat_assignment/residual_seat_assignment.rs` making it impossible for a seat to be reassigned to a list that had a seat assigned to it and which then was retracted.
Now if anyone accidentally makes this change in the future, this unit test will flag it by failing.

closes #3446
closes #3355 

## Reviewer notes

`list_qualifies_for_extra_seat(0, Some(1), &[previous_steps], 1u32)`, 
where
`number_of_seats_largest_remainders = 0`,
`number_of_seats_unique_highest_averages = Some(1)`, 
and `previous_steps` makes sure `has_retracted_seat = true`,

is the unique combination that makes

`(has_retracted_seat
                && number_of_seats_unique_highest_averages == 1
                && number_of_seats_largest_remainders <= 1)`

at line 202 of `residual_seat_assignment.rs` return true.

