### PR TITLE
Add real number of voters to gen test election 

### DIFF
--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -560,9 +560,10 @@ async fn generate_csb_data_entry(
 
         // number of voters that actually came and voted
         let results = if let Some(v) = votes {
+            let total_votes: u32 = v.iter().flatten().sum();
             Results::GSB(generate_gsb_results_from_votes(
                 &election.political_groups,
-                election.number_of_voters,
+                rng.random_range(total_votes..=total_votes * 2),
                 v,
             ))
         } else {


### PR DESCRIPTION
## What & why

Add number of voters value between 100% and 200% of votes to gen test election with given votes instead of default 1. The value 1 is an error and needed to be corrected.

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

Generate P 22-2 variants or drawing lots variants and see that "Kiesgerechtigden" (in Apportionment Kengetallen table) is set to a more logical value instead of 1.

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->