### PR TITLE
Update Codecov config to disable comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,7 @@
 codecov:
   notify:
     after_n_builds: 2
-comment:
-    require_bundle_changes: True
-    bundle_change_threshold: "50Kb"
+comment: false
 coverage:
   status:
     project:


### PR DESCRIPTION
## What & why

Update Codecov config to disable comments so that its output only gets shown on the Checks tab. We did this with the PDF diff workflow (#3449) and Sigrid (#3451) before.

## How to test

~~I think this requires merging this PR first.~~ See this PR!

## Reviewer notes

Codecov config documentation: https://docs.codecov.com/docs/pull-request-comments#disable-comment