### PR TITLE
Reflect drawing lots in SeatChangeStep

### DIFF
--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -831,6 +831,7 @@ pub(crate) mod tests {
                         list_options: vec![1],
                         list_assigned: vec![1],
                         remainder_votes: Fraction::new(900, 15),
+                        drawing_lots: None,
                     })
                 );
                 assert_eq!(
@@ -840,6 +841,23 @@ pub(crate) mod tests {
                         list_options: vec![2, 3, 4, 5, 6],
                         list_assigned: vec![6],
                         remainder_votes: Fraction::new(0, 15),
+                        drawing_lots: Some(ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                            LargestRemainderResidualSeatDrawingLots {
+                                max_remainder: Fraction::new(0, 1),
+                                residual_seat_numbers: vec![2],
+                                options: vec![2, 3, 4, 5, 6],
+                                list_remainders: vec![
+                                    (1, Fraction::new(60, 1)),
+                                    (2, Fraction::new(0, 1)),
+                                    (3, Fraction::new(0, 1)),
+                                    (4, Fraction::new(0, 1)),
+                                    (5, Fraction::new(0, 1)),
+                                    (6, Fraction::new(0, 1)),
+                                    (7, Fraction::new(55, 1)),
+                                    (8, Fraction::new(45, 1)),
+                                ]
+                            }
+                        )),
                     })
                 );
             }
@@ -1973,6 +1991,7 @@ pub(crate) mod tests {
                         list_assigned: vec![1],
                         list_exhausted: vec![],
                         votes_per_seat: Fraction::new(500, 14),
+                        drawing_lots: None,
                     })
                 );
                 assert_eq!(
@@ -1983,6 +2002,19 @@ pub(crate) mod tests {
                         list_assigned: vec![3],
                         list_exhausted: vec![],
                         votes_per_seat: Fraction::new(140, 4),
+                        drawing_lots: Some(ListDrawingLotsVariant::HighestAverageResidualSeat(
+                            HighestAverageResidualSeatDrawingLots {
+                                max_average: Fraction::new(35, 1),
+                                residual_seat_numbers: vec![2],
+                                options: vec![2, 3, 4],
+                                list_averages: vec![
+                                    (1, Fraction::new(500, 15)),
+                                    (2, Fraction::new(140, 4)),
+                                    (3, Fraction::new(140, 4)),
+                                    (4, Fraction::new(140, 4)),
+                                ]
+                            }
+                        )),
                     })
                 );
             }

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -295,16 +295,15 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
     let list_seats = Fraction::from(standing_of_list_with_majority_votes.total_seats());
 
     if list_seats <= half_of_seats_count {
+        let variant = ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+            options: lists_last_residual_seat.to_vec(),
+        });
         if lists_last_residual_seat.len() > 1 {
             info!(
                 "Drawing of lots is required for lists: {:?} to pick a list which the residual seat gets retracted from",
                 lists_last_residual_seat
             );
-            return Ok(AbsoluteMajority::DrawingLotsRequired(
-                ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                    options: lists_last_residual_seat.to_vec(),
-                }),
-            ));
+            return Ok(AbsoluteMajority::DrawingLotsRequired(variant));
         }
 
         // Reassign the seat
@@ -333,6 +332,7 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
                 AbsoluteMajorityReassignedSeat {
                     list_retracted_seat: lists_last_residual_seat[0],
                     list_assigned_seat: majority_list_votes.number(),
+                    drawing_lots: Some(variant),
                 },
             )),
         ))

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -684,7 +684,6 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 mod tests {
     use super::*;
     use crate::test_helpers::{CandidateVotesMock, ListVotesMock};
-
     fn standing(list_number: u32, votes_cast: u32) -> ListStanding<u32> {
         ListStanding::new(
             &ListVotesMock {
@@ -708,6 +707,7 @@ mod tests {
                 list_assigned: vec![list_number],
                 list_exhausted: vec![],
                 votes_per_seat: Fraction::ZERO,
+                drawing_lots: None,
             }),
         }
     }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -566,20 +566,16 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
         .iter()
         .map(|s| (s.list_number(), s.next_votes_per_seat()))
         .collect();
-    let (selected_list, list_options) = match lists_with_highest_average(
+    let (selected_list, list_options, drawing_lots) = match lists_with_highest_average(
         qualifying_for_highest_average,
         list_averages,
         residual_seats,
         residual_seat_number,
         lists_drawn,
     )? {
-        ListStandings::Completed(lists) => (lists[0], list_numbers(&lists)),
+        ListStandings::Completed(lists) => (lists[0], list_numbers(&lists), None),
         ListStandings::CompletedWithDrawingLots(lists, variant) => {
-            let list_options = match variant {
-                ListDrawingLotsVariant::HighestAverageResidualSeat(variant) => variant.options,
-                _ => unreachable!("unexpected list drawing lots variant for highest average"),
-            };
-            (lists[0], list_options)
+            (lists[0], variant.options().to_vec(), Some(variant))
         }
         ListStandings::DrawingLotsRequired(variant) => {
             return Ok(ResidualSeat::DrawingLotsRequired(variant));
@@ -600,6 +596,7 @@ fn step_assign_remainder_using_highest_averages<'a, 'b, LN: Copy + Debug + Eq + 
         list_options,
         list_exhausted: exhausted_list_numbers.to_vec(),
         votes_per_seat: selected_list.next_votes_per_seat(),
+        drawing_lots,
     };
 
     let change = if unique {
@@ -636,22 +633,16 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
             .iter()
             .map(|s| (s.list_number(), s.remainder_votes()))
             .collect();
-        let (selected_list, list_options) = match lists_with_largest_remainder(
+        let (selected_list, list_options, drawing_lots) = match lists_with_largest_remainder(
             qualifying_for_remainder,
             list_remainders,
             residual_seats,
             residual_seat_number,
             lists_drawn,
         )? {
-            ListStandings::Completed(lists) => (lists[0], list_numbers(&lists)),
+            ListStandings::Completed(lists) => (lists[0], list_numbers(&lists), None),
             ListStandings::CompletedWithDrawingLots(lists, variant) => {
-                let list_options = match variant {
-                    ListDrawingLotsVariant::LargestRemainderResidualSeat(variant) => {
-                        variant.options
-                    }
-                    _ => unreachable!("unexpected list drawing lots variant for largest remainder"),
-                };
-                (lists[0], list_options)
+                (lists[0], variant.options().to_vec(), Some(variant))
             }
             ListStandings::DrawingLotsRequired(variant) => {
                 return Ok(ResidualSeat::DrawingLotsRequired(variant));
@@ -668,6 +659,7 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
                 ),
                 list_options,
                 remainder_votes: selected_list.remainder_votes(),
+                drawing_lots,
             }),
         ))
     } else {
@@ -690,9 +682,8 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::{CandidateVotesMock, ListVotesMock};
-
     use super::*;
+    use crate::test_helpers::{CandidateVotesMock, ListVotesMock};
 
     fn standing(list_number: u32, votes_cast: u32) -> ListStanding<u32> {
         ListStanding::new(

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -190,8 +190,8 @@ impl<LN> ListStanding<LN> {
     }
 }
 
-/// Records the change for a specific seat, and how the standing is once
-/// that seat was assigned or removed
+/// Records the change for a specific seat and how the standing were
+/// before that change was applied
 #[derive(Clone, Debug, PartialEq)]
 pub struct SeatChangeStep<LN> {
     pub residual_seat_number: Option<u32>,

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -319,6 +319,8 @@ pub struct HighestAverageAssignedSeat<LN> {
     pub list_exhausted: Vec<LN>,
     /// This is the votes per seat achieved by the selected list
     pub votes_per_seat: Fraction,
+    /// Details for drawing lots if required
+    pub drawing_lots: Option<ListDrawingLotsVariant<LN>>,
 }
 
 /// Contains the details for an assigned seat, assigned through the largest remainder method.
@@ -332,6 +334,8 @@ pub struct LargestRemainderAssignedSeat<LN> {
     pub list_assigned: Vec<LN>,
     /// The number of remainder votes achieved by the selected list
     pub remainder_votes: Fraction,
+    /// Details for drawing lots if required
+    pub drawing_lots: Option<ListDrawingLotsVariant<LN>>,
 }
 
 /// Contains information about the enactment of article P 9 of the Kieswet.
@@ -341,6 +345,8 @@ pub struct AbsoluteMajorityReassignedSeat<LN> {
     pub list_retracted_seat: LN,
     /// List number which the residual seat is assigned to
     pub list_assigned_seat: LN,
+    // Details for drawing lots if required
+    pub drawing_lots: Option<ListDrawingLotsVariant<LN>>,
 }
 
 /// Contains information about the enactment of article P 10 of the Kieswet.

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -33,6 +33,17 @@ pub enum ListDrawingLotsVariant<LN> {
     AbsoluteMajority(AbsoluteMajorityDrawingLots<LN>),
 }
 
+impl<LN> ListDrawingLotsVariant<LN> {
+    /// The list numbers that are options for drawing lots
+    pub fn options(&self) -> &[LN] {
+        match self {
+            Self::HighestAverageResidualSeat(v) => &v.options,
+            Self::LargestRemainderResidualSeat(v) => &v.options,
+            Self::AbsoluteMajority(v) => &v.options,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HighestAverageResidualSeatDrawingLots<LN> {
     pub max_average: Fraction,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5342,6 +5342,9 @@
           "list_assigned_seat"
         ],
         "properties": {
+          "drawing_lots": {
+            "$ref": "#/components/schemas/ListDrawingLotsVariant"
+          },
           "list_assigned_seat": {
             "$ref": "#/components/schemas/PGNumber"
           },
@@ -7460,6 +7463,9 @@
           "votes_per_seat"
         ],
         "properties": {
+          "drawing_lots": {
+            "$ref": "#/components/schemas/ListDrawingLotsVariant"
+          },
           "list_assigned": {
             "type": "array",
             "items": {
@@ -7647,6 +7653,9 @@
           "remainder_votes"
         ],
         "properties": {
+          "drawing_lots": {
+            "$ref": "#/components/schemas/ListDrawingLotsVariant"
+          },
           "list_assigned": {
             "type": "array",
             "items": {

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -118,6 +118,9 @@ pub struct HighestAverageAssignedSeat {
     pub list_assigned: Vec<PGNumber>,
     pub list_exhausted: Vec<PGNumber>,
     pub votes_per_seat: DisplayFraction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub drawing_lots: Option<ListDrawingLotsVariant>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
@@ -126,12 +129,18 @@ pub struct LargestRemainderAssignedSeat {
     pub list_options: Vec<PGNumber>,
     pub list_assigned: Vec<PGNumber>,
     pub remainder_votes: DisplayFraction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub drawing_lots: Option<ListDrawingLotsVariant>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct AbsoluteMajorityReassignedSeat {
     pub list_retracted_seat: PGNumber,
     pub list_assigned_seat: PGNumber,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub drawing_lots: Option<ListDrawingLotsVariant>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
@@ -196,6 +205,7 @@ impl From<&apportionment::SeatChange<PGNumber>> for SeatChange {
                 list_assigned: c.list_assigned.clone(),
                 list_exhausted: c.list_exhausted.clone(),
                 votes_per_seat: DisplayFraction::from(c.votes_per_seat),
+                drawing_lots: c.drawing_lots.clone().map(Into::into),
             };
 
         match change {
@@ -209,12 +219,14 @@ impl From<&apportionment::SeatChange<PGNumber>> for SeatChange {
                     list_options: c.list_options.clone(),
                     list_assigned: c.list_assigned.clone(),
                     remainder_votes: DisplayFraction::from(c.remainder_votes),
+                    drawing_lots: c.drawing_lots.clone().map(Into::into),
                 })
             }
             AbsoluteMajorityReassignment(c) => {
                 SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
                     list_retracted_seat: c.list_retracted_seat,
                     list_assigned_seat: c.list_assigned_seat,
+                    drawing_lots: c.drawing_lots.clone().map(Into::into),
                 })
             }
             ListExhaustionRemoval(c) => {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -404,6 +404,7 @@ export interface AbsoluteMajorityDrawingLots {
 }
 
 export interface AbsoluteMajorityReassignedSeat {
+  drawing_lots?: ListDrawingLotsVariant;
   list_assigned_seat: PGNumber;
   list_retracted_seat: PGNumber;
 }
@@ -1166,6 +1167,7 @@ export interface GenerateElectionArgs {
 }
 
 export interface HighestAverageAssignedSeat {
+  drawing_lots?: ListDrawingLotsVariant;
   list_assigned: PGNumber[];
   list_exhausted: PGNumber[];
   list_options: PGNumber[];
@@ -1207,6 +1209,7 @@ export type InvestigationStatus =
   | { state: InvestigationConcludedWithNewResults; status: "ConcludedWithNewResults" };
 
 export interface LargestRemainderAssignedSeat {
+  drawing_lots?: ListDrawingLotsVariant;
   list_assigned: PGNumber[];
   list_options: PGNumber[];
   remainder_votes: DisplayFraction;


### PR DESCRIPTION
## What & why

Resolves #3408 

Adds optional `drawing_lots` field to `SeatChange` for which drawing of lots are possible. If drawing of lots have been done for a step, the information will be added to the `SeatChange`.

## How to test

Verify the adjusted tests.

## Reviewer notes

- Review per commit
- Drawing of lots is still being implemented for 
  - Absolute majority reassignment #3273, a test to verify `drawing_lots` in the `SeatChange` will be added there.
  - Candidate results #3150 (not relevant for `SeatChange`)
