### PR TITLE
Enforce session uniqueness in database

### DIFF
--- a/backend/migrations/5_sessions.sql
+++ b/backend/migrations/5_sessions.sql
@@ -1,7 +1,7 @@
 CREATE TABLE sessions
 (
     session_key        TEXT                 PRIMARY KEY NOT NULL,
-    user_id            INTEGER              NOT NULL,
+    user_id            INTEGER              NOT NULL UNIQUE,
     user_agent         TEXT                 NOT NULL,
     ip_address         TEXT                 NOT NULL,
     expires_at         TEXT                 NOT NULL,

--- a/backend/src/api/middleware/authentication/middleware.rs
+++ b/backend/src/api/middleware/authentication/middleware.rs
@@ -267,6 +267,11 @@ mod test {
             "extend_session should return the current expiration time"
         );
 
+        // remove the previous session before creating a new one for the same user
+        session_repo::delete(&mut conn, session.session_key())
+            .await
+            .unwrap();
+
         let life_time = SESSION_MIN_LIFE_TIME - TimeDelta::seconds(30); // min life time - 30 seconds
         let session = Session::create(
             user.id(),

--- a/backend/src/api/middleware/authentication/mod.rs
+++ b/backend/src/api/middleware/authentication/mod.rs
@@ -628,6 +628,11 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers().get("set-cookie"), None);
 
+        // remove the previous session before creating a new one for the same user
+        session_repo::delete(&mut conn, session.session_key())
+            .await
+            .unwrap();
+
         // with a session that is about to expire the user should get a new cookie, and the session lifetime should be extended
         let session = Session::create(
             UserId::from(1),

--- a/backend/src/repository/session_repo.rs
+++ b/backend/src/repository/session_repo.rs
@@ -242,6 +242,8 @@ pub(crate) async fn extend_session(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use chrono::TimeDelta;
     use sqlx::SqlitePool;
     use test_log::test;
@@ -299,6 +301,33 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
+    async fn test_session_user_id_is_unique(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let session = Session::create(
+            UserId::from(1),
+            TEST_USER_AGENT,
+            TEST_IP_ADDRESS,
+            TimeDelta::seconds(60),
+        );
+        save(&mut conn, &session).await.unwrap();
+
+        // A second session for the same user violates the UNIQUE constraint on user_id
+        let other_session = Session::create(
+            UserId::from(1),
+            TEST_USER_AGENT,
+            TEST_IP_ADDRESS,
+            TimeDelta::seconds(60),
+        );
+        let result = save(&mut conn, &other_session).await;
+
+        assert_matches!(
+            result,
+            Err(sqlx::Error::Database(e)) if e.is_unique_violation(),
+            "expected a unique constraint violation on sessions.user_id"
+        );
+    }
+
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_delete_old_sessions(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
         let session = Session::create(
@@ -338,7 +367,7 @@ mod tests {
         save(&mut conn, &active_session2).await.unwrap();
 
         let expired_session = Session::create(
-            UserId::from(2),
+            UserId::from(3),
             TEST_USER_AGENT,
             TEST_IP_ADDRESS,
             TimeDelta::seconds(0),


### PR DESCRIPTION
## What & why

Enforce session uniqueness in database, resolves #3443. We discussed adding a database constraint when we implemented a single session per user (https://github.com/kiesraad/abacus/pull/2607#issuecomment-3636813041) but never implemented it. I don't think we need explicit error handling for a very unlikely race condition.

## How to test

See unit tests. No functional changes.

## Reviewer notes

None.