### PR TITLE
Create backups shortcut in Windows installer

### DIFF
--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -2,7 +2,7 @@
 
 Follow the next steps to compile the installer:
 
-1. Download and install [Inno Setup 6.6](https://jrsoftware.org/). Use this version to get the same result.
+1. Download and install [Inno Setup 6.7](https://jrsoftware.org/). Use this version to get the same result.
 2. [Download Visual C++ Redistributable v14 installer](https://aka.ms/vc14/vc_redist.x64.exe) to this folder and save it as `VC_redist.x64.exe`.
 3. Place a recent Abacus build for Windows in this folder under the name `abacus.exe`.
 4. Open `abacus.iss` with Inno Setup and select `Build -> Compile` in the menu or use the keyboard shortcut Ctrl+F9.

--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -17,6 +17,7 @@
 #define MyAppExeName "abacus.exe"
 #define MyAppIcon "abacus.ico"
 #define MyDatabaseFile = "db.sqlite"
+#define MyBackupDirName = "backups"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -72,11 +73,14 @@ Source: ".\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion sign
 Source: ".\VC_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
 Source: ".\{#MyAppIcon}"; DestDir: "{app}"
 
+[Dirs]
+Name: "{app}\{#MyBackupDirName}"
+
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppIcon}"
 Name: "{autodesktop}\1. Start {#MyAppName} server"; Filename: "{sys}\cmd.exe"; Parameters: "/k ""{app}\{#MyAppExeName}"""; WorkingDir: "{app}"; IconFilename: "{app}\{#MyAppIcon}"
 Name: "{autodesktop}\2. Open {#MyAppName} in browser"; Filename: "http://localhost"; IconFilename: "{app}\{#MyAppIcon}"
-Name: "{autodesktop}\{#MyAppName} database map"; Filename: "{app}"; IconFilename: "{sys}\shell32.dll"; IconIndex: 3
+Name: "{autodesktop}\{#MyAppName} backups"; Filename: "{app}\{#MyBackupDirName}"; IconFilename: "{sys}\shell32.dll"; IconIndex: 3
 
 [Run]
 Filename: "{tmp}\VC_redist.x64.exe"; Parameters: "/install /passive /norestart"; StatusMsg: "Visual C++ Redistributable installeren..."
@@ -156,7 +160,7 @@ begin
       if FileExists(ExpandConstant('{app}\{#MyDatabaseFile}')) then
         begin
         case TaskDialogMsgBox('Database verwijderen?',
-                     'De database bevat alle verkiezingsdetails, ingevoerde data en gemaakte processen-verbaal.' + #13#10#13#10 + 'Als u de database verwijdert, gaan deze gegevens definitief verloren.',
+                     'De database bevat alle verkiezingsdetails, ingevoerde data en gemaakte processen-verbaal. Ook alle gemaakte backups worden verwijderd.' + #13#10#13#10 + 'Als u de database verwijdert, gaan deze gegevens definitief verloren.',
                       mbConfirmation,
                       MB_YESNO, ['Database verwijderen', 'Bewaren'],
                       0) of

--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -16,7 +16,6 @@
 #define MyAppURL "https://github.com/kiesraad/abacus"
 #define MyAppExeName "abacus.exe"
 #define MyAppIcon "abacus.ico"
-#define MyDatabaseFile = "db.sqlite"
 #define MyBackupDirName = "backups"
 
 [Setup]
@@ -156,20 +155,17 @@ procedure CurUninstallStepChanged(CurStep: TUninstallStep);
 begin
   if CurStep = usUninstall then
     begin
-      // Check if DB exists and ask question in case
-      if FileExists(ExpandConstant('{app}\{#MyDatabaseFile}')) then
-        begin
-        case TaskDialogMsgBox('Database verwijderen?',
-                     'De database bevat alle verkiezingsdetails, ingevoerde data en gemaakte processen-verbaal. Ook alle gemaakte backups worden verwijderd.' + #13#10#13#10 + 'Als u de database verwijdert, gaan deze gegevens definitief verloren.',
-                      mbConfirmation,
-                      MB_YESNO, ['Database verwijderen', 'Bewaren'],
-                      0) of
-          IDYES: begin
-            MsgBox('Database wordt verwijderd', mbInformation, MB_OK);
-            DelTree(ExpandConstant('{userappdata}\{#MyAppName}'), True, True, True);
-          end;
-          IDNO: MsgBox('Database wordt behouden', mbInformation, MB_OK);
+      // Confirm before deleting the Abacus data folder
+      case TaskDialogMsgBox('Database en backups verwijderen?',
+                   'De database bevat alle verkiezingsdetails, ingevoerde data en gemaakte processen-verbaal. Ook alle gemaakte backups worden verwijderd.' + #13#10#13#10 + 'Als u de database verwijdert, gaan deze gegevens definitief verloren.',
+                    mbConfirmation,
+                    MB_YESNO, ['Database en backups verwijderen', 'Bewaren'],
+                    0) of
+        IDYES: begin
+          DelTree(ExpandConstant('{userappdata}\{#MyAppName}'), True, True, True);
+          MsgBox('Database en backups zijn verwijderd', mbInformation, MB_OK);
         end;
+        IDNO: MsgBox('Database en backups worden behouden', mbInformation, MB_OK);
       end;
 
       RunElevatedCommandWithRetry('netsh advfirewall firewall delete rule name="Abacus server"', 'Het verwijderen van de firewallregel');

--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -1,4 +1,4 @@
-; Made with InnoSetup 6.6, make sure to use this version
+; Made with InnoSetup 6.7, make sure to use this version
 ; Using a different version of InnoSetup can give different results
 
 #define GetVersion() \


### PR DESCRIPTION
## What & why

Create backups folder shortcut on the desktop in the Windows installer, to make it easier to find the backups. The `[Dirs]` section in the installer lets the installer create the backups directory so that the shortcut works without running Abacus first.

The backups shortcut replaces the database folder shortcut to reduce confusion between the two.

Resolves #3500.

## How to test

[Create and run the Windows installer](https://github.com/kiesraad/abacus/blob/main/packaging/windows/README.md), or just review the diff and check out this amazing screenshot:

<img width="784" height="574" alt="Screenshot 2026-07-03 161322" src="https://github.com/user-attachments/assets/c2ec78aa-4f56-4b92-9206-842dd0f74701" />

## Reviewer notes

The Windows installer also needs to be updated for TLS: #3510.
