### PR TITLE
Apportionment list_qualifies_for_extra_seat tests/refactor

### DIFF
--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -817,151 +817,126 @@ mod tests {
         }
     }
 
-    #[test]
-    #[expect(clippy::too_many_lines)]
-    fn test_list_qualifies_for_extra_seat() {
+    mod list_qualifies_for_extra_seat {
+        use super::*;
+
         const LIST: u32 = 1;
         const OTHER_LIST: u32 = 2;
 
-        struct Case {
-            description: &'static str,
-            check_for_unique_highest_average_seats: bool,
-            previous_steps: Vec<SeatChangeStep<u32>>,
-            expected: bool,
+        #[test]
+        fn test_largest_remainder_qualify_when_no_seat_assigned() {
+            let previous_steps = vec![];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, false));
         }
 
-        let cases = vec![
-            // Largest remainder assignment (check_for_unique_highest_average_seats = false)
-            Case {
-                description: "largest remainder: qualifies when no seat was assigned yet",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![],
-                expected: true,
-            },
-            Case {
-                description: "largest remainder: seat assigned to another list does not count",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![largest_remainder_step(OTHER_LIST)],
-                expected: true,
-            },
-            Case {
-                description: "largest remainder: unique highest average seat does not count",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![unique_highest_average_step(LIST)],
-                expected: true,
-            },
-            Case {
-                description: "largest remainder: does not qualify when a seat was assigned",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![largest_remainder_step(LIST)],
-                expected: false,
-            },
-            Case {
-                description: "largest remainder: qualifies again when the assigned seat was retracted by absolute majority reassignment",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![
-                    largest_remainder_step(LIST),
-                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
-                ],
-                expected: true,
-            },
-            Case {
-                description: "largest remainder: retraction from another list does not requalify this list",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![
-                    largest_remainder_step(LIST),
-                    absolute_majority_reassignment_step(OTHER_LIST, LIST),
-                ],
-                expected: false,
-            },
-            Case {
-                description: "largest remainder: does not qualify with two assigned seats even after a retraction",
-                check_for_unique_highest_average_seats: false,
-                previous_steps: vec![
-                    largest_remainder_step(LIST),
-                    largest_remainder_step(LIST),
-                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
-                ],
-                expected: false,
-            },
-            // Unique highest average assignment (check_for_unique_highest_average_seats = true)
-            Case {
-                description: "unique highest average: qualifies when no seat was assigned yet",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![],
-                expected: true,
-            },
-            Case {
-                description: "unique highest average: seat assigned to another list does not count",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![unique_highest_average_step(OTHER_LIST)],
-                expected: true,
-            },
-            Case {
-                description: "unique highest average: largest remainder seat does not count",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![largest_remainder_step(LIST)],
-                expected: true,
-            },
-            Case {
-                description: "unique highest average: does not qualify when a seat was assigned",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![unique_highest_average_step(LIST)],
-                expected: false,
-            },
-            Case {
-                description: "unique highest average: qualifies again when the assigned seat was retracted by absolute majority reassignment",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![
-                    unique_highest_average_step(LIST),
-                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
-                ],
-                expected: true,
-            },
-            Case {
-                description: "unique highest average: retracted seat with one largest remainder seat still qualifies",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![
-                    largest_remainder_step(LIST),
-                    unique_highest_average_step(LIST),
-                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
-                ],
-                expected: true,
-            },
-            Case {
-                description: "unique highest average: retracted seat with two largest remainder seats does not qualify",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![
-                    largest_remainder_step(LIST),
-                    largest_remainder_step(LIST),
-                    unique_highest_average_step(LIST),
-                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
-                ],
-                expected: false,
-            },
-            Case {
-                description: "unique highest average: does not qualify with two assigned seats even after a retraction",
-                check_for_unique_highest_average_seats: true,
-                previous_steps: vec![
-                    unique_highest_average_step(LIST),
-                    unique_highest_average_step(LIST),
-                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
-                ],
-                expected: false,
-            },
-        ];
+        #[test]
+        fn test_largest_remainder_qualify_when_seat_assigned_to_other_list() {
+            let previous_steps = vec![largest_remainder_step(OTHER_LIST)];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, false));
+        }
 
-        for case in cases {
-            assert_eq!(
-                list_qualifies_for_extra_seat(
-                    &case.previous_steps,
-                    LIST,
-                    case.check_for_unique_highest_average_seats,
-                ),
-                case.expected,
-                "{}",
-                case.description
-            );
+        #[test]
+        fn test_largest_remainder_qualify_when_unique_highest_average_step() {
+            let previous_steps = vec![unique_highest_average_step(LIST)];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, false));
+        }
+
+        #[test]
+        fn test_largest_remainder_not_qualify_when_seat_assigned() {
+            let previous_steps = vec![largest_remainder_step(LIST)];
+            assert!(!list_qualifies_for_extra_seat(&previous_steps, LIST, false));
+        }
+
+        #[test]
+        fn test_largest_remainder_qualify_when_seat_retracted_by_absolute_majority() {
+            let previous_steps = vec![
+                largest_remainder_step(LIST),
+                absolute_majority_reassignment_step(LIST, OTHER_LIST),
+            ];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, false));
+        }
+
+        #[test]
+        fn test_largest_remainder_not_qualify_when_seat_retracted_from_other_list() {
+            let previous_steps = vec![
+                largest_remainder_step(LIST),
+                absolute_majority_reassignment_step(OTHER_LIST, LIST),
+            ];
+            assert!(!list_qualifies_for_extra_seat(&previous_steps, LIST, false));
+        }
+
+        #[test]
+        fn test_largest_remainder_not_qualify_with_two_assigned_seats_even_after_retraction() {
+            let previous_steps = vec![
+                largest_remainder_step(LIST),
+                largest_remainder_step(LIST),
+                absolute_majority_reassignment_step(LIST, OTHER_LIST),
+            ];
+            assert!(!list_qualifies_for_extra_seat(&previous_steps, LIST, false));
+        }
+
+        #[test]
+        fn test_unique_highest_average_qualify_when_no_seat_assigned() {
+            let previous_steps = vec![];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unique_highest_average_qualify_when_seat_assigned_to_other_list() {
+            let previous_steps = vec![unique_highest_average_step(OTHER_LIST)];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unique_highest_average_qualify_when_largest_remainder_step() {
+            let previous_steps = vec![largest_remainder_step(LIST)];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unique_highest_average_not_qualify_when_seat_assigned() {
+            let previous_steps = vec![unique_highest_average_step(LIST)];
+            assert!(!list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unique_highest_average_qualify_when_seat_retracted_by_absolute_majority() {
+            let previous_steps = vec![
+                unique_highest_average_step(LIST),
+                absolute_majority_reassignment_step(LIST, OTHER_LIST),
+            ];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unioque_highest_average_qualify_when_retracted_with_one_largest_remainder() {
+            let previous_steps = vec![
+                largest_remainder_step(LIST),
+                unique_highest_average_step(LIST),
+                absolute_majority_reassignment_step(LIST, OTHER_LIST),
+            ];
+            assert!(list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unique_highest_average_not_qualify_when_retracted_with_two_largest_remainders() {
+            let previous_steps = vec![
+                largest_remainder_step(LIST),
+                largest_remainder_step(LIST),
+                unique_highest_average_step(LIST),
+                absolute_majority_reassignment_step(LIST, OTHER_LIST),
+            ];
+            assert!(!list_qualifies_for_extra_seat(&previous_steps, LIST, true));
+        }
+
+        #[test]
+        fn test_unique_highest_average_not_qualify_with_two_assigned_seats_even_after_retraction() {
+            let previous_steps = vec![
+                unique_highest_average_step(LIST),
+                unique_highest_average_step(LIST),
+                absolute_majority_reassignment_step(LIST, OTHER_LIST),
+            ];
+            assert!(!list_qualifies_for_extra_seat(&previous_steps, LIST, true));
         }
     }
 }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -177,34 +177,18 @@ fn list_qualifies_for_extra_seat<LN: Copy + Eq>(
     let number_of_seats_largest_remainders =
         list_largest_remainder_assigned_seats(previous_steps, list_number);
 
-    let number_of_seats_unique_highest_averages_option = if check_for_unique_highest_average_seats {
-        Some(list_unique_highest_average_assigned_seats(
-            previous_steps,
-            list_number,
-        ))
-    } else {
-        None
-    };
-
     // A list qualifies for an extra seat if in a previous step, a seat has been removed
     // due to absolute majority reassignment, and that that seat has then been removed due
     // to list exhaustion. In that case, the seat can be returned to the original list.
-    let has_absolute_majority_retracted_seat: bool = previous_steps.iter().any(|prev| {
+    let has_absolute_majority_retracted_seat = previous_steps.iter().any(|prev| {
         prev.change.is_changed_by_absolute_majority_reassignment()
             && prev.change.list_number_retracted() == list_number
     });
 
-    // In case of largest remainder assignment
-    if number_of_seats_unique_highest_averages_option.is_none() {
-        // If no largest remainder seat has been assigned to this list
-        // or the largest remainder assigned seat has been retracted
-        number_of_seats_largest_remainders == 0
-            || (has_absolute_majority_retracted_seat && number_of_seats_largest_remainders == 1)
-    }
     // In case of unique highest average assignment
-    else if let Some(number_of_seats_unique_highest_averages) =
-        number_of_seats_unique_highest_averages_option
-    {
+    if check_for_unique_highest_average_seats {
+        let number_of_seats_unique_highest_averages =
+            list_unique_highest_average_assigned_seats(previous_steps, list_number);
         // If no unique highest average seat has been assigned to this list
         // or (the unique highest average assigned seat has been retracted,
         // and no largest remainder seat has been retracted and reassigned)
@@ -214,8 +198,13 @@ fn list_qualifies_for_extra_seat<LN: Copy + Eq>(
                 // It is possible to receive one LR seat, then get it retracted
                 // and then received back again based on LR, which would mean 2.
                 && number_of_seats_largest_remainders <= 1)
-    } else {
-        false
+    }
+    // In case of largest remainder assignment
+    else {
+        // If no largest remainder seat has been assigned to this list
+        // or the largest remainder assigned seat has been retracted
+        number_of_seats_largest_remainders == 0
+            || (has_absolute_majority_retracted_seat && number_of_seats_largest_remainders == 1)
     }
 }
 

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -170,15 +170,26 @@ fn exhausted_list_numbers<T: ListVotes>(
 
 /// Returns if a list qualifies for an extra seat.
 fn list_qualifies_for_extra_seat<LN: Copy + Eq>(
-    number_of_seats_largest_remainders: usize,
-    number_of_seats_unique_highest_averages_option: Option<usize>,
     previous_steps: &[SeatChangeStep<LN>],
     list_number: LN,
+    check_for_unique_highest_average_seats: bool,
 ) -> bool {
+    let number_of_seats_largest_remainders =
+        list_largest_remainder_assigned_seats(previous_steps, list_number);
+
+    let number_of_seats_unique_highest_averages_option = if check_for_unique_highest_average_seats {
+        Some(list_unique_highest_average_assigned_seats(
+            previous_steps,
+            list_number,
+        ))
+    } else {
+        None
+    };
+
     // A list qualifies for an extra seat if in a previous step, a seat has been removed
     // due to absolute majority reassignment, and that that seat has then been removed due
     // to list exhaustion. In that case, the seat can be returned to the original list.
-    let has_retracted_seat: bool = previous_steps.iter().any(|prev| {
+    let has_absolute_majority_retracted_seat: bool = previous_steps.iter().any(|prev| {
         prev.change.is_changed_by_absolute_majority_reassignment()
             && prev.change.list_number_retracted() == list_number
     });
@@ -188,7 +199,7 @@ fn list_qualifies_for_extra_seat<LN: Copy + Eq>(
         // If no largest remainder seat has been assigned to this list
         // or the largest remainder assigned seat has been retracted
         number_of_seats_largest_remainders == 0
-            || (has_retracted_seat && number_of_seats_largest_remainders == 1)
+            || (has_absolute_majority_retracted_seat && number_of_seats_largest_remainders == 1)
     }
     // In case of unique highest average assignment
     else if let Some(number_of_seats_unique_highest_averages) =
@@ -198,7 +209,7 @@ fn list_qualifies_for_extra_seat<LN: Copy + Eq>(
         // or (the unique highest average assigned seat has been retracted,
         // and no largest remainder seat has been retracted and reassigned)
         number_of_seats_unique_highest_averages == 0
-            || (has_retracted_seat
+            || (has_absolute_majority_retracted_seat
                 && number_of_seats_unique_highest_averages == 1
                 && number_of_seats_largest_remainders <= 1)
     } else {
@@ -223,12 +234,7 @@ fn list_standings_qualifying_for_largest_remainder<'a, LN: Copy + Eq>(
         s.votes_cast() > 0
             && s.meets_remainder_threshold()
             && !exhausted_list_numbers.contains(&s.list_number())
-            && list_qualifies_for_extra_seat(
-                list_largest_remainder_assigned_seats(previous_steps, s.list_number()),
-                None,
-                previous_steps,
-                s.list_number(),
-            )
+            && list_qualifies_for_extra_seat(previous_steps, s.list_number(), false)
     })
 }
 
@@ -244,19 +250,11 @@ fn list_standings_qualifying_for_unique_highest_average<'a, LN: Copy + Eq>(
     standings.iter().filter(|&s| {
         s.votes_cast() > 0
             && !exhausted_list_numbers.contains(&s.list_number())
-            && list_qualifies_for_extra_seat(
-                list_largest_remainder_assigned_seats(previous_steps, s.list_number()),
-                Some(list_unique_highest_average_assigned_seats(
-                    previous_steps,
-                    s.list_number(),
-                )),
-                previous_steps,
-                s.list_number(),
-            )
+            && list_qualifies_for_extra_seat(previous_steps, s.list_number(), true)
     })
 }
 
-/// Returns the number of seats assigned with highest averages method.
+/// Returns the number of seats assigned with unique highest averages method.
 fn list_unique_highest_average_assigned_seats<LN: Copy + Eq>(
     previous_steps: &[SeatChangeStep<LN>],
     list_number: LN,
@@ -814,10 +812,9 @@ mod tests {
         };
 
         assert!(list_qualifies_for_extra_seat(
-            0,
-            Some(1),
             &[previous_steps],
-            RETRACTED_LIST
+            RETRACTED_LIST,
+            true,
         ))
     }
 }

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -211,6 +211,8 @@ fn list_qualifies_for_extra_seat<LN: Copy + Eq>(
         number_of_seats_unique_highest_averages == 0
             || (has_absolute_majority_retracted_seat
                 && number_of_seats_unique_highest_averages == 1
+                // It is possible to receive one LR seat, then get it retracted
+                // and then received back again based on LR, which would mean 2.
                 && number_of_seats_largest_remainders <= 1)
     } else {
         false
@@ -671,7 +673,10 @@ fn step_assign_remainder_using_largest_remainder<'a, 'b, LN: Copy + Debug + Eq>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{CandidateVotesMock, ListVotesMock};
+    use crate::{
+        seat_assignment::AbsoluteMajorityReassignedSeat,
+        test_helpers::{CandidateVotesMock, ListVotesMock},
+    };
     fn standing(list_number: u32, votes_cast: u32) -> ListStanding<u32> {
         ListStanding::new(
             &ListVotesMock {
@@ -692,6 +697,35 @@ mod tests {
                 list_assigned: vec![list_number],
                 list_exhausted: vec![],
                 votes_per_seat: Fraction::ZERO,
+                drawing_lots: None,
+            }),
+        }
+    }
+
+    fn largest_remainder_step(list_number: u32) -> SeatChangeStep<u32> {
+        SeatChangeStep {
+            residual_seat_number: None,
+            standings: vec![],
+            change: SeatChange::LargestRemainderAssignment(LargestRemainderAssignedSeat {
+                selected_list_number: list_number,
+                list_options: vec![list_number],
+                list_assigned: vec![list_number],
+                remainder_votes: Fraction::ZERO,
+                drawing_lots: None,
+            }),
+        }
+    }
+
+    fn absolute_majority_reassignment_step(
+        list_retracted_seat: u32,
+        list_assigned_seat: u32,
+    ) -> SeatChangeStep<u32> {
+        SeatChangeStep {
+            residual_seat_number: None,
+            standings: vec![],
+            change: SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                list_retracted_seat,
+                list_assigned_seat,
                 drawing_lots: None,
             }),
         }
@@ -793,28 +827,152 @@ mod tests {
             );
         }
     }
-    use crate::seat_assignment::AbsoluteMajorityReassignedSeat;
 
-    /// A list whose seat was retracted via absolute majority reassignment should still qualify for reassignment.
     #[test]
-    fn test_reassignment_allowed_after_seat_was_retracted() {
-        const RETRACTED_LIST: u32 = 1;
-        const ASSIGNED_LIST: u32 = 2;
+    #[expect(clippy::too_many_lines)]
+    fn test_list_qualifies_for_extra_seat() {
+        const LIST: u32 = 1;
+        const OTHER_LIST: u32 = 2;
 
-        let previous_steps = SeatChangeStep {
-            residual_seat_number: None,
-            change: SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
-                list_retracted_seat: RETRACTED_LIST,
-                list_assigned_seat: ASSIGNED_LIST,
-                drawing_lots: None,
-            }),
-            standings: vec![],
-        };
+        struct Case {
+            description: &'static str,
+            check_for_unique_highest_average_seats: bool,
+            previous_steps: Vec<SeatChangeStep<u32>>,
+            expected: bool,
+        }
 
-        assert!(list_qualifies_for_extra_seat(
-            &[previous_steps],
-            RETRACTED_LIST,
-            true,
-        ))
+        let cases = vec![
+            // Largest remainder assignment (check_for_unique_highest_average_seats = false)
+            Case {
+                description: "largest remainder: qualifies when no seat was assigned yet",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![],
+                expected: true,
+            },
+            Case {
+                description: "largest remainder: seat assigned to another list does not count",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![largest_remainder_step(OTHER_LIST)],
+                expected: true,
+            },
+            Case {
+                description: "largest remainder: unique highest average seat does not count",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![unique_highest_average_step(LIST)],
+                expected: true,
+            },
+            Case {
+                description: "largest remainder: does not qualify when a seat was assigned",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![largest_remainder_step(LIST)],
+                expected: false,
+            },
+            Case {
+                description: "largest remainder: qualifies again when the assigned seat was retracted by absolute majority reassignment",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![
+                    largest_remainder_step(LIST),
+                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
+                ],
+                expected: true,
+            },
+            Case {
+                description: "largest remainder: retraction from another list does not requalify this list",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![
+                    largest_remainder_step(LIST),
+                    absolute_majority_reassignment_step(OTHER_LIST, LIST),
+                ],
+                expected: false,
+            },
+            Case {
+                description: "largest remainder: does not qualify with two assigned seats even after a retraction",
+                check_for_unique_highest_average_seats: false,
+                previous_steps: vec![
+                    largest_remainder_step(LIST),
+                    largest_remainder_step(LIST),
+                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
+                ],
+                expected: false,
+            },
+            // Unique highest average assignment (check_for_unique_highest_average_seats = true)
+            Case {
+                description: "unique highest average: qualifies when no seat was assigned yet",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![],
+                expected: true,
+            },
+            Case {
+                description: "unique highest average: seat assigned to another list does not count",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![unique_highest_average_step(OTHER_LIST)],
+                expected: true,
+            },
+            Case {
+                description: "unique highest average: largest remainder seat does not count",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![largest_remainder_step(LIST)],
+                expected: true,
+            },
+            Case {
+                description: "unique highest average: does not qualify when a seat was assigned",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![unique_highest_average_step(LIST)],
+                expected: false,
+            },
+            Case {
+                description: "unique highest average: qualifies again when the assigned seat was retracted by absolute majority reassignment",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![
+                    unique_highest_average_step(LIST),
+                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
+                ],
+                expected: true,
+            },
+            Case {
+                description: "unique highest average: retracted seat with one largest remainder seat still qualifies",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![
+                    largest_remainder_step(LIST),
+                    unique_highest_average_step(LIST),
+                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
+                ],
+                expected: true,
+            },
+            Case {
+                description: "unique highest average: retracted seat with two largest remainder seats does not qualify",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![
+                    largest_remainder_step(LIST),
+                    largest_remainder_step(LIST),
+                    unique_highest_average_step(LIST),
+                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
+                ],
+                expected: false,
+            },
+            Case {
+                description: "unique highest average: does not qualify with two assigned seats even after a retraction",
+                check_for_unique_highest_average_seats: true,
+                previous_steps: vec![
+                    unique_highest_average_step(LIST),
+                    unique_highest_average_step(LIST),
+                    absolute_majority_reassignment_step(LIST, OTHER_LIST),
+                ],
+                expected: false,
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                list_qualifies_for_extra_seat(
+                    &case.previous_steps,
+                    LIST,
+                    case.check_for_unique_highest_average_seats,
+                ),
+                case.expected,
+                "{}",
+                case.description
+            );
+        }
     }
 }


### PR DESCRIPTION
## What & why

Related to #788 

The goal was to implement tests for function `list_qualifies_for_extra_seat`. To do this, I've moved some logic into the function itself in https://github.com/kiesraad/abacus/commit/17619f70d71b0c414e382579fafeeb7e687dbca4.

Test cases have been implemented in https://github.com/kiesraad/abacus/commit/2e3a760d22448602c699d39b917db6b1fc9a839e

After which a small refactor has been applied https://github.com/kiesraad/abacus/commit/2296bb191d17b75656134f0fbdddb6d93c691e6b (tests succeeding before and after). 

## How to test

Run tests / see CI

## Reviewer notes

Review per commit.

- Are the test cases complete, is every path tested?
- Does the function do what you expect, looking at the test cases? 