### PR TITLE
Apportionment always refetch result and state

### DIFF
--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -1,5 +1,6 @@
 import { render as rtlRender } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
 import * as ReactRouter from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
@@ -302,12 +303,19 @@ describe("ApportionmentPage", () => {
     const resetApportionmentState = spyOnHandler(ResetApportionmentStateRequestHandler);
     const getApportionmentState = spyOnHandler(GetApportionmentStateRequestHandler);
     overrideOnce("get", "/api/elections/3", 200, getElectionMockData(election, committee_session));
-    overrideOnce("post", "/api/elections/3/apportionment", 200, {
-      seat_assignment: seat_assignment,
-      candidate_nomination: candidate_nomination,
-      election_summary: election_summary,
-      warnings: ["NotAllSeatsAssigned"],
-    } satisfies ElectionApportionmentResponse);
+    server.use(
+      http.post("/api/elections/3/apportionment", () =>
+        HttpResponse.json(
+          {
+            seat_assignment: seat_assignment,
+            candidate_nomination: candidate_nomination,
+            election_summary: election_summary,
+            warnings: ["NotAllSeatsAssigned"],
+          } satisfies ElectionApportionmentResponse,
+          { status: 200 },
+        ),
+      ),
+    );
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [],
       lists_drawn: [],

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -97,7 +97,7 @@ function renderLinksToSeatAssignmentPages(seatAssignment: SeatAssignment) {
 export function ApportionmentPage() {
   const navigate = useNavigate();
   const { currentCommitteeSession, election } = useElection();
-  const { seatAssignment, candidateNomination, electionSummary, warnings, state, error, refetchState } =
+  const { seatAssignment, candidateNomination, electionSummary, warnings, state, error, refetch } =
     useApportionmentContext();
   const [apiError, setApiError] = useState<AnyApiError>();
   const client = useApiClient();
@@ -117,7 +117,7 @@ export function ApportionmentPage() {
     const response: ApiResult<ApportionmentState> = await client.postRequest(path);
 
     if (isSuccess(response)) {
-      await refetchState();
+      await refetch();
     } else {
       setApiError(response);
     }

--- a/frontend/src/features/apportionment/components/ApportionmentProvider.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentProvider.tsx
@@ -12,8 +12,14 @@ export interface ElectionApportionmentProviderProps {
 }
 
 export function ApportionmentProvider({ children, electionId }: ElectionApportionmentProviderProps) {
-  const { error: apportionmentError, data } = useApportionmentRequest(electionId);
-  const { requestState, refetch } = useApportionmentStateRequest(electionId);
+  const { error: apportionmentError, data, refetch: refetchApportionment } = useApportionmentRequest(electionId);
+  const { requestState, refetch: refetchState } = useApportionmentStateRequest(electionId);
+
+  // Refetch both the apportionment state and result
+  async function refetch(controller?: AbortController) {
+    await Promise.all([refetchApportionment(), refetchState(controller)]);
+  }
+
   let error = apportionmentError;
   let state: ApportionmentState | undefined;
   if (requestState.status === "success") {
@@ -35,7 +41,7 @@ export function ApportionmentProvider({ children, electionId }: ElectionApportio
         state,
         error,
         isLoading: requestState.status === "loading",
-        refetchState: refetch,
+        refetch,
       }}
     >
       {children}

--- a/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
@@ -1,5 +1,6 @@
 import { render as rtlRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
 import * as ReactRouter from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
@@ -39,12 +40,19 @@ const renderAddDeceasedCandidatePage = (electionId: number) => {
 describe("AddDeceasedCandidatesPage", () => {
   beforeEach(() => {
     overrideOnce("get", "/api/elections/3", 200, getElectionMockData(election, committee_session));
-    overrideOnce("post", "/api/elections/3/apportionment", 200, {
-      seat_assignment: seat_assignment,
-      candidate_nomination: candidate_nomination,
-      election_summary: election_summary,
-      warnings: [],
-    } satisfies ElectionApportionmentResponse);
+    server.use(
+      http.post("/api/elections/3/apportionment", () =>
+        HttpResponse.json(
+          {
+            seat_assignment: seat_assignment,
+            candidate_nomination: candidate_nomination,
+            election_summary: election_summary,
+            warnings: [],
+          } satisfies ElectionApportionmentResponse,
+          { status: 200 },
+        ),
+      ),
+    );
     server.use(GetApportionmentStateRequestHandler);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [{ pg_number: 1, candidate_number: 1 }],

--- a/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.tsx
@@ -32,7 +32,7 @@ function checkStateAndRedirect(state: ApportionmentState | undefined, electionId
 export function AddDeceasedCandidatePage() {
   const navigate = useNavigate();
   const { election } = useElection();
-  const { state, error, isLoading, refetchState } = useApportionmentContext();
+  const { state, error, isLoading, refetch } = useApportionmentContext();
   const [apiError, setApiError] = useState<AnyApiError>();
   const [selectedList, setSelectedList] = useState<PoliticalGroup | undefined>(election.political_groups.at(0));
   const client = useApiClient();
@@ -60,7 +60,7 @@ export function AddDeceasedCandidatePage() {
     const response: ApiResult<ApportionmentState> = await client.postRequest(path, body);
 
     if (isSuccess(response)) {
-      await refetchState();
+      await refetch();
       void navigate(`/elections/${election.id}/apportionment/deceased-candidates`);
     } else {
       setApiError(response);

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
@@ -1,5 +1,6 @@
 import { render as rtlRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
 import * as ReactRouter from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
@@ -56,12 +57,19 @@ const renderDeceasedCandidatesPage = (electionId: number, withRouter: boolean) =
 describe("DeceasedCandidatesPage", () => {
   beforeEach(() => {
     overrideOnce("get", "/api/elections/3", 200, getElectionMockData(election, committee_session));
-    overrideOnce("post", "/api/elections/3/apportionment", 200, {
-      seat_assignment: seat_assignment,
-      candidate_nomination: candidate_nomination,
-      election_summary: election_summary,
-      warnings: [],
-    } satisfies ElectionApportionmentResponse);
+    server.use(
+      http.post("/api/elections/3/apportionment", () =>
+        HttpResponse.json(
+          {
+            seat_assignment: seat_assignment,
+            candidate_nomination: candidate_nomination,
+            election_summary: election_summary,
+            warnings: [],
+          } satisfies ElectionApportionmentResponse,
+          { status: 200 },
+        ),
+      ),
+    );
     server.use(GetApportionmentStateRequestHandler);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
       deceased_candidates: [{ pg_number: 1, candidate_number: 1 }],

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.tsx
@@ -118,7 +118,7 @@ function get_detailed_deceased_candidates(
 export function DeceasedCandidatesPage() {
   const navigate = useNavigate();
   const { election } = useElection();
-  const { state, error, isLoading, refetchState } = useApportionmentContext();
+  const { state, error, isLoading, refetch } = useApportionmentContext();
   const [apiError, setApiError] = useState<AnyApiError>();
   const client = useApiClient();
 
@@ -147,7 +147,7 @@ export function DeceasedCandidatesPage() {
     const response: ApiResult<ApportionmentState> = await client.postRequest(path, body);
 
     if (isSuccess(response)) {
-      void refetchState();
+      void refetch();
     } else {
       setApiError(response);
     }
@@ -158,7 +158,7 @@ export function DeceasedCandidatesPage() {
     const response: ApiResult<ApportionmentState> = await client.postRequest(path);
 
     if (isSuccess(response)) {
-      await refetchState();
+      await refetch();
       void navigate(`/elections/${election.id}/apportionment`);
     } else {
       setApiError(response);
@@ -170,7 +170,7 @@ export function DeceasedCandidatesPage() {
     const response: ApiResult<ApportionmentState> = await client.postRequest(path);
 
     if (isSuccess(response)) {
-      await refetchState();
+      await refetch();
     } else {
       setApiError(response);
     }

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
@@ -1,5 +1,6 @@
 import { render as rtlRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
 import * as ReactRouter from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
@@ -39,12 +40,19 @@ const renderIncludeAllCandidatesPage = (electionId: number) =>
 describe("IncludeAllCandidatesPage", () => {
   beforeEach(() => {
     overrideOnce("get", "/api/elections/3", 200, getElectionMockData(election, committee_session));
-    overrideOnce("post", "/api/elections/3/apportionment", 200, {
-      seat_assignment: seat_assignment,
-      candidate_nomination: candidate_nomination,
-      election_summary: election_summary,
-      warnings: [],
-    } satisfies ElectionApportionmentResponse);
+    server.use(
+      http.post("/api/elections/3/apportionment", () =>
+        HttpResponse.json(
+          {
+            seat_assignment: seat_assignment,
+            candidate_nomination: candidate_nomination,
+            election_summary: election_summary,
+            warnings: [],
+          } satisfies ElectionApportionmentResponse,
+          { status: 200 },
+        ),
+      ),
+    );
     server.use(GetApportionmentStateRequestHandler);
   });
 

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.tsx
@@ -64,7 +64,7 @@ function renderForm(radioError: boolean, handleSubmit: (e: SubmitEvent<HTMLFormE
 export function IncludeAllCandidatesPage() {
   const navigate = useNavigate();
   const { election } = useElection();
-  const { state, error, isLoading, refetchState } = useApportionmentContext();
+  const { state, error, isLoading, refetch } = useApportionmentContext();
   const [apiError, setApiError] = useState<AnyApiError>();
   const [radioError, setRadioError] = useState(false);
   const client = useApiClient();
@@ -106,7 +106,7 @@ export function IncludeAllCandidatesPage() {
     const response: ApiResult<ApportionmentState> = await client.postRequest(path);
 
     if (isSuccess(response)) {
-      void refetchState();
+      void refetch();
     } else {
       setApiError(response);
     }

--- a/frontend/src/features/apportionment/hooks/ApportionmentProviderContext.tsx
+++ b/frontend/src/features/apportionment/hooks/ApportionmentProviderContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-import type { ApiError, ApiResult } from "@/api/ApiResult";
+import type { ApiError } from "@/api/ApiResult";
 import type {
   ApportionmentState,
   ApportionmentWarning,
@@ -17,7 +17,7 @@ export interface iElectionApportionmentProviderContext {
   state?: ApportionmentState;
   error?: ApiError;
   isLoading: boolean;
-  refetchState: (controller?: AbortController) => Promise<ApiResult<ApportionmentState>>;
+  refetch: (controller?: AbortController) => Promise<void>;
 }
 
 export const ApportionmentProviderContext = createContext<iElectionApportionmentProviderContext | undefined>(undefined);

--- a/frontend/src/features/apportionment/hooks/useApportionmentRequest.ts
+++ b/frontend/src/features/apportionment/hooks/useApportionmentRequest.ts
@@ -1,8 +1,21 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { type AnyApiError, isSuccess } from "@/api/ApiResult";
+import { type AnyApiError, type ApiResult, isSuccess } from "@/api/ApiResult";
 import { useApiClient } from "@/api/useApiClient";
 import type { ElectionApportionmentResponse, PROCESS_APPORTIONMENT_REQUEST_PATH } from "@/types/generated/openapi";
+
+function handleApiResult(
+  response: ApiResult<ElectionApportionmentResponse>,
+  setData: (data: ElectionApportionmentResponse | undefined) => void,
+  setError: (error: AnyApiError | undefined) => void,
+) {
+  if (isSuccess(response)) {
+    setData(response.data);
+    setError(undefined);
+  } else {
+    setError(response);
+  }
+}
 
 export function useApportionmentRequest(electionId: number) {
   const path: PROCESS_APPORTIONMENT_REQUEST_PATH = `/api/elections/${electionId}/apportionment`;
@@ -10,15 +23,17 @@ export function useApportionmentRequest(electionId: number) {
   const [error, setError] = useState<AnyApiError>();
   const client = useApiClient();
 
+  const refetch = useCallback(async () => {
+    const response = await client.postRequest<ElectionApportionmentResponse>(path);
+    handleApiResult(response, setData, setError);
+    return response;
+  }, [client, path]);
+
   useEffect(() => {
     void client.postRequest<ElectionApportionmentResponse>(path).then((response) => {
-      if (isSuccess(response)) {
-        setData(response.data);
-      } else {
-        setError(response);
-      }
+      handleApiResult(response, setData, setError);
     });
   }, [client, path]);
 
-  return { error, data };
+  return { error, data, refetch };
 }


### PR DESCRIPTION
## What & why

Resolves #3422

- Adds `refetch` for `useApportionmentRequest`
- Adds `refetch` for `ApportionmentProvider` which calls both the apportionment result and state refetch
- Updated calls in several files
- Updated tests to keep mocking responses instead of only once

## How to test

- See reproduction steps in #3422. 
- Check if both the apportionment result and state are being fetched every time

## Reviewer notes

N/A