### PR TITLE
Add more P 22-2 input variants

### DIFF
--- a/backend/src/bin/gen-pdf.rs
+++ b/backend/src/bin/gen-pdf.rs
@@ -68,6 +68,11 @@ static VARIANTS: &[ModelVariant] = &[
         input: "extra-model-p-22-2-variations/gte-19-seats.json",
     },
     ModelVariant {
+        name: "model-p-22-2-gte-19-seats-and-p7",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/gte-19-seats-and-p7.json",
+    },
+    ModelVariant {
         name: "model-p-22-2-gte-19-seats-and-p9",
         model: "model-p-22-2",
         input: "extra-model-p-22-2-variations/gte-19-seats-and-p9.json",
@@ -76,6 +81,11 @@ static VARIANTS: &[ModelVariant] = &[
         name: "model-p-22-2-lt-19-seats",
         model: "model-p-22-2",
         input: "extra-model-p-22-2-variations/lt-19-seats.json",
+    },
+    ModelVariant {
+        name: "model-p-22-2-lt-19-seats-and-p7",
+        model: "model-p-22-2",
+        input: "extra-model-p-22-2-variations/lt-19-seats-and-p7.json",
     },
     // `lt-19-seats-and-p9-and-p10.json` is equal to input `model-p-22-2.json`
     ModelVariant {

--- a/backend/src/domain/summary.rs
+++ b/backend/src/domain/summary.rs
@@ -322,7 +322,7 @@ impl From<ElectionSummary> for ElectionSummaryWithoutVotes {
 }
 
 /// A version of ElectionSummary without the political group votes and investigations
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ElectionSummaryCSB {
     /// The number of voters (i.e. "Kiesgerechtigden")

--- a/backend/src/test_data_gen/api.rs
+++ b/backend/src/test_data_gen/api.rs
@@ -39,40 +39,43 @@ async fn generate_election_handler(
 }
 
 async fn generate_p22_2_variants(args: &GenerateElectionArgs, pool: &SqlitePool) {
-    // 1. Test Election >= 19 seats
-    //    based on test `gte_19_seats::test_with_remainder_seats`
+    let mut args = args.clone();
+
+    // based on test `gte_19_seats::test_with_remainder_seats`
+    args.custom_name = Some("Election >= 19 seats".to_string());
     let _ = create_test_election_with_votes(
-        args,
+        &args,
         pool,
         23,
         default_50_candidates(&[600, 302, 98, 99, 101]),
     )
     .await;
 
-    // 2. Test Election >= 19 seats & Absolute Majority Change
-    //    based on test `gte_19_seats::test_with_absolute_majority_of_votes_but_not_seats`
+    // based on test `gte_19_seats::test_with_absolute_majority_of_votes_but_not_seats`
+    args.custom_name = Some("Election >= 19 seats & Absolute Majority Change".to_string());
     let _ = create_test_election_with_votes(
-        args,
+        &args,
         pool,
         24,
         default_50_candidates(&[7501, 1249, 1249, 1249, 1249, 1249, 1248, 7]),
     )
     .await;
 
-    // 3. Test Election < 19 seats
-    //    based on test `lt_19_seats::test_with_1_list_that_meets_threshold`
+    // based on test `lt_19_seats::test_with_1_list_that_meets_threshold`
+    args.custom_name = Some("Election < 19 seats".to_string());
     let _ = create_test_election_with_votes(
-        args,
+        &args,
         pool,
         15,
         default_50_candidates(&[808, 59, 58, 57, 56, 55, 54, 53]),
     )
     .await;
 
-    // 4. Test Election < 19 seats & Absolute Majority Change & List Exhaustion
-    //    based on test `lt_19_seats::test_with_absolute_majority_of_votes_but_not_seats_and_list_exhaustion`
+    // based on test `lt_19_seats::test_with_absolute_majority_of_votes_but_not_seats_and_list_exhaustion`
+    args.custom_name =
+        Some("Election < 19 seats & Absolute Majority Change & List Exhaustion".to_string());
     let _ = create_test_election_with_votes(
-        args,
+        &args,
         pool,
         15,
         vec![
@@ -85,10 +88,10 @@ async fn generate_p22_2_variants(args: &GenerateElectionArgs, pool: &SqlitePool)
     )
     .await;
 
-    // 5. Test Election < 19 seats & List Exhaustion
-    //    based on test `lt_19_seats::test_with_list_exhaustion_triggering_2nd_round_highest_average_assignment_with_different_averages`
+    // based on test `lt_19_seats::test_with_list_exhaustion_triggering_2nd_round_highest_average_assignment_with_different_averages`
+    args.custom_name = Some("Election < 19 seats & List Exhaustion".to_string());
     let _ =
-        create_test_election_with_votes(args, pool, 6, vec![vec![3, 3], vec![2, 2], vec![25, 25]])
+        create_test_election_with_votes(&args, pool, 6, vec![vec![3, 3], vec![2, 2], vec![25, 25]])
             .await;
 }
 

--- a/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p7.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p7.json
@@ -1,0 +1,3809 @@
+{
+  "committee_session": {
+    "id": 2,
+    "number": 1,
+    "election_id": 8,
+    "location": "Juinen",
+    "start_date_time": "2026-03-19T10:12:00",
+    "status": "completed"
+  },
+  "summary": {
+    "number_of_voters": 1329,
+    "voters_counts": {
+      "poll_card_count": 1200,
+      "proxy_certificate_count": 0,
+      "total_admitted_voters_count": 1200
+    },
+    "votes_counts": {
+      "political_group_total_votes": [
+        {
+          "number": 1,
+          "name": "Stem nu!",
+          "total": 500
+        },
+        {
+          "number": 2,
+          "name": "Stemmers 101",
+          "total": 140
+        },
+        {
+          "number": 3,
+          "name": "Partij van de groepen",
+          "total": 140
+        },
+        {
+          "number": 4,
+          "name": "De Kandidatenlijst",
+          "total": 140
+        },
+        {
+          "number": 5,
+          "name": "Partij van de Wet",
+          "total": 140
+        },
+        {
+          "number": 6,
+          "name": "Algemene Lijst",
+          "total": 140
+        }
+      ],
+      "total_votes_candidates_count": 1200,
+      "blank_votes_count": 0,
+      "invalid_votes_count": 0,
+      "total_votes_cast_count": 1200
+    },
+    "differences_counts": {
+      "more_ballots_count": {
+        "count": 0,
+        "data_entry_sources": []
+      },
+      "fewer_ballots_count": {
+        "count": 0,
+        "data_entry_sources": []
+      }
+    }
+  },
+  "election": {
+    "id": 8,
+    "name": "Drawing lots >= 19 seats, HighestAverageResidualSeat",
+    "committee_category": "CSB",
+    "election_id": "GR2026_Juinen",
+    "location": "Juinen",
+    "domain_id": "0035",
+    "category": "Municipal",
+    "number_of_seats": 23,
+    "number_of_voters": 1,
+    "election_date": "2026-03-18",
+    "nomination_date": "2026-02-02"
+  },
+  "candidate_nomination": {
+    "list_candidate_nomination": [
+      {
+        "list_number": 1,
+        "list_name": "Stem nu!",
+        "list_seats": 10,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "R.",
+              "first_name": "Royce",
+              "last_name": "Oorschot",
+              "locality": "Hoek van Zoom",
+              "gender": "Female"
+            },
+            "votes": 500
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "R.M.",
+              "first_name": "Rachid",
+              "last_name_prefix": "den",
+              "last_name": "Mateman",
+              "locality": "Hoek van Zoom",
+              "gender": "Female"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 3,
+            "candidate": {
+              "number": 3,
+              "initials": "B.B.",
+              "first_name": "Bart",
+              "last_name_prefix": "den",
+              "last_name": "Mateman",
+              "locality": "Juinen",
+              "gender": "X"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 4,
+            "candidate": {
+              "number": 4,
+              "initials": "S.",
+              "first_name": "Salomon",
+              "last_name": "Born",
+              "locality": "Juinen",
+              "gender": "Female"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 5,
+            "candidate": {
+              "number": 5,
+              "initials": "K.",
+              "first_name": "Kris",
+              "last_name": "Meulenkolk",
+              "locality": "Huisden",
+              "gender": "X"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 6,
+            "candidate": {
+              "number": 6,
+              "initials": "T.G.I.W.M.",
+              "first_name": "Teun",
+              "last_name": "Tax",
+              "locality": "Lekkum",
+              "gender": "Male"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 7,
+            "candidate": {
+              "number": 7,
+              "initials": "J.",
+              "first_name": "Jory",
+              "last_name": "Goedhart",
+              "locality": "Hoek van Zoom",
+              "gender": "Female"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 8,
+            "candidate": {
+              "number": 8,
+              "initials": "E.",
+              "first_name": "Esra",
+              "last_name": "Groenen",
+              "locality": "Eksterlo",
+              "gender": "Male"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 9,
+            "candidate": {
+              "number": 9,
+              "initials": "G.E.R.",
+              "first_name": "Gijsbertje",
+              "last_name_prefix": "den",
+              "last_name": "Mateman",
+              "locality": "Eksterlo",
+              "gender": "X"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 10,
+            "candidate": {
+              "number": 10,
+              "initials": "B.",
+              "first_name": "Bart",
+              "last_name": "Tax",
+              "locality": "'s Gravenveen",
+              "gender": "Female"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "R.",
+            "first_name": "Royce",
+            "last_name": "Oorschot",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 2,
+            "initials": "R.M.",
+            "first_name": "Rachid",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 3,
+            "initials": "B.B.",
+            "first_name": "Bart",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "S.",
+            "first_name": "Salomon",
+            "last_name": "Born",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 5,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name": "Meulenkolk",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 6,
+            "initials": "T.G.I.W.M.",
+            "first_name": "Teun",
+            "last_name": "Tax",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 7,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Goedhart",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 8,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name": "Groenen",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "G.E.R.",
+            "first_name": "Gijsbertje",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 10,
+            "initials": "B.",
+            "first_name": "Bart",
+            "last_name": "Tax",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "S.R.",
+            "first_name": "Sammie",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 12,
+            "initials": "R.E.",
+            "first_name": "Ruth",
+            "last_name": "Hoogstraten",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 13,
+            "initials": "S.F.",
+            "first_name": "Silvana",
+            "last_name": "Oorschot",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 14,
+            "initials": "M.X.M.U.",
+            "first_name": "Madelène",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "R.W.",
+            "first_name": "Rachid",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 16,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name": "Groenen",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "L.Z.",
+            "first_name": "Leontien",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 18,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name": "Born",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 19,
+            "initials": "T.",
+            "first_name": "Teun",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 20,
+            "initials": "L.",
+            "first_name": "Leontien",
+            "last_name": "Katsma",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 21,
+            "initials": "C.",
+            "first_name": "Christina",
+            "last_name": "Gopal",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 22,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name": "Groenen",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 23,
+            "initials": "Y.",
+            "first_name": "Yağmur",
+            "last_name": "Philippen",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 24,
+            "initials": "E.I.J.",
+            "first_name": "Eelko",
+            "last_name": "Titulaer",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 25,
+            "initials": "N.F.",
+            "first_name": "Henk",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Boermans",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 27,
+            "initials": "R.M.",
+            "first_name": "Rachid",
+            "last_name": "Cornelis",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name": "Boermans",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 29,
+            "initials": "R.Y.",
+            "first_name": "Rachid",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Tax",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 31,
+            "initials": "T.",
+            "first_name": "Teun",
+            "last_name": "Arets",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "J.Q.",
+            "first_name": "Jelisa",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 33,
+            "initials": "B.",
+            "first_name": "Royce",
+            "last_name": "Titulaer",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 34,
+            "initials": "E.R.",
+            "first_name": "Esra",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 35,
+            "initials": "S.",
+            "first_name": "Sijtze",
+            "last_name": "Prakken",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 36,
+            "initials": "T.J.B.",
+            "first_name": "Teun",
+            "last_name": "Oorschot",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 37,
+            "initials": "J.A.C.D.",
+            "first_name": "Jory",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 38,
+            "initials": "T.H.V.B.V.",
+            "first_name": "Teun",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "S.",
+            "first_name": "Sijtze",
+            "last_name": "Brienen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 40,
+            "initials": "N.",
+            "first_name": "Nikky",
+            "last_name": "Aygün",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "F.G.",
+            "first_name": "Florien",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "C.",
+            "first_name": "Christina",
+            "last_name": "Boermans",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "E.C.I.",
+            "first_name": "Eelko",
+            "last_name": "Born",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 44,
+            "initials": "E.",
+            "first_name": "Edis",
+            "last_name": "Meulenkolk",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "S.",
+            "first_name": "Sijtze",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 46,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name": "Güneş",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 47,
+            "initials": "R.B.",
+            "first_name": "Royce",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 48,
+            "initials": "S.Y.",
+            "first_name": "Salomon",
+            "last_name": "Titulaer",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 49,
+            "initials": "S.",
+            "first_name": "Sibel",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "R.",
+            "first_name": "Renso",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          }
+        ]
+      },
+      {
+        "list_number": 2,
+        "list_name": "Stemmers 101",
+        "list_seats": 3,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "G.",
+              "last_name_prefix": "de",
+              "last_name": "Vegt",
+              "locality": "'s Gravenveen",
+              "gender": "Male"
+            },
+            "votes": 140
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "N.",
+              "last_name": "Tax",
+              "locality": "Bloemstede",
+              "gender": "Male"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 3,
+            "candidate": {
+              "number": 3,
+              "initials": "N.",
+              "last_name_prefix": "van de",
+              "last_name": "Wal",
+              "locality": "Hoek van Zoom",
+              "gender": "X"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "G.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 2,
+            "initials": "N.",
+            "last_name": "Tax",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 3,
+            "initials": "N.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "H.Y.",
+            "last_name": "Katsma",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 5,
+            "initials": "N.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 6,
+            "initials": "P.V.",
+            "last_name": "Titulaer",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 7,
+            "initials": "N.C.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 8,
+            "initials": "F.I.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "I.T.H.F.",
+            "last_name": "Brienen",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 10,
+            "initials": "Y.R.",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "Q.",
+            "last_name": "Wolfswinkel",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 12,
+            "initials": "K.V.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 13,
+            "initials": "F.",
+            "last_name": "Arets",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 14,
+            "initials": "Y.J.",
+            "last_name": "Prakken",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 15,
+            "initials": "Z.",
+            "last_name": "Arets",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 16,
+            "initials": "G.",
+            "last_name": "Boermans",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 17,
+            "initials": "O.",
+            "last_name": "Wiertz",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 18,
+            "initials": "W.",
+            "last_name": "Güneş",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "V.",
+            "last_name": "Born",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 20,
+            "initials": "Q.Y.L.",
+            "last_name": "Katsma",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 21,
+            "initials": "I.F.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 22,
+            "initials": "F.O.",
+            "last_name": "Goedhart",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 23,
+            "initials": "U.T.",
+            "last_name": "Tax",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 24,
+            "initials": "P.E.J.J.",
+            "last_name": "Oorschot",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 25,
+            "initials": "Y.",
+            "last_name": "Boermans",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "W.L.",
+            "last_name": "Tax",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 27,
+            "initials": "B.M.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "P.H.N.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 29,
+            "initials": "R.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 30,
+            "initials": "O.V.M.",
+            "last_name": "Güneş",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "U.",
+            "last_name": "Gopal",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 32,
+            "initials": "Q.V.A.",
+            "last_name": "Arets",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 33,
+            "initials": "E.L.",
+            "last_name": "Goedhart",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "Z.O.",
+            "last_name": "Philippen",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 35,
+            "initials": "C.",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 36,
+            "initials": "E.I.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "L.",
+            "last_name": "Meulenkolk",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 38,
+            "initials": "V.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "E.R.T.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 40,
+            "initials": "U.T.",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "N.",
+            "last_name": "Wiertz",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 42,
+            "initials": "P.",
+            "last_name": "Boermans",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "S.R.",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 44,
+            "initials": "H.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "G.",
+            "last_name": "Meulenkolk",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "G.V.",
+            "last_name": "Prakken",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 47,
+            "initials": "G.I.",
+            "last_name": "Titulaer",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "R.J.",
+            "last_name": "Aygün",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 49,
+            "initials": "T.",
+            "last_name": "Wiertz",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "V.",
+            "last_name": "Wiertz",
+            "locality": "Bloemstede",
+            "gender": "X"
+          }
+        ]
+      },
+      {
+        "list_number": 3,
+        "list_name": "Partij van de groepen",
+        "list_seats": 2,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "K.G.C.",
+              "first_name": "Esra",
+              "last_name": "Wiertz",
+              "locality": "Middelgein",
+              "gender": "Male"
+            },
+            "votes": 140
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "R.",
+              "first_name": "Rachid",
+              "last_name": "Oorschot",
+              "locality": "Eksterlo",
+              "gender": "Male"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "K.G.C.",
+            "first_name": "Esra",
+            "last_name": "Wiertz",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 2,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name": "Oorschot",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 3,
+            "initials": "M.P.",
+            "first_name": "Madelène",
+            "last_name": "Born",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "S.L.R.",
+            "first_name": "Silvana",
+            "last_name": "Aygün",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 5,
+            "initials": "L.K.J.O.",
+            "first_name": "Leontien",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 6,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Güneş",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 7,
+            "initials": "R.V.",
+            "first_name": "Rachid",
+            "last_name": "Born",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 8,
+            "initials": "D.U.",
+            "first_name": "Madelène",
+            "last_name": "Oorschot",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 10,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Hoogstraten",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "B.",
+            "first_name": "Bart",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 12,
+            "initials": "D.D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Born",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 13,
+            "initials": "C.X.",
+            "first_name": "Cornelus",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 14,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 15,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 16,
+            "initials": "C.",
+            "first_name": "Madelène",
+            "last_name": "Gopal",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 17,
+            "initials": "E.",
+            "first_name": "Edis",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "İ.T.",
+            "first_name": "İlknur",
+            "last_name": "Katsma",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 20,
+            "initials": "V.",
+            "first_name": "İlknur",
+            "last_name": "Titulaer",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "N.",
+            "first_name": "Nicolaas",
+            "last_name": "Groenen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 22,
+            "initials": "T.",
+            "first_name": "Teun",
+            "last_name": "Hoogstraten",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 23,
+            "initials": "C.",
+            "first_name": "Cornelus",
+            "last_name": "Philippen",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 24,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 25,
+            "initials": "S.",
+            "first_name": "Sammie",
+            "last_name": "Oorschot",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Hoogstraten",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 27,
+            "initials": "N.S.",
+            "first_name": "Nikky",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Wiertz",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 29,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 30,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Titulaer",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "S.X.",
+            "first_name": "Florien",
+            "last_name": "Hoogstraten",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "A.",
+            "first_name": "Alek",
+            "last_name": "Tax",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 33,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Wiertz",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 34,
+            "initials": "İ.F.",
+            "first_name": "İlknur",
+            "last_name": "Groenen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 35,
+            "initials": "H.",
+            "first_name": "Henk",
+            "last_name": "Boermans",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 36,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name": "Titulaer",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 37,
+            "initials": "A.W.",
+            "first_name": "Alek",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 38,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name": "Tax",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 39,
+            "initials": "N.",
+            "first_name": "Nikky",
+            "last_name": "Katsma",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 40,
+            "initials": "E.",
+            "first_name": "Eelko",
+            "last_name": "Cornelis",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 41,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "H.",
+            "first_name": "Sammie",
+            "last_name": "Aygün",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 44,
+            "initials": "K.M.",
+            "first_name": "Kris",
+            "last_name": "Goedhart",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name": "Titulaer",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "Z.",
+            "first_name": "İlknur",
+            "last_name": "Born",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 47,
+            "initials": "S.D.Z.",
+            "first_name": "Salomon",
+            "last_name": "Hoogstraten",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 48,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name": "Hoogstraten",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 49,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name": "Wolfswinkel",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 50,
+            "initials": "F.O.",
+            "first_name": "Florien",
+            "last_name": "Goedhart",
+            "locality": "Middelgein",
+            "gender": "Female"
+          }
+        ]
+      },
+      {
+        "list_number": 4,
+        "list_name": "De Kandidatenlijst",
+        "list_seats": 3,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "D.B.F.",
+              "last_name_prefix": "van",
+              "last_name": "Jaspers-Gezen",
+              "locality": "'s Gravenveen",
+              "gender": "Female"
+            },
+            "votes": 140
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "A.",
+              "last_name_prefix": "van",
+              "last_name": "Jaspers-Gezen",
+              "locality": "Sluisdam",
+              "gender": "X"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 3,
+            "candidate": {
+              "number": 3,
+              "initials": "T.L.K.",
+              "last_name": "Born",
+              "locality": "Juinen",
+              "gender": "Male"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "D.B.F.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 2,
+            "initials": "A.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 3,
+            "initials": "T.L.K.",
+            "last_name": "Born",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 4,
+            "initials": "H.",
+            "last_name": "Hoogstraten",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 5,
+            "initials": "O.K.",
+            "last_name": "Brienen",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 6,
+            "initials": "Q.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 7,
+            "initials": "Z.B.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 8,
+            "initials": "O.Z.J.M.",
+            "last_name": "Cornelis",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "F.",
+            "last_name": "Güneş",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 10,
+            "initials": "Y.V.",
+            "last_name": "Brienen",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "L.Z.Q.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 12,
+            "initials": "A.J.",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 13,
+            "initials": "F.",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "C.",
+            "last_name": "Aygün",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "M.",
+            "last_name": "Titulaer",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 16,
+            "initials": "K.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "Q.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 18,
+            "initials": "S.",
+            "last_name": "Wolfswinkel",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 19,
+            "initials": "Q.",
+            "last_name": "Born",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 20,
+            "initials": "Z.",
+            "last_name": "Born",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 21,
+            "initials": "C.E.H.",
+            "last_name": "Aygün",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 22,
+            "initials": "P.N.Q.",
+            "last_name": "Katsma",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 23,
+            "initials": "G.H.",
+            "last_name": "Philippen",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 24,
+            "initials": "M.V.Q.",
+            "last_name": "Brienen",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 25,
+            "initials": "V.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "U.",
+            "last_name": "Prakken",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 27,
+            "initials": "X.G.T.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 28,
+            "initials": "S.D.",
+            "last_name": "Katsma",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 29,
+            "initials": "U.P.",
+            "last_name": "Meulenkolk",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "T.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "G.",
+            "last_name": "Aygün",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "E.",
+            "last_name": "Güneş",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 33,
+            "initials": "L.O.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "Z.",
+            "last_name": "Katsma",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 35,
+            "initials": "V.V.",
+            "last_name": "Goedhart",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 36,
+            "initials": "X.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "E.Z.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 38,
+            "initials": "T.R.",
+            "last_name": "Güneş",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "F.C.",
+            "last_name": "Oorschot",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 40,
+            "initials": "G.H.",
+            "last_name": "Brienen",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 41,
+            "initials": "W.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "J.W.",
+            "last_name": "Goedhart",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "M.",
+            "last_name": "Goedhart",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 44,
+            "initials": "Y.B.",
+            "last_name": "Meulenkolk",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 45,
+            "initials": "L.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 46,
+            "initials": "Q.",
+            "last_name": "Wiertz",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 47,
+            "initials": "T.Q.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "W.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 49,
+            "initials": "K.",
+            "last_name": "Aygün",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "M.R.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Middelgein",
+            "gender": "Female"
+          }
+        ]
+      },
+      {
+        "list_number": 5,
+        "list_name": "Partij van de Wet",
+        "list_seats": 2,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "R.U.",
+              "first_name": "Royce",
+              "last_name": "Tax",
+              "locality": "Bloemstede",
+              "gender": "X"
+            },
+            "votes": 140
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "C.I.N.",
+              "first_name": "Cornelus",
+              "last_name": "Born",
+              "locality": "Lekkum",
+              "gender": "X"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "R.U.",
+            "first_name": "Royce",
+            "last_name": "Tax",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 2,
+            "initials": "C.I.N.",
+            "first_name": "Cornelus",
+            "last_name": "Born",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 3,
+            "initials": "S.U.U.",
+            "first_name": "Sijtze",
+            "last_name": "Philippen",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "B.",
+            "first_name": "Bart",
+            "last_name": "Goedhart",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 5,
+            "initials": "J.L.",
+            "first_name": "Jelisa",
+            "last_name": "Oorschot",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 6,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Titulaer",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 7,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name": "Gopal",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 8,
+            "initials": "Y.A.C.",
+            "first_name": "Yağmur",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name": "Prakken",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 10,
+            "initials": "A.",
+            "first_name": "Dirk-Jan",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "B.E.",
+            "first_name": "Bart",
+            "last_name": "Brienen",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 12,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name": "Wiertz",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 13,
+            "initials": "E.J.P.",
+            "first_name": "Eelko",
+            "last_name": "Wiertz",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 14,
+            "initials": "N.",
+            "first_name": "Nicolaas",
+            "last_name": "Gopal",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 15,
+            "initials": "R.U.",
+            "first_name": "Ruth",
+            "last_name": "Wiertz",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 16,
+            "initials": "C.",
+            "first_name": "Christina",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "Y.Y.",
+            "first_name": "Yağmur",
+            "last_name": "Tax",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name": "Meulenkolk",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "L.I.",
+            "first_name": "Leontien",
+            "last_name": "Arets",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 20,
+            "initials": "S.",
+            "first_name": "Sammie",
+            "last_name": "Boermans",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 21,
+            "initials": "B.",
+            "first_name": "Bart",
+            "last_name": "Boermans",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 22,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Hoogstraten",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 23,
+            "initials": "D.",
+            "first_name": "Jory",
+            "last_name": "Tax",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 24,
+            "initials": "A.Q.",
+            "first_name": "Alek",
+            "last_name": "Arets",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 25,
+            "initials": "J.E.",
+            "first_name": "Jelisa",
+            "last_name": "Wolfswinkel",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 26,
+            "initials": "B.Y.",
+            "first_name": "Bart",
+            "last_name": "Gopal",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 27,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Arets",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 28,
+            "initials": "İ.E.",
+            "first_name": "İlknur",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 29,
+            "initials": "S.N.A.",
+            "first_name": "Christina",
+            "last_name": "Boermans",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "A.V.",
+            "first_name": "Alek",
+            "last_name": "Groenen",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Groenen",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "T.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 33,
+            "initials": "O.",
+            "first_name": "Yağmur",
+            "last_name": "Wolfswinkel",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name": "Groenen",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 35,
+            "initials": "R.R.",
+            "first_name": "Ruth",
+            "last_name": "Wiertz",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 36,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 37,
+            "initials": "R.R.",
+            "first_name": "Ruth",
+            "last_name": "Born",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 38,
+            "initials": "Y.",
+            "first_name": "Yağmur",
+            "last_name": "Wolfswinkel",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 39,
+            "initials": "K.",
+            "first_name": "Ruth",
+            "last_name": "Hoogstraten",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 40,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name": "Tax",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 41,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name": "Boermans",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "S.W.",
+            "first_name": "Salomon",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "T.",
+            "first_name": "Tiemen",
+            "last_name": "Cornelis",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 44,
+            "initials": "C.",
+            "first_name": "Cornelus",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 45,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name": "Arets",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 46,
+            "initials": "C.",
+            "first_name": "Cornelus",
+            "last_name": "Wolfswinkel",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 47,
+            "initials": "B.O.D.",
+            "first_name": "Bart",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "U.U.A.",
+            "first_name": "Christina",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 49,
+            "initials": "J.E.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 50,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Goedhart",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          }
+        ]
+      },
+      {
+        "list_number": 6,
+        "list_name": "Algemene Lijst",
+        "list_seats": 3,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "D.",
+              "first_name": "Dirk-Jan",
+              "last_name": "Katsma",
+              "locality": "Huisden",
+              "gender": "X"
+            },
+            "votes": 140
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "S.N.",
+              "first_name": "Salomon",
+              "last_name_prefix": "van de",
+              "last_name": "Kerkhof",
+              "locality": "'s Gravenveen",
+              "gender": "X"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 3,
+            "candidate": {
+              "number": 3,
+              "initials": "İ.",
+              "first_name": "İlknur",
+              "last_name_prefix": "van",
+              "last_name": "Jaspers-Gezen",
+              "locality": "Hovenerwoud",
+              "gender": "Male"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Katsma",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 2,
+            "initials": "S.N.",
+            "first_name": "Salomon",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 3,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 4,
+            "initials": "R.",
+            "first_name": "Royce",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 5,
+            "initials": "N.L.",
+            "first_name": "Nikky",
+            "last_name": "Cornelis",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 6,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 7,
+            "initials": "R.U.",
+            "first_name": "Royce",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 8,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name": "Arets",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 9,
+            "initials": "H.D.H.",
+            "first_name": "Henk",
+            "last_name": "Philippen",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 10,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Brienen",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "L.",
+            "first_name": "Leontien",
+            "last_name": "Wolfswinkel",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 12,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name": "Boermans",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 13,
+            "initials": "S.",
+            "first_name": "Salomon",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "X.Q.",
+            "first_name": "Cornelus",
+            "last_name": "Titulaer",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "C.",
+            "first_name": "Christina",
+            "last_name": "Goedhart",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 16,
+            "initials": "H.",
+            "first_name": "Henk",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Wiertz",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 18,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 19,
+            "initials": "R.",
+            "first_name": "Royce",
+            "last_name": "Hoogstraten",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 20,
+            "initials": "T.",
+            "first_name": "Teun",
+            "last_name": "Tax",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 21,
+            "initials": "T.W.",
+            "first_name": "Tiemen",
+            "last_name": "Born",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 22,
+            "initials": "D.E.E.",
+            "first_name": "Dirk-Jan",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 23,
+            "initials": "E.W.",
+            "first_name": "Edis",
+            "last_name": "Prakken",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 24,
+            "initials": "T.",
+            "first_name": "Teun",
+            "last_name": "Philippen",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 25,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "P.V.",
+            "first_name": "Tiemen",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 27,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "L.M.N.T.",
+            "first_name": "Leontien",
+            "last_name": "Wiertz",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 29,
+            "initials": "N.C.A.P.",
+            "first_name": "Nikky",
+            "last_name": "Gopal",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 30,
+            "initials": "T.G.",
+            "first_name": "Teun",
+            "last_name": "Tax",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "E.",
+            "first_name": "Eelko",
+            "last_name": "Gopal",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 32,
+            "initials": "H.",
+            "first_name": "Henk",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 33,
+            "initials": "J.A.A.Q.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "J.G.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 35,
+            "initials": "T.W.",
+            "first_name": "Tiemen",
+            "last_name": "Cornelis",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 36,
+            "initials": "G.N.",
+            "first_name": "Gijsbertje",
+            "last_name": "Born",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 37,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name": "Boermans",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 38,
+            "initials": "E.R.",
+            "first_name": "Eelko",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name": "Oorschot",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 40,
+            "initials": "H.",
+            "first_name": "Henk",
+            "last_name": "Cornelis",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "S.L.",
+            "first_name": "Silvana",
+            "last_name": "Titulaer",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "E.",
+            "first_name": "Edis",
+            "last_name": "Oorschot",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "S.Q.",
+            "first_name": "Sijtze",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 44,
+            "initials": "G.O.",
+            "first_name": "Gijsbertje",
+            "last_name": "Brienen",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 45,
+            "initials": "R.Q.",
+            "first_name": "Royce",
+            "last_name": "Wiertz",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 46,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 47,
+            "initials": "R.J.",
+            "first_name": "Royce",
+            "last_name": "Brienen",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 48,
+            "initials": "C.K.B.",
+            "first_name": "Christina",
+            "last_name": "Tax",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 49,
+            "initials": "A.",
+            "first_name": "Silvana",
+            "last_name": "Cornelis",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 50,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Middelgein",
+            "gender": "Female"
+          }
+        ]
+      }
+    ],
+    "chosen_candidates": [
+      {
+        "number": 2,
+        "initials": "C.I.N.",
+        "first_name": "Cornelus",
+        "last_name": "Born",
+        "locality": "Lekkum",
+        "gender": "X",
+        "list_number": 5,
+        "list_name": "Partij van de Wet"
+      },
+      {
+        "number": 4,
+        "initials": "S.",
+        "first_name": "Salomon",
+        "last_name": "Born",
+        "locality": "Juinen",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 3,
+        "initials": "T.L.K.",
+        "last_name": "Born",
+        "locality": "Juinen",
+        "gender": "Male",
+        "list_number": 4,
+        "list_name": "De Kandidatenlijst"
+      },
+      {
+        "number": 7,
+        "initials": "J.",
+        "first_name": "Jory",
+        "last_name": "Goedhart",
+        "locality": "Hoek van Zoom",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 8,
+        "initials": "E.",
+        "first_name": "Esra",
+        "last_name": "Groenen",
+        "locality": "Eksterlo",
+        "gender": "Male",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 2,
+        "initials": "A.",
+        "last_name_prefix": "van",
+        "last_name": "Jaspers-Gezen",
+        "locality": "Sluisdam",
+        "gender": "X",
+        "list_number": 4,
+        "list_name": "De Kandidatenlijst"
+      },
+      {
+        "number": 1,
+        "initials": "D.B.F.",
+        "last_name_prefix": "van",
+        "last_name": "Jaspers-Gezen",
+        "locality": "'s Gravenveen",
+        "gender": "Female",
+        "list_number": 4,
+        "list_name": "De Kandidatenlijst"
+      },
+      {
+        "number": 3,
+        "initials": "İ.",
+        "first_name": "İlknur",
+        "last_name_prefix": "van",
+        "last_name": "Jaspers-Gezen",
+        "locality": "Hovenerwoud",
+        "gender": "Male",
+        "list_number": 6,
+        "list_name": "Algemene Lijst"
+      },
+      {
+        "number": 1,
+        "initials": "D.",
+        "first_name": "Dirk-Jan",
+        "last_name": "Katsma",
+        "locality": "Huisden",
+        "gender": "X",
+        "list_number": 6,
+        "list_name": "Algemene Lijst"
+      },
+      {
+        "number": 2,
+        "initials": "S.N.",
+        "first_name": "Salomon",
+        "last_name_prefix": "van de",
+        "last_name": "Kerkhof",
+        "locality": "'s Gravenveen",
+        "gender": "X",
+        "list_number": 6,
+        "list_name": "Algemene Lijst"
+      },
+      {
+        "number": 3,
+        "initials": "B.B.",
+        "first_name": "Bart",
+        "last_name_prefix": "den",
+        "last_name": "Mateman",
+        "locality": "Juinen",
+        "gender": "X",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 9,
+        "initials": "G.E.R.",
+        "first_name": "Gijsbertje",
+        "last_name_prefix": "den",
+        "last_name": "Mateman",
+        "locality": "Eksterlo",
+        "gender": "X",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 2,
+        "initials": "R.M.",
+        "first_name": "Rachid",
+        "last_name_prefix": "den",
+        "last_name": "Mateman",
+        "locality": "Hoek van Zoom",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 5,
+        "initials": "K.",
+        "first_name": "Kris",
+        "last_name": "Meulenkolk",
+        "locality": "Huisden",
+        "gender": "X",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 1,
+        "initials": "R.",
+        "first_name": "Royce",
+        "last_name": "Oorschot",
+        "locality": "Hoek van Zoom",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 2,
+        "initials": "R.",
+        "first_name": "Rachid",
+        "last_name": "Oorschot",
+        "locality": "Eksterlo",
+        "gender": "Male",
+        "list_number": 3,
+        "list_name": "Partij van de groepen"
+      },
+      {
+        "number": 10,
+        "initials": "B.",
+        "first_name": "Bart",
+        "last_name": "Tax",
+        "locality": "'s Gravenveen",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 2,
+        "initials": "N.",
+        "last_name": "Tax",
+        "locality": "Bloemstede",
+        "gender": "Male",
+        "list_number": 2,
+        "list_name": "Stemmers 101"
+      },
+      {
+        "number": 1,
+        "initials": "R.U.",
+        "first_name": "Royce",
+        "last_name": "Tax",
+        "locality": "Bloemstede",
+        "gender": "X",
+        "list_number": 5,
+        "list_name": "Partij van de Wet"
+      },
+      {
+        "number": 6,
+        "initials": "T.G.I.W.M.",
+        "first_name": "Teun",
+        "last_name": "Tax",
+        "locality": "Lekkum",
+        "gender": "Male",
+        "list_number": 1,
+        "list_name": "Stem nu!"
+      },
+      {
+        "number": 1,
+        "initials": "G.",
+        "last_name_prefix": "de",
+        "last_name": "Vegt",
+        "locality": "'s Gravenveen",
+        "gender": "Male",
+        "list_number": 2,
+        "list_name": "Stemmers 101"
+      },
+      {
+        "number": 3,
+        "initials": "N.",
+        "last_name_prefix": "van de",
+        "last_name": "Wal",
+        "locality": "Hoek van Zoom",
+        "gender": "X",
+        "list_number": 2,
+        "list_name": "Stemmers 101"
+      },
+      {
+        "number": 1,
+        "initials": "K.G.C.",
+        "first_name": "Esra",
+        "last_name": "Wiertz",
+        "locality": "Middelgein",
+        "gender": "Male",
+        "list_number": 3,
+        "list_name": "Partij van de groepen"
+      }
+    ]
+  },
+  "seat_assignment": {
+    "quota": {
+      "integer": 52,
+      "numerator": 4,
+      "denominator": 23
+    },
+    "list_seat_assignment": [
+      {
+        "number": 1,
+        "name": "Stem nu!",
+        "total": 500,
+        "initial_full_seats": 9
+      },
+      {
+        "number": 2,
+        "name": "Stemmers 101",
+        "total": 140,
+        "initial_full_seats": 2
+      },
+      {
+        "number": 3,
+        "name": "Partij van de groepen",
+        "total": 140,
+        "initial_full_seats": 2
+      },
+      {
+        "number": 4,
+        "name": "De Kandidatenlijst",
+        "total": 140,
+        "initial_full_seats": 2
+      },
+      {
+        "number": 5,
+        "name": "Partij van de Wet",
+        "total": 140,
+        "initial_full_seats": 2
+      },
+      {
+        "number": 6,
+        "name": "Algemene Lijst",
+        "total": 140,
+        "initial_full_seats": 2
+      }
+    ],
+    "initial_highest_average_steps": [
+      {
+        "residual_seat_number": 1,
+        "change": {
+          "changed_by": "HighestAverageAssignment",
+          "selected_list_number": 1,
+          "list_options": [
+            1
+          ],
+          "list_assigned": [
+            1
+          ],
+          "list_exhausted": [],
+          "votes_per_seat": {
+            "integer": 50,
+            "numerator": 0,
+            "denominator": 10
+          }
+        },
+        "standings": [
+          {
+            "list_number": 1,
+            "votes_cast": 500,
+            "remainder_votes": {
+              "integer": 30,
+              "numerator": 10,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 50,
+              "numerator": 0,
+              "denominator": 10
+            },
+            "full_seats": 9,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 2,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 3,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 4,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 5,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 6,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          }
+        ]
+      },
+      {
+        "residual_seat_number": 2,
+        "change": {
+          "changed_by": "HighestAverageAssignment",
+          "selected_list_number": 4,
+          "list_options": [
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "list_assigned": [
+            4
+          ],
+          "list_exhausted": [],
+          "votes_per_seat": {
+            "integer": 46,
+            "numerator": 2,
+            "denominator": 3
+          },
+          "drawing_lots": {
+            "variant": "HighestAverageResidualSeat",
+            "max_average": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "residual_seat_numbers": [
+              2,
+              3,
+              4
+            ],
+            "options": [
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "list_averages": [
+              {
+                "pg_number": 1,
+                "average": {
+                  "integer": 45,
+                  "numerator": 5,
+                  "denominator": 11
+                }
+              },
+              {
+                "pg_number": 2,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 3,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 4,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 5,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 6,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              }
+            ]
+          }
+        },
+        "standings": [
+          {
+            "list_number": 1,
+            "votes_cast": 500,
+            "remainder_votes": {
+              "integer": 30,
+              "numerator": 10,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 45,
+              "numerator": 5,
+              "denominator": 11
+            },
+            "full_seats": 9,
+            "residual_seats": 1
+          },
+          {
+            "list_number": 2,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 3,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 4,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 5,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 6,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          }
+        ]
+      },
+      {
+        "residual_seat_number": 3,
+        "change": {
+          "changed_by": "HighestAverageAssignment",
+          "selected_list_number": 6,
+          "list_options": [
+            2,
+            3,
+            5,
+            6
+          ],
+          "list_assigned": [
+            4,
+            6
+          ],
+          "list_exhausted": [],
+          "votes_per_seat": {
+            "integer": 46,
+            "numerator": 2,
+            "denominator": 3
+          },
+          "drawing_lots": {
+            "variant": "HighestAverageResidualSeat",
+            "max_average": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "residual_seat_numbers": [
+              3,
+              4
+            ],
+            "options": [
+              2,
+              3,
+              5,
+              6
+            ],
+            "list_averages": [
+              {
+                "pg_number": 1,
+                "average": {
+                  "integer": 45,
+                  "numerator": 5,
+                  "denominator": 11
+                }
+              },
+              {
+                "pg_number": 2,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 3,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 4,
+                "average": {
+                  "integer": 35,
+                  "numerator": 0,
+                  "denominator": 4
+                }
+              },
+              {
+                "pg_number": 5,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 6,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              }
+            ]
+          }
+        },
+        "standings": [
+          {
+            "list_number": 1,
+            "votes_cast": 500,
+            "remainder_votes": {
+              "integer": 30,
+              "numerator": 10,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 45,
+              "numerator": 5,
+              "denominator": 11
+            },
+            "full_seats": 9,
+            "residual_seats": 1
+          },
+          {
+            "list_number": 2,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 3,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 4,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 35,
+              "numerator": 0,
+              "denominator": 4
+            },
+            "full_seats": 2,
+            "residual_seats": 1
+          },
+          {
+            "list_number": 5,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 6,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          }
+        ]
+      },
+      {
+        "residual_seat_number": 4,
+        "change": {
+          "changed_by": "HighestAverageAssignment",
+          "selected_list_number": 2,
+          "list_options": [
+            2,
+            3,
+            5
+          ],
+          "list_assigned": [
+            4,
+            6,
+            2
+          ],
+          "list_exhausted": [],
+          "votes_per_seat": {
+            "integer": 46,
+            "numerator": 2,
+            "denominator": 3
+          },
+          "drawing_lots": {
+            "variant": "HighestAverageResidualSeat",
+            "max_average": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "residual_seat_numbers": [
+              4
+            ],
+            "options": [
+              2,
+              3,
+              5
+            ],
+            "list_averages": [
+              {
+                "pg_number": 1,
+                "average": {
+                  "integer": 45,
+                  "numerator": 5,
+                  "denominator": 11
+                }
+              },
+              {
+                "pg_number": 2,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 3,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 4,
+                "average": {
+                  "integer": 35,
+                  "numerator": 0,
+                  "denominator": 4
+                }
+              },
+              {
+                "pg_number": 5,
+                "average": {
+                  "integer": 46,
+                  "numerator": 2,
+                  "denominator": 3
+                }
+              },
+              {
+                "pg_number": 6,
+                "average": {
+                  "integer": 35,
+                  "numerator": 0,
+                  "denominator": 4
+                }
+              }
+            ]
+          }
+        },
+        "standings": [
+          {
+            "list_number": 1,
+            "votes_cast": 500,
+            "remainder_votes": {
+              "integer": 30,
+              "numerator": 10,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 45,
+              "numerator": 5,
+              "denominator": 11
+            },
+            "full_seats": 9,
+            "residual_seats": 1
+          },
+          {
+            "list_number": 2,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 3,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 4,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 35,
+              "numerator": 0,
+              "denominator": 4
+            },
+            "full_seats": 2,
+            "residual_seats": 1
+          },
+          {
+            "list_number": 5,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 46,
+              "numerator": 2,
+              "denominator": 3
+            },
+            "full_seats": 2,
+            "residual_seats": 0
+          },
+          {
+            "list_number": 6,
+            "votes_cast": 140,
+            "remainder_votes": {
+              "integer": 35,
+              "numerator": 15,
+              "denominator": 23
+            },
+            "meets_remainder_threshold": true,
+            "next_votes_per_seat": {
+              "integer": 35,
+              "numerator": 0,
+              "denominator": 4
+            },
+            "full_seats": 2,
+            "residual_seats": 1
+          }
+        ]
+      }
+    ],
+    "initial_total_full_seats": 19,
+    "initial_total_residual_seats": 4
+  },
+  "hash": "dedf 17b4 684e 1214 fcab b770 925d c75c 624b e338 0bd3 4647 29c3 7a80 a379 40ad",
+  "creation_date_time": "19-03-2023 17:07:00 +02:00"
+}

--- a/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p9.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats-and-p9.json
@@ -75,17 +75,16 @@
   },
   "election": {
     "id": 5,
-    "name": "Test Election >= 19 seats & Absolute Majority Change",
-    "counting_method": "CSO",
+    "name": "Election >= 19 seats & Absolute Majority Change",
     "committee_category": "CSB",
-    "election_id": "Juinen_2026",
+    "election_id": "GR2026_Juinen",
     "location": "Juinen",
     "domain_id": "0035",
     "category": "Municipal",
     "number_of_seats": 24,
+    "number_of_voters": 1,
     "election_date": "2026-03-18",
-    "nomination_date": "2026-02-02",
-    "number_of_voters": 1
+    "nomination_date": "2026-02-02"
   },
   "candidate_nomination": {
     "chosen_candidates": [

--- a/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/gte-19-seats.json
@@ -60,17 +60,16 @@
   },
   "election": {
     "id": 2,
-    "name": "Test Election >= 19 seats",
-    "counting_method": "CSO",
+    "name": "Election >= 19 seats",
     "committee_category": "CSB",
-    "election_id": "Juinen_2026",
+    "election_id": "GR2026_Juinen",
     "location": "Juinen",
     "domain_id": "0035",
     "category": "Municipal",
     "number_of_seats": 23,
+    "number_of_voters": 1,
     "election_date": "2026-03-18",
-    "nomination_date": "2026-02-02",
-    "number_of_voters": 1
+    "nomination_date": "2026-02-02"
   },
   "candidate_nomination": {
     "chosen_candidates": [

--- a/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p10.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p10.json
@@ -50,17 +50,16 @@
   },
   "election": {
     "id": 6,
-    "name": "Test Election < 19 seats & List Exhaustion",
-    "counting_method": "CSO",
+    "name": "Election < 19 seats & List Exhaustion",
     "committee_category": "CSB",
-    "election_id": "Juinen_2026",
+    "election_id": "GR2026_Juinen",
     "location": "Juinen",
     "domain_id": "0035",
     "category": "Municipal",
     "number_of_seats": 6,
+    "number_of_voters": 1,
     "election_date": "2026-03-18",
-    "nomination_date": "2026-02-02",
-    "number_of_voters": 1
+    "nomination_date": "2026-02-02"
   },
   "candidate_nomination": {
     "chosen_candidates": [

--- a/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p7.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p7.json
@@ -1,0 +1,3730 @@
+{
+  "committee_session": {
+    "id": 2,
+    "number": 1,
+    "election_id": 7,
+    "location": "Juinen",
+    "start_date_time": "2026-03-19T10:12:00",
+    "status": "completed"
+  },
+  "summary": {
+    "number_of_voters": 2272,
+    "voters_counts": {
+      "poll_card_count": 1200,
+      "proxy_certificate_count": 0,
+      "total_admitted_voters_count": 1200
+    },
+    "votes_counts": {
+      "political_group_total_votes": [
+        {
+          "number": 1,
+          "name": "Stemmers eerst!",
+          "total": 540
+        },
+        {
+          "number": 2,
+          "name": "GROEP 1",
+          "total": 160
+        },
+        {
+          "number": 3,
+          "name": "GROEP 2",
+          "total": 160
+        },
+        {
+          "number": 4,
+          "name": "GROEP 3",
+          "total": 80
+        },
+        {
+          "number": 5,
+          "name": "GROEP 4",
+          "total": 80
+        },
+        {
+          "number": 6,
+          "name": "GROEP 5",
+          "total": 80
+        },
+        {
+          "number": 7,
+          "name": "GROEP 6",
+          "total": 55
+        },
+        {
+          "number": 8,
+          "name": "GROEP 7",
+          "total": 45
+        }
+      ],
+      "total_votes_candidates_count": 1200,
+      "blank_votes_count": 0,
+      "invalid_votes_count": 0,
+      "total_votes_cast_count": 1200
+    },
+    "differences_counts": {
+      "more_ballots_count": {
+        "count": 0,
+        "data_entry_sources": []
+      },
+      "fewer_ballots_count": {
+        "count": 0,
+        "data_entry_sources": []
+      }
+    }
+  },
+  "election": {
+    "id": 7,
+    "name": "Drawing lots < 19 seats, LargestRemainderResidualSeat",
+    "committee_category": "CSB",
+    "election_id": "GR2026_Juinen",
+    "location": "Juinen",
+    "domain_id": "0035",
+    "category": "Municipal",
+    "number_of_seats": 15,
+    "number_of_voters": 1,
+    "election_date": "2026-03-18",
+    "nomination_date": "2026-02-02"
+  },
+  "candidate_nomination": {
+    "list_candidate_nomination": [
+      {
+        "list_number": 1,
+        "list_name": "Stemmers eerst!",
+        "list_seats": 7,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "T.S.",
+              "last_name_prefix": "van der",
+              "last_name": "Meulen",
+              "locality": "Huisden",
+              "gender": "X"
+            },
+            "votes": 540
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "O.",
+              "last_name": "Boermans",
+              "locality": "Hovenerwoud",
+              "gender": "Female"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 3,
+            "candidate": {
+              "number": 3,
+              "initials": "R.",
+              "last_name": "Goedhart",
+              "locality": "Middelgein",
+              "gender": "Male"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 4,
+            "candidate": {
+              "number": 4,
+              "initials": "L.",
+              "last_name": "Oorschot",
+              "locality": "Eksterlo",
+              "gender": "X"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 5,
+            "candidate": {
+              "number": 5,
+              "initials": "Y.J.",
+              "last_name": "Aygün",
+              "locality": "Hoek van Zoom",
+              "gender": "Male"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 6,
+            "candidate": {
+              "number": 6,
+              "initials": "Q.",
+              "last_name": "Titulaer",
+              "locality": "Eksterlo",
+              "gender": "Female"
+            },
+            "votes": 0
+          },
+          {
+            "list_seat_number": 7,
+            "candidate": {
+              "number": 7,
+              "initials": "K.",
+              "last_name_prefix": "den",
+              "last_name": "Mateman",
+              "locality": "Middelgein",
+              "gender": "X"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "T.S.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 2,
+            "initials": "O.",
+            "last_name": "Boermans",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 3,
+            "initials": "R.",
+            "last_name": "Goedhart",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 4,
+            "initials": "L.",
+            "last_name": "Oorschot",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 5,
+            "initials": "Y.J.",
+            "last_name": "Aygün",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 6,
+            "initials": "Q.",
+            "last_name": "Titulaer",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 7,
+            "initials": "K.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 8,
+            "initials": "X.Q.",
+            "last_name": "Güneş",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 9,
+            "initials": "C.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 10,
+            "initials": "N.",
+            "last_name": "Katsma",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 11,
+            "initials": "Y.U.L.",
+            "last_name": "Gopal",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 12,
+            "initials": "V.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 13,
+            "initials": "L.T.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "Y.J.",
+            "last_name": "Titulaer",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 15,
+            "initials": "O.R.",
+            "last_name": "Güneş",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 16,
+            "initials": "S.",
+            "last_name": "Oorschot",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "P.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "E.L.B.S.",
+            "last_name": "Prakken",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "U.",
+            "last_name": "Brienen",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 20,
+            "initials": "C.T.V.",
+            "last_name": "Meulenkolk",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 21,
+            "initials": "V.",
+            "last_name": "Groenen",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 22,
+            "initials": "K.O.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 23,
+            "initials": "Q.W.X.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 24,
+            "initials": "L.Y.",
+            "last_name": "Prakken",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 25,
+            "initials": "Q.Z.P.E.",
+            "last_name": "Tax",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 26,
+            "initials": "W.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 27,
+            "initials": "C.",
+            "last_name": "Brienen",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 28,
+            "initials": "H.",
+            "last_name": "Wiertz",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 29,
+            "initials": "L.V.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 30,
+            "initials": "F.",
+            "last_name": "Aygün",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 31,
+            "initials": "G.",
+            "last_name": "Gopal",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 32,
+            "initials": "Q.E.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 33,
+            "initials": "I.R.",
+            "last_name": "Born",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 34,
+            "initials": "U.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 35,
+            "initials": "Q.T.L.",
+            "last_name": "Groenen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 36,
+            "initials": "M.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "I.",
+            "last_name": "Cornelis",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 38,
+            "initials": "K.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "E.I.",
+            "last_name": "Prakken",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 40,
+            "initials": "W.",
+            "last_name": "Wolfswinkel",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "B.H.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "P.",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "X.Q.Y.I.",
+            "last_name": "Katsma",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 44,
+            "initials": "I.",
+            "last_name": "Aygün",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 45,
+            "initials": "Z.",
+            "last_name": "Goedhart",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 46,
+            "initials": "T.S.L.D.",
+            "last_name": "Cornelis",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 47,
+            "initials": "J.",
+            "last_name": "Brienen",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "S.",
+            "last_name": "Hoogstraten",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 49,
+            "initials": "J.",
+            "last_name": "Arets",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "D.J.Z.",
+            "last_name": "Hoogstraten",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          }
+        ]
+      },
+      {
+        "list_number": 2,
+        "list_name": "GROEP 1",
+        "list_seats": 2,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "S.",
+              "first_name": "Salomon",
+              "last_name": "Meulenkolk",
+              "locality": "Sluisdam",
+              "gender": "Male"
+            },
+            "votes": 160
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "İ.",
+              "first_name": "İlknur",
+              "last_name_prefix": "den",
+              "last_name": "Mateman",
+              "locality": "Hoek van Zoom",
+              "gender": "Female"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "S.",
+            "first_name": "Salomon",
+            "last_name": "Meulenkolk",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 2,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 3,
+            "initials": "R.Y.",
+            "first_name": "Royce",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "D.U.",
+            "first_name": "Rachid",
+            "last_name": "Philippen",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 5,
+            "initials": "N.M.",
+            "first_name": "Nicolaas",
+            "last_name": "Katsma",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 6,
+            "initials": "B.F.W.",
+            "first_name": "Sijtze",
+            "last_name": "Boermans",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 7,
+            "initials": "I.P.",
+            "first_name": "Sammie",
+            "last_name": "Groenen",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 8,
+            "initials": "B.R.",
+            "first_name": "Dirk-Jan",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 9,
+            "initials": "J.B.G.",
+            "first_name": "Jelisa",
+            "last_name": "Hoogstraten",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 10,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 11,
+            "initials": "E.",
+            "first_name": "Edis",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 12,
+            "initials": "Z.",
+            "first_name": "Nicolaas",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 13,
+            "initials": "A.",
+            "first_name": "Royce",
+            "last_name": "Boermans",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "D.",
+            "first_name": "Damian",
+            "last_name": "Prakken",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 15,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name": "Katsma",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 16,
+            "initials": "R.C.I.",
+            "first_name": "Renso",
+            "last_name": "Güneş",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 17,
+            "initials": "S.H.K.",
+            "first_name": "Sijtze",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "E.R.F.R.",
+            "first_name": "Esra",
+            "last_name": "Güneş",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 19,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name": "Philippen",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 20,
+            "initials": "D.K.",
+            "first_name": "Damian",
+            "last_name": "Philippen",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "A.",
+            "first_name": "Alek",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 22,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name": "Wiertz",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 23,
+            "initials": "S.U.",
+            "first_name": "Salomon",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 24,
+            "initials": "C.H.F.",
+            "first_name": "Christina",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 25,
+            "initials": "R.M.D.",
+            "first_name": "Royce",
+            "last_name": "Philippen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 26,
+            "initials": "R.",
+            "first_name": "Royce",
+            "last_name": "Prakken",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 27,
+            "initials": "N.K.",
+            "first_name": "Nicolaas",
+            "last_name": "Born",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 28,
+            "initials": "M.X.T.",
+            "first_name": "Madelène",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 29,
+            "initials": "S.",
+            "first_name": "Sijtze",
+            "last_name": "Boermans",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Aygün",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 31,
+            "initials": "E.J.K.",
+            "first_name": "Esra",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 32,
+            "initials": "L.",
+            "first_name": "Leontien",
+            "last_name": "Oorschot",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 33,
+            "initials": "M.C.",
+            "first_name": "Madelène",
+            "last_name": "Cornelis",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name": "Oorschot",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 35,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name": "Born",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 36,
+            "initials": "H.",
+            "first_name": "Henk",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 37,
+            "initials": "R.",
+            "first_name": "Royce",
+            "last_name": "Cornelis",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 38,
+            "initials": "C.E.",
+            "first_name": "Cornelus",
+            "last_name": "Boermans",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 39,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 40,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 41,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 42,
+            "initials": "R.V.",
+            "first_name": "Rachid",
+            "last_name": "Philippen",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "D.",
+            "first_name": "Damian",
+            "last_name": "Aygün",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 44,
+            "initials": "S.Q.L.",
+            "first_name": "Sijtze",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name": "Boermans",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "İ.T.",
+            "first_name": "İlknur",
+            "last_name": "Hoogstraten",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 47,
+            "initials": "Z.N.",
+            "first_name": "Cornelus",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name": "Groenen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 49,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "E.C.",
+            "first_name": "Eelko",
+            "last_name": "Groenen",
+            "locality": "Sluisdam",
+            "gender": "X"
+          }
+        ]
+      },
+      {
+        "list_number": 3,
+        "list_name": "GROEP 2",
+        "list_seats": 2,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "V.L.",
+              "last_name": "Born",
+              "locality": "Hoek van Zoom",
+              "gender": "Female"
+            },
+            "votes": 160
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "P.W.",
+              "last_name": "Meulenkolk",
+              "locality": "Hoek van Zoom",
+              "gender": "X"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "V.L.",
+            "last_name": "Born",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 2,
+            "initials": "P.W.",
+            "last_name": "Meulenkolk",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 3,
+            "initials": "Y.M.",
+            "last_name": "Boermans",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 4,
+            "initials": "L.",
+            "last_name": "Hoogstraten",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 5,
+            "initials": "P.",
+            "last_name": "Güneş",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 6,
+            "initials": "V.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 7,
+            "initials": "R.",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 8,
+            "initials": "Y.R.K.",
+            "last_name": "Arets",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 9,
+            "initials": "V.",
+            "last_name": "Meulenkolk",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 10,
+            "initials": "U.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 11,
+            "initials": "S.",
+            "last_name": "Cornelis",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 12,
+            "initials": "V.Z.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 13,
+            "initials": "K.Z.M.Y.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "U.A.",
+            "last_name": "Goedhart",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "I.N.",
+            "last_name": "Cornelis",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 16,
+            "initials": "A.S.J.",
+            "last_name": "Gopal",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 17,
+            "initials": "K.M.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 18,
+            "initials": "M.",
+            "last_name": "Wiertz",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "W.",
+            "last_name": "Boermans",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 20,
+            "initials": "H.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "X.J.U.",
+            "last_name": "Hoogstraten",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 22,
+            "initials": "X.",
+            "last_name": "Aygün",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 23,
+            "initials": "I.B.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 24,
+            "initials": "I.J.",
+            "last_name": "Brienen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 25,
+            "initials": "X.V.",
+            "last_name": "Groenen",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 26,
+            "initials": "N.K.",
+            "last_name": "Born",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 27,
+            "initials": "S.",
+            "last_name": "Wolfswinkel",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 28,
+            "initials": "R.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 29,
+            "initials": "A.",
+            "last_name": "Boermans",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "S.",
+            "last_name": "Arets",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 31,
+            "initials": "R.",
+            "last_name": "Wiertz",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "P.C.Q.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 33,
+            "initials": "D.A.",
+            "last_name": "Prakken",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "N.",
+            "last_name": "Born",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 35,
+            "initials": "G.V.",
+            "last_name": "Aygün",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 36,
+            "initials": "F.V.O.Q.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "O.X.G.X.",
+            "last_name": "Wiertz",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 38,
+            "initials": "Z.",
+            "last_name": "Meulenkolk",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 39,
+            "initials": "E.",
+            "last_name": "Prakken",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 40,
+            "initials": "L.",
+            "last_name": "Aygün",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "I.",
+            "last_name": "Gopal",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 42,
+            "initials": "R.K.",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "G.G.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 44,
+            "initials": "W.J.T.",
+            "last_name": "Groenen",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 45,
+            "initials": "Y.",
+            "last_name": "Hoogstraten",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 46,
+            "initials": "S.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 47,
+            "initials": "O.C.",
+            "last_name": "Tax",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 48,
+            "initials": "C.F.F.",
+            "last_name": "Gopal",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 49,
+            "initials": "V.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "F.G.",
+            "last_name": "Gopal",
+            "locality": "Juinen",
+            "gender": "Male"
+          }
+        ]
+      },
+      {
+        "list_number": 4,
+        "list_name": "GROEP 3",
+        "list_seats": 1,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "S.",
+              "first_name": "Silvana",
+              "last_name": "Boermans",
+              "locality": "Lekkum",
+              "gender": "X"
+            },
+            "votes": 80
+          }
+        ],
+        "other_nomination_columns": [],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Boermans",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 2,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name": "Cornelis",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 3,
+            "initials": "J.T.R.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "S.F.",
+            "first_name": "Salomon",
+            "last_name": "Goedhart",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 5,
+            "initials": "S.H.",
+            "first_name": "Silvana",
+            "last_name": "Hoogstraten",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 6,
+            "initials": "S.Y.",
+            "first_name": "Silvana",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 7,
+            "initials": "U.",
+            "first_name": "Sibel",
+            "last_name": "Gopal",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 8,
+            "initials": "M.",
+            "first_name": "Madelène",
+            "last_name": "Katsma",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "E.",
+            "first_name": "Bart",
+            "last_name": "Boermans",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 10,
+            "initials": "R.M.",
+            "first_name": "Rachid",
+            "last_name": "Philippen",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 11,
+            "initials": "S.",
+            "first_name": "Sibel",
+            "last_name": "Wiertz",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 12,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name": "Prakken",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 13,
+            "initials": "A.",
+            "first_name": "Edis",
+            "last_name": "Cornelis",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "İ.T.X.",
+            "first_name": "İlknur",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 15,
+            "initials": "T.J.I.",
+            "first_name": "Tiemen",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 16,
+            "initials": "S.X.",
+            "first_name": "Sijtze",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 17,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name": "Meulenkolk",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "Y.",
+            "first_name": "Yağmur",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "H.K.",
+            "first_name": "Henk",
+            "last_name": "Arets",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 20,
+            "initials": "R.K.",
+            "first_name": "Renso",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 21,
+            "initials": "B.",
+            "first_name": "Bart",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 22,
+            "initials": "H.U.",
+            "first_name": "Henk",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 23,
+            "initials": "I.",
+            "first_name": "Gijsbertje",
+            "last_name": "Philippen",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 24,
+            "initials": "R.",
+            "first_name": "Renso",
+            "last_name": "Wiertz",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 25,
+            "initials": "N.P.",
+            "first_name": "Nikky",
+            "last_name": "Groenen",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "C.Z.",
+            "first_name": "Cornelus",
+            "last_name": "Güneş",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 27,
+            "initials": "E.",
+            "first_name": "Esra",
+            "last_name": "Gopal",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 28,
+            "initials": "L.",
+            "first_name": "Leontien",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 29,
+            "initials": "C.X.",
+            "first_name": "Cornelus",
+            "last_name": "Hoogstraten",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 30,
+            "initials": "F.P.",
+            "first_name": "Florien",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "W.Q.",
+            "first_name": "Sammie",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "R.",
+            "first_name": "Renso",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 33,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name": "Groenen",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "C.",
+            "first_name": "Cornelus",
+            "last_name": "Boermans",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 35,
+            "initials": "R.D.",
+            "first_name": "Rachid",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 36,
+            "initials": "E.F.",
+            "first_name": "Eelko",
+            "last_name": "Philippen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 37,
+            "initials": "T.Q.",
+            "first_name": "Teun",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 38,
+            "initials": "A.",
+            "first_name": "Alek",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 39,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Born",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 40,
+            "initials": "S.F.K.",
+            "first_name": "Sammie",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name": "Tax",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "J.I.",
+            "first_name": "Jelisa",
+            "last_name": "Katsma",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Philippen",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 44,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Goedhart",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 45,
+            "initials": "T.",
+            "first_name": "Teun",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "A.L.",
+            "first_name": "Alek",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 47,
+            "initials": "C.",
+            "first_name": "Cornelus",
+            "last_name": "Wolfswinkel",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 49,
+            "initials": "X.E.L.N.",
+            "first_name": "Cornelus",
+            "last_name": "Wolfswinkel",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 50,
+            "initials": "S.",
+            "first_name": "Sibel",
+            "last_name": "Wiertz",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          }
+        ]
+      },
+      {
+        "list_number": 5,
+        "list_name": "GROEP 4",
+        "list_seats": 2,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "G.",
+              "first_name": "Gijsbertje",
+              "last_name_prefix": "van de",
+              "last_name": "Kerkhof",
+              "locality": "Heemdamseburg",
+              "gender": "Male"
+            },
+            "votes": 80
+          }
+        ],
+        "other_nomination_columns": [
+          {
+            "list_seat_number": 2,
+            "candidate": {
+              "number": 2,
+              "initials": "K.P.",
+              "first_name": "Kris",
+              "last_name": "Güneş",
+              "locality": "Sluisdam",
+              "gender": "Female"
+            },
+            "votes": 0
+          }
+        ],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 2,
+            "initials": "K.P.",
+            "first_name": "Kris",
+            "last_name": "Güneş",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 3,
+            "initials": "S.V.N.",
+            "first_name": "Sijtze",
+            "last_name": "Goedhart",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 4,
+            "initials": "S.",
+            "first_name": "Sijtze",
+            "last_name": "Philippen",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 5,
+            "initials": "S.",
+            "first_name": "Salomon",
+            "last_name": "Cornelis",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 6,
+            "initials": "S.",
+            "first_name": "Sammie",
+            "last_name": "Boermans",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 7,
+            "initials": "S.",
+            "first_name": "Sammie",
+            "last_name": "Brienen",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 8,
+            "initials": "İ.A.",
+            "first_name": "İlknur",
+            "last_name": "Tax",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 9,
+            "initials": "L.I.",
+            "first_name": "Leontien",
+            "last_name": "Cornelis",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 10,
+            "initials": "R.A.",
+            "first_name": "Rachid",
+            "last_name": "Philippen",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 11,
+            "initials": "A.",
+            "first_name": "Alek",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 12,
+            "initials": "N.",
+            "first_name": "Nikky",
+            "last_name": "Hoogstraten",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 13,
+            "initials": "J.",
+            "first_name": "Jelisa",
+            "last_name": "Philippen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 14,
+            "initials": "J.",
+            "first_name": "Jory",
+            "last_name": "Oorschot",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "R.",
+            "first_name": "Royce",
+            "last_name": "Titulaer",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 16,
+            "initials": "Y.S.J.R.",
+            "first_name": "Yağmur",
+            "last_name": "Tax",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 17,
+            "initials": "S.W.V.",
+            "first_name": "Salomon",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 18,
+            "initials": "C.W.C.",
+            "first_name": "Cornelus",
+            "last_name": "Groenen",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 19,
+            "initials": "R.N.",
+            "first_name": "Renso",
+            "last_name": "Prakken",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 20,
+            "initials": "S.D.",
+            "first_name": "Sibel",
+            "last_name": "Tax",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "Y.",
+            "first_name": "Yağmur",
+            "last_name": "Cornelis",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 22,
+            "initials": "D.J.",
+            "first_name": "Damian",
+            "last_name": "Tax",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 23,
+            "initials": "D.Z.",
+            "first_name": "Damian",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 24,
+            "initials": "S.L.",
+            "first_name": "Sijtze",
+            "last_name": "Born",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 25,
+            "initials": "R.",
+            "first_name": "Edis",
+            "last_name": "Güneş",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 26,
+            "initials": "L.",
+            "first_name": "Leontien",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 27,
+            "initials": "S.",
+            "first_name": "Sammie",
+            "last_name": "Arets",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "V.E.",
+            "first_name": "Renso",
+            "last_name": "Meulenkolk",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 29,
+            "initials": "C.O.",
+            "first_name": "Christina",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "S.",
+            "first_name": "Salomon",
+            "last_name": "Philippen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 31,
+            "initials": "F.Y.",
+            "first_name": "Florien",
+            "last_name": "Oorschot",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 32,
+            "initials": "E.P.G.V.",
+            "first_name": "Esra",
+            "last_name": "Hoogstraten",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 33,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Gopal",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 34,
+            "initials": "D.C.G.M.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Cornelis",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 35,
+            "initials": "S.R.V.",
+            "first_name": "Silvana",
+            "last_name": "Boermans",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 36,
+            "initials": "E.Y.",
+            "first_name": "Edis",
+            "last_name": "Cornelis",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 37,
+            "initials": "D.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Meulenkolk",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 38,
+            "initials": "E.L.V.S.",
+            "first_name": "Eelko",
+            "last_name": "Born",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name": "Arets",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 40,
+            "initials": "Y.A.",
+            "first_name": "Yağmur",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 41,
+            "initials": "E.U.X.",
+            "first_name": "Edis",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 42,
+            "initials": "N.",
+            "first_name": "Nicolaas",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "D.Y.C.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Philippen",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 44,
+            "initials": "F.U.",
+            "first_name": "Florien",
+            "last_name": "Wolfswinkel",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 45,
+            "initials": "B.R.",
+            "first_name": "Bart",
+            "last_name": "Arets",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "R.",
+            "first_name": "Christina",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 47,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name": "Aygün",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 48,
+            "initials": "E.L.",
+            "first_name": "Eelko",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 49,
+            "initials": "A.",
+            "first_name": "Alek",
+            "last_name": "Philippen",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 50,
+            "initials": "E.T.",
+            "first_name": "Esra",
+            "last_name": "Cornelis",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          }
+        ]
+      },
+      {
+        "list_number": 6,
+        "list_name": "GROEP 5",
+        "list_seats": 1,
+        "preferential_nomination_columns": [
+          {
+            "list_seat_number": 1,
+            "candidate": {
+              "number": 1,
+              "initials": "Z.K.",
+              "last_name_prefix": "van",
+              "last_name": "Bekking",
+              "locality": "Hoek van Zoom",
+              "gender": "Male"
+            },
+            "votes": 80
+          }
+        ],
+        "other_nomination_columns": [],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "Z.K.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 2,
+            "initials": "N.G.",
+            "last_name": "Boermans",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 3,
+            "initials": "R.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 4,
+            "initials": "O.",
+            "last_name": "Groenen",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 5,
+            "initials": "H.W.",
+            "last_name": "Brienen",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 6,
+            "initials": "D.M.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 7,
+            "initials": "B.W.",
+            "last_name": "Titulaer",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 8,
+            "initials": "J.",
+            "last_name": "Groenen",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 9,
+            "initials": "W.",
+            "last_name": "Wolfswinkel",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 10,
+            "initials": "Z.P.O.Q.F.",
+            "last_name": "Titulaer",
+            "locality": "Sluisdam",
+            "gender": "X"
+          },
+          {
+            "number": 11,
+            "initials": "Y.V.Q.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 12,
+            "initials": "I.U.",
+            "last_name": "Cornelis",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 13,
+            "initials": "G.Y.I.",
+            "last_name": "Titulaer",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 14,
+            "initials": "Q.",
+            "last_name": "Arets",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "F.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 16,
+            "initials": "J.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "C.",
+            "last_name": "Boermans",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "O.F.F.K.",
+            "last_name": "Titulaer",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "U.",
+            "last_name": "Wolfswinkel",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 20,
+            "initials": "O.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "D.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 22,
+            "initials": "M.",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 23,
+            "initials": "A.I.Z.",
+            "last_name": "Wolfswinkel",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 24,
+            "initials": "N.O.",
+            "last_name": "Meulenkolk",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 25,
+            "initials": "L.",
+            "last_name": "Prakken",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "M.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Middelgein",
+            "gender": "Male"
+          },
+          {
+            "number": 27,
+            "initials": "V.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "Y.",
+            "last_name": "Wolfswinkel",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 29,
+            "initials": "D.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "T.D.",
+            "last_name": "Hoogstraten",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 31,
+            "initials": "R.B.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 32,
+            "initials": "Q.R.",
+            "last_name": "Boermans",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 33,
+            "initials": "P.",
+            "last_name": "Born",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 34,
+            "initials": "M.P.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 35,
+            "initials": "M.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 36,
+            "initials": "O.P.S.",
+            "last_name": "Hoogstraten",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "J.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 38,
+            "initials": "Z.",
+            "last_name": "Arets",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "J.W.D.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 40,
+            "initials": "C.",
+            "last_name": "Cornelis",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 41,
+            "initials": "A.K.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 42,
+            "initials": "Z.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "K.R.O.O.",
+            "last_name": "Gopal",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 44,
+            "initials": "V.M.",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "P.",
+            "last_name": "Oorschot",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 46,
+            "initials": "J.",
+            "last_name": "Oorschot",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 47,
+            "initials": "X.V.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 48,
+            "initials": "M.X.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Middelgein",
+            "gender": "Female"
+          },
+          {
+            "number": 49,
+            "initials": "N.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 50,
+            "initials": "M.R.",
+            "last_name": "Brienen",
+            "locality": "Middelgein",
+            "gender": "Male"
+          }
+        ]
+      },
+      {
+        "list_number": 7,
+        "list_name": "GROEP 6",
+        "list_seats": 0,
+        "preferential_nomination_columns": [],
+        "other_nomination_columns": [],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "D.Y.",
+            "first_name": "Nikky",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 2,
+            "initials": "A.O.",
+            "first_name": "Alek",
+            "last_name": "Tax",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 3,
+            "initials": "N.J.",
+            "first_name": "Nicolaas",
+            "last_name": "Gopal",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 4,
+            "initials": "A.",
+            "first_name": "Alek",
+            "last_name": "Oorschot",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 5,
+            "initials": "D.",
+            "first_name": "Damian",
+            "last_name": "Brienen",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 6,
+            "initials": "R.K.",
+            "first_name": "Renso",
+            "last_name": "Güneş",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 7,
+            "initials": "S.X.F.",
+            "first_name": "Sijtze",
+            "last_name": "Hoogstraten",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 8,
+            "initials": "C.S.",
+            "first_name": "Christina",
+            "last_name": "Oorschot",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 9,
+            "initials": "R.S.H.C.Z.",
+            "first_name": "Renso",
+            "last_name": "Titulaer",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 10,
+            "initials": "T.C.",
+            "first_name": "Tiemen",
+            "last_name": "Born",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 11,
+            "initials": "K.",
+            "first_name": "Kris",
+            "last_name": "Born",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 12,
+            "initials": "K.H.S.N.",
+            "first_name": "Kris",
+            "last_name": "Meulenkolk",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 13,
+            "initials": "E.",
+            "first_name": "Eelko",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 14,
+            "initials": "G.",
+            "first_name": "Gijsbertje",
+            "last_name": "Wiertz",
+            "locality": "Eemstricht",
+            "gender": "Male"
+          },
+          {
+            "number": 15,
+            "initials": "L.",
+            "first_name": "Leontien",
+            "last_name": "Titulaer",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 16,
+            "initials": "T.J.G.",
+            "first_name": "Sammie",
+            "last_name": "Titulaer",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 17,
+            "initials": "R.",
+            "first_name": "Rachid",
+            "last_name": "Prakken",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 18,
+            "initials": "D.P.",
+            "first_name": "Dirk-Jan",
+            "last_name": "Brienen",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 19,
+            "initials": "L.Y.",
+            "first_name": "Leontien",
+            "last_name": "Wiertz",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 20,
+            "initials": "C.",
+            "first_name": "Christina",
+            "last_name": "Goedhart",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "F.Y.",
+            "first_name": "Florien",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Huisden",
+            "gender": "Male"
+          },
+          {
+            "number": 22,
+            "initials": "N.Q.",
+            "first_name": "Nicolaas",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 23,
+            "initials": "C.",
+            "first_name": "Christina",
+            "last_name": "Wiertz",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 24,
+            "initials": "D.V.",
+            "first_name": "Dirk-Jan",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 25,
+            "initials": "S.",
+            "first_name": "Silvana",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 26,
+            "initials": "C.K.",
+            "first_name": "Christina",
+            "last_name": "Tax",
+            "locality": "Eemstricht",
+            "gender": "X"
+          },
+          {
+            "number": 27,
+            "initials": "C.P.",
+            "first_name": "Christina",
+            "last_name": "Güneş",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "H.",
+            "first_name": "Henk",
+            "last_name": "Wolfswinkel",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 29,
+            "initials": "J.Q.",
+            "first_name": "Jelisa",
+            "last_name": "Prakken",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 30,
+            "initials": "J.",
+            "first_name": "Yağmur",
+            "last_name_prefix": "de",
+            "last_name": "Vegt",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 31,
+            "initials": "S.Q.C.T.",
+            "first_name": "Salomon",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 32,
+            "initials": "İ.",
+            "first_name": "İlknur",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Huisden",
+            "gender": "Female"
+          },
+          {
+            "number": 33,
+            "initials": "M.V.",
+            "first_name": "Madelène",
+            "last_name": "Goedhart",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 34,
+            "initials": "R.S.T.",
+            "first_name": "Renso",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 35,
+            "initials": "R.U.G.",
+            "first_name": "Royce",
+            "last_name": "Philippen",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 36,
+            "initials": "T.U.",
+            "first_name": "Teun",
+            "last_name": "Groenen",
+            "locality": "Eksterlo",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "D.",
+            "first_name": "Damian",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 38,
+            "initials": "N.K.",
+            "first_name": "Nikky",
+            "last_name": "Philippen",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 39,
+            "initials": "L.K.",
+            "first_name": "Leontien",
+            "last_name": "Born",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 40,
+            "initials": "N.",
+            "first_name": "Nicolaas",
+            "last_name": "Katsma",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 41,
+            "initials": "N.",
+            "first_name": "Nicolaas",
+            "last_name": "Aygün",
+            "locality": "Heemdamseburg",
+            "gender": "X"
+          },
+          {
+            "number": 42,
+            "initials": "D.W.",
+            "first_name": "Damian",
+            "last_name": "Philippen",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 43,
+            "initials": "F.",
+            "first_name": "Florien",
+            "last_name": "Tax",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 44,
+            "initials": "F.",
+            "first_name": "Teun",
+            "last_name": "Boermans",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "N.",
+            "first_name": "Nicolaas",
+            "last_name": "Aygün",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "N.R.S.",
+            "first_name": "Nikky",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 47,
+            "initials": "K.E.",
+            "first_name": "Silvana",
+            "last_name": "Born",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 48,
+            "initials": "R.",
+            "first_name": "Ruth",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 49,
+            "initials": "E.",
+            "first_name": "Edis",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "C.V.",
+            "first_name": "Christina",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          }
+        ]
+      },
+      {
+        "list_number": 8,
+        "list_name": "GROEP 7",
+        "list_seats": 0,
+        "preferential_nomination_columns": [],
+        "other_nomination_columns": [],
+        "updated_candidate_ranking": [
+          {
+            "number": 1,
+            "initials": "X.",
+            "last_name": "Tax",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 2,
+            "initials": "P.A.",
+            "last_name": "Gopal",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 3,
+            "initials": "T.",
+            "last_name": "Arets",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 4,
+            "initials": "K.S.",
+            "last_name": "Cornelis",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 5,
+            "initials": "Z.I.",
+            "last_name_prefix": "van de",
+            "last_name": "Wal",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 6,
+            "initials": "U.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 7,
+            "initials": "C.",
+            "last_name": "Güneş",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 8,
+            "initials": "U.",
+            "last_name": "Prakken",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 9,
+            "initials": "X.K.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Hovenerwoud",
+            "gender": "Female"
+          },
+          {
+            "number": 10,
+            "initials": "W.J.",
+            "last_name": "Gopal",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 11,
+            "initials": "Z.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 12,
+            "initials": "N.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 13,
+            "initials": "X.",
+            "last_name": "Gopal",
+            "locality": "Juinen",
+            "gender": "Male"
+          },
+          {
+            "number": 14,
+            "initials": "S.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Eemstricht",
+            "gender": "Female"
+          },
+          {
+            "number": 15,
+            "initials": "E.",
+            "last_name_prefix": "van de",
+            "last_name": "Kerkhof",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 16,
+            "initials": "Y.K.",
+            "last_name": "Katsma",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 17,
+            "initials": "Q.",
+            "last_name": "Arets",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 18,
+            "initials": "J.E.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 19,
+            "initials": "Z.N.",
+            "last_name": "Güneş",
+            "locality": "Eksterlo",
+            "gender": "Male"
+          },
+          {
+            "number": 20,
+            "initials": "O.",
+            "last_name": "Born",
+            "locality": "Hoek van Zoom",
+            "gender": "X"
+          },
+          {
+            "number": 21,
+            "initials": "P.K.",
+            "last_name": "Wolfswinkel",
+            "locality": "Sluisdam",
+            "gender": "Female"
+          },
+          {
+            "number": 22,
+            "initials": "W.H.",
+            "last_name": "Prakken",
+            "locality": "'s Gravenveen",
+            "gender": "Male"
+          },
+          {
+            "number": 23,
+            "initials": "R.W.A.",
+            "last_name": "Katsma",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 24,
+            "initials": "A.",
+            "last_name": "Born",
+            "locality": "Lekkum",
+            "gender": "Female"
+          },
+          {
+            "number": 25,
+            "initials": "F.C.K.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 26,
+            "initials": "O.Y.",
+            "last_name": "Tax",
+            "locality": "Juinen",
+            "gender": "X"
+          },
+          {
+            "number": 27,
+            "initials": "K.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Juinen",
+            "gender": "Female"
+          },
+          {
+            "number": 28,
+            "initials": "O.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Bloemstede",
+            "gender": "Male"
+          },
+          {
+            "number": 29,
+            "initials": "K.Y.H.",
+            "last_name_prefix": "van der",
+            "last_name": "Spek",
+            "locality": "Middelgein",
+            "gender": "X"
+          },
+          {
+            "number": 30,
+            "initials": "U.Q.",
+            "last_name": "Hoogstraten",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 31,
+            "initials": "V.",
+            "last_name": "Gopal",
+            "locality": "'s Gravenveen",
+            "gender": "Female"
+          },
+          {
+            "number": 32,
+            "initials": "S.G.K.",
+            "last_name_prefix": "van",
+            "last_name": "Jaspers-Gezen",
+            "locality": "Hovenerwoud",
+            "gender": "X"
+          },
+          {
+            "number": 33,
+            "initials": "M.L.A.I.",
+            "last_name": "Boermans",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 34,
+            "initials": "G.T.",
+            "last_name": "Gopal",
+            "locality": "'s Gravenveen",
+            "gender": "X"
+          },
+          {
+            "number": 35,
+            "initials": "A.",
+            "last_name": "Arets",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 36,
+            "initials": "L.O.",
+            "last_name": "Cornelis",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 37,
+            "initials": "C.E.",
+            "last_name": "Katsma",
+            "locality": "Bloemstede",
+            "gender": "X"
+          },
+          {
+            "number": 38,
+            "initials": "C.P.",
+            "last_name": "Katsma",
+            "locality": "Eksterlo",
+            "gender": "X"
+          },
+          {
+            "number": 39,
+            "initials": "T.Z.",
+            "last_name": "Wolfswinkel",
+            "locality": "Heemdamseburg",
+            "gender": "Male"
+          },
+          {
+            "number": 40,
+            "initials": "G.",
+            "last_name_prefix": "van",
+            "last_name": "Lent",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 41,
+            "initials": "N.W.",
+            "last_name": "Gopal",
+            "locality": "Hoek van Zoom",
+            "gender": "Male"
+          },
+          {
+            "number": 42,
+            "initials": "F.",
+            "last_name": "Wiertz",
+            "locality": "Lekkum",
+            "gender": "X"
+          },
+          {
+            "number": 43,
+            "initials": "C.D.",
+            "last_name": "Goedhart",
+            "locality": "Hovenerwoud",
+            "gender": "Male"
+          },
+          {
+            "number": 44,
+            "initials": "E.",
+            "last_name_prefix": "den",
+            "last_name": "Mateman",
+            "locality": "Heemdamseburg",
+            "gender": "Female"
+          },
+          {
+            "number": 45,
+            "initials": "M.I.",
+            "last_name": "Bruins-Van den Kerk",
+            "locality": "Hoek van Zoom",
+            "gender": "Female"
+          },
+          {
+            "number": 46,
+            "initials": "E.",
+            "last_name": "Güneş",
+            "locality": "Bloemstede",
+            "gender": "Female"
+          },
+          {
+            "number": 47,
+            "initials": "Y.",
+            "last_name": "Katsma",
+            "locality": "Huisden",
+            "gender": "X"
+          },
+          {
+            "number": 48,
+            "initials": "K.",
+            "last_name_prefix": "van der",
+            "last_name": "Meulen",
+            "locality": "Sluisdam",
+            "gender": "Male"
+          },
+          {
+            "number": 49,
+            "initials": "B.W.",
+            "last_name_prefix": "van",
+            "last_name": "Bekking",
+            "locality": "Lekkum",
+            "gender": "Male"
+          },
+          {
+            "number": 50,
+            "initials": "O.",
+            "last_name": "Katsma",
+            "locality": "Middelgein",
+            "gender": "Male"
+          }
+        ]
+      }
+    ],
+    "chosen_candidates": [
+      {
+        "number": 5,
+        "initials": "Y.J.",
+        "last_name": "Aygün",
+        "locality": "Hoek van Zoom",
+        "gender": "Male",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      },
+      {
+        "number": 1,
+        "initials": "Z.K.",
+        "last_name_prefix": "van",
+        "last_name": "Bekking",
+        "locality": "Hoek van Zoom",
+        "gender": "Male",
+        "list_number": 6,
+        "list_name": "GROEP 5"
+      },
+      {
+        "number": 2,
+        "initials": "O.",
+        "last_name": "Boermans",
+        "locality": "Hovenerwoud",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      },
+      {
+        "number": 1,
+        "initials": "S.",
+        "first_name": "Silvana",
+        "last_name": "Boermans",
+        "locality": "Lekkum",
+        "gender": "X",
+        "list_number": 4,
+        "list_name": "GROEP 3"
+      },
+      {
+        "number": 1,
+        "initials": "V.L.",
+        "last_name": "Born",
+        "locality": "Hoek van Zoom",
+        "gender": "Female",
+        "list_number": 3,
+        "list_name": "GROEP 2"
+      },
+      {
+        "number": 3,
+        "initials": "R.",
+        "last_name": "Goedhart",
+        "locality": "Middelgein",
+        "gender": "Male",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      },
+      {
+        "number": 2,
+        "initials": "K.P.",
+        "first_name": "Kris",
+        "last_name": "Güneş",
+        "locality": "Sluisdam",
+        "gender": "Female",
+        "list_number": 5,
+        "list_name": "GROEP 4"
+      },
+      {
+        "number": 1,
+        "initials": "G.",
+        "first_name": "Gijsbertje",
+        "last_name_prefix": "van de",
+        "last_name": "Kerkhof",
+        "locality": "Heemdamseburg",
+        "gender": "Male",
+        "list_number": 5,
+        "list_name": "GROEP 4"
+      },
+      {
+        "number": 7,
+        "initials": "K.",
+        "last_name_prefix": "den",
+        "last_name": "Mateman",
+        "locality": "Middelgein",
+        "gender": "X",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      },
+      {
+        "number": 2,
+        "initials": "İ.",
+        "first_name": "İlknur",
+        "last_name_prefix": "den",
+        "last_name": "Mateman",
+        "locality": "Hoek van Zoom",
+        "gender": "Female",
+        "list_number": 2,
+        "list_name": "GROEP 1"
+      },
+      {
+        "number": 1,
+        "initials": "T.S.",
+        "last_name_prefix": "van der",
+        "last_name": "Meulen",
+        "locality": "Huisden",
+        "gender": "X",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      },
+      {
+        "number": 2,
+        "initials": "P.W.",
+        "last_name": "Meulenkolk",
+        "locality": "Hoek van Zoom",
+        "gender": "X",
+        "list_number": 3,
+        "list_name": "GROEP 2"
+      },
+      {
+        "number": 1,
+        "initials": "S.",
+        "first_name": "Salomon",
+        "last_name": "Meulenkolk",
+        "locality": "Sluisdam",
+        "gender": "Male",
+        "list_number": 2,
+        "list_name": "GROEP 1"
+      },
+      {
+        "number": 4,
+        "initials": "L.",
+        "last_name": "Oorschot",
+        "locality": "Eksterlo",
+        "gender": "X",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      },
+      {
+        "number": 6,
+        "initials": "Q.",
+        "last_name": "Titulaer",
+        "locality": "Eksterlo",
+        "gender": "Female",
+        "list_number": 1,
+        "list_name": "Stemmers eerst!"
+      }
+    ]
+  },
+  "seat_assignment": {
+    "quota": {
+      "integer": 80,
+      "numerator": 0,
+      "denominator": 15
+    },
+    "list_seat_assignment": [
+      {
+        "number": 1,
+        "name": "Stemmers eerst!",
+        "total": 540,
+        "initial_full_seats": 6,
+        "largest_remainder": {
+          "remainder_votes": {
+            "integer": 60,
+            "numerator": 0,
+            "denominator": 15
+          },
+          "residual_seats": 1
+        }
+      },
+      {
+        "number": 2,
+        "name": "GROEP 1",
+        "total": 160,
+        "initial_full_seats": 2,
+        "largest_remainder": {
+          "remainder_votes": {
+            "integer": 0,
+            "numerator": 0,
+            "denominator": 15
+          },
+          "residual_seats": 0
+        }
+      },
+      {
+        "number": 3,
+        "name": "GROEP 2",
+        "total": 160,
+        "initial_full_seats": 2,
+        "largest_remainder": {
+          "remainder_votes": {
+            "integer": 0,
+            "numerator": 0,
+            "denominator": 15
+          },
+          "residual_seats": 0
+        }
+      },
+      {
+        "number": 4,
+        "name": "GROEP 3",
+        "total": 80,
+        "initial_full_seats": 1,
+        "largest_remainder": {
+          "remainder_votes": {
+            "integer": 0,
+            "numerator": 0,
+            "denominator": 15
+          },
+          "residual_seats": 0
+        }
+      },
+      {
+        "number": 5,
+        "name": "GROEP 4",
+        "total": 80,
+        "initial_full_seats": 1,
+        "largest_remainder": {
+          "remainder_votes": {
+            "integer": 0,
+            "numerator": 0,
+            "denominator": 15
+          },
+          "residual_seats": 1
+        }
+      },
+      {
+        "number": 6,
+        "name": "GROEP 5",
+        "total": 80,
+        "initial_full_seats": 1,
+        "largest_remainder": {
+          "remainder_votes": {
+            "integer": 0,
+            "numerator": 0,
+            "denominator": 15
+          },
+          "residual_seats": 0
+        }
+      },
+      {
+        "number": 7,
+        "name": "GROEP 6",
+        "total": 55,
+        "initial_full_seats": 0
+      },
+      {
+        "number": 8,
+        "name": "GROEP 7",
+        "total": 45,
+        "initial_full_seats": 0
+      }
+    ],
+    "initial_total_full_seats": 13,
+    "initial_total_residual_seats": 2
+  },
+  "hash": "dedf 17b4 684e 1214 fcab b770 925d c75c 624b e338 0bd3 4647 29c3 7a80 a379 40ad",
+  "creation_date_time": "19-03-2023 17:07:00 +02:00"
+}

--- a/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p9-and-p10.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats-and-p9-and-p10.json
@@ -60,17 +60,17 @@
   },
   "election": {
     "id": 4,
-    "name": "Test Election < 19 seats & Absolute Majority Change & List Exhaustion",
+    "name": "Election < 19 seats & Absolute Majority Change & List Exhaustion",
     "counting_method": "CSO",
     "committee_category": "CSB",
-    "election_id": "Juinen_2026",
+    "election_id": "GR2026_Juinen",
     "location": "Juinen",
     "domain_id": "0035",
     "category": "Municipal",
     "number_of_seats": 15,
+    "number_of_voters": 1,
     "election_date": "2026-03-18",
-    "nomination_date": "2026-02-02",
-    "number_of_voters": 1
+    "nomination_date": "2026-02-02"
   },
   "candidate_nomination": {
     "chosen_candidates": [

--- a/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats.json
+++ b/backend/templates/inputs/extra-model-p-22-2-variations/lt-19-seats.json
@@ -75,17 +75,16 @@
   },
   "election": {
     "id": 3,
-    "name": "Test Election < 19 seats",
-    "counting_method": "CSO",
+    "name": "Election < 19 seats",
     "committee_category": "CSB",
-    "election_id": "Juinen_2026",
+    "election_id": "GR2026_Juinen",
     "location": "Juinen",
     "domain_id": "0035",
     "category": "Municipal",
     "number_of_seats": 15,
+    "number_of_voters": 1,
     "election_date": "2026-03-18",
-    "nomination_date": "2026-02-02",
-    "number_of_voters": 1
+    "nomination_date": "2026-02-02"
   },
   "candidate_nomination": {
     "chosen_candidates": [

--- a/backend/templates/inputs/model-p-22-2.json
+++ b/backend/templates/inputs/model-p-22-2.json
@@ -60,17 +60,17 @@
   },
   "election": {
     "id": 4,
-    "name": "Test Election < 19 seats & Absolute Majority Change & List Exhaustion",
+    "name": "Election < 19 seats & Absolute Majority Change & List Exhaustion",
     "counting_method": "CSO",
     "committee_category": "CSB",
-    "election_id": "Juinen_2026",
+    "election_id": "GR2026_Juinen",
     "location": "Juinen",
     "domain_id": "0035",
     "category": "Municipal",
     "number_of_seats": 15,
+    "number_of_voters": 1,
     "election_date": "2026-03-18",
-    "nomination_date": "2026-02-02",
-    "number_of_voters": 1
+    "nomination_date": "2026-02-02"
   },
   "candidate_nomination": {
     "chosen_candidates": [

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
@@ -2065,17 +2065,16 @@ export const committee_session: CommitteeSession = {
 
 export const election: ElectionWithPoliticalGroups = {
   id: 5,
-  name: "Test Election >= 19 seats & Absolute Majority Change",
-  counting_method: "CSO",
+  name: "Election >= 19 seats & Absolute Majority Change",
   committee_category: "CSB",
-  election_id: "TestLocation_2026",
-  location: "Test Location",
-  domain_id: "0000",
+  election_id: "GR2026_Juinen",
+  location: "Juinen",
+  domain_id: "0035",
   category: "Municipal",
   number_of_seats: 24,
+  number_of_voters: 1,
   election_date: "2026-03-18",
   nomination_date: "2026-02-02",
-  number_of_voters: 1,
   political_groups: [
     {
       number: 1,

--- a/frontend/src/features/apportionment/testing/gte-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats.ts
@@ -1380,17 +1380,16 @@ export const committee_session: CommitteeSession = {
 
 export const election: ElectionWithPoliticalGroups = {
   id: 2,
-  name: "Test Election >= 19 seats",
-  counting_method: "CSO",
+  name: "Election >= 19 seats",
   committee_category: "CSB",
-  election_id: "TestLocation_2026",
-  location: "Test Location",
-  domain_id: "0000",
+  election_id: "GR2026_Juinen",
+  location: "Juinen",
+  domain_id: "0035",
   category: "Municipal",
   number_of_seats: 23,
+  number_of_voters: 1,
   election_date: "2026-03-18",
   nomination_date: "2026-02-02",
-  number_of_voters: 1,
   political_groups: [
     {
       number: 1,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
@@ -855,17 +855,16 @@ export const committee_session: CommitteeSession = {
 
 export const election: ElectionWithPoliticalGroups = {
   id: 6,
-  name: "Test Election < 19 seats & List Exhaustion",
-  counting_method: "CSO",
+  name: "Election < 19 seats & List Exhaustion",
   committee_category: "CSB",
-  election_id: "TestLocation_2026",
-  location: "Test Location",
-  domain_id: "0000",
+  election_id: "GR2026_Juinen",
+  location: "Juinen",
+  domain_id: "0035",
   category: "Municipal",
   number_of_seats: 6,
+  number_of_voters: 1,
   election_date: "2026-03-18",
   nomination_date: "2026-02-02",
-  number_of_voters: 1,
   political_groups: [
     {
       number: 1,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
@@ -1560,17 +1560,16 @@ export const committee_session: CommitteeSession = {
 
 export const election: ElectionWithPoliticalGroups = {
   id: 4,
-  name: "Test Election Absolute Majority Change and List Exhaustion",
-  counting_method: "CSO",
+  name: "Election Absolute Majority Change and List Exhaustion",
   committee_category: "CSB",
-  election_id: "TestLocation_2026",
-  location: "Test Location",
-  domain_id: "0000",
+  election_id: "GR2026_Juinen",
+  location: "Juinen",
+  domain_id: "0035",
   category: "Municipal",
   number_of_seats: 15,
+  number_of_voters: 1,
   election_date: "2026-03-18",
   nomination_date: "2026-02-02",
-  number_of_voters: 1,
   political_groups: [
     {
       number: 1,

--- a/frontend/src/features/apportionment/testing/lt-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats.ts
@@ -1696,17 +1696,16 @@ export const committee_session: CommitteeSession = {
 
 export const election: ElectionWithPoliticalGroups = {
   id: 3,
-  name: "Test Election < 19 seats",
-  counting_method: "CSO",
+  name: "Election < 19 seats",
   committee_category: "CSB",
-  election_id: "TestLocation_2026",
-  location: "Test Location",
-  domain_id: "0000",
+  election_id: "GR2026_Juinen",
+  location: "Juinen",
+  domain_id: "0035",
   category: "Municipal",
   number_of_seats: 15,
+  number_of_voters: 1,
   election_date: "2026-03-18",
   nomination_date: "2026-02-02",
-  number_of_voters: 1,
   political_groups: [
     political_group_1,
     {


### PR DESCRIPTION
Not ready for review yet

## What & why

- First add custom names to gen test election p22-2 variants
- Corrected current variant files (removing counting method)
- Also corrected frontend test variants (removing counting method)
- Added drawing lots variants (P7)

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

Check the pdf diff. New variants also added to https://typst.app/project/pPlJpmsT8NlSoRlIFborCw so viewable there with an account.

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

Other variants will be added when other drawing of lots are implemented.

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->