### PR TITLE
Add plain HTTP server for redirect and CA download

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -114,11 +114,19 @@ server (leaf) certificate is created in memory on every start, signed by the CA
 and covering `localhost`, `abacus.local`, and all routable LAN addresses.
 
 To trust the server, import the CA into the client trust store: `ca.pem` on
-Linux/macOS/Firefox, `ca.cer` (DER) on Windows.
+Linux/macOS/Firefox, `ca.cer` (DER) on Windows. The CA can be downloaded from the
+running server at `/ca.pem` and `/ca.cer`.
 
 With the `tls` feature enabled, the default port is 8443 in debug builds and 443
 in release builds. Binding to 443 requires elevated privileges (e.g. the
 `CAP_NET_BIND_SERVICE` capability on Linux).
+
+Alongside the HTTPS port, Abacus runs a plain HTTP server that provides the CA
+certificate at `/ca.pem` and `/ca.cer` over plain HTTP (so clients can fetch it
+before trusting the server) and redirects every other request to HTTPS. Its port
+is set by `--http-port` / `ABACUS_HTTP_PORT`, defaulting to 80 in release builds
+and 8080 in debug builds. The CA is served over HTTPS as well. Failing to bind the
+HTTP port (for example without the required privileges) is logged but not fatal.
 
 #### Building with TLS enabled on Windows
 
@@ -250,12 +258,13 @@ The abacus binary supports a few arguments, which can be passed on the command l
 
 ```
 Options:
-  -p, --port <PORT>          Server port, optional [env: ABACUS_PORT=] [default: 8080]
-  -d, --database <DATABASE>  Location of the database file, will be created if it doesn't exist [env: ABACUS_DATABASE=] [default: db.sqlite]
-      --tls-dir <TLS_DIR>    Location of the TLS directory (CA certificate and key), will be created if it doesn't exist [env: ABACUS_TLS_DIR=] [default: tls]
-  -a, --airgap-detection     Enable airgap detection [env: ABACUS_AIRGAP_DETECTION=]
-  -V, --version              Show version
-  -h, --help                 Print help
+  -p, --port <PORT>            Server port, optional [env: ABACUS_PORT=] [default: 8443]
+  -d, --database <DATABASE>    Location of the database file, will be created if it doesn't exist [env: ABACUS_DATABASE=] [default: db.sqlite]
+      --tls-dir <TLS_DIR>      Location of the TLS directory (CA certificate and key), will be created if it doesn't exist [env: ABACUS_TLS_DIR=] [default: tls]
+      --http-port <HTTP_PORT>  Port for the plain HTTP server that serves the CA certificate and redirects to HTTPS [env: ABACUS_HTTP_PORT=] [default: 8080]
+  -a, --airgap-detection       Enable airgap detection [env: ABACUS_AIRGAP_DETECTION=]
+  -V, --version                Show version
+  -h, --help                   Print help
 ```
 
 Note that airgap-detection is forced in our (pre-)releases.

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -11,14 +11,66 @@ use tokio::net::TcpListener;
 use tracing::{error, level_filters::LevelFilter};
 use tracing_subscriber::EnvFilter;
 
+/// Default plain HTTP port: 8080 (debug) / 80 (release). With the `tls` feature
+/// this is the redirect/CA download port, without TLS it is the main server port.
+const fn default_http_port() -> u16 {
+    if cfg!(debug_assertions) { 8080 } else { 80 }
+}
+
 /// Default port: with the `tls` feature 8443 (debug) / 443 (release),
-/// without it 8080 (debug) / 80 (release).
+/// without it the plain-HTTP default (8080 debug / 80 release).
 fn get_default_port() -> u16 {
-    match (cfg!(feature = "tls"), cfg!(debug_assertions)) {
-        (true, true) => 8443,
-        (true, false) => 443,
-        (false, true) => 8080,
-        (false, false) => 80,
+    if cfg!(feature = "tls") {
+        if cfg!(debug_assertions) { 8443 } else { 443 }
+    } else {
+        default_http_port()
+    }
+}
+
+/// Bind a dual-stack (IPv4 + IPv6) TCP listener on the given port.
+fn bind_listener(port: u16) -> Result<TcpListener, AppError> {
+    let socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_nonblocking(true)?;
+    socket.set_only_v6(false)?;
+    socket.set_reuse_address(true)?;
+
+    let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port));
+    socket.bind(&address.into()).map_err(|e| match e.kind() {
+        ErrorKind::AddrInUse => AppError::PortAlreadyInUse(port),
+        ErrorKind::PermissionDenied => AppError::PermissionDeniedToBindPort(port),
+        _ => AppError::Io(e),
+    })?;
+    socket.listen(1024)?;
+
+    Ok(TcpListener::from_std(socket.into())?)
+}
+
+/// Start a plain HTTP server on `http_port` that serves the CA certificate and
+/// redirects everything else to HTTPS on `https_port`.
+/// A TCP bind failure is logged, not fatal.
+#[cfg(feature = "tls")]
+fn spawn_plain_http_server(
+    http_port: u16,
+    https_port: u16,
+    ca: std::sync::Arc<abacus::infra::tls::CaCertificate>,
+) {
+    match bind_listener(http_port) {
+        Ok(http_listener) => {
+            tokio::spawn(async move {
+                if let Err(e) = abacus::infra::plain_http::start_plain_http_server(
+                    http_listener,
+                    ca,
+                    https_port,
+                )
+                .await
+                {
+                    tracing::warn!("HTTP redirect server stopped with error: {e}");
+                }
+            });
+        }
+        Err(e) => {
+            tracing::warn!("could not bind port {http_port} for HTTP to HTTPS redirect: {e}");
+        }
     }
 }
 
@@ -37,6 +89,11 @@ struct Args {
     #[cfg(feature = "tls")]
     #[arg(long, default_value = "tls", env = "ABACUS_TLS_DIR")]
     tls_dir: std::path::PathBuf,
+
+    /// Port for the plain HTTP server that serves the CA certificate and redirects to HTTPS
+    #[cfg(feature = "tls")]
+    #[arg(long, default_value_t = default_http_port(), env = "ABACUS_HTTP_PORT")]
+    http_port: u16,
 
     /// Seed the database with initial data using the fixtures
     #[cfg(feature = "dev-database")]
@@ -99,27 +156,18 @@ async fn run() -> Result<(), AppError> {
     #[cfg(not(feature = "airgap-detection"))]
     let enable_airgap_detection = args.airgap_detection;
 
-    let socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
-    socket.set_nonblocking(true)?;
-    socket.set_only_v6(false)?;
-    socket.set_reuse_address(true)?;
-
-    let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, args.port));
-    socket.bind(&address.into()).map_err(|e| match e.kind() {
-        ErrorKind::AddrInUse => AppError::PortAlreadyInUse(args.port),
-        ErrorKind::PermissionDenied => AppError::PermissionDeniedToBindPort(args.port),
-        _ => AppError::Io(e),
-    })?;
-    socket.listen(1024)?;
-
-    let listener = TcpListener::from_std(socket.into())?;
+    let listener = bind_listener(args.port)?;
 
     // When compiled with the `tls` feature the server always serves HTTPS.
     #[cfg(feature = "tls")]
     {
         let certificates = abacus::infra::tls::load_or_generate(&args.tls_dir)?;
         let tls_config = certificates.server_config()?;
-        abacus::start_server_tls(pool, listener, enable_airgap_detection, tls_config).await
+        let ca = std::sync::Arc::new(certificates.ca);
+
+        spawn_plain_http_server(args.http_port, args.port, ca.clone());
+
+        abacus::start_server_tls(pool, listener, enable_airgap_detection, tls_config, ca).await
     }
     #[cfg(not(feature = "tls"))]
     abacus::start_server(pool, listener, enable_airgap_detection).await

--- a/backend/src/infra/mod.rs
+++ b/backend/src/infra/mod.rs
@@ -1,6 +1,8 @@
 pub mod audit_log;
 pub mod backup;
 pub mod pdf_gen;
+#[cfg(feature = "tls")]
+pub mod plain_http;
 pub mod router;
 #[cfg(feature = "dev-database")]
 pub mod seed_data;

--- a/backend/src/infra/plain_http.rs
+++ b/backend/src/infra/plain_http.rs
@@ -1,0 +1,212 @@
+//! Plaintext HTTP server for redirects and serving the local CA certificate
+//!
+//! Alongside HTTPS, Abacus runs a small HTTP server that lets clients download
+//! the local CA certificate (so they can trust the server before reaching it
+//! over HTTPS) and redirects every other request to HTTPS. Its port is
+//! configurable via the `--http-port` CLI argument.
+
+use std::sync::Arc;
+
+use axum::{
+    http::{HeaderMap, StatusCode, Uri, header, uri::Authority},
+    response::{IntoResponse, Redirect, Response},
+};
+use tokio::net::TcpListener;
+use tracing::info;
+
+use crate::{
+    AppError,
+    infra::{router::ca_router, tls::CaCertificate},
+};
+
+/// Redirect any request to the same path on HTTPS.
+fn redirect_to_https(uri: &Uri, headers: &HeaderMap, https_port: u16) -> Response {
+    let Some(authority) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<Authority>().ok())
+    else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let host = authority.host();
+    let target = if https_port == 443 {
+        host.to_owned()
+    } else {
+        format!("{host}:{https_port}")
+    };
+    let path_and_query = uri.path_and_query().map_or("/", |pq| pq.as_str());
+    Redirect::permanent(&format!("https://{target}{path_and_query}")).into_response()
+}
+
+/// Start the plaintext HTTP server on `listener`: it serves the CA
+/// certificate for download and redirects everything else to HTTPS.
+pub async fn start_plain_http_server(
+    listener: TcpListener,
+    ca: Arc<CaCertificate>,
+    https_port: u16,
+) -> Result<(), AppError> {
+    let app = ca_router(&ca).fallback(move |uri: Uri, headers: HeaderMap| async move {
+        redirect_to_https(&uri, &headers, https_port)
+    });
+    info!(
+        "Starting HTTP redirect and CA download server on http://{}",
+        listener.local_addr()?
+    );
+    axum::serve(listener, app.into_make_service())
+        .with_graceful_shutdown(crate::shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, sync::Arc};
+
+    use axum::http::{HeaderMap, Uri};
+    use reqwest::{StatusCode, header, redirect::Policy};
+    use tokio::{net::TcpListener, task::JoinHandle};
+
+    use super::{redirect_to_https, start_plain_http_server};
+    use crate::infra::tls::{CaCertificate, load_or_generate};
+
+    /// Test helper to build the redirect location for a given host header and HTTPS port
+    fn redirect_location(host: &str, https_port: u16) -> String {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::HOST, host.parse().unwrap());
+        let uri: Uri = "/some/path?x=1".parse().unwrap();
+        redirect_to_https(&uri, &headers, https_port)
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    /// Test helper to spawn the redirect server
+    async fn spawn_redirect_server(https_port: u16) -> (SocketAddr, CaCertificate, JoinHandle<()>) {
+        let dir = tempfile::tempdir().unwrap();
+        let certificates = load_or_generate(&dir.path().join("tls")).unwrap();
+        let ca = certificates.ca.clone();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_ca = Arc::new(ca.clone());
+        let task = tokio::spawn(async move {
+            start_plain_http_server(listener, server_ca, https_port)
+                .await
+                .unwrap();
+        });
+        (addr, ca, task)
+    }
+
+    /// Test helper to execute a non-CA request and return its response.
+    async fn redirect_response(addr: SocketAddr) -> reqwest::Response {
+        let client = reqwest::Client::builder()
+            .redirect(Policy::none())
+            .build()
+            .unwrap();
+        client
+            .get(format!("http://{addr}/some/path?x=1"))
+            .send()
+            .await
+            .unwrap()
+    }
+
+    #[test]
+    fn test_redirect_location_port() {
+        assert_eq!(
+            redirect_location("example.com:80", 443),
+            "https://example.com/some/path?x=1"
+        );
+        assert_eq!(
+            redirect_location("example.com", 8443),
+            "https://example.com:8443/some/path?x=1"
+        );
+        assert_eq!(
+            redirect_location("127.0.0.1:8080", 443),
+            "https://127.0.0.1/some/path?x=1"
+        );
+        assert_eq!(
+            redirect_location("[::1]:80", 8443),
+            "https://[::1]:8443/some/path?x=1"
+        );
+        assert_eq!(
+            redirect_location("[2001:db8::1]:443", 443),
+            "https://[2001:db8::1]/some/path?x=1"
+        );
+    }
+
+    #[test]
+    fn test_redirect_without_host_header_is_bad_request() {
+        let response = redirect_to_https(&"/foo".parse::<Uri>().unwrap(), &HeaderMap::new(), 443);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_serves_ca_certificate_over_http() {
+        let (addr, ca, task) = spawn_redirect_server(443).await;
+        let client = reqwest::Client::new();
+
+        let pem = client
+            .get(format!("http://{addr}/ca.pem"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(pem.status(), StatusCode::OK);
+        assert_eq!(
+            pem.headers()[header::CONTENT_TYPE],
+            "application/x-pem-file"
+        );
+        assert_eq!(
+            pem.headers()[header::X_CONTENT_TYPE_OPTIONS],
+            "nosniff",
+            "the CA download carries the app's security headers"
+        );
+        assert_eq!(pem.text().await.unwrap(), ca.pem);
+
+        let cer = client
+            .get(format!("http://{addr}/ca.cer"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(cer.status(), StatusCode::OK);
+        assert_eq!(cer.headers()[header::CONTENT_TYPE], "application/pkix-cert");
+        assert_eq!(cer.bytes().await.unwrap().as_ref(), ca.der.as_slice());
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test]
+    async fn test_redirect_to_https_omits_default_port() {
+        let (addr, _ca, task) = spawn_redirect_server(443).await;
+
+        let response = redirect_response(addr).await;
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            response.headers()[header::LOCATION],
+            "https://127.0.0.1/some/path?x=1",
+            "default port 443 is omitted, path and query preserved"
+        );
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test]
+    async fn test_redirect_to_https_includes_nondefault_port() {
+        let (addr, _ca, task) = spawn_redirect_server(8443).await;
+
+        let response = redirect_response(addr).await;
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            response.headers()[header::LOCATION],
+            "https://127.0.0.1:8443/some/path?x=1",
+            "a non-default HTTPS port is included in the redirect target"
+        );
+
+        task.abort();
+        let _ = task.await;
+    }
+}

--- a/backend/src/infra/router.rs
+++ b/backend/src/infra/router.rs
@@ -17,6 +17,8 @@ use utoipa_axum::router::OpenApiRouter;
 #[cfg(feature = "openapi")]
 use utoipa_swagger_ui::SwaggerUi;
 
+#[cfg(feature = "tls")]
+use crate::infra::tls::CaCertificate;
 #[cfg(feature = "dev-database")]
 use crate::test_data_gen;
 use crate::{
@@ -25,6 +27,8 @@ use crate::{
     error,
     infra::audit_log,
 };
+#[cfg(feature = "tls")]
+use axum::{body::Bytes, routing::get};
 
 pub fn openapi_router() -> OpenApiRouter<AppState> {
     #[derive(utoipa::OpenApi)]
@@ -184,7 +188,10 @@ fn add_storybook_memory_serve(router: Router<AppState>) -> Router<AppState> {
 
 /// Add headers for security hardening
 /// Best practices according to the OWASP Secure Headers Project, https://owasp.org/www-project-secure-headers/
-fn add_security_headers(router: Router<AppState>) -> Router<AppState> {
+pub(crate) fn add_security_headers<S>(router: Router<S>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     let security_headers_service = tower::ServiceBuilder::new()
         .layer(SetResponseHeaderLayer::if_not_present(
             header::X_FRAME_OPTIONS,
@@ -211,6 +218,51 @@ fn add_security_headers(router: Router<AppState>) -> Router<AppState> {
             HeaderValue::from_static("same-origin"),
         ));
     router.layer(security_headers_service)
+}
+
+/// Routes that serve the local CA certificate for download.
+#[cfg(feature = "tls")]
+pub fn ca_router(ca: &CaCertificate) -> Router {
+    let pem = Bytes::from(ca.pem.clone());
+    let der = Bytes::from(ca.der.clone());
+    let routes = Router::new()
+        .route(
+            "/ca.pem",
+            get(move || {
+                let pem = pem.clone();
+                async move {
+                    (
+                        [
+                            (header::CONTENT_TYPE, "application/x-pem-file"),
+                            (
+                                header::CONTENT_DISPOSITION,
+                                "attachment; filename=\"abacus-ca.pem\"",
+                            ),
+                        ],
+                        pem,
+                    )
+                }
+            }),
+        )
+        .route(
+            "/ca.cer",
+            get(move || {
+                let der = der.clone();
+                async move {
+                    (
+                        [
+                            (header::CONTENT_TYPE, "application/pkix-cert"),
+                            (
+                                header::CONTENT_DISPOSITION,
+                                "attachment; filename=\"abacus-ca.cer\"",
+                            ),
+                        ],
+                        der,
+                    )
+                }
+            }),
+        );
+    add_security_headers(routes)
 }
 
 /// Complete Axum router for the application

--- a/backend/src/infra/tls.rs
+++ b/backend/src/infra/tls.rs
@@ -24,6 +24,7 @@ fn tls_err<E: core::fmt::Debug>(e: E) -> AppError {
 
 /// The local CA certificate, in the two encodings clients import:
 /// PEM (Linux/macOS/Firefox) and DER (Windows `.cer`).
+#[derive(Clone)]
 pub struct CaCertificate {
     pub pem: String,
     pub der: Vec<u8>,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -120,6 +120,7 @@ pub async fn start_server_tls(
     listener: TcpListener,
     enable_airgap_detection: bool,
     tls_config: std::sync::Arc<rustls::ServerConfig>,
+    ca: std::sync::Arc<infra::tls::CaCertificate>,
 ) -> Result<(), AppError> {
     use std::time::Duration;
 
@@ -128,7 +129,7 @@ pub async fn start_server_tls(
         tls_rustls::{RustlsAcceptor, RustlsConfig},
     };
 
-    let app = build_app(&pool, enable_airgap_detection)?;
+    let app = build_app(&pool, enable_airgap_detection)?.merge(infra::router::ca_router(&ca));
 
     info!("Starting Abacus on https://{}", listener.local_addr()?);
 
@@ -476,11 +477,12 @@ mod test {
             let certificates = load_or_generate(&dir.path().join("tls")).unwrap();
             let ca_pem = certificates.ca.pem.clone();
             let server_config = certificates.server_config().unwrap();
+            let ca = std::sync::Arc::new(certificates.ca);
 
             let listener = TcpListener::bind(bind_addr).await.unwrap();
             let addr = listener.local_addr().unwrap();
             let task = tokio::spawn(async move {
-                start_server_tls(pool, listener, false, server_config)
+                start_server_tls(pool, listener, false, server_config, ca)
                     .await
                     .unwrap();
             });
@@ -573,6 +575,34 @@ mod test {
             assert!(
                 format!("{err:?}").contains("UnknownIssuer"),
                 "expected an untrusted-issuer certificate error, got: {err:?}"
+            );
+
+            task.abort();
+            let _ = task.await;
+        }
+
+        /// The CA certificate is downloadable over HTTPS as well as over the
+        /// plaintext HTTP redirect server.
+        #[test(sqlx::test)]
+        async fn test_ca_download_over_https(pool: SqlitePool) {
+            let (addr, ca_pem, task) = spawn_https_server(pool, "127.0.0.1:0").await;
+            let client = client_trusting(&ca_pem);
+
+            let response = client
+                .get(format!("https://{addr}/ca.pem"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                response.headers()[reqwest::header::X_CONTENT_TYPE_OPTIONS],
+                "nosniff",
+                "the CA download carries the app's security headers"
+            );
+            assert_eq!(
+                response.text().await.unwrap(),
+                ca_pem,
+                "the served CA matches the trusted CA"
             );
 
             task.abort();


### PR DESCRIPTION
## What & why

Add a plaintext HTTP server that redirects to HTTPS and makes the CA certificates available on HTTP, so that the CA certificate can be imported into client browser trust stores. Resolves #3412.

We need to document that the fingerprint of the downloaded certificate should be verified against the fingerprint logged by the Abacus server, to prevent man-in-the-middle attacks.

## How to test

From a terminal:
```shell
cargo run --features tls
# and in another terminal
curl -v localhost:8080
curl -v localhost:8080/ca.pem
curl -v localhost:8080/ca.cer
curl --cacert tls/ca.pem -v https://localhost:8443/ca.pem
curl --cacert tls/ca.pem -v https://localhost:8443/ca.cer
```

Then check that the redirect works and that the CA certificates are available.

## Reviewer notes

None.