### PR TITLE
Drawing lots for candidate nominations (P 15)

### DIFF
--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -6,7 +6,7 @@ pub use structs::{
 use tracing::{debug, info};
 
 use crate::{
-    ApportionmentError, CandidateVotes, ListVotes,
+    ApportionmentError, CandidateDrawn, CandidateVotes, ListVotes,
     fraction::Fraction,
     structs::{
         CandidateDrawingLotsVariant, CandidateNominationInput, CandidateNumber, DeceasedCandidates,
@@ -24,6 +24,9 @@ pub enum CandidateNomination<'a, LV: ListVotes> {
 #[expect(clippy::cognitive_complexity)]
 pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     input: &CandidateNominationInput<'a, L>,
+    candidates_drawn: impl Iterator<
+        Item = &'a (impl CandidateDrawn<ListNumber<L>, CandidateNumber<L>> + 'a),
+    >,
 ) -> Result<CandidateNomination<'a, L>, ApportionmentError> {
     info!("Candidate nomination");
 
@@ -42,7 +45,7 @@ pub(crate) fn candidate_nomination<'a, L: ListVotes>(
     info!("Preference threshold: {}", preference_threshold);
 
     let list_candidate_nomination =
-        match candidate_nomination_per_list(input, preference_threshold)? {
+        match candidate_nomination_per_list(input, preference_threshold, candidates_drawn)? {
             ListCandidateNominations::Completed(list) => list,
             ListCandidateNominations::DrawingLotsRequired(variant) => {
                 return Ok(CandidateNomination::DrawingLotsRequired(variant));
@@ -126,13 +129,15 @@ enum ListCandidateNominations<'a, LV: ListVotes> {
 fn candidate_nomination_per_list<'a, LV: ListVotes>(
     input: &CandidateNominationInput<'a, LV>,
     preference_threshold: Fraction,
+    mut candidates_drawn: impl Iterator<
+        Item = &'a (impl CandidateDrawn<ListNumber<LV>, CandidateNumber<LV>> + 'a),
+    >,
 ) -> Result<ListCandidateNominations<'a, LV>, ApportionmentError> {
     let mut list_candidate_nomination: Vec<ListCandidateNomination<LV>> = vec![];
     for list in input.list_votes {
-        let (list_number, list_seats) = input
+        let total_seats = input
             .total_seats_per_list
-            .iter()
-            .find(|(number, _)| *number == list.number())
+            .get(&list.number())
             .expect("Total seats exists")
             .to_owned();
 
@@ -149,14 +154,15 @@ fn candidate_nomination_per_list<'a, LV: ListVotes>(
         let preferential_candidate_nomination = match preferential_candidate_nomination::<LV>(
             list.number(),
             &candidate_votes_meeting_preference_threshold,
-            list_seats,
+            total_seats,
+            &mut candidates_drawn,
         )? {
             PreferentialCandidateNomination::Completed(nomination) => nomination,
             PreferentialCandidateNomination::DrawingLotsRequired(variant) => {
                 return Ok(ListCandidateNominations::DrawingLotsRequired(variant));
             }
         };
-        let non_assigned_seats = list_seats as usize - preferential_candidate_nomination.len();
+        let non_assigned_seats = total_seats as usize - preferential_candidate_nomination.len();
 
         // [Artikel P 17 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP17)
         let other_candidate_nomination = other_candidate_nomination(
@@ -168,7 +174,7 @@ fn candidate_nomination_per_list<'a, LV: ListVotes>(
         // [Artikel P 19 Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19)
         let updated_candidate_ranking = if input.deceased_candidates.get(&list.number()).is_none()
             && (candidate_votes_meeting_preference_threshold.is_empty()
-                || (input.number_of_seats >= LARGE_COUNCIL_THRESHOLD && list_seats == 0))
+                || (input.number_of_seats >= LARGE_COUNCIL_THRESHOLD && total_seats == 0))
         {
             vec![]
         } else {
@@ -194,8 +200,8 @@ fn candidate_nomination_per_list<'a, LV: ListVotes>(
         };
 
         list_candidate_nomination.push(ListCandidateNomination {
-            list_number,
-            list_seats,
+            list_number: list.number(),
+            list_seats: total_seats,
             preferential_candidate_nomination,
             other_candidate_nomination,
             updated_candidate_ranking,
@@ -248,55 +254,73 @@ fn other_candidate_nomination<'a, T: CandidateVotes>(
         .collect()
 }
 
+#[derive(Debug)]
 enum PreferentialCandidateNomination<'a, LV: ListVotes> {
     Completed(Vec<&'a LV::Cv>),
     DrawingLotsRequired(CandidateDrawingLotsVariant<ListNumber<LV>, CandidateNumber<LV>>),
 }
 
 /// List the candidates nominated with preferential votes
+/// * list - List number
+/// * candidates - Candidates that meet the preference_threshold,
+///   sorted by votes descending then by candidate number
+/// * total_seats - Total number of seats for this list
+/// * candidates_drawn - Iterator with candidate drawing lots
 fn preferential_candidate_nomination<'a, LV: ListVotes>(
     list: LV::ListNumber,
-    candidates_meeting_preference_threshold: &[&'a LV::Cv],
-    list_seats: u32,
+    candidates: &[&'a LV::Cv],
+    total_seats: u32,
+    candidates_drawn: &mut impl Iterator<
+        Item = &'a (impl CandidateDrawn<ListNumber<LV>, CandidateNumber<LV>> + 'a),
+    >,
 ) -> Result<PreferentialCandidateNomination<'a, LV>, ApportionmentError> {
-    let mut preferential_candidate_nomination: Vec<&LV::Cv> = vec![];
-    if candidates_meeting_preference_threshold.len() <= list_seats as usize {
-        preferential_candidate_nomination.extend(candidates_meeting_preference_threshold);
-    } else {
-        // Loop over non-assigned seats
-        for (index, non_assigned_seats) in (1..=list_seats).rev().enumerate() {
-            // List all candidates with the same number of votes that have not been nominated yet
-            let same_votes_candidates: Vec<&LV::Cv> = candidates_meeting_preference_threshold
-                .iter()
-                .copied()
-                .filter(|candidate_votes| {
-                    !preferential_candidate_nomination.contains(candidate_votes)
-                        && candidate_votes.votes()
-                            == candidates_meeting_preference_threshold[index].votes()
-                })
-                .collect();
-            // Check if we can actually nominate all these candidates, otherwise we would need to draw lots
-            if same_votes_candidates.len() > non_assigned_seats as usize {
-                info!(
-                    "Drawing of lots is required for candidates: {:?}, only {non_assigned_seats} seat(s) available",
-                    candidate_votes_numbers(&same_votes_candidates)
-                );
+    if candidates.len() <= total_seats as usize {
+        // All candidates can be nominated
+        return Ok(PreferentialCandidateNomination::Completed(
+            candidates.to_vec(),
+        ));
+    }
+
+    // Loop over all seats one by one, keeping track of how many seats are remaining
+    let mut nomination: Vec<&LV::Cv> = vec![];
+    for (index, seats_remaining) in (1..=total_seats).rev().enumerate() {
+        // Get all candidates with the same number of votes, that have not been nominated yet
+        let same_votes_candidates_remaining: Vec<&LV::Cv> = candidates
+            .iter()
+            .copied()
+            .filter(|cv| !nomination.contains(cv) && cv.votes() == candidates[index].votes())
+            .collect();
+
+        // Check if we can nominate all these candidates, else we draw lots
+        if same_votes_candidates_remaining.len() <= seats_remaining as usize {
+            nomination.push(candidates[index]);
+        } else {
+            let options = candidate_votes_numbers(&same_votes_candidates_remaining);
+            info!(
+                "Drawing of lots is required for candidates: {options:?}, only {seats_remaining} seat(s) available",
+            );
+
+            let variant = CandidateDrawingLotsVariant { list, options };
+
+            let Some(candidate_drawn) = candidates_drawn.next() else {
                 return Ok(PreferentialCandidateNomination::DrawingLotsRequired(
-                    CandidateDrawingLotsVariant {
-                        list,
-                        options: candidate_votes_numbers(&same_votes_candidates),
-                    },
+                    variant,
                 ));
-            } else {
-                // Nominate candidate to seat
-                preferential_candidate_nomination
-                    .push(candidates_meeting_preference_threshold[index]);
-            }
+            };
+
+            variant.validate(candidate_drawn)?;
+
+            let candidate = same_votes_candidates_remaining
+                .iter()
+                .find(|c| c.number() == *candidate_drawn.drawn())
+                .ok_or(ApportionmentError::InvalidLotDrawing(
+                    "Could not find candidate".to_string(),
+                ))?;
+
+            nomination.push(candidate);
         }
     }
-    Ok(PreferentialCandidateNomination::Completed(
-        preferential_candidate_nomination,
-    ))
+    Ok(PreferentialCandidateNomination::Completed(nomination))
 }
 
 /// Update the candidate list, moving the candidates meeting the preference threshold
@@ -325,32 +349,22 @@ fn update_candidate_ranking<T: CandidateVotes>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        iter,
+    };
 
     use test_log::test;
 
-    use crate::{
-        ListVotes,
-        candidate_nomination::{CandidateNomination, candidate_nomination},
-        fraction::Fraction,
-        structs::{CandidateDrawingLotsVariant, DeceasedCandidates},
-        test_helpers::{
-            ListVotesMock,
-            candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats,
-            candidate_nomination_fixture_with_given_number_of_seats, check_chosen_candidates,
-            check_list_candidate_nomination, get_chosen_and_not_chosen_candidates_for_a_list,
-            seat_assignment_fixture_with_given_candidate_votes,
-            seat_assignment_fixture_with_given_list_numbers_candidate_numbers_and_votes,
-        },
-    };
+    use super::*;
+    use crate::test_helpers::*;
 
     #[test]
     fn test_filter_out_deceased_candidates() {
         let deceased_candidates: DeceasedCandidates<ListVotesMock> =
             HashMap::from([(1, HashSet::from([1, 3])), (2, HashSet::from([2]))]);
         let list = ListVotesMock::from_test_data_auto(1, vec![100, 80, 60, 40, 20]);
-        let filtered_candidate_votes =
-            super::filter_out_deceased_candidates(&list, &deceased_candidates);
+        let filtered_candidate_votes = filter_out_deceased_candidates(&list, &deceased_candidates);
         assert_eq!(
             filtered_candidate_votes,
             vec![
@@ -363,12 +377,12 @@ mod tests {
 
     /// Candidate nomination with non-consecutive list and candidate numbers
     ///
-    /// List seats: [(1, 8), (2, 3), (4, 2), (5, 1), (7, 1)]  
-    /// List 1: Preferential candidate nominations of candidates 1, 4, 3, 5 and 12 and other candidate nominations of candidates 7, 8 and 9  
-    /// List 2: Preferential candidate nomination of candidate 2 and 6 and other candidate nomination of candidates 3  
-    /// List 3: Preferential candidate nomination of candidate 1 and 4 and no other candidate nominations  
-    /// List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations  
-    /// List 5: Preferential candidate nomination of candidate 3 and no other candidate nominations
+    /// List seats: [(1, 8), (2, 3), (4, 2), (5, 1), (7, 1)]
+    /// - List 1: Preferential candidate nominations of candidates 1, 4, 3, 5 and 12 and other candidate nominations of candidates 7, 8 and 9
+    /// - List 2: Preferential candidate nomination of candidate 2 and 6 and other candidate nomination of candidates 3
+    /// - List 3: Preferential candidate nomination of candidate 1 and 4 and no other candidate nominations
+    /// - List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations
+    /// - List 5: Preferential candidate nomination of candidate 3 and no other candidate nominations
     #[test]
     fn test_with_lt_19_seats_and_non_consecutive_list_and_candidate_numbers() {
         let quota = Fraction::new(5104, 15);
@@ -400,9 +414,12 @@ mod tests {
         let input = candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats(
             quota,
             &seat_assignment_input,
-            vec![(1, 8), (2, 3), (4, 2), (5, 1), (7, 1)],
+            [(1, 8), (2, 3), (4, 2), (5, 1), (7, 1)].into(),
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -482,13 +499,13 @@ mod tests {
 
     /// Candidate nomination with ranking change due to preferential candidate nomination
     ///
-    /// Actual case from GR2022  
-    /// List seats: [8, 3, 2, 1, 1]  
-    /// List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8  
-    /// List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3  
-    /// List 3: Preferential candidate nomination of candidate 1 and other candidate nomination of candidate 2  
-    /// List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations  
-    /// List 5: Preferential candidate nomination of candidate 1 and no other candidate nominations
+    /// Actual case from GR2022
+    /// List seats: [8, 3, 2, 1, 1]
+    /// - List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8
+    /// - List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3
+    /// - List 3: Preferential candidate nomination of candidate 1 and other candidate nomination of candidate 2
+    /// - List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations
+    /// - List 5: Preferential candidate nomination of candidate 1 and no other candidate nominations
     #[test]
     fn test_with_lt_19_seats_and_preferential_candidate_nomination_and_updated_candidate_ranking() {
         let quota = Fraction::new(5104, 15);
@@ -509,7 +526,9 @@ mod tests {
             &seat_assignment_input,
             vec![8, 3, 2, 1, 1],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -563,13 +582,13 @@ mod tests {
 
     /// Candidate nomination with ranking change due to preferential candidate nomination and deceased candidates
     ///
-    /// Actual case from GR2022 (excluding the deceased candidates)  
-    /// List seats: [8, 3, 2, 1, 1]  
-    /// List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8  
-    /// List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3  
-    /// List 3: Preferential candidate nomination of candidate 1 and other candidate nomination of candidate 2  
-    /// List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations  
-    /// List 5: Preferential candidate nomination of candidate 1 and no other candidate nominations
+    /// Actual case from GR2022 (excluding the deceased candidates)
+    /// List seats: [8, 3, 2, 1, 1]
+    /// - List 1: Preferential candidate nominations of candidates 1, 3, 2 and 4 and other candidate nominations of candidates 5, 6, 7 and 8
+    /// - List 2: Preferential candidate nomination of candidate 1 and other candidate nomination of candidates 2 and 3
+    /// - List 3: Preferential candidate nomination of candidate 1 and other candidate nomination of candidate 2
+    /// - List 4: Preferential candidate nomination of candidate 1 and no other candidate nominations
+    /// - List 5: Preferential candidate nomination of candidate 1 and no other candidate nominations
     #[test]
     fn test_with_lt_19_seats_and_preferential_candidate_nomination_and_deceased_candidates() {
         let quota = Fraction::new(5104, 15);
@@ -593,7 +612,9 @@ mod tests {
             &seat_assignment_input,
             vec![8, 3, 2, 1, 1],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -660,12 +681,12 @@ mod tests {
 
     /// Candidate nomination with no preferential candidate nomination
     ///
-    /// List seats: [1, 1, 1, 1, 1]  
-    /// List 1: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 2: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 3: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 4: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 5: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// List seats: [1, 1, 1, 1, 1]
+    /// - List 1: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 2: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 3: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 4: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 5: No preferential candidate nominations and other candidate nomination of candidate 1
     #[test]
     fn test_with_lt_19_seats_and_no_preferential_candidate_nomination() {
         let quota = Fraction::new(105, 5);
@@ -684,7 +705,9 @@ mod tests {
             &seat_assignment_input,
             vec![1, 1, 1, 1, 1],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -733,12 +756,12 @@ mod tests {
 
     /// Candidate nomination with no preferential candidate nomination and deceased candidates
     ///
-    /// List seats: [1, 1, 1, 1, 1]  
-    /// List 1: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 2: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 3: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 4: No preferential candidate nominations and other candidate nomination of candidate 1  
-    /// List 5: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// List seats: [1, 1, 1, 1, 1]
+    /// - List 1: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 2: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 3: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 4: No preferential candidate nominations and other candidate nomination of candidate 1
+    /// - List 5: No preferential candidate nominations and other candidate nomination of candidate 1
     #[test]
     fn test_with_lt_19_seats_and_no_preferential_candidate_nomination_and_deceased_candidates() {
         let quota = Fraction::new(105, 5);
@@ -761,7 +784,9 @@ mod tests {
             &seat_assignment_input,
             vec![1, 1, 1, 1, 1],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -819,10 +844,10 @@ mod tests {
 
     /// Candidate nomination with candidate votes meeting preference threshold but no seat
     ///
-    /// List seats: [11, 7, 0]  
-    /// List 1: Preferential candidate nominations of candidates 1, 2, 3, 4, 5, 6 and 7 and other candidate nominations of candidates 8, 9, 10 and 11  
-    /// List 2: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidates 5, 6 and 7  
-    /// List 3: No preferential candidate nominations and no other candidate nomination
+    /// List seats: [11, 7, 0]
+    /// - List 1: Preferential candidate nominations of candidates 1, 2, 3, 4, 5, 6 and 7 and other candidate nominations of candidates 8, 9, 10 and 11
+    /// - List 2: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidates 5, 6 and 7
+    /// - List 3: No preferential candidate nominations and no other candidate nomination
     #[test]
     fn test_with_lt_19_seats_and_candidate_votes_meeting_preference_threshold_but_no_seat() {
         let quota = Fraction::new(570, 18);
@@ -839,7 +864,9 @@ mod tests {
             &seat_assignment_input,
             vec![11, 7, 0],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -889,12 +916,12 @@ mod tests {
 
     /// Candidate nomination with candidate votes meeting preference threshold but no seat
     ///
-    /// List seats: [6, 6, 5, 2, 0]  
-    /// List 1: Preferential candidate nominations of candidates 1, 2, 3, 4 and 5 and other candidate nominations of candidate 6  
-    /// List 2: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidates 5 and 6  
-    /// List 3: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidate 5  
-    /// List 4: Preferential candidate nominations of candidates 1 and 2 and no other candidate nominations  
-    /// List 5: No preferential candidate nominations and no other candidate nomination
+    /// List seats: [6, 6, 5, 2, 0]
+    /// - List 1: Preferential candidate nominations of candidates 1, 2, 3, 4 and 5 and other candidate nominations of candidate 6
+    /// - List 2: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidates 5 and 6
+    /// - List 3: Preferential candidate nominations of candidates 1, 2, 3 and 4 and other candidate nominations of candidate 5
+    /// - List 4: Preferential candidate nominations of candidates 1 and 2 and no other candidate nominations
+    /// - List 5: No preferential candidate nominations and no other candidate nomination
     #[test]
     fn test_with_gte_19_seats_and_candidate_votes_meeting_preference_threshold_but_no_seat() {
         let quota = Fraction::new(960, 19);
@@ -913,7 +940,9 @@ mod tests {
             &seat_assignment_input,
             vec![6, 6, 5, 2, 0],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -977,16 +1006,16 @@ mod tests {
 
     /// Candidate nomination with more candidates eligible for preferential nomination than seats
     ///
-    /// List seats: [6, 5, 4, 2, 2]  
-    /// List 1: Preferential candidate nominations of candidates 1, 3, 4, 5, 6 and 7 no other candidate nominations  
-    /// List 2: Preferential candidate nomination of candidates 1, 2, 4, 5 and 6 and no other candidate nominations  
-    ///       Candidate 7 also meets the preferential threshold but does not get a seat  
-    /// List 3: Preferential candidate nomination of candidate 1, 2, 3 and 5 and no other candidate nominations  
-    ///       Candidates 6 and 7 also meet the preferential threshold but do not get seats  
-    /// List 4: Preferential candidate nomination of candidate 1 and 2 and no other candidate nominations  
-    ///       Candidates 3, 4, 6 and 7 also meet the preferential threshold but do not get seats  
-    /// List 5: Preferential candidate nomination of candidate 1 and 2 and no other candidate nominations  
-    ///       Candidates 4, 5 and 7 also meet the preferential threshold but do not get seats
+    /// List seats: [6, 5, 4, 2, 2]
+    /// - List 1: Preferential candidate nominations of candidates 1, 3, 4, 5, 6 and 7 no other candidate nominations
+    /// - List 2: Preferential candidate nomination of candidates 1, 2, 4, 5 and 6 and no other candidate nominations
+    ///   - Candidate 7 also meets the preferential threshold but does not get a seat
+    /// - List 3: Preferential candidate nomination of candidate 1, 2, 3 and 5 and no other candidate nominations
+    ///   - Candidates 6 and 7 also meet the preferential threshold but do not get seats
+    /// - List 4: Preferential candidate nomination of candidate 1 and 2 and no other candidate nominations
+    ///   - Candidates 3, 4, 6 and 7 also meet the preferential threshold but do not get seats
+    /// - List 5: Preferential candidate nomination of candidate 1 and 2 and no other candidate nominations
+    ///   - Candidates 4, 5 and 7 also meet the preferential threshold but do not get seats
     #[test]
     fn test_with_ge_19_seats_and_more_candidates_eligible_for_preferential_nomination_than_seats() {
         let quota = Fraction::new(9500, 19);
@@ -1005,7 +1034,9 @@ mod tests {
             &seat_assignment_input,
             vec![6, 5, 4, 2, 2],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -1143,7 +1174,9 @@ mod tests {
             &seat_assignment_input,
             vec![2],
         );
-        let Ok(CandidateNomination::Completed(result)) = candidate_nomination(&input) else {
+        let Ok(CandidateNomination::Completed(result)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
             panic!("should be completed");
         };
 
@@ -1157,9 +1190,9 @@ mod tests {
 
     /// Candidate nomination with more candidates eligible for preferential nomination than seats
     ///
-    /// List seats: [6, 5, 4, 2, 2]  
-    /// List 1: Preferential candidate nominations of candidates 1, 2, 3, 4, 5 and 6 no other candidate nominations  
-    /// List 2: Drawing of lots is required for candidates: [1, 2, 3, 4, 5, 6], only 5 seats available
+    /// List seats: [6, 3]
+    /// - List 1: Preferential candidate nominations of candidates 1, 2, 3, 4, 5 and 6 no other candidate nominations
+    /// - List 2: Drawing of lots is required for candidates: [2, 3, 4, 5, 6], only 3 seats available
     #[test]
     fn test_with_drawing_of_lots_error() {
         let quota = Fraction::new(9600, 19);
@@ -1167,27 +1200,215 @@ mod tests {
             19,
             vec![
                 vec![500, 500, 500, 500, 500, 500],
-                vec![400, 400, 400, 400, 400, 400],
-                vec![300, 300, 300, 300, 300, 300],
-                vec![200, 200, 200, 200, 200, 200],
-                vec![200, 200, 200, 200, 200, 200],
+                vec![500, 400, 400, 400, 400, 400],
             ],
         );
         let input = candidate_nomination_fixture_with_given_number_of_seats(
             quota,
             &seat_assignment_input,
-            vec![6, 5, 4, 2, 2],
+            vec![6, 3],
         );
-        let result = candidate_nomination(&input);
+
+        let Ok(CandidateNomination::DrawingLotsRequired(variant_one)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
+            panic!("should be DrawingLotsRequired");
+        };
 
         assert_eq!(
-            result,
-            Ok(CandidateNomination::DrawingLotsRequired(
-                CandidateDrawingLotsVariant {
-                    list: 2,
-                    options: vec![1, 2, 3, 4, 5, 6]
-                }
-            ))
+            variant_one,
+            CandidateDrawingLotsVariant {
+                list: 2,
+                options: vec![2, 3, 4, 5, 6]
+            }
         );
+
+        // Candidate drawn is 5
+        let candidates_drawn = [CandidateDrawnMock {
+            variant: variant_one.clone(),
+            drawn: 5,
+        }];
+
+        let result = candidate_nomination(&input, &mut candidates_drawn.iter());
+        let Ok(CandidateNomination::DrawingLotsRequired(variant_two)) = result else {
+            panic!("should be DrawingLotsRequired, but was {:?}", result);
+        };
+
+        assert_eq!(
+            variant_two,
+            CandidateDrawingLotsVariant {
+                list: 2,
+                options: vec![2, 3, 4, 6]
+            }
+        );
+
+        // Next candidate drawn is 3
+        let candidates_drawn = [
+            CandidateDrawnMock {
+                variant: variant_one,
+                drawn: 5,
+            },
+            CandidateDrawnMock {
+                variant: variant_two,
+                drawn: 3,
+            },
+        ];
+
+        let result = candidate_nomination(&input, &mut candidates_drawn.iter());
+        let Ok(CandidateNomination::Completed(details)) = result else {
+            panic!("should be Completed, but was {:?}", result);
+        };
+
+        assert_eq!(
+            details.list_candidate_nomination,
+            vec![
+                ListCandidateNomination {
+                    list_number: 1,
+                    list_seats: 6,
+                    preferential_candidate_nomination: vec![
+                        &CandidateVotesMock(1, 500),
+                        &CandidateVotesMock(2, 500),
+                        &CandidateVotesMock(3, 500),
+                        &CandidateVotesMock(4, 500),
+                        &CandidateVotesMock(5, 500),
+                        &CandidateVotesMock(6, 500),
+                    ],
+                    other_candidate_nomination: Vec::new(),
+                    updated_candidate_ranking: Vec::new()
+                },
+                ListCandidateNomination {
+                    list_number: 2,
+                    list_seats: 3,
+                    preferential_candidate_nomination: vec![
+                        &CandidateVotesMock(1, 500),
+                        &CandidateVotesMock(5, 400),
+                        &CandidateVotesMock(3, 400),
+                    ],
+                    other_candidate_nomination: Vec::new(),
+                    updated_candidate_ranking: Vec::new()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_preferential_candidate_nomination_scenarios() {
+        struct Case {
+            name: &'static str,
+            candidates: Vec<(u32, u32)>,
+            total_seats: u32,
+            candidates_drawn: Vec<CandidateDrawnMock>,
+            expected_nominations: Vec<u32>,
+        }
+
+        let cases = vec![
+            Case {
+                name: "all candidates nominated",
+                candidates: vec![(1, 1000), (3, 900), (4, 800)],
+                total_seats: 5,
+                candidates_drawn: vec![],
+                expected_nominations: vec![1, 3, 4],
+            },
+            Case {
+                name: "first two candidates nominated because of total seats",
+                candidates: vec![(1, 1000), (3, 900), (4, 800)],
+                total_seats: 2,
+                candidates_drawn: vec![],
+                expected_nominations: vec![1, 3],
+            },
+            Case {
+                name: "first two candidates nominated with drawing lots",
+                candidates: vec![(1, 1000), (3, 900), (4, 900)],
+                total_seats: 2,
+                candidates_drawn: vec![CandidateDrawnMock {
+                    variant: CandidateDrawingLotsVariant {
+                        list: 1,
+                        options: vec![3, 4],
+                    },
+                    drawn: 4,
+                }],
+                expected_nominations: vec![1, 4],
+            },
+            Case {
+                name: "first three candidates nominated with drawing lots twice",
+                candidates: vec![(1, 1000), (3, 900), (4, 900), (5, 900)],
+                total_seats: 3,
+                candidates_drawn: vec![
+                    CandidateDrawnMock {
+                        variant: CandidateDrawingLotsVariant {
+                            list: 1,
+                            options: vec![3, 4, 5],
+                        },
+                        drawn: 4,
+                    },
+                    CandidateDrawnMock {
+                        variant: CandidateDrawingLotsVariant {
+                            list: 1,
+                            options: vec![3, 5],
+                        },
+                        drawn: 3,
+                    },
+                ],
+                expected_nominations: vec![1, 4, 3],
+            },
+            Case {
+                name: "no need for drawing of lots if all candidates can be nominated",
+                candidates: vec![(1, 1000), (3, 900), (4, 900), (5, 900)],
+                total_seats: 4,
+                candidates_drawn: vec![],
+                expected_nominations: vec![1, 3, 4, 5],
+            },
+        ];
+
+        for case in cases {
+            let candidates: Vec<CandidateVotesMock> = case
+                .candidates
+                .iter()
+                .map(|(number, votes)| CandidateVotesMock(*number, *votes))
+                .collect();
+
+            // preferential_candidate_nomination() takes a &[&CandidateVotesMock]
+            let candidate_refs: Vec<&CandidateVotesMock> = candidates.iter().collect();
+
+            let mut candidates_drawn = case.candidates_drawn.iter();
+
+            let result: Result<
+                PreferentialCandidateNomination<'_, ListVotesMock>,
+                ApportionmentError,
+            > = preferential_candidate_nomination(
+                1,
+                &candidate_refs,
+                case.total_seats,
+                &mut candidates_drawn,
+            );
+
+            // Assert result Ok(Completed())
+            let Ok(PreferentialCandidateNomination::Completed(nomination)) = result else {
+                panic!(
+                    "should be completed successfully for case '{}', but was {:?}",
+                    case.name, result
+                );
+            };
+
+            // Assert nomination candidate numbers
+            assert_eq!(
+                nomination
+                    .into_iter()
+                    .map(CandidateVotesMock::number)
+                    .collect::<Vec<_>>(),
+                case.expected_nominations,
+                "nominations should match: {}",
+                case.name
+            );
+
+            // Assert all candidates_drawn from iterator used
+            let next_candidate_drawn = candidates_drawn.next();
+            assert!(
+                next_candidate_drawn.is_none(),
+                "candidates drawn iterator should be empty for '{}', but there still was {:?}",
+                case.name,
+                next_candidate_drawn
+            )
+        }
     }
 }

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -58,15 +58,16 @@ pub fn process<T: ApportionmentInput>(
     };
 
     let candidate_nomination_input = as_candidate_nomination_input(input, &seat_assignment);
-    let candidate_nomination = match candidate_nomination(&candidate_nomination_input)? {
-        CandidateNomination::Completed(candidate_nomination) => candidate_nomination,
-        CandidateNomination::DrawingLotsRequired(variant) => {
-            return Ok(ApportionmentOutput::CandidateDrawingLotsRequired(
-                variant,
-                seat_assignment,
-            ));
-        }
-    };
+    let candidate_nomination =
+        match candidate_nomination(&candidate_nomination_input, input.candidates_drawn())? {
+            CandidateNomination::Completed(candidate_nomination) => candidate_nomination,
+            CandidateNomination::DrawingLotsRequired(variant) => {
+                return Ok(ApportionmentOutput::CandidateDrawingLotsRequired(
+                    variant,
+                    seat_assignment,
+                ));
+            }
+        };
 
     Ok(ApportionmentOutput::Completed(ApportionmentDetails {
         seat_assignment,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, collections::HashMap, hash::Hash};
 
 mod residual_seat_assignment;
 mod structs;
@@ -18,8 +18,8 @@ use crate::{
         AbsoluteMajority, AbsoluteMajorityResult, GetListStandingByNumber, RemainderAssignment,
     },
     structs::{
-        AbsoluteMajorityDrawingLots, CandidateNominationInput, CandidateNominationInputType,
-        DeceasedCandidates, ListDrawingLotsVariant, ListNumber,
+        AbsoluteMajorityDrawingLots, CandidateNominationInput, DeceasedCandidates,
+        ListDrawingLotsVariant, ListNumber,
     },
 };
 
@@ -201,14 +201,14 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
 }
 
 /// Returns the total number of seats each list number received in the apportionment result.
-pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy>(
+pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy + Eq + Hash>(
     result: &SeatAssignmentDetails<LN>,
-) -> Vec<(LN, u32)> {
+) -> HashMap<LN, u32> {
     result
         .standings
         .iter()
         .map(|p| (p.list_number, p.total_seats))
-        .collect::<Vec<_>>()
+        .collect()
 }
 
 /// Returns candidate nomination input created from the initial apportionment input
@@ -216,7 +216,7 @@ pub fn get_total_seats_per_list_number_from_apportionment_result<LN: Copy>(
 pub fn as_candidate_nomination_input<'a, T: ApportionmentInput>(
     input: &'a T,
     seat_assignment: &SeatAssignmentDetails<ListNumber<T::List>>,
-) -> CandidateNominationInputType<'a, T> {
+) -> CandidateNominationInput<'a, T::List> {
     CandidateNominationInput {
         number_of_seats: input.number_of_seats(),
         list_votes: input.list_votes(),
@@ -431,7 +431,7 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::fmt::Debug;
+    use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
     use test_log::test;
 
@@ -444,13 +444,13 @@ pub(crate) mod tests {
         test_helpers::{CandidateVotesMock, ListVotesMock},
     };
 
-    fn check_total_seats_per_list<LN: Copy + Debug + PartialEq>(
+    fn check_total_seats_per_list<LN: Copy + Debug + Eq + Hash>(
         result: &SeatAssignmentDetails<LN>,
-        expected_total_seats_per_list: &[(LN, u32)],
+        expected_total_seats_per_list: &HashMap<LN, u32>,
     ) {
         let total_seats_per_list_number =
             get_total_seats_per_list_number_from_apportionment_result(result);
-        assert_eq!(expected_total_seats_per_list, total_seats_per_list_number);
+        assert_eq!(expected_total_seats_per_list, &total_seats_per_list_number);
     }
 
     #[test]
@@ -460,10 +460,7 @@ pub(crate) mod tests {
                 ListStanding::new(
                     &ListVotesMock {
                         number: n,
-                        candidate_votes: vec![CandidateVotesMock {
-                            number: 1,
-                            votes: 1249,
-                        }],
+                        candidate_votes: vec![CandidateVotesMock(1, 1249)],
                     },
                     Fraction::new(100, 1),
                 )
@@ -1690,7 +1687,7 @@ pub(crate) mod tests {
             assert_eq!(result.steps[1].change.list_number_assigned(), 3);
             assert_eq!(result.steps[2].change.list_number_assigned(), 1);
             assert_eq!(result.steps[3].change.list_number_assigned(), 6);
-            check_total_seats_per_list(&result, &[(1, 12), (3, 6), (4, 1), (6, 2), (7, 2)]);
+            check_total_seats_per_list(&result, &[(1, 12), (3, 6), (4, 1), (6, 2), (7, 2)].into());
         }
 
         /// Apportionment with residual seats assigned with highest averages method

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -678,10 +678,7 @@ mod tests {
         ListStanding::new(
             &ListVotesMock {
                 number: list_number,
-                candidate_votes: vec![CandidateVotesMock {
-                    number: 1,
-                    votes: votes_cast,
-                }],
+                candidate_votes: vec![CandidateVotesMock(1, votes_cast)],
             },
             Fraction::new(100, 1),
         )

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -127,13 +127,38 @@ pub trait ListDrawn<LN> {
 
 /// Variant of drawing lots for candidates, with all the information needed to do the drawing
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CandidateDrawingLotsVariant<LN, CN> {
+pub struct CandidateDrawingLotsVariant<LN: PartialEq, CN: PartialEq> {
     pub list: LN,
     pub options: Vec<CN>,
 }
 
+impl<LN: PartialEq, CN: PartialEq> CandidateDrawingLotsVariant<LN, CN> {
+    /// Validate the candidate drawn against this variant.
+    ///
+    /// Return [[ApportionmentError::InvalidLotDrawing]] if the variant is different
+    /// or the candidate drawn is not one of the options.
+    pub fn validate(
+        &self,
+        candidate_drawn: &impl CandidateDrawn<LN, CN>,
+    ) -> Result<(), ApportionmentError> {
+        if candidate_drawn.variant() != *self {
+            return Err(ApportionmentError::InvalidLotDrawing(
+                "Variant mismatch".to_string(),
+            ));
+        }
+
+        if !self.options.contains(candidate_drawn.drawn()) {
+            return Err(ApportionmentError::InvalidLotDrawing(
+                "Invalid number drawn".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 /// The candidate that has been drawn and the variant with all information about the drawing
-pub trait CandidateDrawn<LN, CN> {
+pub trait CandidateDrawn<LN: PartialEq, CN: PartialEq> {
     /// The type and information for drawing lots
     fn variant(&self) -> CandidateDrawingLotsVariant<LN, CN>;
     /// The candidate that the lot was drawn for
@@ -189,11 +214,8 @@ pub(crate) struct CandidateNominationInput<'a, L: ListVotes> {
     pub list_votes: &'a [L],
     pub deceased_candidates: &'a DeceasedCandidates<L>,
     pub quota: Fraction,
-    pub total_seats_per_list: Vec<(L::ListNumber, u32)>,
+    pub total_seats_per_list: HashMap<L::ListNumber, u32>,
 }
-
-pub(crate) type CandidateNominationInputType<'a, T> =
-    CandidateNominationInput<'a, <T as ApportionmentInput>::List>;
 
 #[cfg(test)]
 mod tests {

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -63,20 +63,17 @@ impl ListVotes for ListVotesMock {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct CandidateVotesMock {
-    pub number: u32,
-    pub votes: u32,
-}
+pub struct CandidateVotesMock(pub u32, pub u32);
 
 impl CandidateVotes for CandidateVotesMock {
     type CandidateNumber = u32;
 
     fn number(&self) -> Self::CandidateNumber {
-        self.number
+        self.0
     }
 
     fn votes(&self) -> u32 {
-        self.votes
+        self.1
     }
 }
 
@@ -87,10 +84,7 @@ impl ListVotesMock {
             candidate_votes: candidate_votes
                 .into_iter()
                 .enumerate()
-                .map(|(i, votes)| CandidateVotesMock {
-                    number: u32::try_from(i + 1).unwrap(),
-                    votes,
-                })
+                .map(|(i, votes)| CandidateVotesMock(u32::try_from(i + 1).unwrap(), votes))
                 .collect(),
         }
     }
@@ -120,9 +114,10 @@ impl ListDrawn<u32> for ListDrawnMock {
     }
 }
 
+#[derive(Debug)]
 pub struct CandidateDrawnMock {
-    variant: CandidateDrawingLotsVariant<u32, u32>,
-    drawn: u32,
+    pub variant: CandidateDrawingLotsVariant<u32, u32>,
+    pub drawn: u32,
 }
 
 impl CandidateDrawn<u32, u32> for CandidateDrawnMock {
@@ -237,7 +232,7 @@ pub fn candidate_nomination_fixture_with_given_number_of_seats(
 pub fn candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats(
     quota: Fraction,
     seat_assignment_input: &ApportionmentInputMock,
-    total_seats_per_list_number: Vec<(u32, u32)>,
+    total_seats_per_list_number: HashMap<u32, u32>,
 ) -> CandidateNominationInput<'_, ListVotesMock> {
     CandidateNominationInput {
         number_of_seats: seat_assignment_input.number_of_seats,
@@ -334,10 +329,7 @@ pub fn seat_assignment_fixture_with_given_list_numbers_candidate_numbers_and_vot
             number: list_number,
             candidate_votes: list_candidate_votes
                 .into_iter()
-                .map(|(number, candidate_votes)| CandidateVotesMock {
-                    number,
-                    votes: candidate_votes,
-                })
+                .map(|(number, candidate_votes)| CandidateVotesMock(number, candidate_votes))
                 .collect(),
         })
     }


### PR DESCRIPTION
## What & why

- Implements https://github.com/kiesraad/abacus/issues/3150

## How to test

Unit test `test_with_drawing_of_lots_error()` has been updated with drawing lots for candidates and asserting the result

Unit test `test_preferential_candidate_nomination_scenarios()` tests multiple scenarios for candidate nomination (P 15)

Frontend will be implemented in a later issue from Epic https://github.com/kiesraad/abacus/issues/788

## Reviewer notes

Main change is in `candidate_nomination_per_list()` in `backend/apportionment/src/candidate_nomination/mod.rs` and I suggest starting there.

Two other changes are:
- Change `CandidateNominationInput::total_seats_per_list` from a `Vec` to a `HashMap`
- Change `CandidateVotesMock` to a tuple struct for one-line construction, to improve test readability

I've tried adding the `candidates_drawn` iterator to the `CandidateNominationInput` struct instead of passing it as a separate argument, but the generics became even more complex, and also the whole input would then have to become mutable. I decided that that was not making things more clear.


<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->