### PR TITLE
Use secure cookies when TLS is enabled

### DIFF
--- a/backend/src/api/authentication.rs
+++ b/backend/src/api/authentication.rs
@@ -529,7 +529,8 @@ mod tests {
 
         assert_eq!(cookie.path().unwrap(), "/");
         assert!(cookie.http_only().unwrap());
-        assert_eq!(cookie.secure().unwrap(), SECURE_COOKIES);
+        // Secure flag is set when serving over HTTPS (`tls` feature)
+        assert_eq!(cookie.secure().unwrap(), cfg!(feature = "tls"));
         assert_eq!(cookie.same_site().unwrap(), SameSite::Strict);
     }
 

--- a/backend/src/api/middleware/authentication/mod.rs
+++ b/backend/src/api/middleware/authentication/mod.rs
@@ -22,8 +22,8 @@ pub const SECURITY_SCHEME_NAME: &str = "cookie_auth";
 /// Session cookie name
 pub const SESSION_COOKIE_NAME: &str = "ABACUS_SESSION";
 
-/// Only send cookies over a secure (https) connection
-pub const SECURE_COOKIES: bool = false;
+/// Only send cookies over a secure (HTTPS) connection when the `tls` feature is enabled
+pub const SECURE_COOKIES: bool = cfg!(feature = "tls");
 
 /// Do not extend session header, only its existence is checked, not the value
 pub const DO_NOT_EXTEND_SESSION_HEADER: &str = "x-do-not-extend-session";
@@ -105,9 +105,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        assert!(response.headers().get("set-cookie").is_some());
 
-        response.headers().get("set-cookie").unwrap().clone()
+        let set_cookie = response.headers().get("set-cookie").unwrap().clone();
+        let value = set_cookie.to_str().unwrap();
+        // Secure flag is set when serving over HTTPS (`tls` feature)
+        #[cfg(feature = "tls")]
+        assert!(
+            value.contains("Secure"),
+            "Set-Cookie missing Secure: {value}"
+        );
+        #[cfg(not(feature = "tls"))]
+        assert!(
+            !value.contains("Secure"),
+            "Set-Cookie unexpectedly Secure: {value}"
+        );
+
+        set_cookie
     }
 
     #[test(sqlx::test(fixtures("../../../../fixtures/users.sql")))]


### PR DESCRIPTION
## What & why

Use secure cookies when TLS is enabled. Resolves #2928.

## How to test

From a terminal:
```shell
cargo run --features tls -- --seed-data
# and in another terminal
curl --cacert tls/ca.pem -i -X POST https://localhost:8443/api/login \
  -H 'Content-Type: application/json' \
  -d '{"username":"admin1","password":"Admin1Password01"}' | grep set-cookie
```

Or build frontend, run `cargo run --features memory-serve,tls`, then trust `tls/ca.pem` / `tls/ca.cer` in your browser and go to https://localhost:8443/. Then log in and use your browser's devtools to inspect the cookies and the secure flag.

## Reviewer notes

None.