### PR TITLE
Ensure apportionment only accepts CSB election

### DIFF
--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -25,6 +25,7 @@ pub enum ApportionmentApiError {
     CommitteeSessionNotCompleted,
     InvalidLotDrawing(String),
     InvalidState(String),
+    NotCSBElection,
 }
 
 impl ApiErrorResponse for ApportionmentApiError {
@@ -62,6 +63,14 @@ impl ApiErrorResponse for ApportionmentApiError {
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ErrorResponse::new(
                     format!("Apportionment invalid state: {}", message),
+                    ErrorReference::InternalServerError,
+                    true,
+                ),
+            ),
+            ApportionmentApiError::NotCSBElection => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::new(
+                    "Apportionment is only available for CSB elections",
                     ErrorReference::InternalServerError,
                     true,
                 ),

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -17,7 +17,9 @@ use crate::{
         apportionment_state::{ApportionmentState, ApportionmentStateError, DrawingLotsRequired},
         committee_session::CommitteeSessionId,
         committee_session_status::CommitteeSessionStatus,
-        election::{CandidateNumber, ElectionId, ElectionWithPoliticalGroups, PGNumber},
+        election::{
+            CandidateNumber, CommitteeCategory, ElectionId, ElectionWithPoliticalGroups, PGNumber,
+        },
         summary::ElectionSummary,
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
@@ -112,6 +114,7 @@ pub async fn next_state(
     .await
 }
 
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ApportionmentResult {
     Ok(ElectionApportionmentResponse),
@@ -197,6 +200,10 @@ pub async fn process(
     conn: &mut SqliteConnection,
     election: &ElectionWithPoliticalGroups,
 ) -> Result<ApportionmentResult, APIError> {
+    if election.committee_category != CommitteeCategory::CSB {
+        return Err(ApportionmentApiError::NotCSBElection.into());
+    }
+
     let (committee_session_id, state) = service::get_apportionment_state(conn, election.id).await?;
 
     let data_entry_results =
@@ -257,6 +264,7 @@ mod tests {
         domain::{apportionment_state::DeceasedCandidate, committee_session::CommitteeSessionId},
         error::assert_delegated,
         infra::audit_log::assert_last_event,
+        repository::election_repo,
     };
 
     const ELECTION_ID: u32 = 5;
@@ -278,6 +286,20 @@ mod tests {
                 .await
                 .expect("should upsert apportionment state");
         }
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    async fn test_process_requires_csb_election(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let election = election_repo::get(&mut conn, ElectionId::from(ELECTION_ID))
+            .await
+            .unwrap();
+
+        let err = process(&mut conn, &election)
+            .await
+            .expect_err("should error for a non-CSB election");
+
+        assert_delegated(err, &ApportionmentApiError::NotCSBElection);
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -23,7 +23,9 @@ use crate::{
         summary::ElectionSummary,
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
-    repository::{apportionment_state_repo, committee_session_repo, data_entry_repo},
+    repository::{
+        apportionment_state_repo, committee_session_repo, data_entry_repo, election_repo,
+    },
     service,
 };
 
@@ -47,6 +49,11 @@ pub async fn get_state(
     conn: &mut SqliteConnection,
     election_id: ElectionId,
 ) -> Result<(CommitteeSessionId, ApportionmentState), APIError> {
+    let election = election_repo::get(conn, election_id).await?;
+    if election.committee_category != CommitteeCategory::CSB {
+        return Err(ApportionmentApiError::NotCSBElection.into());
+    }
+
     let committee_session =
         committee_session_repo::get_election_committee_session(conn, election_id).await?;
 
@@ -264,11 +271,10 @@ mod tests {
         domain::{apportionment_state::DeceasedCandidate, committee_session::CommitteeSessionId},
         error::assert_delegated,
         infra::audit_log::assert_last_event,
-        repository::election_repo,
     };
 
-    const ELECTION_ID: u32 = 5;
-    const COMMITTEE_SESSION_ID: u32 = 6;
+    const ELECTION_ID: u32 = 8;
+    const COMMITTEE_SESSION_ID: u32 = 801;
 
     async fn set_states(
         conn: &mut SqliteConnection,
@@ -291,7 +297,7 @@ mod tests {
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_process_requires_csb_election(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let election = election_repo::get(&mut conn, ElectionId::from(ELECTION_ID))
+        let election = election_repo::get(&mut conn, ElectionId::from(5))
             .await
             .unwrap();
 
@@ -303,6 +309,17 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    async fn test_get_state_requires_csb_election(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+
+        let err = get_state(&mut conn, ElectionId::from(5))
+            .await
+            .expect_err("should error for a non-CSB election");
+
+        assert_delegated(err, &ApportionmentApiError::NotCSBElection);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_election_not_found(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 
@@ -322,7 +339,7 @@ mod tests {
         );
     }
 
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_invalid_committee_session_status(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 
@@ -340,7 +357,7 @@ mod tests {
         assert_delegated(err, &ApportionmentApiError::CommitteeSessionNotCompleted);
     }
 
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_get_apportionment_state_not_found(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 
@@ -356,7 +373,7 @@ mod tests {
         assert_eq!(state, ApportionmentState::Uninitialised);
     }
 
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_update_apportionment_state_not_found(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 
@@ -383,7 +400,7 @@ mod tests {
         assert_eq!(state, Some(ApportionmentState::Uninitialised));
     }
 
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_update_apportionment_state(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
 

--- a/backend/src/service/change_committee_session_status.rs
+++ b/backend/src/service/change_committee_session_status.rs
@@ -7,7 +7,7 @@ use crate::{
     domain::{
         committee_session::{CommitteeSession, CommitteeSessionId},
         committee_session_status::CommitteeSessionStatus,
-        election::ElectionId,
+        election::{CommitteeCategory, ElectionId},
         file::{File, FileId},
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
@@ -113,13 +113,19 @@ pub async fn change_committee_session_status(
     {
         delete_committee_session_files(&mut tx, audit_service.clone(), committee_session.id)
             .await?;
-        update_apportionment_state(
-            &mut tx,
-            &audit_service,
-            committee_session.election_id,
-            |state| state.reset(),
-        )
-        .await?;
+
+        // Apportionment state only applies to CSB committee sessions
+        if committee_session_repo::get_committee_category(&mut tx, committee_session_id).await?
+            == CommitteeCategory::CSB
+        {
+            update_apportionment_state(
+                &mut tx,
+                &audit_service,
+                committee_session.election_id,
+                |state| state.reset(),
+            )
+            .await?;
+        }
     }
 
     let committee_session =
@@ -216,14 +222,10 @@ mod tests {
         let session = committee_session_repo::get(&mut conn, committee_session_id).await?;
         assert_eq!(session.status, CommitteeSessionStatus::DataEntry);
 
-        // No FileDeleted events should be logged
+        // No FileDeleted and ApportionmentStateUpdated events should be logged
         assert_eq!(
             list_event_names(&mut conn).await?,
-            [
-                "CommitteeSessionUpdated",
-                "ApportionmentStateUpdated",
-                "CommitteeSessionUpdated"
-            ]
+            ["CommitteeSessionUpdated", "CommitteeSessionUpdated"]
         );
         Ok(())
     }
@@ -268,19 +270,18 @@ mod tests {
                 "FileDeleted",
                 "FileDeleted",
                 "FileDeleted",
-                "ApportionmentStateUpdated",
                 "CommitteeSessionUpdated",
             ]
         );
         Ok(())
     }
 
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_reset_apportionment_state_on_resume(pool: SqlitePool) -> Result<(), APIError> {
         let mut conn = pool.acquire().await?;
         let audit_service = AuditService::new(None, Some(TEST_IP_V4_ADDR.into()));
 
-        let committee_session_id = CommitteeSessionId::from(6);
+        let committee_session_id = CommitteeSessionId::from(801);
 
         // DataEntry --> Completed
         change_committee_session_status(
@@ -292,11 +293,11 @@ mod tests {
         .await?;
 
         // Finalise apportionment state
-        update_apportionment_state(&mut conn, &audit_service, ElectionId::from(5), |state| {
+        update_apportionment_state(&mut conn, &audit_service, ElectionId::from(8), |state| {
             state.finalise()
         })
         .await?;
-        let (_, state) = get_apportionment_state(&mut conn, ElectionId::from(5)).await?;
+        let (_, state) = get_apportionment_state(&mut conn, ElectionId::from(8)).await?;
         assert!(state.is_finalised());
 
         // Completed --> DataEntry
@@ -307,7 +308,7 @@ mod tests {
             audit_service,
         )
         .await?;
-        let state_result = get_apportionment_state(&mut conn, ElectionId::from(5)).await;
+        let state_result = get_apportionment_state(&mut conn, ElectionId::from(8)).await;
         // Expect error, because apportionment state can only be retrieved when committee session is in Completed status
         assert!(state_result.is_err());
 


### PR DESCRIPTION
## What & why

Ensure apportionment only accepts a CSB election and apportionment state is only changed for CSB elections. Prevents and resolves more instances of using GSB fixtures for apportionment, just as #3489.

## How to test

Covered by unit tests.

## Reviewer notes

None.