### PR TITLE
Add info console log for database backups

### DIFF
--- a/backend/src/infra/backup.rs
+++ b/backend/src/infra/backup.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::Mutex;
+use tracing::info;
 
 #[derive(Clone)]
 pub struct BackupConfig {
@@ -69,6 +70,7 @@ pub async fn create_local_backup(
         return Err(err);
     }
     drop(guard);
+    info!("Created database backup: {filename}");
     Ok(BackupResult {
         filename,
         created_at: now,


### PR DESCRIPTION
## What & why

Followup of #3495 to log to the console when a backup is created.

## How to test

Run backend and frontend:
```
cargo run -- --reset-database --seed-data
# other terminal
pnpm run dev
```

Log in as admin or coordinator in the browser, then in devtools console:
```js
fetch('/api/backup', { method: 'POST' }).then(r => r.json()).then(console.log)
```

Console should log `Created database backup: db_backup_<timestamp>.sqlite`.

## Reviewer notes

None.