### PR TITLE
Use `abacus.internal` as well-known TLS hostname

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -111,7 +111,7 @@ cargo build --release --features tls
 On startup Abacus loads (or, on first run, generates) a local certificate
 authority under the directory given by `--tls-dir` (defaults to `tls`). A fresh
 server (leaf) certificate is created in memory on every start, signed by the CA
-and covering `localhost`, `abacus.local`, and all routable LAN addresses.
+and covering `localhost`, `abacus.internal`, and all routable LAN addresses.
 
 To trust the server, import the CA into the client trust store: `ca.pem` on
 Linux/macOS/Firefox, `ca.cer` (DER) on Windows. The CA can be downloaded from the

--- a/backend/src/infra/tls.rs
+++ b/backend/src/infra/tls.rs
@@ -177,13 +177,13 @@ fn create_leaf(
 }
 
 /// Get the Subject Alternative Names for the leaf certificate:
-/// localhost, `abacus.local`, and every routable LAN address
+/// localhost, `abacus.internal`, and every routable LAN address
 fn get_subjects() -> Vec<String> {
     let mut subjects = vec![
         "localhost".to_owned(),
         "127.0.0.1".to_owned(),
         "::1".to_owned(),
-        "abacus.local".to_owned(),
+        "abacus.internal".to_owned(),
     ];
     if let Ok(interfaces) = if_addrs::get_if_addrs() {
         for iface in interfaces {


### PR DESCRIPTION
## What & why

Use `abacus.internal` as well-known TLS hostname, instead of `abacus.local`. The [`.local` TLD](https://en.wikipedia.org/wiki/.local) is used for mDNS which we do not yet implement (#3414), whereas the [`.internal` TLD](https://en.wikipedia.org/wiki/.internal) is reserved for private-use applications like Abacus.

Resolves #3456

## How to test

Build frontend, run `cargo run --features memory-serve,tls`, then trust `tls/ca.pem` / `tls/ca.cer` in your browser and go to `https://localhost:8443/`.

Then check that your browser shows `abacus.internal` in the certificate subject alternative names. Or add `127.0.0.1 abacus.internal` to your hosts file and check that `https://abacus.internal:8443` works in your browser without a certificate error.

## Reviewer notes

None.