### PR TITLE
Drawing lots for absolute majority

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/apportionment.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use apportionment::{ApportionmentError, ApportionmentOutput, CandidateVotes, process};
+use apportionment::{ApportionmentOutput, CandidateVotes, process};
 use apportionment_fuzz::{
     FuzzedApportionmentInput, SimpleCandidateVotes, SimpleListVotes, init_tracing, run_with_log,
 };
@@ -160,8 +160,8 @@ fuzz_target!(
         Ok(ApportionmentOutput::ListDrawingLotsRequired(..) | ApportionmentOutput::CandidateDrawingLotsRequired(..)) => {
             // Accepted error in this fuzzer
         }
-        Err(ApportionmentError::InvalidLotDrawing(message)) => {
-            panic!("Invalid lot drawing: {}", message)
+        Err(e) => {
+            panic!("Apportionment error: {:?}", e)
         }
     }
 });

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use apportionment::{ApportionmentError, ApportionmentOutput, CandidateVotes, process};
+use apportionment::{ApportionmentOutput, CandidateVotes, process};
 use apportionment_fuzz::{FuzzedApportionmentInput, get_total_seats, init_tracing, run_with_log};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
@@ -296,8 +296,8 @@ fn fuzz(data: FuzzedApportionmentInput) {
                 }
             }
         }
-        Err(ApportionmentError::InvalidLotDrawing(message)) => {
-            panic!("Invalid lot drawing: {}", message)
+        Err(e) => {
+            panic!("Apportionment error: {:?}", e)
         }
     }
 }

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 
 mod residual_seat_assignment;
 mod structs;
+#[cfg(test)]
+pub use structs::LargestRemainderAssignedSeat;
 pub use structs::{
     AbsoluteMajorityReassignedSeat, ApportionmentWarning, HighestAverageAssignedSeat,
     ListExhaustionRemovedSeat, ListStanding, SeatAssignmentDetails, SeatChange, SeatChangeStep,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -12,7 +12,9 @@ use self::{residual_seat_assignment::assign_remainder, structs::RemainderAssignm
 use crate::{
     ApportionmentError, ApportionmentInput, ListDrawn, ListVotes,
     fraction::Fraction,
-    seat_assignment::structs::{AbsoluteMajority, AbsoluteMajorityResult, RemainderAssignment},
+    seat_assignment::structs::{
+        AbsoluteMajority, AbsoluteMajorityResult, GetListStandingByNumber, RemainderAssignment,
+    },
     structs::{
         AbsoluteMajorityDrawingLots, CandidateNominationInput, CandidateNominationInputType,
         DeceasedCandidates, ListDrawingLotsVariant, ListNumber,
@@ -103,8 +105,9 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
             input.number_of_seats(),
             total_votes_cast,
             input.list_votes(),
-            &last_step.change.list_assigned(),
+            &last_step.change,
             current_standings.clone(),
+            &mut lists_drawn,
         )? {
             AbsoluteMajority::Completed(cumulative_standings, assigned_seat) => {
                 (cumulative_standings, assigned_seat)
@@ -269,12 +272,13 @@ fn list_numbers_with_exhausted_seats<T: ListVotes>(
 /// If a list got the absolute majority of votes but not the absolute majority of seats,
 /// re-assign the last residual seat to the list with the absolute majority.  
 /// This re-assignment is done according to article P 9 of the Kieswet.
-fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
+fn reassign_residual_seat_for_absolute_majority<'a, T: ListVotes>(
     seats: u32,
     total_votes_cast: u32,
     list_votes: &[T],
-    lists_last_residual_seat: &[T::ListNumber],
+    last_seat_change: &SeatChange<T::ListNumber>,
     previous_standings: Vec<ListStanding<T::ListNumber>>,
+    lists_drawn: &mut impl Iterator<Item = &'a (impl ListDrawn<T::ListNumber> + 'a)>,
 ) -> AbsoluteMajorityResult<T::ListNumber> {
     let half_of_votes_count = Fraction::from(total_votes_cast) * Fraction::new(1, 2);
 
@@ -287,51 +291,62 @@ fn reassign_residual_seat_for_absolute_majority<T: ListVotes>(
     };
 
     let half_of_seats_count = Fraction::from(seats) * Fraction::new(1, 2);
-    let standing_of_list_with_majority_votes = previous_standings
-        .iter()
-        .find(|list_standing| list_standing.list_number() == majority_list_votes.number())
-        .expect("Standing exists");
 
-    let list_seats = Fraction::from(standing_of_list_with_majority_votes.total_seats());
+    let list_seats: Fraction = previous_standings
+        .get_by_number(majority_list_votes.number())
+        .total_seats()
+        .into();
 
     if list_seats <= half_of_seats_count {
-        if lists_last_residual_seat.len() > 1 {
+        let lists_last_residual_seat = last_seat_change.list_assigned();
+        let list_retracted_seat = if lists_last_residual_seat.len() == 1 {
+            lists_last_residual_seat[0]
+        } else {
             info!(
                 "Drawing of lots is required for lists: {:?} to pick a list which the residual seat gets retracted from",
                 lists_last_residual_seat
             );
-            return Ok(AbsoluteMajority::DrawingLotsRequired(
-                ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                    options: lists_last_residual_seat.to_vec(),
-                }),
-            ));
-        }
+
+            let variant = ListDrawingLotsVariant::absolute_majority_for_seat_change(
+                last_seat_change,
+                AbsoluteMajorityDrawingLots {
+                    assign_to: majority_list_votes.number(),
+                    options: lists_last_residual_seat,
+                },
+            )?;
+
+            // Get a list from the lists_drawn
+            let Some(list_drawn) = lists_drawn.next() else {
+                return Ok(AbsoluteMajority::DrawingLotsRequired(variant));
+            };
+
+            // Assert the required variant including all data
+            list_drawn.variant().ensure_eq(&variant)?;
+
+            *list_drawn.drawn()
+        };
 
         // Reassign the seat
         let mut current_standings = previous_standings.clone();
 
-        let from_list_standing = current_standings
-            .iter_mut()
-            .find(|list_standing| list_standing.list_number() == lists_last_residual_seat[0])
-            .expect("standing to remove residual seat from should exist");
-        from_list_standing.remove_residual_seat();
+        current_standings
+            .get_by_number_mut(list_retracted_seat)
+            .remove_residual_seat();
 
-        let to_list_standing = current_standings
-            .iter_mut()
-            .find(|list_standing| list_standing.list_number() == majority_list_votes.number())
-            .expect("standing to add residual seat to should exist");
-        to_list_standing.add_residual_seat();
+        current_standings
+            .get_by_number_mut(majority_list_votes.number())
+            .add_residual_seat();
 
         info!(
             "Seat first assigned to list {:?} has been reassigned to list {:?} in accordance with Article P 9 Kieswet",
-            lists_last_residual_seat[0],
+            list_retracted_seat,
             majority_list_votes.number()
         );
         Ok(AbsoluteMajority::Completed(
             current_standings,
             Some(SeatChange::AbsoluteMajorityReassignment(
                 AbsoluteMajorityReassignedSeat {
-                    list_retracted_seat: lists_last_residual_seat[0],
+                    list_retracted_seat,
                     list_assigned_seat: majority_list_votes.number(),
                 },
             )),
@@ -700,7 +715,10 @@ pub(crate) mod tests {
 
             use crate::{
                 Fraction, SeatChange, seat_assignment,
-                seat_assignment::{SeatAssignment, structs::LargestRemainderAssignedSeat},
+                seat_assignment::{
+                    AbsoluteMajorityReassignedSeat, SeatAssignment,
+                    structs::LargestRemainderAssignedSeat,
+                },
                 structs::{
                     AbsoluteMajorityDrawingLots, LargestRemainderResidualSeatDrawingLots,
                     ListDrawingLotsVariant,
@@ -724,7 +742,7 @@ pub(crate) mod tests {
             /// 4 - Drawing of lots is required for lists: [2, 3, 4] to pick a list which the residual seat gets retracted from
             #[test]
             fn test_with_absolute_majority_of_votes_but_not_seats_with_drawing_of_lots_error() {
-                let input = seat_assignment_fixture_with_default_50_candidates(
+                let mut input = seat_assignment_fixture_with_default_50_candidates(
                     15,
                     vec![2552, 511, 511, 511, 509, 509],
                 );
@@ -735,24 +753,46 @@ pub(crate) mod tests {
                 };
                 assert_eq!(
                     variant,
-                    ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                        options: vec![2, 3, 4]
-                    }),
+                    ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(
+                        AbsoluteMajorityDrawingLots {
+                            assign_to: 1,
+                            options: vec![2, 3, 4],
+                        }
+                    ),
                 );
                 assert_eq!(preliminary_result.seats, 15);
                 assert_eq!(preliminary_result.full_seats, 12);
                 assert_eq!(preliminary_result.residual_seats, 3);
-                assert_eq!(
-                    preliminary_result.quota,
-                    Fraction {
-                        numerator: 5103,
-                        denominator: 15
-                    }
-                );
+                assert_eq!(preliminary_result.quota, Fraction::new(5103, 15));
                 assert_eq!(preliminary_result.steps.len(), 3);
                 assert_eq!(
                     get_standings_residual_seats(&preliminary_result),
                     vec![0, 1, 1, 1, 0, 0]
+                );
+
+                // Draw list 3
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.seats, 15);
+                assert_eq!(result.full_seats, 12);
+                assert_eq!(result.residual_seats, 3);
+                assert_eq!(result.quota, Fraction::new(5103, 15));
+
+                assert_eq!(
+                    get_standings_residual_seats(&result),
+                    vec![1, 1, 0, 1, 0, 0]
+                );
+
+                assert_eq!(result.steps.len(), 4);
+                assert_eq!(
+                    result.steps[3].change,
+                    SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                        list_retracted_seat: 3,
+                        list_assigned_seat: 1,
+                    })
                 );
             }
 
@@ -1754,7 +1794,9 @@ pub(crate) mod tests {
 
             use crate::{
                 Fraction, HighestAverageAssignedSeat, SeatChange,
-                seat_assignment::{SeatAssignment, seat_assignment},
+                seat_assignment::{
+                    AbsoluteMajorityReassignedSeat, SeatAssignment, seat_assignment,
+                },
                 structs::{
                     AbsoluteMajorityDrawingLots, HighestAverageResidualSeatDrawingLots,
                     ListDrawingLotsVariant,
@@ -1780,7 +1822,7 @@ pub(crate) mod tests {
             /// 7 - Drawing of lots is required for lists: [6, 7] to pick a list which the residual seat gets retracted from
             #[test]
             fn test_with_absolute_majority_of_votes_but_not_seats_with_drawing_of_lots_error() {
-                let input = seat_assignment_fixture_with_default_50_candidates(
+                let mut input = seat_assignment_fixture_with_default_50_candidates(
                     24,
                     vec![7501, 1249, 1249, 1249, 1249, 1248, 1248, 8],
                 );
@@ -1791,24 +1833,46 @@ pub(crate) mod tests {
                 };
                 assert_eq!(
                     variant,
-                    ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                        options: vec![6, 7]
-                    })
+                    ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
+                        AbsoluteMajorityDrawingLots {
+                            assign_to: 1,
+                            options: vec![6, 7],
+                        }
+                    )
                 );
                 assert_eq!(preliminary_result.seats, 24);
                 assert_eq!(preliminary_result.full_seats, 18);
                 assert_eq!(preliminary_result.residual_seats, 6);
-                assert_eq!(
-                    preliminary_result.quota,
-                    Fraction {
-                        numerator: 15001,
-                        denominator: 24
-                    }
-                );
+                assert_eq!(preliminary_result.quota, Fraction::new(15001, 24));
                 assert_eq!(preliminary_result.steps.len(), 6);
                 assert_eq!(
                     get_standings_residual_seats(&preliminary_result),
                     vec![0, 1, 1, 1, 1, 1, 1, 0]
+                );
+
+                // Draw lot 6
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 6 });
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(
+                    get_standings_residual_seats(&result),
+                    vec![1, 1, 1, 1, 1, 0, 1, 0]
+                );
+
+                assert_eq!(result.seats, 24);
+                assert_eq!(result.full_seats, 18);
+                assert_eq!(result.residual_seats, 6);
+                assert_eq!(result.quota, Fraction::new(15001, 24));
+
+                assert_eq!(result.steps.len(), 7);
+                assert_eq!(
+                    result.steps[6].change,
+                    SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                        list_retracted_seat: 6,
+                        list_assigned_seat: 1,
+                    })
                 );
             }
 

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -322,8 +322,7 @@ fn reassign_residual_seat_for_absolute_majority<'a, T: ListVotes>(
                 return Ok(AbsoluteMajority::DrawingLotsRequired(variant));
             };
 
-            // Assert the required variant including all data
-            list_drawn.variant().ensure_eq(&variant)?;
+            variant.validate(list_drawn)?;
 
             (*list_drawn.drawn(), Some(variant))
         };

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -345,12 +345,7 @@ fn lists_with_highest_average<'a, 'b, LN: Copy + Debug + Eq>(
             return Ok(ListStandings::DrawingLotsRequired(variant));
         };
 
-        // Assert the required variant including all data
-        if list_drawn.variant() != variant {
-            return Err(ApportionmentError::InvalidLotDrawing(
-                "Variant mismatch".to_string(),
-            ));
-        }
+        variant.validate(list_drawn)?;
 
         let list = lists
             .iter()
@@ -434,12 +429,7 @@ fn lists_with_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
             return Ok(ListStandings::DrawingLotsRequired(variant));
         };
 
-        // Assert the required variant including all data
-        if list_drawn.variant() != variant {
-            return Err(ApportionmentError::InvalidLotDrawing(
-                "Variant mismatch".to_string(),
-            ));
-        }
+        variant.validate(list_drawn)?;
 
         let list = lists
             .iter()

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -166,7 +166,7 @@ impl<LN: Debug> ListStanding<LN> {
     }
 }
 
-impl<LN> ListStanding<LN> {
+impl<LN: Copy> ListStanding<LN> {
     pub fn list_number(self) -> LN {
         self.list_number
     }
@@ -187,6 +187,36 @@ impl<LN> ListStanding<LN> {
     }
     pub fn residual_seats(self) -> u32 {
         self.residual_seats
+    }
+}
+
+pub trait GetListStandingByNumber {
+    type ListNumber;
+
+    fn get_by_number(&self, number: Self::ListNumber) -> &ListStanding<Self::ListNumber>;
+
+    fn get_by_number_mut(
+        &mut self,
+        number: Self::ListNumber,
+    ) -> &mut ListStanding<Self::ListNumber>;
+}
+
+impl<LN: Copy + PartialEq> GetListStandingByNumber for [ListStanding<LN>] {
+    type ListNumber = LN;
+
+    fn get_by_number(&self, number: Self::ListNumber) -> &ListStanding<Self::ListNumber> {
+        self.iter()
+            .find(|s| s.list_number() == number)
+            .expect("ListStanding should exist")
+    }
+
+    fn get_by_number_mut(
+        &mut self,
+        number: Self::ListNumber,
+    ) -> &mut ListStanding<Self::ListNumber> {
+        self.iter_mut()
+            .find(|s| s.list_number() == number)
+            .expect("ListStanding should exist")
     }
 }
 

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use super::{
-    candidate_nomination::CandidateNominationDetails, fraction::Fraction,
+    SeatChange, candidate_nomination::CandidateNominationDetails, fraction::Fraction,
     seat_assignment::SeatAssignmentDetails,
 };
 
@@ -20,6 +20,7 @@ pub type CandidateNumber<LV> = <<LV as ListVotes>::Cv as CandidateVotes>::Candid
 #[derive(Debug, PartialEq)]
 pub enum ApportionmentError {
     InvalidLotDrawing(String),
+    InvalidState(String),
 }
 
 /// Different variants of drawing lots for lists, with all the information needed to do the drawing
@@ -29,8 +30,47 @@ pub enum ListDrawingLotsVariant<LN> {
     HighestAverageResidualSeat(HighestAverageResidualSeatDrawingLots<LN>),
     /// Draw lots for assigning a largest remainder residual seat
     LargestRemainderResidualSeat(LargestRemainderResidualSeatDrawingLots<LN>),
-    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9)
-    AbsoluteMajority(AbsoluteMajorityDrawingLots<LN>),
+    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9),
+    /// retracted seat was from a highest average assignment
+    AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots<LN>),
+    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9),
+    /// retracted seat was from a largest remainder assignment
+    AbsoluteMajorityLargestRemainder(AbsoluteMajorityDrawingLots<LN>),
+}
+
+impl<LN: Debug + PartialEq> ListDrawingLotsVariant<LN> {
+    /// Return the absolute majority ListDrawingLotsVariant variant that corresponds
+    /// with the seat change given.
+    pub fn absolute_majority_for_seat_change(
+        seat_change: &SeatChange<LN>,
+        drawing_lots_details: AbsoluteMajorityDrawingLots<LN>,
+    ) -> Result<ListDrawingLotsVariant<LN>, ApportionmentError> {
+        match seat_change {
+            SeatChange::HighestAverageAssignment(_)
+            | SeatChange::UniqueHighestAverageAssignment(_) => Ok(
+                ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(drawing_lots_details),
+            ),
+            SeatChange::LargestRemainderAssignment(_) => Ok(
+                ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(drawing_lots_details),
+            ),
+            _ => Err(ApportionmentError::InvalidState(format!(
+                "Expected seat change highest average or largest remainder but got {:?}",
+                seat_change
+            ))),
+        }
+    }
+
+    /// Ensure that this variant is the same as the other variant.
+    /// Return [[ApportionmentError::InvalidLotDrawing]] when they are different.
+    pub fn ensure_eq(&self, other: &Self) -> Result<(), ApportionmentError> {
+        if self != other {
+            Err(ApportionmentError::InvalidLotDrawing(
+                "Variant mismatch".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -51,6 +91,9 @@ pub struct LargestRemainderResidualSeatDrawingLots<LN> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AbsoluteMajorityDrawingLots<LN> {
+    /// The list where the reassigned residual seat will go to
+    pub assign_to: LN,
+    /// The list options where the residual seat should come from
     pub options: Vec<LN>,
 }
 

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -174,3 +174,78 @@ pub(crate) struct CandidateNominationInput<'a, L: ListVotes> {
 
 pub(crate) type CandidateNominationInputType<'a, T> =
     CandidateNominationInput<'a, <T as ApportionmentInput>::List>;
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches;
+
+    use super::*;
+    use crate::seat_assignment::{LargestRemainderAssignedSeat, ListExhaustionRemovedSeat};
+
+    #[test]
+    fn test_absolute_majority_for_seat_change_ok() {
+        let details = AbsoluteMajorityDrawingLots {
+            assign_to: 1,
+            options: vec![1],
+        };
+
+        let seat_change = SeatChange::LargestRemainderAssignment(LargestRemainderAssignedSeat {
+            selected_list_number: 1,
+            list_options: vec![1],
+            list_assigned: vec![1],
+            remainder_votes: Fraction::ZERO,
+        });
+
+        assert_eq!(
+            ListDrawingLotsVariant::absolute_majority_for_seat_change(
+                &seat_change,
+                details.clone()
+            ),
+            Ok(ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(
+                details
+            ))
+        );
+    }
+
+    #[test]
+    fn test_absolute_majority_for_seat_change_err() {
+        let details = AbsoluteMajorityDrawingLots {
+            assign_to: 1,
+            options: vec![1],
+        };
+
+        let seat_change = SeatChange::ListExhaustionRemoval(ListExhaustionRemovedSeat {
+            list_retracted_seat: 1,
+            full_seat: false,
+        });
+
+        assert_matches!(
+            ListDrawingLotsVariant::absolute_majority_for_seat_change(&seat_change, details),
+            Err(ApportionmentError::InvalidState(_))
+        );
+    }
+
+    #[test]
+    fn test_list_variant_ensure_eq_ok() {
+        let variant =
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots {
+                assign_to: 1,
+                options: vec![1, 2],
+            });
+
+        assert_eq!(variant.clone().ensure_eq(&variant), Ok(()));
+
+        let another_variant =
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots {
+                assign_to: 2,
+                options: vec![1, 2],
+            });
+
+        assert_eq!(
+            variant.clone().ensure_eq(&another_variant),
+            Err(ApportionmentError::InvalidLotDrawing(
+                "Variant mismatch".to_string(),
+            ))
+        );
+    }
+}

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -60,16 +60,24 @@ impl<LN: Debug + PartialEq> ListDrawingLotsVariant<LN> {
         }
     }
 
-    /// Ensure that this variant is the same as the other variant.
-    /// Return [[ApportionmentError::InvalidLotDrawing]] when they are different.
-    pub fn ensure_eq(&self, other: &Self) -> Result<(), ApportionmentError> {
-        if self != other {
-            Err(ApportionmentError::InvalidLotDrawing(
+    /// Validate the list drawn against this variant.
+    ///
+    /// Return [[ApportionmentError::InvalidLotDrawing]] if the variant is different
+    /// or the list drawn is not one of the options.
+    pub fn validate(&self, list_drawn: &impl ListDrawn<LN>) -> Result<(), ApportionmentError> {
+        if list_drawn.variant() != *self {
+            return Err(ApportionmentError::InvalidLotDrawing(
                 "Variant mismatch".to_string(),
-            ))
-        } else {
-            Ok(())
+            ));
         }
+
+        if !self.options().contains(list_drawn.drawn()) {
+            return Err(ApportionmentError::InvalidLotDrawing(
+                "Invalid number drawn".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -192,7 +200,10 @@ mod tests {
     use std::assert_matches;
 
     use super::*;
-    use crate::seat_assignment::{LargestRemainderAssignedSeat, ListExhaustionRemovedSeat};
+    use crate::{
+        seat_assignment::{LargestRemainderAssignedSeat, ListExhaustionRemovedSeat},
+        test_helpers::ListDrawnMock,
+    };
 
     #[test]
     fn test_absolute_majority_for_seat_change_ok() {
@@ -239,26 +250,33 @@ mod tests {
     }
 
     #[test]
-    fn test_list_variant_ensure_eq_ok() {
+    fn test_list_drawing_lots_variant_validate() {
         let variant =
             ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots {
                 assign_to: 1,
-                options: vec![1, 2],
+                options: vec![2, 3],
             });
-
-        assert_eq!(variant.clone().ensure_eq(&variant), Ok(()));
 
         let another_variant =
             ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots {
-                assign_to: 2,
-                options: vec![1, 2],
+                assign_to: 4,
+                options: vec![2, 3],
             });
 
         assert_eq!(
-            variant.clone().ensure_eq(&another_variant),
+            variant.validate(&ListDrawnMock::new(&another_variant, 3)),
             Err(ApportionmentError::InvalidLotDrawing(
-                "Variant mismatch".to_string(),
+                "Variant mismatch".to_string()
             ))
         );
+
+        assert_eq!(
+            variant.validate(&ListDrawnMock::new(&variant, 9)),
+            Err(ApportionmentError::InvalidLotDrawing(
+                "Invalid number drawn".to_string()
+            ))
+        );
+
+        assert_eq!(variant.validate(&ListDrawnMock::new(&variant, 2)), Ok(()));
     }
 }

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -101,6 +101,15 @@ pub struct ListDrawnMock {
     pub drawn: u32,
 }
 
+impl ListDrawnMock {
+    pub fn new(variant: &ListDrawingLotsVariant<u32>, drawn: u32) -> Self {
+        Self {
+            variant: variant.clone(),
+            drawn,
+        }
+    }
+}
+
 impl ListDrawn<u32> for ListDrawnMock {
     fn variant(&self) -> ListDrawingLotsVariant<u32> {
         self.variant.clone()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5324,14 +5324,20 @@
       "AbsoluteMajorityDrawingLots": {
         "type": "object",
         "required": [
+          "assign_to",
           "options"
         ],
         "properties": {
+          "assign_to": {
+            "$ref": "#/components/schemas/PGNumber",
+            "description": "The list where the reassigned residual seat will go to"
+          },
           "options": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PGNumber"
-            }
+            },
+            "description": "The list options where the residual seat should come from"
           }
         }
       },
@@ -7810,7 +7816,7 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/AbsoluteMajorityDrawingLots",
-                "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9)"
+                "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9),\nretracted seat was from a highest average assignment"
               },
               {
                 "type": "object",
@@ -7821,13 +7827,36 @@
                   "variant": {
                     "type": "string",
                     "enum": [
-                      "AbsoluteMajority"
+                      "AbsoluteMajorityHighestAverage"
                     ]
                   }
                 }
               }
             ],
-            "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9)"
+            "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9),\nretracted seat was from a highest average assignment"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AbsoluteMajorityDrawingLots",
+                "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9),\nretracted seat was from a largest remainder assignment"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "variant"
+                ],
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "enum": [
+                      "AbsoluteMajorityLargestRemainder"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Draw lots for retracting a seat to be reassigned because of absolute majority (P9),\nretracted seat was from a largest remainder assignment"
           }
         ]
       },

--- a/backend/src/api/apportionment/handlers/add_list_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_list_drawn.rs
@@ -87,7 +87,8 @@ mod tests {
             .expect("should change committee session status");
 
         let drawing_lots_required = DrawingLotsRequired::ListDrawingLotsRequired(
-            ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots {
+                assign_to: PGNumber::from(1),
                 options: PGNumber::from_values(vec![8, 9]),
             }),
         );
@@ -106,9 +107,12 @@ mod tests {
         .expect("should upsert initial state");
 
         let list_drawn = ListDrawn {
-            variant: ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots {
-                options: PGNumber::from_values(vec![8, 9]),
-            }),
+            variant: ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
+                AbsoluteMajorityDrawingLots {
+                    assign_to: PGNumber::from(1),
+                    options: PGNumber::from_values(vec![8, 9]),
+                },
+            ),
             drawn: PGNumber::from(8),
         };
 

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -23,7 +23,8 @@ use crate::{
 pub enum ApportionmentApiError {
     ApportionmentNotCompleted,
     CommitteeSessionNotCompleted,
-    InvalidLotDrawing,
+    InvalidLotDrawing(String),
+    InvalidState(String),
 }
 
 impl ApiErrorResponse for ApportionmentApiError {
@@ -49,11 +50,19 @@ impl ApiErrorResponse for ApportionmentApiError {
                     false,
                 ),
             ),
-            ApportionmentApiError::InvalidLotDrawing => (
+            ApportionmentApiError::InvalidLotDrawing(message) => (
                 StatusCode::CONFLICT,
                 ErrorResponse::new(
-                    "Drawn lot is invalid",
+                    format!("Drawn lot is invalid: {}", message),
                     ErrorReference::ApportionmentInvalidLotDrawing,
+                    true,
+                ),
+            ),
+            ApportionmentApiError::InvalidState(message) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::new(
+                    format!("Apportionment invalid state: {}", message),
+                    ErrorReference::InternalServerError,
                     true,
                 ),
             ),
@@ -62,8 +71,15 @@ impl ApiErrorResponse for ApportionmentApiError {
 }
 
 impl From<apportionment::ApportionmentError> for APIError {
-    fn from(_err: apportionment::ApportionmentError) -> Self {
-        ApportionmentApiError::InvalidLotDrawing.into()
+    fn from(error: apportionment::ApportionmentError) -> Self {
+        match error {
+            apportionment::ApportionmentError::InvalidLotDrawing(message) => {
+                ApportionmentApiError::InvalidLotDrawing(message).into()
+            }
+            apportionment::ApportionmentError::InvalidState(message) => {
+                ApportionmentApiError::InvalidState(message).into()
+            }
+        }
     }
 }
 

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -148,8 +148,19 @@ impl From<ListDrawingLotsVariant> for apportionment::ListDrawingLotsVariant<PGNu
                         .collect(),
                 },
             ),
-            ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots { options }) => {
-                Self::AbsoluteMajority(apportionment::AbsoluteMajorityDrawingLots { options })
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
+                AbsoluteMajorityDrawingLots { assign_to, options },
+            ) => Self::AbsoluteMajorityHighestAverage(apportionment::AbsoluteMajorityDrawingLots {
+                assign_to,
+                options,
+            }),
+            ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(
+                AbsoluteMajorityDrawingLots { assign_to, options },
+            ) => {
+                Self::AbsoluteMajorityLargestRemainder(apportionment::AbsoluteMajorityDrawingLots {
+                    assign_to,
+                    options,
+                })
             }
         }
     }

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -328,8 +328,12 @@ pub enum ListDrawingLotsVariant {
     HighestAverageResidualSeat(HighestAverageResidualSeatDrawingLots),
     /// Draw lots for assigning a largest remainder residual seat
     LargestRemainderResidualSeat(LargestRemainderResidualSeatDrawingLots),
-    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9)
-    AbsoluteMajority(AbsoluteMajorityDrawingLots),
+    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9),
+    /// retracted seat was from a highest average assignment
+    AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots),
+    /// Draw lots for retracting a seat to be reassigned because of absolute majority (P9),
+    /// retracted seat was from a largest remainder assignment
+    AbsoluteMajorityLargestRemainder(AbsoluteMajorityDrawingLots),
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
@@ -362,6 +366,9 @@ pub struct ListRemainder {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct AbsoluteMajorityDrawingLots {
+    /// The list where the reassigned residual seat will go to
+    pub assign_to: PGNumber,
+    /// The list options where the residual seat should come from
     pub options: Vec<PGNumber>,
 }
 

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -308,11 +308,12 @@ mod tests {
     use crate::domain::apportionment::{AbsoluteMajorityDrawingLots, CandidateDrawingLotsVariant};
 
     fn list_required() -> DrawingLotsRequired {
-        DrawingLotsRequired::ListDrawingLotsRequired(ListDrawingLotsVariant::AbsoluteMajority(
-            AbsoluteMajorityDrawingLots {
+        DrawingLotsRequired::ListDrawingLotsRequired(
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(AbsoluteMajorityDrawingLots {
+                assign_to: PGNumber::from(1),
                 options: PGNumber::from_values(vec![8, 9]),
-            },
-        ))
+            }),
+        )
     }
 
     fn list_drawn() -> ListDrawn {

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -96,8 +96,9 @@ mod tests {
                 ),
                 deceased_candidates: vec![DeceasedCandidate::from(4, 4)],
                 lists_drawn: vec![ListDrawn {
-                    variant: ListDrawingLotsVariant::AbsoluteMajority(
+                    variant: ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
                         AbsoluteMajorityDrawingLots {
+                            assign_to: PGNumber::from(1),
                             options: PGNumber::from_values(vec![2, 3, 4]),
                         },
                     ),

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -175,9 +175,16 @@ impl From<apportionment::ListDrawingLotsVariant<PGNumber>> for ListDrawingLotsVa
                         .collect(),
                 },
             ),
-            apportionment::ListDrawingLotsVariant::AbsoluteMajority(
-                apportionment::AbsoluteMajorityDrawingLots { options },
-            ) => ListDrawingLotsVariant::AbsoluteMajority(AbsoluteMajorityDrawingLots { options }),
+            apportionment::ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
+                apportionment::AbsoluteMajorityDrawingLots { assign_to, options },
+            ) => ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
+                AbsoluteMajorityDrawingLots { assign_to, options },
+            ),
+            apportionment::ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(
+                apportionment::AbsoluteMajorityDrawingLots { assign_to, options },
+            ) => ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(
+                AbsoluteMajorityDrawingLots { assign_to, options },
+            ),
         }
     }
 }

--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -69,7 +69,12 @@ describe("ApportionmentPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
@@ -65,7 +65,12 @@ describe("AddDeceasedCandidatesPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
@@ -82,7 +82,12 @@ describe("DeceasedCandidatesPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
@@ -61,7 +61,12 @@ describe("IncludeAllCandidatesPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
@@ -40,7 +40,12 @@ describe("ApportionmentFullSeatsPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -66,7 +66,12 @@ describe("ApportionmentListDetailsPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -43,7 +43,12 @@ describe("ApportionmentResidualSeatsPage", () => {
       DrawingLots: {
         state: {
           deceased_candidates: [],
-          drawing_lots_required: { variant: "AbsoluteMajority", options: [1, 2], type: "ListDrawingLotsRequired" },
+          drawing_lots_required: {
+            variant: "AbsoluteMajorityLargestRemainder",
+            assign_to: 1,
+            options: [2, 3],
+            type: "ListDrawingLotsRequired",
+          },
           candidates_drawn: [],
           lists_drawn: [],
           type: "DrawingLots",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -400,6 +400,9 @@ export type USER_DELETE_REQUEST_PATH = `/api/users/${UserId}`;
 /** TYPES **/
 
 export interface AbsoluteMajorityDrawingLots {
+  /** The list where the reassigned residual seat will go to */
+  assign_to: PGNumber;
+  /** The list options where the residual seat should come from */
   options: PGNumber[];
 }
 
@@ -1237,7 +1240,8 @@ export interface ListCandidateNomination {
 export type ListDrawingLotsVariant =
   | (HighestAverageResidualSeatDrawingLots & { variant: "HighestAverageResidualSeat" })
   | (LargestRemainderResidualSeatDrawingLots & { variant: "LargestRemainderResidualSeat" })
-  | (AbsoluteMajorityDrawingLots & { variant: "AbsoluteMajority" });
+  | (AbsoluteMajorityDrawingLots & { variant: "AbsoluteMajorityHighestAverage" })
+  | (AbsoluteMajorityDrawingLots & { variant: "AbsoluteMajorityLargestRemainder" });
 
 /**
  * The list that has been drawn plus information to assert the correct drawing


### PR DESCRIPTION
## What & why

- Resolves https://github.com/kiesraad/abacus/issues/3273
- Implements using drawing lots for absolute majority (P 9) in the apportionment crate

Implementation details:
- Update `reassign_residual_seat_for_absolute_majority()` to try and use a list from `lists_drawn` when drawing lots is needed
- Split `ListDrawingLotsVariant::AbsoluteMajority` into two variants, corresponding to a seat that is reassigned from a previous largest remainder or highest average seat change
- Add `assign_to` field to the `AbsoluteMajorityDrawingLots` variant details to be used in the frontend
- Add `ApportionmentError::InvalidState` variant and use it when a previous seat change is not one of the expected variants
- Helper functions and traits to keep the line count of `reassign_residual_seat_for_absolute_majority()` within acceptable limits

## How to test

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

Unit tests are adjusted accordingly, frontend will be built in later issues from https://github.com/kiesraad/abacus/issues/788

## Reviewer notes

Start in `backend/apportionment/src/seat_assignment/mod.rs` to see the core change in `reassign_residual_seat_for_absolute_majority()` and what the results are in the tests below. Then check what other changes were needed to make this happen.


<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->