### PR TITLE
Add SQLite backup REST API

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,3 +6,4 @@
 /templates/**/*.pdf
 /tmp-pdf-gen
 cobertura.xml
+/backups/

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -84,7 +84,7 @@ eml-nl = { version = "0.6.0" }
 hyper = { version = "1", features = ["full"] }
 tokio.workspace = true
 memory-serve = { version = "2.1.0", optional = true, features = ["force-embed"] }
-utoipa = { version = "5.4.0", features = ["axum_extras"] }
+utoipa = { version = "5.4.0", features = ["axum_extras", "chrono"] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"], optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -209,7 +209,7 @@ Additionally, the following development dependencies are used:
 - `test-log`: show tracing messages while running tests
 - `reqwest`: HTTP client for testing the API.
 - `http-body-util`: trait used to extract a response body in some tests.
-- `tempfile`: to create temporary directories for TLS certificate tests.
+- `tempfile`: to create temporary directories in tests.
 
 ### Database
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -108,6 +108,73 @@
         ]
       }
     },
+    "/api/backup": {
+      "post": {
+        "summary": "administrator, coordinator_csb, coordinator_gsb",
+        "operationId": "create_backup",
+        "responses": {
+          "201": {
+            "description": "Backup created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Backup already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "administrator",
+              "coordinator_csb",
+              "coordinator_gsb"
+            ]
+          }
+        ]
+      }
+    },
     "/api/data_entries/{data_entry_id}": {
       "delete": {
         "summary": "Reset the data entry to empty (coordinator_csb, coordinator_gsb)",
@@ -5548,6 +5615,7 @@
           "AirGapViolationDetected",
           "AirGapViolationResolved",
           "ApplicationStarted",
+          "DatabaseBackupCreated",
           "ApiError",
           "ApiWarning",
           "UnknownEvent"
@@ -5661,6 +5729,22 @@
           }
         },
         "additionalProperties": false
+      },
+      "BackupResponse": {
+        "type": "object",
+        "required": [
+          "filename",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "filename": {
+            "type": "string"
+          }
+        }
       },
       "BasePollingStation": {
         "type": "object",
@@ -7113,6 +7197,7 @@
         "enum": [
           "AirgapViolation",
           "AlreadyInitialised",
+          "BackupAlreadyExists",
           "ApportionmentNotCompleted",
           "ApportionmentCommitteeSessionNotCompleted",
           "ApportionmentInvalidLotDrawing",

--- a/backend/src/api/backup.rs
+++ b/backend/src/api/backup.rs
@@ -1,0 +1,77 @@
+use axum::{Json, extract::State, http::StatusCode};
+use chrono::Local;
+use serde::Serialize;
+use sqlx::SqlitePool;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::{
+    APIError, AppState, ErrorResponse,
+    api::middleware::authentication::RouteAuthorization,
+    domain::role::Role,
+    infra::{
+        audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
+        backup::{BackupConfig, BackupResult, create_local_backup},
+    },
+};
+
+#[derive(Serialize, ToSchema)]
+pub struct BackupResponse {
+    pub filename: String,
+    pub created_at: chrono::DateTime<Local>,
+}
+
+#[derive(Serialize)]
+struct DatabaseBackupCreatedAuditData {
+    filename: String,
+}
+
+impl AsAuditEvent for DatabaseBackupCreatedAuditData {
+    const EVENT_TYPE: AuditEventType = AuditEventType::DatabaseBackupCreated;
+    const EVENT_LEVEL: AuditEventLevel = AuditEventLevel::Success;
+}
+
+pub fn router() -> OpenApiRouter<AppState> {
+    use Role::*;
+    const ALLOWED_ROLES: &[Role] = &[Administrator, CoordinatorCSB, CoordinatorGSB];
+    OpenApiRouter::default().routes(routes!(create_backup).authorize(ALLOWED_ROLES))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/backup",
+    responses(
+        (status = 201, description = "Backup created successfully", body = BackupResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 409, description = "Backup already exists", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+)]
+async fn create_backup(
+    State(pool): State<SqlitePool>,
+    State(backup_config): State<BackupConfig>,
+    audit_service: AuditService,
+) -> Result<(StatusCode, Json<BackupResponse>), APIError> {
+    let BackupResult {
+        filename,
+        created_at,
+    } = create_local_backup(&pool, &backup_config).await?;
+    let response = BackupResponse {
+        filename,
+        created_at,
+    };
+
+    let mut conn = pool.acquire().await?;
+    audit_service
+        .log(
+            &mut conn,
+            &DatabaseBackupCreatedAuditData {
+                filename: response.filename.clone(),
+            },
+            None,
+        )
+        .await?;
+
+    Ok((StatusCode::CREATED, Json(response)))
+}

--- a/backend/src/api/middleware/airgap/detect.rs
+++ b/backend/src/api/middleware/airgap/detect.rs
@@ -400,7 +400,6 @@ mod tests {
         let backup_config =
             crate::infra::backup::BackupConfig::new(backup_dir.path().to_path_buf());
         tokio::spawn(async move {
-            let _backup_dir = backup_dir;
             let app = router::create_router(pool, airgap_detection, backup_config).unwrap();
 
             axum::serve(

--- a/backend/src/api/middleware/airgap/detect.rs
+++ b/backend/src/api/middleware/airgap/detect.rs
@@ -396,8 +396,13 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
+        let backup_dir = tempfile::tempdir().unwrap();
+        let backup_config = crate::infra::backup::BackupConfig {
+            directory: backup_dir.path().to_path_buf(),
+        };
         tokio::spawn(async move {
-            let app = router::create_router(pool, airgap_detection).unwrap();
+            let _backup_dir = backup_dir;
+            let app = router::create_router(pool, airgap_detection, backup_config).unwrap();
 
             axum::serve(
                 listener,

--- a/backend/src/api/middleware/airgap/detect.rs
+++ b/backend/src/api/middleware/airgap/detect.rs
@@ -397,9 +397,8 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let backup_dir = tempfile::tempdir().unwrap();
-        let backup_config = crate::infra::backup::BackupConfig {
-            directory: backup_dir.path().to_path_buf(),
-        };
+        let backup_config =
+            crate::infra::backup::BackupConfig::new(backup_dir.path().to_path_buf());
         tokio::spawn(async move {
             let _backup_dir = backup_dir;
             let app = router::create_router(pool, airgap_detection, backup_config).unwrap();

--- a/backend/src/api/middleware/authentication/mod.rs
+++ b/backend/src/api/middleware/authentication/mod.rs
@@ -70,9 +70,7 @@ mod tests {
         let state = AppState {
             pool: pool.clone(),
             airgap_detection: AirgapDetection::nop(),
-            backup_config: BackupConfig {
-                directory: backup_dir.path().to_path_buf(),
-            },
+            backup_config: BackupConfig::new(backup_dir.path().to_path_buf()),
         };
 
         Router::from(router())

--- a/backend/src/api/middleware/authentication/mod.rs
+++ b/backend/src/api/middleware/authentication/mod.rs
@@ -55,7 +55,7 @@ mod tests {
         api::{authentication::*, middleware::airgap::AirgapDetection, user::*},
         domain::role::Role,
         error::ErrorReference,
-        infra::audit_log::LogFilter,
+        infra::{audit_log::LogFilter, backup::BackupConfig},
         repository::{
             session_repo::{self, Session},
             user_repo::{self, User, UserId},
@@ -66,9 +66,13 @@ mod tests {
     };
 
     fn create_app(pool: &SqlitePool) -> Router {
+        let backup_dir = tempfile::tempdir().unwrap();
         let state = AppState {
             pool: pool.clone(),
             airgap_detection: AirgapDetection::nop(),
+            backup_config: BackupConfig {
+                directory: backup_dir.path().to_path_buf(),
+            },
         };
 
         Router::from(router())

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod apportionment;
 pub mod audit;
 pub mod authentication;
+pub mod backup;
 pub mod committee_session;
 pub mod data_entry;
 pub mod document;

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -4,7 +4,7 @@ use std::{
     process,
 };
 
-use abacus::{AppError, create_sqlite_pool};
+use abacus::{AppError, create_sqlite_pool, infra::backup::BackupConfig};
 use clap::Parser;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::TcpListener;
@@ -85,6 +85,10 @@ struct Args {
     #[arg(short, long, default_value = "db.sqlite", env = "ABACUS_DATABASE")]
     database: String,
 
+    /// Directory for database backups
+    #[arg(long, default_value = "backups", env = "ABACUS_BACKUP_DIR")]
+    backup_dir: std::path::PathBuf,
+
     /// Location of the TLS directory (CA certificate and key), will be created if it doesn't exist
     #[cfg(feature = "tls")]
     #[arg(long, default_value = "tls", env = "ABACUS_TLS_DIR")]
@@ -149,6 +153,10 @@ async fn run() -> Result<(), AppError> {
     )
     .await?;
 
+    let backup_config = BackupConfig {
+        directory: args.backup_dir,
+    };
+
     // Enable airgap detection if the feature is enabled or if the command line argument is set.
     #[cfg(feature = "airgap-detection")]
     let enable_airgap_detection = true;
@@ -167,8 +175,16 @@ async fn run() -> Result<(), AppError> {
 
         spawn_plain_http_server(args.http_port, args.port, ca.clone());
 
-        abacus::start_server_tls(pool, listener, enable_airgap_detection, tls_config, ca).await
+        abacus::start_server_tls(
+            pool,
+            listener,
+            enable_airgap_detection,
+            backup_config,
+            tls_config,
+            ca,
+        )
+        .await
     }
     #[cfg(not(feature = "tls"))]
-    abacus::start_server(pool, listener, enable_airgap_detection).await
+    abacus::start_server(pool, listener, enable_airgap_detection, backup_config).await
 }

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -153,9 +153,7 @@ async fn run() -> Result<(), AppError> {
     )
     .await?;
 
-    let backup_config = BackupConfig {
-        directory: args.backup_dir,
-    };
+    let backup_config = BackupConfig::new(args.backup_dir);
 
     // Enable airgap detection if the feature is enabled or if the command line argument is set.
     #[cfg(feature = "airgap-detection")]

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -366,7 +366,7 @@ impl From<BackupError> for APIError {
     fn from(err: BackupError) -> Self {
         match err {
             BackupError::AlreadyExists => APIError::Conflict(
-                "A backup for this timestamp already exists".to_string(),
+                "A backup with this filename already exists".to_string(),
                 ErrorReference::BackupAlreadyExists,
             ),
             BackupError::InvalidPath => {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -22,6 +22,7 @@ use crate::{
         role::RoleNotAuthorizedError, validate::DataError,
     },
     eml::EMLImportError,
+    infra::backup::BackupError,
     repository::polling_station_repo,
     service::{DataEntryServiceError, PollingStationServiceError, SubCommitteeServiceError},
 };
@@ -41,6 +42,7 @@ pub trait ApiErrorResponse: Debug + Any {
 pub enum ErrorReference {
     AirgapViolation,
     AlreadyInitialised,
+    BackupAlreadyExists,
     ApportionmentNotCompleted,
     ApportionmentCommitteeSessionNotCompleted,
     ApportionmentInvalidLotDrawing,
@@ -356,6 +358,22 @@ impl From<sqlx::Error> for APIError {
                 _ => APIError::SqlxError(err),
             },
             _ => APIError::SqlxError(err),
+        }
+    }
+}
+
+impl From<BackupError> for APIError {
+    fn from(err: BackupError) -> Self {
+        match err {
+            BackupError::AlreadyExists => APIError::Conflict(
+                "A backup for this timestamp already exists".to_string(),
+                ErrorReference::BackupAlreadyExists,
+            ),
+            BackupError::InvalidPath => {
+                APIError::StdError(Box::new(std::io::Error::other("invalid backup path")))
+            }
+            BackupError::Io(err) => APIError::StdError(Box::new(err)),
+            BackupError::Database(err) => APIError::SqlxError(err),
         }
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -372,6 +372,9 @@ impl From<BackupError> for APIError {
             BackupError::InvalidPath => {
                 APIError::StdError(Box::new(std::io::Error::other("invalid backup path")))
             }
+            BackupError::IntegrityCheckFailed(output) => APIError::StdError(Box::new(
+                std::io::Error::other(format!("backup integrity check failed: {output}")),
+            )),
             BackupError::Io(err) => APIError::StdError(Box::new(err)),
             BackupError::Database(err) => APIError::SqlxError(err),
         }

--- a/backend/src/infra/audit_log/audit_event.rs
+++ b/backend/src/infra/audit_log/audit_event.rs
@@ -147,6 +147,7 @@ pub enum AuditEventType {
     AirGapViolationResolved,
     // system events
     ApplicationStarted,
+    DatabaseBackupCreated,
     // API events (one for each severity level)
     ApiError,
     ApiWarning,

--- a/backend/src/infra/backup.rs
+++ b/backend/src/infra/backup.rs
@@ -1,6 +1,6 @@
 use chrono::Local;
 use sqlx::{
-    Connection, Row, SqlitePool,
+    Connection, SqlitePool,
     sqlite::{SqliteConnectOptions, SqliteConnection},
 };
 use std::{
@@ -104,11 +104,11 @@ async fn verify_backup(backup_path: &Path) -> Result<(), BackupError> {
         .filename(backup_path)
         .read_only(true);
     let mut connection = SqliteConnection::connect_with(&options).await?;
-    let result = sqlx::query("PRAGMA integrity_check")
+    let result = sqlx::query_scalar::<_, String>("PRAGMA integrity_check")
         .fetch_one(&mut connection)
         .await;
     connection.close().await?;
-    let message = result?.try_get::<String, _>(0)?;
+    let message = result?;
     if message == "ok" {
         Ok(())
     } else {

--- a/backend/src/infra/backup.rs
+++ b/backend/src/infra/backup.rs
@@ -119,52 +119,42 @@ async fn verify_backup(backup_path: &Path) -> Result<(), BackupError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use tempfile::TempDir;
 
-    static TEST_ID: AtomicU32 = AtomicU32::new(0);
-
-    fn setup_backup_config() -> BackupConfig {
-        let id = TEST_ID.fetch_add(1, Ordering::Relaxed);
-        let backup_directory =
-            std::env::temp_dir().join(format!("backups_{}_{}", std::process::id(), id));
-        BackupConfig::new(backup_directory)
-    }
-
-    fn delete_backup_directory(backup_config: &BackupConfig) {
-        std::fs::remove_dir_all(&backup_config.directory).unwrap();
+    fn setup_backup_config() -> (TempDir, BackupConfig) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backup_config = BackupConfig::new(temp_dir.path().join("backups"));
+        (temp_dir, backup_config)
     }
 
     #[tokio::test]
     async fn backup_directory_is_created_succesfully() {
-        let backup_config = setup_backup_config();
+        let (_temp_dir, backup_config) = setup_backup_config();
         create_backup_directory(&backup_config).unwrap();
-        delete_backup_directory(&backup_config);
+        assert!(backup_config.directory.exists());
     }
 
     #[tokio::test]
     async fn backup_directory_creation_is_idempotent() {
-        let backup_config = setup_backup_config();
+        let (_temp_dir, backup_config) = setup_backup_config();
         create_backup_directory(&backup_config).unwrap();
         create_backup_directory(&backup_config).unwrap();
-        delete_backup_directory(&backup_config);
     }
 
     #[sqlx::test]
     async fn local_backup_is_successful(pool: SqlitePool) {
-        let backup_config = setup_backup_config();
+        let (_temp_dir, backup_config) = setup_backup_config();
         create_backup_directory(&backup_config).unwrap();
         let result = create_local_backup(&pool, &backup_config).await.unwrap();
         assert!(backup_config.directory.join(&result.filename).exists());
-        delete_backup_directory(&backup_config);
     }
 
     #[tokio::test]
     async fn verify_backup_fails_on_corrupt_file() {
-        let backup_config = setup_backup_config();
+        let (_temp_dir, backup_config) = setup_backup_config();
         create_backup_directory(&backup_config).unwrap();
         let backup_path = backup_config.directory.join("corrupt.sqlite");
         std::fs::write(&backup_path, b"corrupt database").unwrap();
         assert!(verify_backup(&backup_path).await.is_err());
-        delete_backup_directory(&backup_config);
     }
 }

--- a/backend/src/infra/backup.rs
+++ b/backend/src/infra/backup.rs
@@ -1,10 +1,25 @@
 use chrono::Local;
 use sqlx::SqlitePool;
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tokio::sync::Mutex;
 
 #[derive(Clone)]
 pub struct BackupConfig {
     pub directory: PathBuf,
+    /// Mutex to prevent concurrent backup creation
+    lock: Arc<Mutex<()>>,
+}
+
+impl BackupConfig {
+    pub fn new(directory: PathBuf) -> Self {
+        Self {
+            directory,
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
 }
 
 pub struct BackupResult {
@@ -36,6 +51,7 @@ pub async fn create_local_backup(
     pool: &SqlitePool,
     backup_config: &BackupConfig,
 ) -> Result<BackupResult, BackupError> {
+    let guard = backup_config.lock.lock().await;
     create_backup_directory(backup_config)?;
     let now = Local::now();
     let filename = format!("db_backup_{}.sqlite", now.format("%Y-%m-%d_%H-%M-%S"));
@@ -44,6 +60,7 @@ pub async fn create_local_backup(
         return Err(BackupError::AlreadyExists);
     }
     backup_database(pool, &backup_path).await?;
+    drop(guard);
     Ok(BackupResult {
         filename,
         created_at: now,
@@ -79,9 +96,7 @@ mod tests {
         let id = TEST_ID.fetch_add(1, Ordering::Relaxed);
         let backup_directory =
             std::env::temp_dir().join(format!("backups_{}_{}", std::process::id(), id));
-        BackupConfig {
-            directory: backup_directory,
-        }
+        BackupConfig::new(backup_directory)
     }
 
     fn delete_backup_directory(backup_config: &BackupConfig) {

--- a/backend/src/infra/backup.rs
+++ b/backend/src/infra/backup.rs
@@ -2,33 +2,20 @@ use chrono::Local;
 use sqlx::SqlitePool;
 use std::path::{Path, PathBuf};
 
-/// Configuration for the local database backup system.
 #[derive(Clone)]
 pub struct BackupConfig {
-    /// Directory where backup files are stored.
     pub directory: PathBuf,
 }
 
-impl BackupConfig {
-    /// Creates a new `BackupConfig` using a `backups` directory
-    /// in the same folder as the database file.
-    pub fn new(database: &str) -> Result<Self, BackupError> {
-        let database_path = Path::new(database);
-        let working_directory = database_path
-            .parent()
-            .ok_or(BackupError::InvalidDatabasePath)?;
-        let backup_directory = working_directory.join("backups");
-        Ok(BackupConfig {
-            directory: backup_directory,
-        })
-    }
+pub struct BackupResult {
+    pub filename: String,
+    pub created_at: chrono::DateTime<Local>,
 }
 
-/// Errors that can occur during backup operations.
 #[derive(Debug)]
 pub enum BackupError {
+    AlreadyExists,
     InvalidPath,
-    InvalidDatabasePath,
     Io(std::io::Error),
     Database(sqlx::Error),
 }
@@ -48,12 +35,19 @@ impl From<sqlx::Error> for BackupError {
 pub async fn create_local_backup(
     pool: &SqlitePool,
     backup_config: &BackupConfig,
-) -> Result<(), BackupError> {
+) -> Result<BackupResult, BackupError> {
     create_backup_directory(backup_config)?;
-    let filename = format!("backup_{}.db", Local::now().format("%Y-%m-%d_%H-%M-%S"));
-    let backup_path = backup_config.directory.join(filename);
+    let now = Local::now();
+    let filename = format!("db_backup_{}.sqlite", now.format("%Y-%m-%d_%H-%M-%S"));
+    let backup_path = backup_config.directory.join(&filename);
+    if backup_path.exists() {
+        return Err(BackupError::AlreadyExists);
+    }
     backup_database(pool, &backup_path).await?;
-    Ok(())
+    Ok(BackupResult {
+        filename,
+        created_at: now,
+    })
 }
 
 fn create_backup_directory(backup_config: &BackupConfig) -> Result<(), BackupError> {
@@ -109,18 +103,12 @@ mod tests {
         delete_backup_directory(&backup_config);
     }
 
-    #[test]
-    fn backup_path_ends_with_correct_directory_name() {
-        let backup_config = BackupConfig::new("db.sqlite").unwrap();
-        assert!(backup_config.directory.ends_with("backups"));
-    }
-
     #[sqlx::test]
-    async fn local_backup_is_succesfull(pool: SqlitePool) {
+    async fn local_backup_is_successful(pool: SqlitePool) {
         let backup_config = setup_backup_config();
         create_backup_directory(&backup_config).unwrap();
-        create_local_backup(&pool, &backup_config).await.unwrap();
-        assert!(backup_config.directory.read_dir().unwrap().next().is_some());
+        let result = create_local_backup(&pool, &backup_config).await.unwrap();
+        assert!(backup_config.directory.join(&result.filename).exists());
         delete_backup_directory(&backup_config);
     }
 }

--- a/backend/src/infra/backup.rs
+++ b/backend/src/infra/backup.rs
@@ -1,5 +1,8 @@
 use chrono::Local;
-use sqlx::SqlitePool;
+use sqlx::{
+    Connection, Row, SqlitePool,
+    sqlite::{SqliteConnectOptions, SqliteConnection},
+};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -31,6 +34,7 @@ pub struct BackupResult {
 pub enum BackupError {
     AlreadyExists,
     InvalidPath,
+    IntegrityCheckFailed(String),
     Io(std::io::Error),
     Database(sqlx::Error),
 }
@@ -59,7 +63,11 @@ pub async fn create_local_backup(
     if backup_path.exists() {
         return Err(BackupError::AlreadyExists);
     }
-    backup_database(pool, &backup_path).await?;
+    if let Err(err) = write_and_verify_backup(pool, &backup_path).await {
+        // try to delete the backup, ignore error if deleting fails
+        let _ = std::fs::remove_file(&backup_path);
+        return Err(err);
+    }
     drop(guard);
     Ok(BackupResult {
         filename,
@@ -70,6 +78,11 @@ pub async fn create_local_backup(
 fn create_backup_directory(backup_config: &BackupConfig) -> Result<(), BackupError> {
     std::fs::create_dir_all(&backup_config.directory)?;
     Ok(())
+}
+
+async fn write_and_verify_backup(pool: &SqlitePool, backup_path: &Path) -> Result<(), BackupError> {
+    backup_database(pool, backup_path).await?;
+    verify_backup(backup_path).await
 }
 
 async fn backup_database(pool: &SqlitePool, destination: &Path) -> Result<(), BackupError> {
@@ -83,6 +96,24 @@ async fn backup_database(pool: &SqlitePool, destination: &Path) -> Result<(), Ba
         .execute(&mut *connection)
         .await?;
     Ok(())
+}
+
+/// Run SQLite integrity check on a separate read-only connection.
+async fn verify_backup(backup_path: &Path) -> Result<(), BackupError> {
+    let options = SqliteConnectOptions::new()
+        .filename(backup_path)
+        .read_only(true);
+    let mut connection = SqliteConnection::connect_with(&options).await?;
+    let result = sqlx::query("PRAGMA integrity_check")
+        .fetch_one(&mut connection)
+        .await;
+    connection.close().await?;
+    let message = result?.try_get::<String, _>(0)?;
+    if message == "ok" {
+        Ok(())
+    } else {
+        Err(BackupError::IntegrityCheckFailed(message))
+    }
 }
 
 #[cfg(test)]
@@ -124,6 +155,16 @@ mod tests {
         create_backup_directory(&backup_config).unwrap();
         let result = create_local_backup(&pool, &backup_config).await.unwrap();
         assert!(backup_config.directory.join(&result.filename).exists());
+        delete_backup_directory(&backup_config);
+    }
+
+    #[tokio::test]
+    async fn verify_backup_fails_on_corrupt_file() {
+        let backup_config = setup_backup_config();
+        create_backup_directory(&backup_config).unwrap();
+        let backup_path = backup_config.directory.join("corrupt.sqlite");
+        std::fs::write(&backup_path, b"corrupt database").unwrap();
+        assert!(verify_backup(&backup_path).await.is_err());
         delete_backup_directory(&backup_config);
     }
 }

--- a/backend/src/infra/router.rs
+++ b/backend/src/infra/router.rs
@@ -25,7 +25,7 @@ use crate::{
     AppError, AppState, MAX_BODY_SIZE_MB, api,
     api::middleware::{airgap, airgap::AirgapDetection, authentication},
     error,
-    infra::audit_log,
+    infra::{audit_log, backup::BackupConfig},
 };
 #[cfg(feature = "tls")]
 use axum::{body::Bytes, routing::get};
@@ -69,7 +69,8 @@ fn build_routes(doc: utoipa::openapi::OpenApi) -> OpenApiRouter<AppState> {
         .merge(api::polling_station::router())
         .merge(api::report::router())
         .merge(api::document::router())
-        .merge(api::investigation::router());
+        .merge(api::investigation::router())
+        .merge(api::backup::router());
 
     #[cfg(feature = "dev-database")]
     let router = router.merge(test_data_gen::router());
@@ -269,11 +270,13 @@ pub fn ca_router(ca: &CaCertificate) -> Router {
 pub fn create_router(
     pool: SqlitePool,
     airgap_detection: AirgapDetection,
+    backup_config: BackupConfig,
 ) -> Result<Router, AppError> {
     let router = axum_router_from_openapi(openapi_router());
     let state = AppState {
         pool,
         airgap_detection,
+        backup_config,
     };
     let router = add_middleware(router, &state);
     #[cfg(feature = "memory-serve")]
@@ -283,10 +286,6 @@ pub fn create_router(
     let router = add_security_headers(router);
     let router = router.with_state(state);
     Ok(router)
-}
-
-pub fn create_router_without_airgap_detection(pool: SqlitePool) -> Result<Router, AppError> {
-    create_router(pool, AirgapDetection::nop())
 }
 
 #[cfg(test)]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -315,7 +315,6 @@ mod test {
             directory: backup_dir.path().to_path_buf(),
         };
         let server_task = tokio::spawn(async move {
-            let _backup_dir = backup_dir; // keep tempdir alive for the duration of the test
             start_server(pool, listener, false, backup_config)
                 .await
                 .unwrap();

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -27,7 +27,7 @@ pub use app_error::AppError;
 pub use error::{APIError, ErrorResponse};
 #[cfg(feature = "dev-database")]
 use infra::seed_data;
-use infra::{audit_log, router};
+use infra::{audit_log, backup::BackupConfig, router};
 
 use crate::{
     app_error::{DatabaseErrorWithPath, DatabaseMigrationErrorWithPath},
@@ -57,6 +57,7 @@ impl SqlitePoolExt for SqlitePool {
 pub struct AppState {
     pool: SqlitePool,
     airgap_detection: AirgapDetection,
+    backup_config: BackupConfig,
 }
 
 /// Start airgap detection if enabled, logging which path was taken.
@@ -72,10 +73,14 @@ fn setup_airgap_detection(pool: &SqlitePool, enable: bool) -> AirgapDetection {
 
 /// Log startup, start airgap detection, and build the router shared by the
 /// HTTP and HTTPS servers.
-fn build_app(pool: &SqlitePool, enable_airgap_detection: bool) -> Result<axum::Router, AppError> {
+fn build_app(
+    pool: &SqlitePool,
+    enable_airgap_detection: bool,
+    backup_config: BackupConfig,
+) -> Result<axum::Router, AppError> {
     info!("Starting Abacus (version {})", env!("ABACUS_GIT_VERSION"));
     let airgap_detection = setup_airgap_detection(pool, enable_airgap_detection);
-    router::create_router(pool.clone(), airgap_detection)
+    router::create_router(pool.clone(), airgap_detection, backup_config)
 }
 
 /// Close the database pool (flushing SQLite WAL/shm) and log a clean shutdown.
@@ -89,8 +94,9 @@ pub async fn start_server(
     pool: SqlitePool,
     listener: TcpListener,
     enable_airgap_detection: bool,
+    backup_config: BackupConfig,
 ) -> Result<(), AppError> {
-    let app = build_app(&pool, enable_airgap_detection)?;
+    let app = build_app(&pool, enable_airgap_detection, backup_config)?;
 
     warn!("TLS is disabled, serving Abacus over plain HTTP. This is not allowed in production.");
     info!("Starting Abacus on http://{}", listener.local_addr()?);
@@ -119,6 +125,7 @@ pub async fn start_server_tls(
     pool: SqlitePool,
     listener: TcpListener,
     enable_airgap_detection: bool,
+    backup_config: BackupConfig,
     tls_config: std::sync::Arc<rustls::ServerConfig>,
     ca: std::sync::Arc<infra::tls::CaCertificate>,
 ) -> Result<(), AppError> {
@@ -129,7 +136,8 @@ pub async fn start_server_tls(
         tls_rustls::{RustlsAcceptor, RustlsConfig},
     };
 
-    let app = build_app(&pool, enable_airgap_detection)?.merge(infra::router::ca_router(&ca));
+    let app = build_app(&pool, enable_airgap_detection, backup_config)?
+        .merge(infra::router::ca_router(&ca));
 
     info!("Starting Abacus on https://{}", listener.local_addr()?);
 
@@ -289,7 +297,7 @@ mod test {
     use tokio::net::TcpListener;
 
     use super::start_server;
-    use crate::{AppError, create_sqlite_pool};
+    use crate::{AppError, create_sqlite_pool, infra::backup::BackupConfig};
 
     pub(crate) async fn run_server_test<F, Fut>(pool: SqlitePool, test_fn: F)
     where
@@ -302,8 +310,15 @@ mod test {
         let base_url = format!("http://{addr}");
 
         // Start server in background task
+        let backup_dir = tempfile::tempdir().unwrap();
+        let backup_config = BackupConfig {
+            directory: backup_dir.path().to_path_buf(),
+        };
         let server_task = tokio::spawn(async move {
-            start_server(pool, listener, false).await.unwrap();
+            let _backup_dir = backup_dir; // keep tempdir alive for the duration of the test
+            start_server(pool, listener, false, backup_config)
+                .await
+                .unwrap();
         });
 
         // Run the test
@@ -466,7 +481,10 @@ mod test {
         use test_log::test;
         use tokio::{net::TcpListener, task::JoinHandle};
 
-        use crate::{infra::audit_log, infra::tls::load_or_generate, start_server_tls};
+        use crate::{
+            infra::audit_log, infra::backup::BackupConfig, infra::tls::load_or_generate,
+            start_server_tls,
+        };
 
         /// Helper to start an HTTPS server on `bind_addr` with a new CA+leaf certificate
         async fn spawn_https_server(
@@ -478,11 +496,15 @@ mod test {
             let ca_pem = certificates.ca.pem.clone();
             let server_config = certificates.server_config().unwrap();
             let ca = std::sync::Arc::new(certificates.ca);
+            let backup_config = BackupConfig {
+                directory: dir.path().join("backups"),
+            };
 
             let listener = TcpListener::bind(bind_addr).await.unwrap();
             let addr = listener.local_addr().unwrap();
             let task = tokio::spawn(async move {
-                start_server_tls(pool, listener, false, server_config, ca)
+                let _dir = dir; // keep tempdir alive for the duration of the test
+                start_server_tls(pool, listener, false, backup_config, server_config, ca)
                     .await
                     .unwrap();
             });

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -311,9 +311,7 @@ mod test {
 
         // Start server in background task
         let backup_dir = tempfile::tempdir().unwrap();
-        let backup_config = BackupConfig {
-            directory: backup_dir.path().to_path_buf(),
-        };
+        let backup_config = BackupConfig::new(backup_dir.path().to_path_buf());
         let server_task = tokio::spawn(async move {
             start_server(pool, listener, false, backup_config)
                 .await
@@ -495,9 +493,7 @@ mod test {
             let ca_pem = certificates.ca.pem.clone();
             let server_config = certificates.server_config().unwrap();
             let ca = std::sync::Arc::new(certificates.ca);
-            let backup_config = BackupConfig {
-                directory: dir.path().join("backups"),
-            };
+            let backup_config = BackupConfig::new(dir.path().join("backups"));
 
             let listener = TcpListener::bind(bind_addr).await.unwrap();
             let addr = listener.local_addr().unwrap();

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -498,7 +498,6 @@ mod test {
             let listener = TcpListener::bind(bind_addr).await.unwrap();
             let addr = listener.local_addr().unwrap();
             let task = tokio::spawn(async move {
-                let _dir = dir; // keep tempdir alive for the duration of the test
                 start_server_tls(pool, listener, false, backup_config, server_config, ca)
                     .await
                     .unwrap();

--- a/backend/tests/backup_integration_test.rs
+++ b/backend/tests/backup_integration_test.rs
@@ -1,0 +1,91 @@
+#![cfg(test)]
+
+use axum::http::StatusCode;
+use sqlx::SqlitePool;
+use test_log::test;
+
+use crate::{
+    shared::{FixtureUser::*, login},
+    utils::serve_api_with_backup_dir,
+};
+pub mod shared;
+pub mod utils;
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn backup_unauthenticated(pool: SqlitePool) {
+    let (addr, _backup_dir) = serve_api_with_backup_dir(pool).await;
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/api/backup"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn backup_forbidden_typist(pool: SqlitePool) {
+    let (addr, _backup_dir) = serve_api_with_backup_dir(pool).await;
+    let cookie = login(&addr, TypistGSB).await;
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/api/backup"))
+        .header("cookie", cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn backup_success_as_admin(pool: SqlitePool) {
+    let (addr, backup_dir) = serve_api_with_backup_dir(pool).await;
+    let cookie = login(&addr, Admin).await;
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/api/backup"))
+        .header("cookie", cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body: serde_json::Value = response.json().await.unwrap();
+    let filename = body["filename"].as_str().unwrap();
+    assert!(filename.starts_with("db_backup_") && filename.ends_with(".sqlite"));
+    assert!(body["created_at"].is_string());
+    assert!(backup_dir.path().join(filename).exists());
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn backup_success_as_coordinator_csb(pool: SqlitePool) {
+    let (addr, _backup_dir) = serve_api_with_backup_dir(pool).await;
+    let cookie = login(&addr, CoordinatorCSB).await;
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/api/backup"))
+        .header("cookie", cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn backup_conflict(pool: SqlitePool) {
+    let (addr, _backup_dir) = serve_api_with_backup_dir(pool).await;
+    let cookie = login(&addr, Admin).await;
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/api/backup");
+
+    let first = client
+        .post(&url)
+        .header("cookie", cookie.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let second = client
+        .post(&url)
+        .header("cookie", cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+}

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -2,25 +2,36 @@
 
 use std::net::SocketAddr;
 
-use abacus::{infra::router, shutdown_signal};
+use abacus::{
+    api::middleware::airgap::AirgapDetection,
+    infra::{backup::BackupConfig, router},
+    shutdown_signal,
+};
 use sqlx::SqlitePool;
+use tempfile::TempDir;
 use tokio::net::TcpListener;
 
 pub async fn serve_api(pool: SqlitePool) -> SocketAddr {
+    serve_api_with_backup_dir(pool).await.0
+}
+
+pub async fn serve_api_with_backup_dir(pool: SqlitePool) -> (SocketAddr, TempDir) {
+    let backup_dir = tempfile::tempdir().unwrap();
+    let backup_config = BackupConfig {
+        directory: backup_dir.path().to_path_buf(),
+    };
+    let app = router::create_router(pool, AirgapDetection::nop(), backup_config)
+        .unwrap()
+        .into_make_service_with_connect_info::<SocketAddr>();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
     tokio::spawn(async move {
-        let app = router::create_router_without_airgap_detection(pool).unwrap();
-
-        axum::serve(
-            listener,
-            app.into_make_service_with_connect_info::<SocketAddr>(),
-        )
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await
+            .unwrap();
     });
 
-    addr
+    (addr, backup_dir)
 }

--- a/backend/tests/utils/mod.rs
+++ b/backend/tests/utils/mod.rs
@@ -17,9 +17,7 @@ pub async fn serve_api(pool: SqlitePool) -> SocketAddr {
 
 pub async fn serve_api_with_backup_dir(pool: SqlitePool) -> (SocketAddr, TempDir) {
     let backup_dir = tempfile::tempdir().unwrap();
-    let backup_config = BackupConfig {
-        directory: backup_dir.path().to_path_buf(),
-    };
+    let backup_config = BackupConfig::new(backup_dir.path().to_path_buf());
     let app = router::create_router(pool, AirgapDetection::nop(), backup_config)
         .unwrap()
         .into_make_service_with_connect_info::<SocketAddr>();

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -10,6 +10,7 @@
     "ApportionmentNotCompleted": "De documenten kunnen pas gedownload worden als de zetelverdeling is afgerond",
     "ApportionmentCommitteeSessionNotCompleted": "De zetelverdeling kan pas gemaakt worden als de zitting is afgerond",
     "ApportionmentInvalidLotDrawing": "Loting is ongeldig",
+    "BackupAlreadyExists": "De backup met deze naam bestaat al, probeer het later opnieuw",
     "CommitteeSessionPaused": "De coördinator heeft het invoeren van stemmen gepauzeerd. Je kan niet meer verder.",
     "DatabaseError": "Er is een fout opgetreden bij het opslaan van de invoer",
     "DataEntryAlreadyClaimed": "Een andere invoerder is bezig met dit stembureau",

--- a/frontend/src/i18n/locales/nl/log.json
+++ b/frontend/src/i18n/locales/nl/log.json
@@ -15,6 +15,7 @@
     "CommitteeSessionCreated": "Zitting aangemaakt",
     "CommitteeSessionDeleted": "Zitting verwijderd",
     "CommitteeSessionUpdated": "Zitting bijgewerkt",
+    "DatabaseBackupCreated": "Databasebackup gemaakt",
     "DataEntryDeleted": "Invoer verwijderd",
     "DataEntryDiscardedBoth": "Beide invoeren verwijderd",
     "DataEntryDiscardedFirst": "Eerste invoer verwijderd",

--- a/frontend/src/i18n/locales/nl/log.json
+++ b/frontend/src/i18n/locales/nl/log.json
@@ -76,6 +76,7 @@
     "file_mime_type": "Bestandstype",
     "file_name": "Bestandsnaam",
     "file_size_bytes": "Bestandsgrootte (bytes)",
+    "filename": "Bestandsnaam",
     "findings": "Bevindingen",
     "finished_at": "Afgerond op",
     "first_entry_user_id": "Eerste invoer Gebruikers-ID",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -9,6 +9,10 @@ export type ACCOUNT_UPDATE_REQUEST_PARAMS = Record<string, never>;
 export type ACCOUNT_UPDATE_REQUEST_PATH = `/api/account`;
 export type ACCOUNT_UPDATE_REQUEST_BODY = AccountUpdateRequest;
 
+// /api/backup
+export type CREATE_BACKUP_REQUEST_PARAMS = Record<string, never>;
+export type CREATE_BACKUP_REQUEST_PATH = `/api/backup`;
+
 // /api/data_entries/{data_entry_id}
 export interface DATA_ENTRY_RESET_REQUEST_PARAMS {
   data_entry_id: DataEntryId;
@@ -480,6 +484,7 @@ export const auditEventTypeValues = [
   "AirGapViolationDetected",
   "AirGapViolationResolved",
   "ApplicationStarted",
+  "DatabaseBackupCreated",
   "ApiError",
   "ApiWarning",
   "UnknownEvent",
@@ -514,6 +519,11 @@ export interface AuditLogUser {
   id: number;
   role: Role;
   username: string;
+}
+
+export interface BackupResponse {
+  created_at: string;
+  filename: string;
 }
 
 /**
@@ -1006,6 +1016,7 @@ export interface ElectionWithPoliticalGroups {
 export const errorReferenceValues = [
   "AirgapViolation",
   "AlreadyInitialised",
+  "BackupAlreadyExists",
   "ApportionmentNotCompleted",
   "ApportionmentCommitteeSessionNotCompleted",
   "ApportionmentInvalidLotDrawing",


### PR DESCRIPTION
## What & why

Add SQLite backup REST API, resolves #3468.

## How to test

Run backend and frontend:
```
cargo run -- --reset-database --seed-data
# other terminal
pnpm run dev
```

Log in as admin or coordinator in the browser, then in devtools console:
```js
fetch('/api/backup', { method: 'POST' }).then(r => r.json()).then(console.log)
```

This should return the database backup filename and the backup should be created in the `backend/backups` directory. When not logged in or logged in as typst an error is returned.

## Reviewer notes

Frontend will be done in #3469.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->