### PR TITLE
Apportionment: Fix number formatting in election summary table

### DIFF
--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -168,9 +168,9 @@ describe("ApportionmentPage", () => {
     expect(election_summary_table).toBeVisible();
     expect(election_summary_table).toHaveTableContent([
       ["Kiesgerechtigden", "2.000", ""],
-      ["Getelde stembiljetten", "1.205", "Opkomst: 60.25%"],
-      ["Blanco stemmen", "3", "0.25%"],
-      ["Ongeldige stemmen", "2", "0.17%"],
+      ["Getelde stembiljetten", "1.205", "Opkomst: 60,25%"],
+      ["Blanco stemmen", "3", "0,25%"],
+      ["Ongeldige stemmen", "2", "0,17%"],
       ["Totaal stemmen op kandidaten", "1.200", ""],
       ["Aantal raadszetels", "15", ""],
       ["Kiesdeler", "80", "Benodigde stemmen per volle zetel"],
@@ -223,9 +223,9 @@ describe("ApportionmentPage", () => {
     expect(election_summary_table).toBeVisible();
     expect(election_summary_table).toHaveTableContent([
       ["Kiesgerechtigden", "2.000", ""],
-      ["Getelde stembiljetten", "1.205", "Opkomst: 60.25%"],
-      ["Blanco stemmen", "3", "0.25%"],
-      ["Ongeldige stemmen", "2", "0.17%"],
+      ["Getelde stembiljetten", "1.205", "Opkomst: 60,25%"],
+      ["Blanco stemmen", "3", "0,25%"],
+      ["Ongeldige stemmen", "2", "0,17%"],
       ["Totaal stemmen op kandidaten", "1.200", ""],
       ["Aantal raadszetels", "15", ""],
       ["Kiesdeler", "80", "Benodigde stemmen per volle zetel"],

--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
@@ -28,9 +28,9 @@ export const DefaultWithNumberOfVoters: StoryObj = {
     await expect(table).toBeVisible();
     expect(table).toHaveTableContent([
       ["Kiesgerechtigden", "2.000", ""],
-      ["Getelde stembiljetten", "1.205", "Opkomst: 60.25%"],
-      ["Blanco stemmen", "2", "0.17%"],
-      ["Ongeldige stemmen", "3", "0.25%"],
+      ["Getelde stembiljetten", "1.205", "Opkomst: 60,25%"],
+      ["Blanco stemmen", "2", "0,17%"],
+      ["Ongeldige stemmen", "3", "0,25%"],
       ["Totaal stemmen op kandidaten", "1.200", ""],
       ["Aantal raadszetels", "23", ""],
       ["Kiesdeler", "52 4/23", "Benodigde stemmen per volle zetel"],
@@ -65,13 +65,54 @@ export const DefaultWithoutNumberOfVoters: StoryObj = {
     expect(table).toHaveTableContent([
       ["Kiesgerechtigden", "", ""],
       ["Getelde stembiljetten", "1.205", ""],
-      ["Blanco stemmen", "2", "0.17%"],
-      ["Ongeldige stemmen", "3", "0.25%"],
+      ["Blanco stemmen", "2", "0,17%"],
+      ["Ongeldige stemmen", "3", "0,25%"],
       ["Totaal stemmen op kandidaten", "1.200", ""],
       ["Aantal raadszetels", "23", ""],
       ["Kiesdeler", "52 4/23", "Benodigde stemmen per volle zetel"],
       ["Voorkeursdrempel", "13 100/2300", "25% van de kiesdeler"],
       ["Kandidaten voor zetelverdeling", "33 - 0 † = 33", "Beheer overleden kandidaten"],
+    ]);
+  },
+};
+
+export const DefaultWithoutBlankAndInvalidVotes: StoryObj = {
+  render: () => {
+    return (
+      <ElectionSummaryTable
+        votesCounts={{
+          ...gte19Seats.election_summary.votes_counts,
+          blank_votes_count: 0,
+          invalid_votes_count: 0,
+          total_votes_candidates_count: 1205,
+        }}
+        seats={gte19Seats.seat_assignment.seats}
+        quota={gte19Seats.seat_assignment.quota}
+        numberOfVoters={gte19Seats.election_summary.number_of_voters}
+        preferenceThreshold={gte19Seats.candidate_nomination.preference_threshold}
+        deceasedCandidatesInfo={
+          {
+            numberOfCandidates: getNumberOfCandidates(gte19Seats.election.political_groups),
+            numberOfDeceasedCandidates: 3,
+            deceasedCandidatesLink: "",
+          } satisfies DeceasedCandidatesInfo
+        }
+      />
+    );
+  },
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table");
+    await expect(table).toBeVisible();
+    expect(table).toHaveTableContent([
+      ["Kiesgerechtigden", "2.000", ""],
+      ["Getelde stembiljetten", "1.205", "Opkomst: 60,25%"],
+      ["Blanco stemmen", "0", ""],
+      ["Ongeldige stemmen", "0", ""],
+      ["Totaal stemmen op kandidaten", "1.205", ""],
+      ["Aantal raadszetels", "23", ""],
+      ["Kiesdeler", "52 4/23", "Benodigde stemmen per volle zetel"],
+      ["Voorkeursdrempel", "13 100/2300", "25% van de kiesdeler"],
+      ["Kandidaten voor zetelverdeling", "33 - 3 † = 30", "Beheer overleden kandidaten"],
     ]);
   },
 };

--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.tsx
@@ -9,7 +9,7 @@ import type {
   VotesCounts,
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
-import { formatNumber } from "@/utils/number";
+import { formatNumber, formatPercentage } from "@/utils/number";
 import cls from "./Apportionment.module.css";
 
 export interface DeceasedCandidatesInfo {
@@ -54,7 +54,7 @@ export function ElectionSummaryTable({
           <Table.NumberCell>{formatNumber(votesCounts.total_votes_cast_count)}</Table.NumberCell>
           <Table.Cell className="fs-sm">
             {numberOfVoters
-              ? `${t("apportionment.turnout")}: ${((votesCounts.total_votes_cast_count / numberOfVoters) * 100).toFixed(2)}%`
+              ? `${t("apportionment.turnout")}: ${formatPercentage(votesCounts.total_votes_cast_count, numberOfVoters)}`
               : ""}
           </Table.Cell>
         </Table.Row>
@@ -62,18 +62,26 @@ export function ElectionSummaryTable({
           <Table.HeaderCell scope="row" className="normal">
             {t("voters_votes_counts.votes_counts.blank_votes_count")}
           </Table.HeaderCell>
-          <Table.NumberCell>{formatNumber(votesCounts.blank_votes_count)}</Table.NumberCell>
+          <Table.NumberCell>
+            {votesCounts.blank_votes_count > 0 ? formatNumber(votesCounts.blank_votes_count) : "0"}
+          </Table.NumberCell>
           <Table.Cell className="fs-sm">
-            {`${((votesCounts.blank_votes_count / votesCounts.total_votes_cast_count) * 100).toFixed(2)}%`}
+            {votesCounts.blank_votes_count > 0
+              ? formatPercentage(votesCounts.blank_votes_count, votesCounts.total_votes_cast_count)
+              : ""}
           </Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.HeaderCell scope="row" className="normal">
             {t("voters_votes_counts.votes_counts.invalid_votes_count")}
           </Table.HeaderCell>
-          <Table.NumberCell>{formatNumber(votesCounts.invalid_votes_count)}</Table.NumberCell>
+          <Table.NumberCell>
+            {votesCounts.invalid_votes_count > 0 ? formatNumber(votesCounts.invalid_votes_count) : "0"}
+          </Table.NumberCell>
           <Table.Cell className="fs-sm">
-            {`${((votesCounts.invalid_votes_count / votesCounts.total_votes_cast_count) * 100).toFixed(2)}%`}
+            {votesCounts.invalid_votes_count > 0
+              ? formatPercentage(votesCounts.invalid_votes_count, votesCounts.total_votes_cast_count)
+              : ""}
           </Table.Cell>
         </Table.Row>
         <Table.Row>

--- a/frontend/src/utils/number.test.ts
+++ b/frontend/src/utils/number.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { deformatNumber, formatNumber, validateNumberString } from "./number";
+import { deformatNumber, formatNumber, formatPercentage, validateNumberString } from "./number";
 
 describe("Number util", () => {
   test.each([
@@ -51,5 +51,29 @@ describe("Number util", () => {
     ["x", NaN],
   ])("Deformat number %j as %j", (input: string, expected: number) => {
     expect(deformatNumber(input)).toBe(expected);
+  });
+
+  test.each([
+    [0, 100, "0,00%"],
+    [1, 100, "1,00%"],
+    [1, 1000, "0,10%"],
+    [1, 9999, "0,01%"],
+    [1, 10000, "0,01%"],
+    [1, 100000, "0,00%"],
+    [13, 10_000, "0,13%"],
+  ])("Percentage format %j/%j as %j", (value: number, total: number, expected: string) => {
+    expect(formatPercentage(value, total)).toBe(expected);
+  });
+
+  test.each<[number, number]>([
+    [1, 0],
+    [1, -100],
+    [-1, 100],
+    [NaN, 100],
+    [Infinity, 100],
+    [1, NaN],
+    [1, Infinity],
+  ])("Return empty string for %j/%j", (value, total) => {
+    expect(formatPercentage(value, total)).toBe("");
   });
 });

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -2,6 +2,12 @@ const numberFormatter = new Intl.NumberFormat("nl-NL", {
   maximumFractionDigits: 0,
 });
 
+const percentageFormatter = new Intl.NumberFormat("nl-NL", {
+  style: "percent",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 export function formatNumber(s: string | number | null | undefined | readonly string[]) {
   if ((typeof s !== "string" && typeof s !== "number") || (typeof s === "number" && s === 0)) {
     return "";
@@ -29,4 +35,12 @@ export function validateNumberString(s: string | null | undefined) {
   if (s === null || s === undefined || s === "") return false;
   const result = s.trim();
   return !!result.match(/^(\d*\.?)$|^(\d{1,3}(\.\d{3})+\.?)$/g);
+}
+
+export function formatPercentage(value: number, total: number): string {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || value < 0 || total <= 0) {
+    return "";
+  }
+
+  return percentageFormatter.format(value / total);
 }


### PR DESCRIPTION
## What & why
Closes #3354.

- Turnout, blank/invalid-vote percentages now use the Dutch decimal separator
- Zero blank/invalid vote counts now display as 0 instead of empty string
- Percentages are hidden for zero blank/invalid vote counts 

<img width="843" height="239" alt="image" src="https://github.com/user-attachments/assets/d24ae9d7-5ac0-4ee8-b8f4-8e10becae6c8" />

<img width="848" height="237" alt="image" src="https://github.com/user-attachments/assets/8c6b853a-524f-4b8d-ad30-2ff03b643dbb" />



## How to test
From `./frontend`
```
pnpm test --run src/utils/number.test.ts

pnpm test --run src/features/apportionment/components/ApportionmentPage.test.tsx -t "Election summary and apportionment tables visible"

pnpm test --run src/features/apportionment/components/ApportionmentPage.test.tsx -t "Renders number of deceased candidates and redirects on clicking manage deceased candidates"
```

Storybook: `/features/apportionment/components/ElectionSummaryTable`

## Reviewer notes
- 'Getelde stembiljetten' and 'Totaal stemmen op kandidaten' still display empty string when their value is 0
- When 'Getelde stembiljetten' is 0, its count cell is empty while 'Opkomst' is displayed as 0,00%
