### PR TITLE
Adjusted highest averages table description for lt 19 seats in P 22-2

### DIFF
--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -395,9 +395,9 @@ Na toewijzing van de volle zetels blijft een aantal te verdelen zetels over. Dit
     #if initial_highest_average_steps.len() > 0 [
       #v(8pt)
       #if initial_highest_average_steps.len() == 1 {
-        [Hierna was er nog #initial_highest_average_steps.len() restzetel te verdelen. Deze zetel is toegewezen aan de lijst die met een zetel erbij het grootste gemiddelde aantal stemmen per zetel zou hebben.]
+        [Nadat de restzetels zijn verdeeld via het systeem van de grootste gemiddelden, is er nog #initial_highest_average_steps.len() zetel te verdelen. Deze zetel wordt nogmaals verdeeld via het systeem van de grootste gemiddelden, met dien verstande dat de bepaling dat aan iedere lijst maar eenmaal een zetel mag worden toegekend buiten beschouwing wordt gelaten.]
       } else {
-        [Hierna waren er nog #initial_highest_average_steps.len() restzetels te verdelen. Deze zetels zijn toegewezen aan de lijsten die met een zetel erbij het grootste gemiddelde aantal stemmen per zetel zouden hebben.]
+        [Nadat de restzetels zijn verdeeld via het systeem van de grootste gemiddelden, zijn er nog #initial_highest_average_steps.len() zetels te verdelen. Deze zetels worden nogmaals verdeeld via het systeem van de grootste gemiddelden, met dien verstande dat de bepaling dat aan iedere lijst maar eenmaal een zetel mag worden toegekend buiten beschouwing wordt gelaten.]
       }
       #highest_averages_table(initial_highest_average_steps, input.seat_assignment.list_seat_assignment)
     ]


### PR DESCRIPTION
## What & why

Quote from Michelle:
> Dag allen,
>
> Zoals eerder aangegeven zouden we vanuit JKA nog met een verduidelijkende tekst komen die bij de tabel kan worden getoond als de situatie zich voordoet dat na verdelen van restzetels op basis van het systeem van de grootste gemiddelden nog zetels overblijven. E.e.a. wordt overigens niet in het model opgenomen.
>
> De volgende tekst kan boven de tabel worden getoond:
> Nadat de restzetels zijn verdeeld via het systeem van de grootste gemiddelden, zijn er nog zetels te verdelen. Deze zetels worden nogmaals verdeeld via het systeem van de grootste gemiddelden, met dien verstande dat de bepaling dat aan iedere lijst maar eenmaal een zetel mag worden toegekend buiten beschouwing wordt gelaten.
> 
> Groet,
> Michelle

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

Just check the text in the typst file. It's not something that can happen IRL so we don't have a variant for it (since the P22-2 only shows the initial steps and only adds footnotes for P9 (absolute majority), P10 (list exhaustion), etc.). You need list exhaustion to trigger the highest averages round, which is shown in the frontend for the lt-19-seats-and-p10 test election.

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->