### PR TITLE
Expand PDF diff with P 22-2 variants

### DIFF
--- a/.github/workflows/scripts/pdf-diff.js
+++ b/.github/workflows/scripts/pdf-diff.js
@@ -14,23 +14,29 @@ exports.pdfDiff = ({ core }) => {
   // Ensure diff folder exists
   fs.mkdirSync(dirs.diff, { recursive: true });
 
-  // Reads .pdf files in the given directory (if it exists) and returns file names
-  const listPdfFiles = (root) => {
-    if (!fs.existsSync(root)) {
-      return [];
+  // Read the manifest gen-pdf writes next to the PDFs
+  const loadManifest = (root) => {
+    const manifestPath = path.join(root, "manifest.json");
+    if (!fs.existsSync(manifestPath)) {
+      return {};
     }
-
-    return fs
-      .readdirSync(root, { withFileTypes: true })
-      .filter(
-        (entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".pdf"),
-      )
-      .map((entry) => entry.name);
+    try {
+      return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    } catch (err) {
+      core.warning(`Failed to parse ${manifestPath}: ${err}`);
+      return {};
+    }
   };
 
-  const allFiles = Array.from(
-    new Set([...listPdfFiles(dirs.base), ...listPdfFiles(dirs.head)]),
-  ).sort();
+  // Retrieve and merge manifests
+  const baseManifest = loadManifest(dirs.base);
+  const headManifest = loadManifest(dirs.head);
+  const manifest = { ...baseManifest, ...headManifest };
+
+  // The manifest's keys enumerate exactly the PDFs gen-pdf produced on each side.
+  const baseFiles = new Set(Object.keys(baseManifest));
+  const headFiles = new Set(Object.keys(headManifest));
+  const allFiles = Array.from(new Set([...baseFiles, ...headFiles])).sort();
 
   // Markdown table that will be posted as a comment on the PR
   const baseRef = process.env.BASE_REF;
@@ -58,8 +64,8 @@ exports.pdfDiff = ({ core }) => {
   for (const relativePath of allFiles) {
     const baseFile = path.join(dirs.base, relativePath);
     const headFile = path.join(dirs.head, relativePath);
-    const hasBase = fs.existsSync(baseFile);
-    const hasHead = fs.existsSync(headFile);
+    const hasBase = baseFiles.has(relativePath);
+    const hasHead = headFiles.has(relativePath);
     let status = "";
 
     if (hasBase && hasHead) {
@@ -112,15 +118,21 @@ exports.pdfDiff = ({ core }) => {
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${rows.join("\n")}\n`);
   }
 
+  // Resolve a PDF output name to its source template via the manifest
+  const resolveTemplate = (relativePath) => {
+    const templateName = manifest[relativePath];
+    if (!templateName) {
+      return null;
+    }
+    const templatePath = path.join("backend", "templates", templateName);
+    return fs.existsSync(templatePath) ? templatePath : null;
+  };
+
   // Add a yellow warning annotation for every changed PDF
   for (const { relativePath, status } of changedFiles) {
-    const template = path.join(
-      "backend",
-      "templates",
-      `${relativePath.replace(/\.pdf$/i, "")}.typ`,
-    );
+    const template = resolveTemplate(relativePath);
     const annotation = { title: "PDF output changed" };
-    if (fs.existsSync(template)) {
+    if (template) {
       annotation.file = template;
       annotation.startLine = 1;
     }

--- a/backend/src/bin/gen-pdf.rs
+++ b/backend/src/bin/gen-pdf.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use abacus::domain::models::{PdfFileModel, PdfModel};
 use clap::Parser;
 use pdf_gen::generate_pdf;
@@ -13,17 +15,84 @@ struct Args {
     directory: Option<String>,
 }
 
-/// List of all available models
-static MODELS: &[&str] = &[
-    "model-na-14-2",
-    "model-na-14-2-bijlage1",
-    "model-na-31-2",
-    "model-na-31-2-bijlage1",
-    "model-na-31-2-inlegvel",
-    "model-n-10-2",
-    "model-p-2a",
-    "model-p-22-2",
-    "model-p-22-2-bijlage1",
+/// A model variant is a Typst template with a JSON input
+struct ModelVariant {
+    /// Output PDF base name (must be unique)
+    name: &'static str,
+    /// Canonical model name passed to `PdfModel::from_name_with_input`
+    model: &'static str,
+    /// Input JSON path relative to `templates/inputs/`
+    input: &'static str,
+}
+
+/// List of all model variants to render
+static VARIANTS: &[ModelVariant] = &[
+    ModelVariant {
+        name: "model-na-14-2",
+        model: "model-na-14-2",
+        input: "model-na-14-2.json",
+    },
+    ModelVariant {
+        name: "model-na-14-2-bijlage1",
+        model: "model-na-14-2-bijlage1",
+        input: "model-na-14-2-bijlage1.json",
+    },
+    ModelVariant {
+        name: "model-na-31-2",
+        model: "model-na-31-2",
+        input: "model-na-31-2.json",
+    },
+    ModelVariant {
+        name: "model-na-31-2-bijlage1",
+        model: "model-na-31-2-bijlage1",
+        input: "model-na-31-2-bijlage1.json",
+    },
+    ModelVariant {
+        name: "model-na-31-2-inlegvel",
+        model: "model-na-31-2-inlegvel",
+        input: "model-na-31-2-inlegvel.json",
+    },
+    ModelVariant {
+        name: "model-n-10-2",
+        model: "model-n-10-2",
+        input: "model-n-10-2.json",
+    },
+    ModelVariant {
+        name: "model-p-2a",
+        model: "model-p-2a",
+        input: "model-p-2a.json",
+    },
+    ModelVariant {
+        name: "model-p-22-2-gte-19-seats",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/gte-19-seats.json",
+    },
+    ModelVariant {
+        name: "model-p-22-2-gte-19-seats-and-p9",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/gte-19-seats-and-p9.json",
+    },
+    ModelVariant {
+        name: "model-p-22-2-lt-19-seats",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/lt-19-seats.json",
+    },
+    // `lt-19-seats-and-p9-and-p10.json` is equal to input `model-p-22-2.json`
+    ModelVariant {
+        name: "model-p-22-2-lt-19-seats-and-p9-and-p10",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/lt-19-seats-and-p9-and-p10.json",
+    },
+    ModelVariant {
+        name: "model-p-22-2-lt-19-seats-and-p10",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/lt-19-seats-and-p10.json",
+    },
+    ModelVariant {
+        name: "model-p-22-2-bijlage1",
+        model: "model-p-22-2-bijlage1",
+        input: "model-p-22-2-bijlage1.json",
+    },
 ];
 
 /// Temporary path to store generated PDFs
@@ -58,13 +127,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create tmp directory
     fs::create_dir_all(&path).await?;
 
-    for model in MODELS {
+    let mut manifest: BTreeMap<String, String> = BTreeMap::new();
+
+    for variant in VARIANTS {
         let now_pdf = std::time::SystemTime::now();
 
-        let input_path = format!("templates/inputs/{}.json", model);
+        let input_path = format!("templates/inputs/{}", variant.input);
         let contents = fs::read_to_string(input_path).await?;
-        let model = PdfModel::from_name_with_input(model, &contents)?;
-        let file_name = format!("{path}/{}.pdf", model.as_model_name());
+        let model = PdfModel::from_name_with_input(variant.model, &contents)?;
+        let file_name = format!("{path}/{}.pdf", variant.name);
+        manifest.insert(
+            format!("{}.pdf", variant.name),
+            model.as_template_path_str().to_string(),
+        );
         let file_model = PdfFileModel::new(file_name.clone(), model);
 
         let pdf = match generate_pdf(file_model).await {
@@ -80,6 +155,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let elapsed = now_pdf.elapsed()?.as_millis();
         println!("Generated PDF {file_name} in {elapsed}ms");
     }
+
+    let manifest_path = format!("{path}/manifest.json");
+    fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?).await?;
 
     let elapsed = now.elapsed()?.as_millis();
     println!("PDFs generated in {elapsed}ms");
@@ -98,32 +176,38 @@ mod tests {
     }
 
     #[test]
-    fn each_model_has_a_template_input() {
-        let dir = inputs_dir();
-
-        for model in MODELS {
-            let path = dir.join(format!("{model}.json"));
+    fn variant_names_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for variant in VARIANTS {
             assert!(
-                path.exists(),
-                "Missing template input for `{model}` at {}",
-                path.display()
+                seen.insert(variant.name),
+                "Duplicate variant output name `{}`; output names must be unique",
+                variant.name
             );
         }
     }
 
+    /// Check that all models exist and can be parsed
     #[test]
-    fn models_deserialize_using_their_template_input() {
-        let dir = inputs_dir();
+    fn variant_templates_exist() {
+        let inputs = inputs_dir();
+        let templates = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("templates");
 
-        for model in MODELS {
-            let path = dir.join(format!("{model}.json"));
-            let contents = fs::read_to_string(&path)
-                .unwrap_or_else(|err| panic!("Failed to read {}: {err}", path.display()));
+        for variant in VARIANTS {
+            let input_path = inputs.join(variant.input);
+            let contents = fs::read_to_string(&input_path)
+                .unwrap_or_else(|err| panic!("Failed to read {}: {err}", input_path.display()));
 
-            let parsed = PdfModel::from_name_with_input(model, &contents)
-                .unwrap_or_else(|err| panic!("Failed to parse `{model}`: {err}"));
+            let parsed = PdfModel::from_name_with_input(variant.model, &contents)
+                .unwrap_or_else(|err| panic!("Failed to parse `{}`: {err}", variant.name));
 
-            assert_eq!(parsed.as_model_name(), *model);
+            let template_path = templates.join(parsed.as_template_path_str());
+            assert!(
+                template_path.exists(),
+                "Variant `{}` maps to missing template {}",
+                variant.name,
+                template_path.display()
+            );
         }
     }
 }


### PR DESCRIPTION
## What & why

Expand PDF diff with P 22-2 variants as noted in https://github.com/kiesraad/abacus/pull/3461#issuecomment-4786694751. All variants are configured in `backend/src/bin/gen-pdf.rs`, which now also writes a manifest file that `pdf-diff.js` uses to link PDF files to the Typst templates.

## How to test

See CI. Because the manifest doesn't exist for `main`, all PDF files will probably get reported as new.

## Reviewer notes

None.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->