### PR TITLE
Round progress percentages appropriately

### DIFF
--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -895,7 +895,7 @@ export const noRecountNoDifferencesDrawingLotsDataEntryGSB: GSBResults & { model
 };
 
 export const dataEntryRequest: DataEntry = {
-  progress: 88,
+  progress: 87,
   data: noRecountNoDifferencesDataEntry,
   client_state: {
     furthest: "political_group_votes_3",
@@ -1047,7 +1047,7 @@ export const noRecountNoDifferencesDataEntryWithGaps: Results = {
 };
 
 export const dataEntryRequestWithGaps: DataEntry = {
-  progress: 86,
+  progress: 85,
   data: noRecountNoDifferencesDataEntryWithGaps,
   client_state: {
     furthest: "political_group_votes_3",

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -11,8 +11,10 @@ import {
   getDefaultFormSection,
   getInitialValues,
 } from "../testing/mock-data";
+import type { FormState } from "../types/types";
 import {
   addValidationResultsToFormState,
+  calculateDataEntryProgress,
   formSectionComplete,
   getNextSectionID,
   isFormSectionEmpty,
@@ -192,6 +194,24 @@ describe("isFormSectionEmpty", () => {
     };
 
     expect(isFormSectionEmpty([booleanSection], section, valuesWithTrue)).toBeFalsy();
+  });
+});
+
+describe("calculateDataEntryProgress", () => {
+  test("data entry progress is rounded down", () => {
+    const formState: FormState = {
+      furthest: "voters_votes_counts",
+      sections: {
+        voters_votes_counts: getDefaultFormSection("voters_votes_counts", 0),
+        differences_counts: getDefaultFormSection("differences_counts", 1),
+        political_group_votes_1: getDefaultFormSection("political_group_votes_1", 2),
+        political_group_votes_2: getDefaultFormSection("political_group_votes_2", 3),
+        political_group_votes_3: getDefaultFormSection("political_group_votes_3", 4),
+        save: getDefaultFormSection("save", 5),
+      },
+    };
+    const progress = calculateDataEntryProgress(formState);
+    expect(progress).toBe(16);
   });
 });
 

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -2,7 +2,6 @@ import type { ValidationResult, ValidationResults } from "@/types/generated/open
 import type { DataEntryResults, DataEntryStructure, FormSectionId } from "@/types/types";
 import { extractFieldInfoFromSection, getValueAtPath } from "@/utils/dataEntryMapping";
 import { doesValidationResultApplyToSection, ValidationResultSet } from "@/utils/ValidationResults";
-
 import type { ClientState, FormSection, FormState } from "../types/types";
 
 export function formSectionComplete(section: FormSection): boolean {

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -138,7 +138,7 @@ export function calculateDataEntryProgress(formState: FormState) {
     return 0;
   }
 
-  return Math.round(((furthestSection.index + 1) / totalSections) * 100);
+  return Math.floor(((furthestSection.index + 1) / totalSections) * 100);
 }
 
 export function buildFormState(

--- a/frontend/src/features/data_entry_home/components/ElectionProgress.test.tsx
+++ b/frontend/src/features/data_entry_home/components/ElectionProgress.test.tsx
@@ -29,4 +29,31 @@ describe("ElectionProgress", () => {
     expect(definitiveBar).toHaveTextContent("1e en 2e invoer klaar");
     expect(definitiveBar).toHaveTextContent("25%");
   });
+
+  test("rounds down the percentages in the progress bar", () => {
+    vi.spyOn(useElectionStatus, "useElectionStatus").mockReturnValue({
+      ...getElectionStatusMockData([
+        { status: "definitive" },
+        { status: "definitive" },
+        { status: "definitive" },
+        { status: "first_entry_finalised" },
+        { status: "first_entry_finalised" },
+        { status: "first_entry_finalised" },
+        { status: "first_entry_in_progress" },
+      ]),
+      refetch: vi.fn(),
+    });
+
+    render(<ElectionProgress />);
+
+    const firstEntryFinishedBar = screen.getByTestId("progressbar-first-entry-finished");
+    expect(firstEntryFinishedBar).toBeInTheDocument();
+    expect(firstEntryFinishedBar).toHaveTextContent("1e invoer klaar");
+    expect(firstEntryFinishedBar).toHaveTextContent("85%");
+
+    const definitiveBar = screen.getByTestId("progressbar-first-and-second-entry-finished");
+    expect(definitiveBar).toBeInTheDocument();
+    expect(definitiveBar).toHaveTextContent("1e en 2e invoer klaar");
+    expect(definitiveBar).toHaveTextContent("42%");
+  });
 });

--- a/frontend/src/features/data_entry_home/components/ElectionProgress.tsx
+++ b/frontend/src/features/data_entry_home/components/ElectionProgress.tsx
@@ -5,6 +5,7 @@ import { ProgressBar } from "@/components/ui/ProgressBar/ProgressBar";
 import { useElectionStatus } from "@/hooks/election/useElectionStatus";
 import { t } from "@/i18n/translate";
 import type { DataEntryStatusName } from "@/types/generated/openapi";
+import { calculateProgressPercentage } from "@/utils/progressPercentage";
 
 type Stat = {
   title: string;
@@ -31,12 +32,14 @@ export function ElectionProgress() {
       {
         title: t("status.first_entry_finished_short"),
         id: "first-entry-finished",
-        percentage: total > 0 ? Math.floor((totalFirstEntryFinished / total) * 100) : 0,
+        // The percentage is rounded up when between 0.5 and 1, so that progress is not set to 0% for too long, when the total is large.
+        percentage: total > 0 ? calculateProgressPercentage(totalFirstEntryFinished, total, 0.5, 1) : 0,
       },
       {
         title: t("status.first_and_second_entry_finished"),
         id: "first-and-second-entry-finished",
-        percentage: total > 0 ? Math.floor((totalFirstAndSecondEntryFinished / total) * 100) : 0,
+        // The percentage is rounded up when between 0.5 and 1, so that progress is not set to 0% for too long, when the total is large.
+        percentage: total > 0 ? calculateProgressPercentage(totalFirstAndSecondEntryFinished, total, 0.5, 1) : 0,
       },
     ];
   }, [statuses]);

--- a/frontend/src/features/data_entry_home/components/ElectionProgress.tsx
+++ b/frontend/src/features/data_entry_home/components/ElectionProgress.tsx
@@ -31,12 +31,12 @@ export function ElectionProgress() {
       {
         title: t("status.first_entry_finished_short"),
         id: "first-entry-finished",
-        percentage: total > 0 ? Math.round((totalFirstEntryFinished / total) * 100) : 0,
+        percentage: total > 0 ? Math.floor((totalFirstEntryFinished / total) * 100) : 0,
       },
       {
         title: t("status.first_and_second_entry_finished"),
         id: "first-and-second-entry-finished",
-        percentage: total > 0 ? Math.round((totalFirstAndSecondEntryFinished / total) * 100) : 0,
+        percentage: total > 0 ? Math.floor((totalFirstAndSecondEntryFinished / total) * 100) : 0,
       },
     ];
   }, [statuses]);

--- a/frontend/src/features/data_entry_home/components/ElectionProgress.tsx
+++ b/frontend/src/features/data_entry_home/components/ElectionProgress.tsx
@@ -33,13 +33,13 @@ export function ElectionProgress() {
         title: t("status.first_entry_finished_short"),
         id: "first-entry-finished",
         // The percentage is rounded up when between 0.5 and 1, so that progress is not set to 0% for too long, when the total is large.
-        percentage: total > 0 ? calculateProgressPercentage(totalFirstEntryFinished, total, 0.5, 1) : 0,
+        percentage: calculateProgressPercentage(totalFirstEntryFinished, total, 0.5, 1),
       },
       {
         title: t("status.first_and_second_entry_finished"),
         id: "first-and-second-entry-finished",
         // The percentage is rounded up when between 0.5 and 1, so that progress is not set to 0% for too long, when the total is large.
-        percentage: total > 0 ? calculateProgressPercentage(totalFirstAndSecondEntryFinished, total, 0.5, 1) : 0,
+        percentage: calculateProgressPercentage(totalFirstAndSecondEntryFinished, total, 0.5, 1),
       },
     ];
   }, [statuses]);

--- a/frontend/src/features/election_status/components/ElectionStatus.stories.tsx
+++ b/frontend/src/features/election_status/components/ElectionStatus.stories.tsx
@@ -65,11 +65,11 @@ export const ElectionStatusNoLinks: StoryObj<StoryProps> = {
       await expect(canvas.getByTestId("progressbar-all")).toBeVisible();
       const bars = canvas.getByTestId("multi-outer-bar").children;
       const expectedData = [
-        { index: 0, percentage: 13, class: "definitive" },
+        { index: 0, percentage: 12, class: "definitive" },
         { index: 1, percentage: 25, class: "first-entry-finished" },
         { index: 2, percentage: 25, class: "in-progress" },
         { index: 3, percentage: 25, class: "errors-and-warnings" },
-        { index: 4, percentage: 13, class: "not-started" },
+        { index: 4, percentage: 12, class: "not-started" },
       ];
 
       for (const data of expectedData) {

--- a/frontend/src/features/election_status/hooks/useElectionStatus.ts
+++ b/frontend/src/features/election_status/hooks/useElectionStatus.ts
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import type { PercentageAndColorClass, ProgressBarColorClass } from "@/components/ui/ProgressBar/ProgressBar";
 import { useUsers } from "@/hooks/user/useUsers";
 import type { DataEntryStatusName, ElectionStatusResponseEntry } from "@/types/generated/openapi";
+import { calculateProgressPercentage } from "@/utils/progressPercentage";
 
 export const statusCategories = [
   "errors_and_warnings",
@@ -73,12 +74,15 @@ export function useElectionStatus(statuses: ElectionStatusResponseEntry[]): Elec
 
   const progressBarData: PercentageAndColorClass[] = useMemo(() => {
     const total = statuses.length;
-    // Reverse the categories and make sure not started is at the end of the progress bar
     const [notStarted, ...data] = statusCategories
-      .map((cat) => ({
-        percentage: total > 0 ? Math.floor((categoryCounts[cat] / total) * 100) : 0,
-        class: categoryColorClass[cat],
-      }))
+      .map((cat) => {
+        return {
+          // The percentage is rounded up when between 0 and 1, so even with 1 item in a category and a large total, the item is shown in the progress bar.
+          percentage: calculateProgressPercentage(categoryCounts[cat], total, 0, 1),
+          class: categoryColorClass[cat],
+        };
+      })
+      // Reverse the categories and make sure not started is at the end of the progress bar
       .reverse();
     if (notStarted) {
       data.push(notStarted);

--- a/frontend/src/features/election_status/hooks/useElectionStatus.ts
+++ b/frontend/src/features/election_status/hooks/useElectionStatus.ts
@@ -76,7 +76,7 @@ export function useElectionStatus(statuses: ElectionStatusResponseEntry[]): Elec
     // Reverse the categories and make sure not started is at the end of the progress bar
     const [notStarted, ...data] = statusCategories
       .map((cat) => ({
-        percentage: total > 0 ? Math.round((categoryCounts[cat] / total) * 100) : 0,
+        percentage: total > 0 ? Math.floor((categoryCounts[cat] / total) * 100) : 0,
         class: categoryColorClass[cat],
       }))
       .reverse();

--- a/frontend/src/utils/progressPercentage.test.ts
+++ b/frontend/src/utils/progressPercentage.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { calculateProgressPercentage } from "./progressPercentage";
 
-// froms: 0.5, 0
-
 describe("progressPercentage util", () => {
   test.each([
     [5, 0, 0, 1, 0], // total of 0 returns 0

--- a/frontend/src/utils/progressPercentage.test.ts
+++ b/frontend/src/utils/progressPercentage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { calculateProgressPercentage } from "./progressPercentage";
+
+// froms: 0.5, 0
+
+describe("progressPercentage util", () => {
+  test.each([
+    [5, 0, 0, 1, 0], // total of 0 returns 0
+    [0, 0, 0, 1, 0], // total of 0 returns 0
+    [0, 5, 0, 1, 0], // 0 count returns 0
+    [4, 1000, 0.5, 1, 0], // round down below ceiling threshold
+    [5, 1000, 0.5, 1, 1], // round up within ceiling threshold
+    [999, 1000, 0.5, 1, 99], // round down above ceiling threshold
+    [0, 1000, 0, 1, 0], // 0 count returns 0
+    [1, 1000, 0, 1, 1], // round up within ceiling threshold
+    [999, 1000, 0, 1, 99], // round down above ceiling threshold
+  ])("Percentage for %j/%j with threshold from %j to %j results in %j", (count: number, total: number, from: number, to: number, expected: number) => {
+    expect(calculateProgressPercentage(count, total, from, to)).toBe(expected);
+  });
+});

--- a/frontend/src/utils/progressPercentage.ts
+++ b/frontend/src/utils/progressPercentage.ts
@@ -10,7 +10,6 @@ export function calculateProgressPercentage(
     return 0;
   }
   const percentage = (count / total) * 100;
-  if (percentage >= ceilingThresholdFrom && percentage < ceilingThresholdTo) {
-    return Math.ceil(percentage);
-  } else return Math.floor(percentage);
+  const shouldRoundUp = percentage >= ceilingThresholdFrom && percentage < ceilingThresholdTo;
+  return shouldRoundUp ? Math.ceil(percentage) : Math.floor(percentage);
 }

--- a/frontend/src/utils/progressPercentage.ts
+++ b/frontend/src/utils/progressPercentage.ts
@@ -1,0 +1,16 @@
+export function calculateProgressPercentage(
+  count: number,
+  total: number,
+  ceilingThresholdFrom: number,
+  ceilingThresholdTo: number,
+) {
+  // Calculates the progress percentage for count / total, rounding up for percentages within the threshold, rounding down for all other cases.
+  // This allows us to determine when to round up a percentage between 0 and 1 (e.g. 0.5%) to 1. And it makes sure we don't round a percantage of 99.5% or higher up to 100%.
+  if (total === 0) {
+    return 0;
+  }
+  const percentage = (count / total) * 100;
+  if (percentage >= ceilingThresholdFrom && percentage < ceilingThresholdTo) {
+    return Math.ceil(percentage);
+  } else return Math.floor(percentage);
+}


### PR DESCRIPTION
## What & why

<!-- What does this change do, and why is it needed? Link the issue(s). -->

Solves one of the three findings in #3159:

> ProgressBar percentage should be with floored instead of rounded input percentage: example Math.floor((totalFirstEntryFinished / total) * 100) : 0

Reason it should be floor is to avoid rounding a percentage >= 99.5% to 100%, suggesting a completed status. However, always using floor also means we round a percentage between 0 and 1 down to 0 in some cases where we shouldn't.

So we introduced a function (hat tip to @stacktraceghost for the conversation and the pair programming) `calculateProgressPercentage()` that calculates the percentage and rounds it down, except when it's within a range provided, in which case it rounds up.

There are three occurrences where we calculate a progress percentage. The function is used in two of them:

1. In ElectionProgress, which is used for the progress bars for typists, any percentage >= 0.5 and < 1 is rounded up. So when you have e.g. 600 polling stations, the 0% of progress dissappears as soon as 3 polling stations have been entered.
2. In useElectionStatus, which is used for the progress bar per status on the election status page, any percentage >=0 and < 1 is rounded up. So when you have e.g. 600 polling stations of which 599 are complete and 1 has errrors, part of the progress bar is red.

*Sidenote on the MultiProgressBar: it accepts values that add up to a total larger than 100. It seems to handle that fine. Because of the data we provide it, the total will at most be slightly larger than 100.*

For the third occurrence, calculateDataEntryProgress, which is used for data entry progress of a single entry when a typist submits data entry, I did not introduce the function, since it serves no purpose. It calculates the percentage completed of the pages in data entry. Since it is extremely unlikely we will ever have more than 100 pages, the issue of rounding down to 0 or up to 100 when we shouldn't, will not occur.  
Since my initial solution was changing the round to a floor for all three occurrences, I have kept that change for this occurrence in this PR. At least it is consistent with floor being the default way to round in `calculateProgressPercentage()`.

## How to test

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

Tests were updated or added for each of the changes.

## Reviewer notes

No notes.

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->