### PR TITLE
Enable TLS in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Run tests
-        run: cargo --locked test --release --workspace --no-default-features --features memory-serve,embed-typst,airgap-detection --target=${{ matrix.target.name }}
+        run: cargo --locked test --release --workspace --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
       # no airgap detection build
       - name: Build without airgap detection
         run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
@@ -90,7 +90,7 @@ jobs:
           path: ${{ matrix.target.binary }}
       # airgap detection build
       - name: Build
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst,airgap-detection --target=${{ matrix.target.name }}
+        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,7 @@ jobs:
           name: Version ${{ github.ref_name }}
 
   deploy:
+    if: github.repository == 'kiesraad/abacus'
     name: Deploy to abacus-test.nl, without airgap detection
     needs:
       - build


### PR DESCRIPTION
## What & why

Enable TLS in release builds, so that release builds always use TLS. In addition, the deploy to abacus-test.nl is disabled for release workflow runs in forks to prevent this step from failing due to a missing abacus-test token. Resolves #3413.

## How to test

Push this branch to `main` on your fork and then create a tag:
```
git push -f <fork> 3413-release-builds-tls:main
git tag v42.13.37
git push <fork> v42.13.37
```

This will trigger the CI ([example CI run in my fork](https://github.com/praseodym/abacus/actions/runs/28268776381)) and create a release ([example release in my fork](https://github.com/praseodym/abacus/releases/tag/untagged-6af77e5a5c1df3dd8bdb)).

The tagged commit needs to be part of a branch for GitHub to allow creating releases, that's why you need to push to main.

## Reviewer notes

None.