### PR TITLE
Add footnote about drawing lots to Model P 22-2

### DIFF
--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -78,6 +78,24 @@ impl SeatChange {
         matches!(self, Self::ListExhaustionRemoval(_))
     }
 
+    pub fn drawn_lots(&self) -> Option<&ListDrawingLotsVariant> {
+        match self {
+            Self::HighestAverageAssignment(highest_average_assigned_seat) => {
+                highest_average_assigned_seat.drawing_lots.as_ref()
+            }
+            Self::UniqueHighestAverageAssignment(unique_highest_average_assigned_seat) => {
+                unique_highest_average_assigned_seat.drawing_lots.as_ref()
+            }
+            Self::LargestRemainderAssignment(largest_remainder_assigned_seat) => {
+                largest_remainder_assigned_seat.drawing_lots.as_ref()
+            }
+            Self::AbsoluteMajorityReassignment(absolute_majority_reassigned_seat) => {
+                absolute_majority_reassigned_seat.drawing_lots.as_ref()
+            }
+            Self::ListExhaustionRemoval(_) => None,
+        }
+    }
+
     pub fn list_number_assigned(&self) -> PGNumber {
         match self {
             Self::HighestAverageAssignment(highest_average_assigned_seat) => {

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -130,6 +130,7 @@ impl SeatChange {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+#[cfg_attr(test, derive(Default))]
 pub struct HighestAverageAssignedSeat {
     pub selected_list_number: PGNumber,
     pub list_options: Vec<PGNumber>,
@@ -142,6 +143,7 @@ pub struct HighestAverageAssignedSeat {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+#[cfg_attr(test, derive(Default))]
 pub struct LargestRemainderAssignedSeat {
     pub selected_list_number: PGNumber,
     pub list_options: Vec<PGNumber>,
@@ -281,6 +283,7 @@ impl From<&apportionment::SeatChangeStep<PGNumber>> for SeatChangeStep {
 
 /// Fraction with the integer part split out for display purposes
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+#[cfg_attr(test, derive(Default))]
 pub struct DisplayFraction {
     pub integer: u64,
     pub numerator: u64,
@@ -367,6 +370,7 @@ pub enum ListDrawingLotsVariant {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Default))]
 pub struct HighestAverageResidualSeatDrawingLots {
     pub max_average: DisplayFraction,
     pub residual_seat_numbers: Vec<u32>,
@@ -381,6 +385,7 @@ pub struct ListAverage {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Default))]
 pub struct LargestRemainderResidualSeatDrawingLots {
     pub max_remainder: DisplayFraction,
     pub residual_seat_numbers: Vec<u32>,
@@ -395,6 +400,7 @@ pub struct ListRemainder {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Default))]
 pub struct AbsoluteMajorityDrawingLots {
     /// The list where the reassigned residual seat will go to
     pub assign_to: PGNumber,

--- a/backend/src/domain/election.rs
+++ b/backend/src/domain/election.rs
@@ -329,15 +329,12 @@ pub(crate) mod tests {
 
     use super::*;
 
-    /// Create a test election with some political groups and a given number of seats.
-    /// The number of political groups is the length of the `political_groups_candidates` slice.
-    /// The number of candidates in each political group is equal to the value in the slice at that index.
-    pub fn election_fixture_with_given_number_of_seats(
-        committee_category: CommitteeCategory,
+    /// Creates a vector of political groups with candidates, where the number of candidates in each
+    /// political group is equal to the value in the slice at that index.
+    pub fn political_groups_with_candidates(
         political_groups_candidates: &[u32],
-        number_of_seats: u32,
-    ) -> ElectionWithPoliticalGroups {
-        let political_groups = political_groups_candidates
+    ) -> Vec<PoliticalGroup> {
+        political_groups_candidates
             .iter()
             .enumerate()
             .map(|(i, &candidates)| PoliticalGroup {
@@ -357,8 +354,17 @@ pub(crate) mod tests {
                     })
                     .collect(),
             })
-            .collect();
+            .collect()
+    }
 
+    /// Create a test election with some political groups and a given number of seats.
+    /// The number of political groups is the length of the `political_groups_candidates` slice.
+    /// The number of candidates in each political group is equal to the value in the slice at that index.
+    pub fn election_fixture_with_given_number_of_seats(
+        committee_category: CommitteeCategory,
+        political_groups_candidates: &[u32],
+        number_of_seats: u32,
+    ) -> ElectionWithPoliticalGroups {
         ElectionWithPoliticalGroups {
             id: ElectionId::from(1),
             name: "Test".to_string(),
@@ -372,7 +378,7 @@ pub(crate) mod tests {
             number_of_voters: 1000,
             election_date: NaiveDate::from_ymd_opt(2023, 11, 1).unwrap(),
             nomination_date: NaiveDate::from_ymd_opt(2023, 11, 1).unwrap(),
-            political_groups,
+            political_groups: political_groups_with_candidates(political_groups_candidates),
         }
     }
 

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     APIError,
     domain::{
-        apportionment::{ListDrawingLotsVariant, SeatAssignment, SeatChangeStep},
+        apportionment::{ListDrawingLotsVariant, SeatChangeStep},
         election::{PGNumber, PoliticalGroup},
     },
 };
@@ -42,11 +42,11 @@ struct FootnoteSteps<'a> {
 }
 
 /// Retrieves [SeatChangeStep]s of type AbsoluteMajorityReassignment/ListExhaustionRemoval
-fn get_footnote_steps(seat_assignment: &SeatAssignment) -> FootnoteSteps<'_> {
+fn get_footnote_steps(steps: &[SeatChangeStep]) -> FootnoteSteps<'_> {
     let mut absolute_majority_reassignment = None;
     let mut drawn_lots_steps = vec![];
     let mut list_exhaustion_steps = vec![];
-    for step in &seat_assignment.steps {
+    for step in steps {
         if step.change.is_changed_by_absolute_majority_reassignment() {
             absolute_majority_reassignment = Some(step);
         }
@@ -164,9 +164,9 @@ impl ApportionmentFootnotes {
 
     pub fn new(
         political_groups: &[PoliticalGroup],
-        seat_assignment: &SeatAssignment,
+        steps: &[SeatChangeStep],
     ) -> Result<Option<Self>, APIError> {
-        let footnote_steps = get_footnote_steps(seat_assignment);
+        let footnote_steps = get_footnote_steps(steps);
         let absolute_majority = Self::get_absolute_majority(
             footnote_steps.absolute_majority_reassignment,
             political_groups,

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     APIError,
     domain::{
-        apportionment::{SeatAssignment, SeatChangeStep},
+        apportionment::{ListDrawingLotsVariant, SeatAssignment, SeatChangeStep},
         election::{PGNumber, PoliticalGroup},
     },
 };
@@ -15,27 +15,50 @@ pub struct ApportionmentFootnotes {
     #[serde(skip_serializing_if = "Option::is_none")]
     absolute_majority: Option<FootnotePoliticalGroup>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    drawn_lots: Option<Vec<FootnoteDrawnLots>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exhausted_lists: Option<Vec<FootnotePoliticalGroup>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "variant")]
+pub enum FootnoteDrawnLots {
+    HighestAverageResidualSeat { lists: Vec<FootnotePoliticalGroup> },
+    LargestRemainderResidualSeat { lists: Vec<FootnotePoliticalGroup> },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FootnotePoliticalGroup {
+    /// Political group number
+    number: PGNumber,
+    /// Political group display name
+    name: String,
 }
 
 struct FootnoteSteps<'a> {
     absolute_majority_reassignment: Option<&'a SeatChangeStep>,
+    drawn_lots_steps: Vec<&'a SeatChangeStep>,
     list_exhaustion_steps: Vec<&'a SeatChangeStep>,
 }
 
 /// Retrieves [SeatChangeStep]s of type AbsoluteMajorityReassignment/ListExhaustionRemoval
 fn get_footnote_steps(seat_assignment: &SeatAssignment) -> FootnoteSteps<'_> {
     let mut absolute_majority_reassignment = None;
+    let mut drawn_lots_steps = vec![];
     let mut list_exhaustion_steps = vec![];
     for step in &seat_assignment.steps {
         if step.change.is_changed_by_absolute_majority_reassignment() {
             absolute_majority_reassignment = Some(step);
+        }
+        if step.change.drawn_lots().is_some() {
+            drawn_lots_steps.push(step);
         }
         if step.change.is_changed_by_list_exhaustion_removal() {
             list_exhaustion_steps.push(step);
         }
     }
     FootnoteSteps {
+        drawn_lots_steps,
         absolute_majority_reassignment,
         list_exhaustion_steps,
     }
@@ -59,6 +82,54 @@ impl ApportionmentFootnotes {
             })
         } else {
             None
+        }
+    }
+
+    fn get_drawn_lots(
+        drawn_lots_steps: Vec<&SeatChangeStep>,
+        political_groups: &[PoliticalGroup],
+    ) -> Option<Vec<FootnoteDrawnLots>> {
+        let footnote_groups = |options: &[PGNumber]| -> Vec<FootnotePoliticalGroup> {
+            options
+                .iter()
+                .map(|&number| FootnotePoliticalGroup {
+                    number,
+                    name: political_groups
+                        .iter()
+                        .find(|pg| pg.number == number)
+                        .expect("political group should exist")
+                        .name
+                        .clone(),
+                })
+                .collect()
+        };
+
+        let mut drawn_lots = vec![];
+        for step in drawn_lots_steps {
+            let footnote = match step.change.drawn_lots() {
+                Some(ListDrawingLotsVariant::HighestAverageResidualSeat(lots)) => {
+                    FootnoteDrawnLots::HighestAverageResidualSeat {
+                        lists: footnote_groups(&lots.options),
+                    }
+                }
+                Some(ListDrawingLotsVariant::LargestRemainderResidualSeat(lots)) => {
+                    FootnoteDrawnLots::LargestRemainderResidualSeat {
+                        lists: footnote_groups(&lots.options),
+                    }
+                }
+                // Absolute majority drawing of lots is reported by the absolute majority footnote
+                Some(ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(_))
+                | Some(ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(_))
+                | None => continue,
+            };
+
+            drawn_lots.push(footnote);
+        }
+
+        if drawn_lots.is_empty() {
+            None
+        } else {
+            Some(drawn_lots)
         }
     }
 
@@ -100,10 +171,12 @@ impl ApportionmentFootnotes {
             footnote_steps.absolute_majority_reassignment,
             political_groups,
         );
+        let drawn_lots = Self::get_drawn_lots(footnote_steps.drawn_lots_steps, political_groups);
         let exhausted_lists =
             Self::get_exhausted_lists(footnote_steps.list_exhaustion_steps, political_groups);
-        if absolute_majority.is_some() || exhausted_lists.is_some() {
+        if drawn_lots.is_some() || absolute_majority.is_some() || exhausted_lists.is_some() {
             Ok(Some(ApportionmentFootnotes {
+                drawn_lots,
                 absolute_majority,
                 exhausted_lists,
             }))
@@ -111,14 +184,6 @@ impl ApportionmentFootnotes {
             Ok(None)
         }
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FootnotePoliticalGroup {
-    /// Political group number
-    number: PGNumber,
-    /// Political group display name
-    name: String,
 }
 
 #[cfg(test)]

--- a/backend/src/domain/models/apportionment_footnotes.rs
+++ b/backend/src/domain/models/apportionment_footnotes.rs
@@ -188,137 +188,330 @@ impl ApportionmentFootnotes {
 
 #[cfg(test)]
 mod tests {
-    use apportionment::ApportionmentOutput;
     use test_log::test;
 
-    use crate::{
-        api::apportionment::{ApportionmentInputData, map_seat_assignment},
-        domain::{
-            election::{CommitteeCategory, tests::election_fixture_with_given_number_of_seats},
-            models::apportionment_footnotes::ApportionmentFootnotes,
-            results::political_group_candidate_votes::create_political_group_candidate_votes,
+    use super::*;
+    use crate::domain::{
+        apportionment::{
+            AbsoluteMajorityDrawingLots, AbsoluteMajorityReassignedSeat,
+            HighestAverageAssignedSeat, HighestAverageResidualSeatDrawingLots,
+            LargestRemainderAssignedSeat, LargestRemainderResidualSeatDrawingLots,
+            ListExhaustionRemovedSeat, SeatChange,
         },
+        election::tests::political_groups_with_candidates,
     };
 
-    #[test]
-    fn test_apportionment_footnotes_none() {
-        let candidate_votes = vec![
-            vec![1069, 303, 321, 210, 36, 101, 79, 121, 150, 181],
-            vec![452, 39, 81, 274, 131],
-            vec![229, 147, 191],
-            vec![347, 100],
-            vec![266, 187],
-        ];
-        let election = election_fixture_with_given_number_of_seats(
-            CommitteeCategory::CSB,
-            &candidate_votes
-                .iter()
-                .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>(),
-            15,
-        );
-        let list_votes =
-            create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
-        let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result = apportionment::process(&apportionment_input);
-        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
-            panic!("should be Completed");
-        };
+    fn change_step(change: SeatChange) -> SeatChangeStep {
+        SeatChangeStep {
+            residual_seat_number: None,
+            change,
+            standings: vec![],
+        }
+    }
 
-        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
-        let result = ApportionmentFootnotes::new(&election.political_groups, &seat_assignment)
-            .expect("ApportionmentFootnotes::new should succeed");
-        assert!(result.is_none());
+    /// * `seat_variant` - Can be HighestAverageAssignment/UniqueHighestAverageAssignment
+    fn highest_average_step(
+        seat_variant: impl FnOnce(HighestAverageAssignedSeat) -> SeatChange,
+        selected: u32,
+        options: &[u32],
+    ) -> SeatChangeStep {
+        let drawing_lots = (!options.is_empty()).then(|| {
+            ListDrawingLotsVariant::HighestAverageResidualSeat(
+                HighestAverageResidualSeatDrawingLots {
+                    options: PGNumber::from_values(options.iter().copied()),
+                    ..Default::default()
+                },
+            )
+        });
+
+        change_step(seat_variant(HighestAverageAssignedSeat {
+            selected_list_number: PGNumber::from(selected),
+            drawing_lots,
+            ..Default::default()
+        }))
+    }
+
+    fn largest_remainder_step(selected: u32, options: &[u32]) -> SeatChangeStep {
+        let drawing_lots = (!options.is_empty()).then(|| {
+            ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                LargestRemainderResidualSeatDrawingLots {
+                    options: PGNumber::from_values(options.iter().copied()),
+                    ..Default::default()
+                },
+            )
+        });
+
+        change_step(SeatChange::LargestRemainderAssignment(
+            LargestRemainderAssignedSeat {
+                selected_list_number: PGNumber::from(selected),
+                drawing_lots,
+                ..Default::default()
+            },
+        ))
+    }
+
+    /// * `lot_variant` - Can be AbsoluteMajorityHighestAverage/AbsoluteMajorityLargestRemainder
+    fn absolute_majority_step(
+        lot_variant: impl FnOnce(AbsoluteMajorityDrawingLots) -> ListDrawingLotsVariant,
+        retracted: u32,
+        assigned: u32,
+        options: &[u32],
+    ) -> SeatChangeStep {
+        let drawing_lots = (!options.is_empty()).then(|| {
+            lot_variant(AbsoluteMajorityDrawingLots {
+                options: PGNumber::from_values(options.iter().copied()),
+                ..Default::default()
+            })
+        });
+
+        change_step(SeatChange::AbsoluteMajorityReassignment(
+            AbsoluteMajorityReassignedSeat {
+                list_retracted_seat: PGNumber::from(retracted),
+                list_assigned_seat: PGNumber::from(assigned),
+                drawing_lots,
+            },
+        ))
+    }
+
+    fn exhaustion_step(retracted: u32) -> SeatChangeStep {
+        change_step(SeatChange::ListExhaustionRemoval(
+            ListExhaustionRemovedSeat {
+                list_retracted_seat: PGNumber::from(retracted),
+                full_seat: true,
+            },
+        ))
+    }
+
+    fn get_footnotes(steps: &[SeatChangeStep]) -> Option<ApportionmentFootnotes> {
+        let political_groups = political_groups_with_candidates(&[1, 1, 1, 1, 1]);
+        ApportionmentFootnotes::new(&political_groups, steps)
+            .expect("ApportionmentFootnotes::new should succeed")
     }
 
     #[test]
-    fn test_apportionment_footnotes_absolute_majority() {
-        let candidate_votes = vec![
-            vec![1069, 303, 321, 210, 36, 101, 79, 121, 150, 149, 15, 17],
-            vec![
-                452, 39, 81, 76, 35, 109, 29, 25, 17, 6, 18, 9, 25, 30, 5, 18, 3,
-            ],
-            vec![229, 63, 65, 9, 10, 58, 29, 50, 6, 11, 37],
-            vec![347, 33, 14, 82, 30, 30],
-            vec![266, 36, 39, 36, 38, 38],
-        ];
-        let election = election_fixture_with_given_number_of_seats(
-            CommitteeCategory::CSB,
-            &candidate_votes
-                .iter()
-                .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>(),
-            15,
-        );
-        let list_votes =
-            create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
-        let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result = apportionment::process(&apportionment_input);
-        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
-            panic!("should be Completed");
-        };
-
-        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
-        let result = ApportionmentFootnotes::new(&election.political_groups, &seat_assignment)
-            .expect("ApportionmentFootnotes::new should succeed");
-        assert!(result.is_some());
-        let footnotes = result.unwrap();
-        assert!(footnotes.exhausted_lists.is_none());
-        assert!(footnotes.absolute_majority.is_some());
-        let absolute_majority = footnotes.absolute_majority.unwrap();
-        assert_eq!(
-            absolute_majority.number,
-            election.political_groups[0].number
-        );
-        assert_eq!(absolute_majority.name, election.political_groups[0].name);
+    fn test_none_for_empty_steps() {
+        assert!(get_footnotes(&[]).is_none());
     }
 
     #[test]
-    fn test_apportionment_footnotes_exhausted_lists() {
-        let candidate_votes = vec![
-            vec![80, 70, 60, 50, 40],
-            vec![80, 70, 60, 50, 5],
-            vec![80, 70, 60, 50, 0],
-            vec![80, 40, 0, 0],
-            vec![0, 0, 0, 0, 15],
-        ];
-        let election = election_fixture_with_given_number_of_seats(
-            CommitteeCategory::CSB,
-            &candidate_votes
-                .iter()
-                .map(|cv| u32::try_from(cv.len()).expect("Should fit in u32"))
-                .collect::<Vec<u32>>(),
-            19,
-        );
-        let list_votes =
-            create_political_group_candidate_votes(&election.political_groups, &candidate_votes);
-        let apportionment_input =
-            ApportionmentInputData::new(election.number_of_seats, &list_votes, &[], &[], &[]);
-        let apportionment_result = apportionment::process(&apportionment_input);
-        let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
-            panic!("should be Completed");
-        };
+    fn test_none_for_non_footnote_steps() {
+        // A step which is not drawing lots, exhaustion or absolute majority.
+        let steps = vec![highest_average_step(
+            SeatChange::HighestAverageAssignment,
+            1,
+            &[],
+        )];
+        assert!(get_footnotes(&steps).is_none());
+    }
 
-        let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
-        let result = ApportionmentFootnotes::new(&election.political_groups, &seat_assignment)
-            .expect("ApportionmentFootnotes::new should succeed");
-        assert!(result.is_some());
-        let footnotes = result.unwrap();
-        assert!(footnotes.exhausted_lists.is_some());
+    #[test]
+    fn test_majority_highest_average_footnote() {
+        let variants = vec![
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage,
+            ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder,
+        ];
+
+        for variant in variants {
+            let steps = vec![absolute_majority_step(variant, 3, 1, &[])];
+            let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+            assert!(footnotes.drawn_lots.is_none());
+            assert!(footnotes.exhausted_lists.is_none());
+            let absolute_majority = footnotes
+                .absolute_majority
+                .expect("absolute majority footnote should be present");
+            assert_eq!(absolute_majority.number, PGNumber::from(1));
+            assert_eq!(absolute_majority.name, "Political group 1");
+        }
+    }
+
+    #[test]
+    fn test_drawn_lots_averages() {
+        let steps = vec![highest_average_step(
+            SeatChange::HighestAverageAssignment,
+            1,
+            &[1, 2],
+        )];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
         assert!(footnotes.absolute_majority.is_none());
-        let exhausted_lists = footnotes.exhausted_lists.unwrap();
+        assert!(footnotes.exhausted_lists.is_none());
+        let drawn_lots = footnotes
+            .drawn_lots
+            .expect("drawn lots footnote should be present");
+        assert_eq!(drawn_lots.len(), 1);
+
+        let FootnoteDrawnLots::HighestAverageResidualSeat { lists } = &drawn_lots[0] else {
+            panic!("expected HighestAverageResidualSeat variant");
+        };
+        assert_eq!(lists.len(), 2);
+        assert_eq!(lists[0].number, PGNumber::from(1));
+        assert_eq!(lists[0].name, "Political group 1");
+        assert_eq!(lists[1].number, PGNumber::from(2));
+        assert_eq!(lists[1].name, "Political group 2");
+    }
+
+    #[test]
+    fn test_drawn_lots_remainders() {
+        let steps = vec![largest_remainder_step(2, &[2, 3])];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        assert!(footnotes.absolute_majority.is_none());
+        assert!(footnotes.exhausted_lists.is_none());
+        let drawn_lots = footnotes
+            .drawn_lots
+            .expect("drawn lots footnote should be present");
+        assert_eq!(drawn_lots.len(), 1);
+
+        let FootnoteDrawnLots::LargestRemainderResidualSeat { lists } = &drawn_lots[0] else {
+            panic!("expected LargestRemainderResidualSeat variant");
+        };
+        assert_eq!(lists[0].number, PGNumber::from(2));
+        assert_eq!(lists[0].name, "Political group 2");
+        assert_eq!(lists[1].number, PGNumber::from(3));
+        assert_eq!(lists[1].name, "Political group 3");
+    }
+
+    #[test]
+    fn test_drawn_lots_unique_highest_average() {
+        let steps = vec![highest_average_step(
+            SeatChange::UniqueHighestAverageAssignment,
+            1,
+            &[1, 2],
+        )];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        let drawn_lots = footnotes
+            .drawn_lots
+            .expect("drawn lots footnote should be present");
+        assert_eq!(drawn_lots.len(), 1);
+        assert!(matches!(
+            &drawn_lots[0],
+            FootnoteDrawnLots::HighestAverageResidualSeat { .. }
+        ));
+    }
+
+    #[test]
+    fn test_drawn_lots_absolute_majority_variant_skipped() {
+        // The absolute majority variant is skipped, but the absolute majority
+        // footnote should be present.
+        let steps = vec![absolute_majority_step(
+            ListDrawingLotsVariant::AbsoluteMajorityHighestAverage,
+            3,
+            1,
+            &[1, 3],
+        )];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        assert!(footnotes.drawn_lots.is_none());
+        let absolute_majority = footnotes
+            .absolute_majority
+            .expect("absolute majority footnote should be present");
+        assert_eq!(absolute_majority.number, PGNumber::from(1));
+    }
+
+    #[test]
+    fn test_drawn_lots_preserve_step_order() {
+        let steps = vec![
+            highest_average_step(SeatChange::HighestAverageAssignment, 3, &[3, 4]),
+            highest_average_step(SeatChange::HighestAverageAssignment, 1, &[1, 2]),
+            highest_average_step(SeatChange::HighestAverageAssignment, 2, &[2, 3]),
+        ];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        let drawn_lots = footnotes
+            .drawn_lots
+            .expect("drawn lots footnote should be present");
+        assert_eq!(drawn_lots.len(), 3);
+        assert!(matches!(
+            &drawn_lots[0],
+            FootnoteDrawnLots::HighestAverageResidualSeat { lists }
+                if lists[0].number == PGNumber::from(3)
+        ));
+        assert!(matches!(
+            &drawn_lots[1],
+            FootnoteDrawnLots::HighestAverageResidualSeat { lists }
+                if lists[0].number == PGNumber::from(1)
+        ));
+        assert!(matches!(
+            &drawn_lots[2],
+            FootnoteDrawnLots::HighestAverageResidualSeat { lists }
+                if lists[0].number == PGNumber::from(2)
+        ));
+    }
+
+    #[test]
+    fn test_drawn_lots_not_deduplicated() {
+        // Two steps with drawing lots assigning the same list each produce their own footnote entry.
+        let steps = vec![
+            highest_average_step(SeatChange::HighestAverageAssignment, 1, &[1, 2]),
+            largest_remainder_step(1, &[1, 3]),
+        ];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        let drawn_lots = footnotes
+            .drawn_lots
+            .expect("drawn lots footnote should be present");
+        assert_eq!(drawn_lots.len(), 2);
+        assert!(matches!(
+            &drawn_lots[0],
+            FootnoteDrawnLots::HighestAverageResidualSeat { .. }
+        ));
+        assert!(matches!(
+            &drawn_lots[1],
+            FootnoteDrawnLots::LargestRemainderResidualSeat { .. }
+        ));
+    }
+
+    #[test]
+    fn test_exhausted_lists() {
+        let steps = vec![exhaustion_step(1), exhaustion_step(2)];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        assert!(footnotes.absolute_majority.is_none());
+        assert!(footnotes.drawn_lots.is_none());
+        let exhausted_lists = footnotes
+            .exhausted_lists
+            .expect("exhausted lists footnote should be present");
         assert_eq!(exhausted_lists.len(), 2);
-        assert_eq!(
-            exhausted_lists[0].number,
-            election.political_groups[0].number
-        );
-        assert_eq!(exhausted_lists[0].name, election.political_groups[0].name);
-        assert_eq!(
-            exhausted_lists[1].number,
-            election.political_groups[1].number
-        );
-        assert_eq!(exhausted_lists[1].name, election.political_groups[1].name);
+        assert_eq!(exhausted_lists[0].number, PGNumber::from(1));
+        assert_eq!(exhausted_lists[0].name, "Political group 1");
+        assert_eq!(exhausted_lists[1].number, PGNumber::from(2));
+        assert_eq!(exhausted_lists[1].name, "Political group 2");
+    }
+
+    #[test]
+    fn test_exhausted_lists_sorted_and_deduplicated() {
+        // The BTreeMap sorts ascending and deduplicates.
+        let steps = vec![exhaustion_step(3), exhaustion_step(1), exhaustion_step(3)];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        let exhausted_lists = footnotes
+            .exhausted_lists
+            .expect("exhausted lists footnote should be present");
+        assert_eq!(exhausted_lists.len(), 2);
+        assert_eq!(exhausted_lists[0].number, PGNumber::from(1));
+        assert_eq!(exhausted_lists[0].name, "Political group 1");
+        assert_eq!(exhausted_lists[1].number, PGNumber::from(3));
+        assert_eq!(exhausted_lists[1].name, "Political group 3");
+    }
+
+    #[test]
+    fn test_all_footnotes() {
+        let steps = vec![
+            absolute_majority_step(
+                ListDrawingLotsVariant::AbsoluteMajorityHighestAverage,
+                4,
+                1,
+                &[],
+            ),
+            highest_average_step(SeatChange::HighestAverageAssignment, 2, &[2, 3]),
+            exhaustion_step(5),
+        ];
+        let footnotes = get_footnotes(&steps).expect("footnotes should be present");
+
+        assert!(footnotes.absolute_majority.is_some());
+        assert!(footnotes.drawn_lots.is_some());
+        assert!(footnotes.exhausted_lists.is_some());
     }
 }

--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -361,7 +361,7 @@ impl ResultsInputCSB {
         let enriched_candidate_nomination =
             EnrichedCandidateNomination::new(&data.election, &candidate_nomination)?;
         let footnotes =
-            ApportionmentFootnotes::new(&data.election.political_groups, &seat_assignment)?;
+            ApportionmentFootnotes::new(&data.election.political_groups, &seat_assignment.steps)?;
         let pdf_file: PdfFileModel = ModelP22_2Input {
             committee_session: data.committee_session.clone(),
             election: data.election.clone().into(),

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -779,7 +779,7 @@ async fn test_p_22_2() {
     let enriched_candidate_nomination =
         EnrichedCandidateNomination::new(&election, &candidate_nomination).unwrap();
     let footnotes =
-        ApportionmentFootnotes::new(&election.political_groups, &seat_assignment).unwrap();
+        ApportionmentFootnotes::new(&election.political_groups, &seat_assignment.steps).unwrap();
 
     let hash = random_string(&mut rng, 64);
     let creation_date_time = random_date_time(&mut rng)

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -139,12 +139,18 @@
 }
 
 /// Format a list of items with comma separation, or return - if empty
-#let comma_list(items, empty: "-") = {
+#let comma_list(items, empty: "-", last_separator: none) = {
   if items.len() == 0 {
     return empty
   }
 
-  items.map(str).join(", ")
+  if items.len() == 1 {
+    return str(items.at(0))
+  }
+
+  let result = items.map(str).slice(0, -1).join(", ")
+  result += if last_separator == none { "," } else { " " + last_separator } + " " + str(items.at(-1))
+  result
 }
 
 /// Format a number with thousands separator, return as str

--- a/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p7.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p7.json
@@ -3804,6 +3804,73 @@
     "initial_total_full_seats": 19,
     "initial_total_residual_seats": 4
   },
+  "footnotes": {
+    "drawn_lots": [
+      {
+        "variant": "HighestAverageResidualSeat",
+        "lists": [
+          {
+            "number": 2,
+            "name": "Stemmers 101"
+          },
+          {
+            "number": 3,
+            "name": "Partij van de groepen"
+          },
+          {
+            "number": 4,
+            "name": "De Kandidatenlijst"
+          },
+          {
+            "number": 5,
+            "name": "Partij van de Wet"
+          },
+          {
+            "number": 6,
+            "name": "Algemene Lijst"
+          }
+        ]
+      },
+      {
+        "variant": "HighestAverageResidualSeat",
+        "lists": [
+          {
+            "number": 2,
+            "name": "Stemmers 101"
+          },
+          {
+            "number": 3,
+            "name": "Partij van de groepen"
+          },
+          {
+            "number": 5,
+            "name": "Partij van de Wet"
+          },
+          {
+            "number": 6,
+            "name": "Algemene Lijst"
+          }
+        ]
+      },
+      {
+        "variant": "HighestAverageResidualSeat",
+        "lists": [
+          {
+            "number": 2,
+            "name": "Stemmers 101"
+          },
+          {
+            "number": 3,
+            "name": "Partij van de groepen"
+          },
+          {
+            "number": 5,
+            "name": "Partij van de Wet"
+          }
+        ]
+      }
+    ]
+  },
   "hash": "dedf 17b4 684e 1214 fcab b770 925d c75c 624b e338 0bd3 4647 29c3 7a80 a379 40ad",
   "creation_date_time": "19-03-2023 17:07:00 +02:00"
 }

--- a/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p7.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p7.json
@@ -3725,6 +3725,35 @@
     "initial_total_full_seats": 13,
     "initial_total_residual_seats": 2
   },
+  "footnotes": {
+    "drawn_lots": [
+      {
+        "variant": "LargestRemainderResidualSeat",
+        "lists": [
+          {
+            "number": 2,
+            "name": "GROEP 1"
+          },
+          {
+            "number": 3,
+            "name": "GROEP 2"
+          },
+          {
+            "number": 4,
+            "name": "GROEP 3"
+          },
+          {
+            "number": 5,
+            "name": "GROEP 4"
+          },
+          {
+            "number": 6,
+            "name": "GROEP 5"
+          }
+        ]
+      }
+    ]
+  },
   "hash": "dedf 17b4 684e 1214 fcab b770 925d c75c 624b e338 0bd3 4647 29c3 7a80 a379 40ad",
   "creation_date_time": "19-03-2023 17:07:00 +02:00"
 }

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -351,8 +351,9 @@ Na toewijzing van de volle zetels blijft een aantal te verdelen zetels over. Dit
     set enum(spacing: 12pt, numbering: numbering("I", 1))
     for drawn_lot in drawn_lots {
       let lot_variant = if drawn_lot.variant == "HighestAverageResidualSeat" { [gemiddelden] } else { [overschotten] };
-      let list_names = comma_list(drawn_lot.lists.map((list) => format_political_group_name(list.number, list.name, with_prefix: "with_list_prefix")));
-      [+ De lijsten #list_names hebben gelijke #lot_variant, maar er zijn niet voldoende restzetels voor toekenning ervan aan die lijst. Er is daarom geloot welke lijst de restzetel krijgt.]
+      let list_names = drawn_lot.lists.map((list) => format_political_group_name(list.number, list.name, with_prefix: "with_list_prefix"));
+      let list_names_formatted = comma_list(list_names, last_separator: "en");
+      [+ De lijsten #list_names_formatted hebben gelijke #lot_variant, maar er zijn niet voldoende restzetels voor toekenning ervan aan die lijst. Er is daarom geloot welke lijst de restzetel krijgt.]
     }
     if absolute_majority != none {
       [+ #format_political_group_name(absolute_majority.number, absolute_majority.name, with_prefix: "with_list_prefix") heeft meer dan de helft van de stemmen behaald en heeft daardoor een volstrekte meerderheid. Omdat de lijst op basis van de zetelverdeling niet meer dan de helft van de zetels heeft gekregen, heeft de lijst via de restzetelverdeling een extra (rest)zetel gekregen.]

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -344,10 +344,16 @@ Na toewijzing van de volle zetels blijft een aantal te verdelen zetels over. Dit
   #let footnotes = if input.keys().contains("footnotes") { input.footnotes } else { () }
   
   #if footnotes.len() > 0 {
+    let drawn_lots = if footnotes.keys().contains("drawn_lots") { footnotes.drawn_lots } else { () };
     let absolute_majority = if footnotes.keys().contains("absolute_majority") { footnotes.absolute_majority } else { none };
     let exhausted_lists = if footnotes.keys().contains("exhausted_lists") { footnotes.exhausted_lists } else { () };
 
     set enum(spacing: 12pt, numbering: numbering("I", 1))
+    for drawn_lot in drawn_lots {
+      let lot_variant = if drawn_lot.variant == "HighestAverageResidualSeat" { [gemiddelden] } else { [overschotten] };
+      let list_names = comma_list(drawn_lot.lists.map((list) => format_political_group_name(list.number, list.name, with_prefix: "with_list_prefix")));
+      [+ De lijsten #list_names hebben gelijke #lot_variant, maar er zijn niet voldoende restzetels voor toekenning ervan aan die lijst. Er is daarom geloot welke lijst de restzetel krijgt.]
+    }
     if absolute_majority != none {
       [+ #format_political_group_name(absolute_majority.number, absolute_majority.name, with_prefix: "with_list_prefix") heeft meer dan de helft van de stemmen behaald en heeft daardoor een volstrekte meerderheid. Omdat de lijst op basis van de zetelverdeling niet meer dan de helft van de zetels heeft gekregen, heeft de lijst via de restzetelverdeling een extra (rest)zetel gekregen.]
     }


### PR DESCRIPTION
## What & why

Resolves #3405

Added the following footnote (https://github.com/kiesraad/abacus/pull/3463/commits/c4c32910d469963f34d434caf227f4d41e4b4771)
```
De lijsten [namen van de lijsten] hebben gelijke [gemiddelden/overschotten], maar er zijn niet voldoende restzetels voor toekenning ervan aan die lijst. Er is daarom geloot welke lijst de restzetel krijgt.
```
The footnote will be repeated in chronological order for each largest remainder/highest average step with drawing lots, but not for absolute majority.

Adjusted `ApportionmentFootnotes` to only require `SeatChangeStep` and not the entire `SeatAssignment` struct. This way we can write tests on a more local scope (https://github.com/kiesraad/abacus/pull/3463/commits/49114e693a8dc8b754dc14ab57942f46be23a84f).

Refactored and added tests accordingly (https://github.com/kiesraad/abacus/pull/3463/commits/bd3fd74aefd53d89a6c1a87ca7257e02b25b6366).

## How to test
- Add the following JSON to `seat_assignment.footnotes.drawn_lots` in `backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p9-and-p10.json` and run `cargo run --bin gen-pdf -- --directory base`
```
"drawn_lots": [
  {
    "variant": "HighestAverageResidualSeat",
    "lists": [
      {
        "number": 1,
        "name": "Political Group A"
      },
      {
        "number": 3,
        "name": "Political Group C"
      }
    ]
  },
  {
    "variant": "LargestRemainderResidualSeat",
    "lists": [
      {
        "number": 2,
        "name": "Political Group B"
      },
      {
        "number": 4,
        "name": "Political Group D"
      },
      {
        "number": 5,
        "name": "Political Group E"
      }
    ]
  }
]
```

Verify that the JSON above is the actual serialized representation of the struct. 

## Reviewer notes

- Review per commit.
- Review the PDF diffs

Example screenshot of the footnotes (page 9):
<img width="1711" height="976" alt="image" src="https://github.com/user-attachments/assets/2e3ddfe5-7e10-423a-ae5b-c2dcc807176c" />

Open questions:
1. Shouldn't drawing lots for absolute majority also get a footnote? -> Absolute majority already gets a footnote in the model (but not for drawing lots)
2. Is the formatting of multiple political groups good or should it for example contain `en` before the last list? -> done in https://github.com/kiesraad/abacus/pull/3463/commits/4efffb2e2352fd5080f3f3cc0ba8d1bb3805417a
3. Shouldn't `backend/templates/inputs/extra-model-p-22-2-variations/` also contain footnotes? How have these been generated? -> They do contain footnotes
4. Can we add these variations to the PDF diff or check them somehow? -> Done in https://github.com/kiesraad/abacus/pull/3463/commits/90807a80281c1228293a1ecbb53dd5b5785a63b8
