### PR TITLE
Apportionment: Improve formatting in the election summary table

### DIFF
--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
@@ -76,7 +76,7 @@ export const DefaultWithoutNumberOfVoters: StoryObj = {
   },
 };
 
-export const DefaultWithoutBlankAndInvalidVotes: StoryObj = {
+export const DefaultWithoutVotes: StoryObj = {
   render: () => {
     return (
       <ElectionSummaryTable
@@ -84,7 +84,8 @@ export const DefaultWithoutBlankAndInvalidVotes: StoryObj = {
           ...gte19Seats.election_summary.votes_counts,
           blank_votes_count: 0,
           invalid_votes_count: 0,
-          total_votes_candidates_count: 1205,
+          total_votes_candidates_count: 0,
+          total_votes_cast_count: 0,
         }}
         seats={gte19Seats.seat_assignment.seats}
         quota={gte19Seats.seat_assignment.quota}
@@ -105,10 +106,10 @@ export const DefaultWithoutBlankAndInvalidVotes: StoryObj = {
     await expect(table).toBeVisible();
     expect(table).toHaveTableContent([
       ["Kiesgerechtigden", "2.000", ""],
-      ["Getelde stembiljetten", "1.205", "Opkomst: 60,25%"],
+      ["Getelde stembiljetten", "0", ""],
       ["Blanco stemmen", "0", ""],
       ["Ongeldige stemmen", "0", ""],
-      ["Totaal stemmen op kandidaten", "1.205", ""],
+      ["Totaal stemmen op kandidaten", "0", ""],
       ["Aantal raadszetels", "23", ""],
       ["Kiesdeler", "52 4/23", "Benodigde stemmen per volle zetel"],
       ["Voorkeursdrempel", "13 100/2300", "25% van de kiesdeler"],

--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.tsx
@@ -27,6 +27,14 @@ interface ElectionSummaryTableProps {
   deceasedCandidatesInfo: DeceasedCandidatesInfo;
 }
 
+function formatVoteCount(count: number): string {
+  return count > 0 ? formatNumber(count) : "0";
+}
+
+function formatVotePercentage(count: number, total: number): string {
+  return count > 0 ? formatPercentage(count, total) : "";
+}
+
 export function ElectionSummaryTable({
   votesCounts,
   seats,
@@ -51,10 +59,10 @@ export function ElectionSummaryTable({
           <Table.HeaderCell scope="row" className="normal">
             {t("apportionment.total_votes_cast_count")}
           </Table.HeaderCell>
-          <Table.NumberCell>{formatNumber(votesCounts.total_votes_cast_count)}</Table.NumberCell>
+          <Table.NumberCell>{formatVoteCount(votesCounts.total_votes_cast_count)}</Table.NumberCell>
           <Table.Cell className="fs-sm">
-            {numberOfVoters
-              ? `${t("apportionment.turnout")}: ${formatPercentage(votesCounts.total_votes_cast_count, numberOfVoters)}`
+            {numberOfVoters && votesCounts.total_votes_cast_count > 0
+              ? `${t("apportionment.turnout")}: ${formatVotePercentage(votesCounts.total_votes_cast_count, numberOfVoters)}`
               : ""}
           </Table.Cell>
         </Table.Row>
@@ -62,33 +70,25 @@ export function ElectionSummaryTable({
           <Table.HeaderCell scope="row" className="normal">
             {t("voters_votes_counts.votes_counts.blank_votes_count")}
           </Table.HeaderCell>
-          <Table.NumberCell>
-            {votesCounts.blank_votes_count > 0 ? formatNumber(votesCounts.blank_votes_count) : "0"}
-          </Table.NumberCell>
+          <Table.NumberCell>{formatVoteCount(votesCounts.blank_votes_count)}</Table.NumberCell>
           <Table.Cell className="fs-sm">
-            {votesCounts.blank_votes_count > 0
-              ? formatPercentage(votesCounts.blank_votes_count, votesCounts.total_votes_cast_count)
-              : ""}
+            {formatVotePercentage(votesCounts.blank_votes_count, votesCounts.total_votes_cast_count)}
           </Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.HeaderCell scope="row" className="normal">
             {t("voters_votes_counts.votes_counts.invalid_votes_count")}
           </Table.HeaderCell>
-          <Table.NumberCell>
-            {votesCounts.invalid_votes_count > 0 ? formatNumber(votesCounts.invalid_votes_count) : "0"}
-          </Table.NumberCell>
+          <Table.NumberCell>{formatVoteCount(votesCounts.invalid_votes_count)}</Table.NumberCell>
           <Table.Cell className="fs-sm">
-            {votesCounts.invalid_votes_count > 0
-              ? formatPercentage(votesCounts.invalid_votes_count, votesCounts.total_votes_cast_count)
-              : ""}
+            {formatVotePercentage(votesCounts.invalid_votes_count, votesCounts.total_votes_cast_count)}
           </Table.Cell>
         </Table.Row>
         <Table.Row>
           <Table.HeaderCell scope="row" className="normal">
             {t("voters_votes_counts.votes_counts.total_votes_candidates_count")}
           </Table.HeaderCell>
-          <Table.NumberCell>{formatNumber(votesCounts.total_votes_candidates_count)}</Table.NumberCell>
+          <Table.NumberCell>{formatVoteCount(votesCounts.total_votes_candidates_count)}</Table.NumberCell>
           <Table.Cell className="fs-sm" />
         </Table.Row>
         <Table.Row>


### PR DESCRIPTION
## What & why
Resolves https://github.com/kiesraad/abacus/issues/3501.

- 'Getelde stembiljetten' and 'Totaal stemmen op kandidaten' need to display `0` instead of empty string in case of no value
- 'Getelde stembiljetten' -> 'Opkomst: xx,xx%` should be hidden in case of no value

<img width="654" height="295" alt="image" src="https://github.com/user-attachments/assets/a464aee4-001f-4fae-ad00-4a49257fadca" />

## How to test

Storybook: [`/features/apportionment/components/ElectionSummaryTable`](https://centraal-overeenkomstig-algemeen.abacus-test.nl/storybook/?path=/story/features-apportionment-components-electionsummarytable--default-without-votes).

## Reviewer notes

None.