### PR TITLE
Use CSB fixtures for apportionment tests

### DIFF
--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -75,13 +75,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_add_candidate_drawn(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -118,7 +118,7 @@ mod tests {
             user,
             State(pool),
             audit_service,
-            Path(ElectionId::from(5)),
+            Path(ElectionId::from(8)),
             Json::from(candidate_drawn.clone()),
         )
         .await

--- a/backend/src/api/apportionment/handlers/add_deceased_candidate.rs
+++ b/backend/src/api/apportionment/handlers/add_deceased_candidate.rs
@@ -68,13 +68,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_add_deceased_candidate(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -95,7 +95,7 @@ mod tests {
             user,
             State(pool),
             audit_service,
-            Path(ElectionId::from(5)),
+            Path(ElectionId::from(8)),
             Json::from(candidate),
         )
         .await

--- a/backend/src/api/apportionment/handlers/add_list_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_list_drawn.rs
@@ -74,13 +74,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_add_list_drawn(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -120,7 +120,7 @@ mod tests {
             user,
             State(pool),
             audit_service,
-            Path(ElectionId::from(5)),
+            Path(ElectionId::from(8)),
             Json::from(list_drawn.clone()),
         )
         .await

--- a/backend/src/api/apportionment/handlers/delete_deceased_candidate.rs
+++ b/backend/src/api/apportionment/handlers/delete_deceased_candidate.rs
@@ -68,13 +68,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_delete_deceased_candidate(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -95,7 +95,7 @@ mod tests {
             user,
             State(pool),
             audit_service,
-            Path(ElectionId::from(5)),
+            Path(ElectionId::from(8)),
             Json::from(candidate),
         )
         .await

--- a/backend/src/api/apportionment/handlers/finalise_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/finalise_deceased_candidates.rs
@@ -62,13 +62,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_finalise_deceased_candidates(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -89,7 +89,7 @@ mod tests {
             user,
             State(pool),
             audit_service,
-            Path(ElectionId::from(5)),
+            Path(ElectionId::from(8)),
         )
         .await
         .expect("should call the handler successfully");

--- a/backend/src/api/apportionment/handlers/get_apportionment_state.rs
+++ b/backend/src/api/apportionment/handlers/get_apportionment_state.rs
@@ -57,18 +57,18 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_get_state(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
-        let id = CommitteeSessionId::from(6);
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
             .expect("should change committee session status");
 
-        let state = get_apportionment_state(user, State(pool), Path(ElectionId::from(5)))
+        let state = get_apportionment_state(user, State(pool), Path(ElectionId::from(8)))
             .await
             .expect("should call the handler successfully")
             .0;

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -115,17 +115,17 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_election_apportionment(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
 
         change_committee_session_status(
             &mut conn,
-            CommitteeSessionId::from(6),
+            CommitteeSessionId::from(801),
             CommitteeSessionStatus::Completed,
             audit_service.clone(),
         )
@@ -133,20 +133,20 @@ mod tests {
         .unwrap();
 
         let response =
-            process_apportionment(user, State(pool), audit_service, Path(ElectionId::from(5)))
+            process_apportionment(user, State(pool), audit_service, Path(ElectionId::from(8)))
                 .await
                 .into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    #[test(sqlx::test(fixtures(path = "../../../../fixtures", scripts("election_4"))))]
+    #[test(sqlx::test(fixtures(path = "../../../../fixtures", scripts("election_9_csb"))))]
     async fn test_election_apportionment_not_complete(pool: SqlitePool) {
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
 
         let response =
-            process_apportionment(user, State(pool), audit_service, Path(ElectionId::from(4)))
+            process_apportionment(user, State(pool), audit_service, Path(ElectionId::from(9)))
                 .await
                 .into_response();
 
@@ -171,31 +171,31 @@ mod tests {
             pool: SqlitePool,
             coordinator_role: Role,
         ) -> Vec<(&'static str, Response)> {
-            let user = User::test_user(coordinator_role, UserId::from(1));
+            let user = User::test_user(coordinator_role, UserId::from(3));
             let audit = AuditService::new(Some(user.clone()), None);
 
             #[rustfmt::skip]
             let results = vec![
-                ("apportionment", process_apportionment(user.clone(), State(pool.clone()), audit.clone(), Path(ElectionId::from(5))).await.into_response()),
+                ("apportionment", process_apportionment(user.clone(), State(pool.clone()), audit.clone(), Path(ElectionId::from(8))).await.into_response()),
             ];
             results
         }
 
         #[test(sqlx::test(fixtures(
             path = "../../../../fixtures",
-            scripts("election_5_with_results")
+            scripts("election_8_csb_with_results")
         )))]
         async fn test_committee_category_authorization_err(pool: SqlitePool) {
-            let results = call_handlers(pool, Role::CoordinatorCSB).await;
+            let results = call_handlers(pool, Role::CoordinatorGSB).await;
             assert_committee_category_authorization_err(results).await;
         }
 
         #[test(sqlx::test(fixtures(
             path = "../../../../fixtures",
-            scripts("election_5_with_results")
+            scripts("election_8_csb_with_results")
         )))]
         async fn test_committee_category_authorization_ok(pool: SqlitePool) {
-            let results = call_handlers(pool, Role::CoordinatorGSB).await;
+            let results = call_handlers(pool, Role::CoordinatorCSB).await;
             assert_committee_category_authorization_ok(results);
         }
     }

--- a/backend/src/api/apportionment/handlers/register_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/register_deceased_candidates.rs
@@ -63,13 +63,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_register_deceased_candidates(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -79,7 +79,7 @@ mod tests {
             user,
             State(pool),
             audit_service,
-            Path(ElectionId::from(5)),
+            Path(ElectionId::from(8)),
         )
         .await
         .expect("should call the handler successfully");

--- a/backend/src/api/apportionment/handlers/reset_apportionment_state.rs
+++ b/backend/src/api/apportionment/handlers/reset_apportionment_state.rs
@@ -62,13 +62,13 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_reset_apportionment_state(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
@@ -85,7 +85,7 @@ mod tests {
         .expect("should upsert initial state");
 
         let state =
-            reset_apportionment_state(user, State(pool), audit_service, Path(ElectionId::from(5)))
+            reset_apportionment_state(user, State(pool), audit_service, Path(ElectionId::from(8)))
                 .await
                 .expect("should call the handler successfully");
 

--- a/backend/src/api/apportionment/handlers/skip_deceased_candidates.rs
+++ b/backend/src/api/apportionment/handlers/skip_deceased_candidates.rs
@@ -60,20 +60,20 @@ mod tests {
 
     #[test(sqlx::test(fixtures(
         path = "../../../../fixtures",
-        scripts("election_5_with_results")
+        scripts("election_8_csb_with_results")
     )))]
     async fn test_skip_deceased_candidates(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let user = User::test_user(Role::CoordinatorCSB, UserId::from(3));
         let audit_service = AuditService::new(Some(user.clone()), None);
-        let id = CommitteeSessionId::from(6);
+        let id = CommitteeSessionId::from(801);
 
         committee_session_repo::change_status(&mut conn, id, CommitteeSessionStatus::Completed)
             .await
             .expect("should change committee session status");
 
         let state =
-            skip_deceased_candidates(user, State(pool), audit_service, Path(ElectionId::from(5)))
+            skip_deceased_candidates(user, State(pool), audit_service, Path(ElectionId::from(8)))
                 .await
                 .expect("should call the handler successfully");
 


### PR DESCRIPTION
## What & why

When fixing tests for #3487, it became clear that apportionment tests were still using GSB fixtures instead of CSB. 

## How to test

CI should pass

## Reviewer notes

N/A