### PR TITLE
Always use locally zoned timestamps for EML files

### DIFF
--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -292,7 +292,7 @@ impl ResultsInputCSB {
 
         let xml_results_data = data.election.as_result_eml(
             None,
-            data.created_at.with_timezone(&Utc),
+            data.created_at,
             &apportionment_result.candidate_nomination,
         )?;
         let xml_results_string = xml_results_data.write_eml_root_str(true, true)?;

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -4,7 +4,7 @@ mod error;
 pub mod hash;
 
 use apportionment::CandidateNominationDetails;
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Local};
 use eml_nl::{
     EMLError,
     common::{
@@ -371,9 +371,9 @@ impl ElectionWithPoliticalGroups {
     pub fn as_candidates_eml(
         &self,
         transaction_id: Option<u64>,
-        timestamp: Option<DateTime<Utc>>,
+        timestamp: Option<DateTime<Local>>,
     ) -> Result<CandidateLists, EMLError> {
-        let timestamp = timestamp.unwrap_or_else(Utc::now);
+        let timestamp = timestamp.unwrap_or_else(Local::now);
 
         CandidateLists::builder()
             .transaction_id(transaction_id.unwrap_or(1))
@@ -417,9 +417,9 @@ impl ElectionWithPoliticalGroups {
     pub fn as_definition_eml(
         &self,
         transaction_id: Option<u64>,
-        timestamp: Option<DateTime<Utc>>,
+        timestamp: Option<DateTime<Local>>,
     ) -> Result<ElectionDefinition, EMLError> {
-        let timestamp = timestamp.unwrap_or_else(Utc::now);
+        let timestamp = timestamp.unwrap_or_else(Local::now);
 
         ElectionDefinition::builder()
             .transaction_id(transaction_id.unwrap_or(1))
@@ -459,9 +459,9 @@ impl ElectionWithPoliticalGroups {
         &self,
         polling_stations: &[crate::domain::polling_station::PollingStation],
         transaction_id: Option<u64>,
-        timestamp: Option<DateTime<Utc>>,
+        timestamp: Option<DateTime<Local>>,
     ) -> Result<PollingStations, EMLError> {
-        let timestamp = timestamp.unwrap_or_else(Utc::now);
+        let timestamp = timestamp.unwrap_or_else(Local::now);
 
         PollingStations::builder()
             .transaction_id(transaction_id.unwrap_or(1))
@@ -699,7 +699,7 @@ impl ElectionWithPoliticalGroups {
     pub fn as_result_eml(
         &self,
         transaction_id: Option<u64>,
-        timestamp: DateTime<Utc>,
+        timestamp: DateTime<Local>,
         nominations: &CandidateNominationDetails<PoliticalGroupCandidateVotes>,
     ) -> Result<ElectionResult, EMLError> {
         if self.committee_category != CommitteeCategory::CSB {
@@ -1051,7 +1051,7 @@ mod tests {
         };
 
         let eml_result = election
-            .as_result_eml(None, chrono::Utc::now(), &details)
+            .as_result_eml(None, Local::now(), &details)
             .unwrap();
         assert_eq!(
             eml_result


### PR DESCRIPTION
## What & why

Fixes #3365 (also part of #3429). We now use local timestamps for all EML document generation functions.

## How to test

Create a CSB election and complete it. The results document (EML520) will have a local timestamp instead of an UTC one.

## Reviewer notes

- Main target here was EML520, but I've applied the same to all EML documents
- Note that we don't have additional unit tests: these would fail on any computer that doesn't have the correct timezone (unfortunately chrono makes mocking of timezones difficult, especially in a cross platform way). But all these tests would do is test that chrono formatting would work, which we would hope already works accordingly (and up until this point already assumed to be working correctly). We do however have type system safety that we always generate local timestamps.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->