### PR TITLE
Apportionment add extra information to CandidateDrawingLotsVariant

### DIFF
--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -302,7 +302,17 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
                 "Drawing of lots is required for candidates: {options:?}, {seats_remaining} seat(s) available",
             );
 
-            let variant = CandidateDrawingLotsVariant { list, options };
+            let current_seat_number = index + 1;
+            let nr_of_seats = options.len().min(seats_remaining as usize);
+            let seat_numbers = (current_seat_number..current_seat_number + nr_of_seats)
+                .map(|n| u32::try_from(n).expect("should fit in u32"))
+                .collect();
+
+            let variant = CandidateDrawingLotsVariant {
+                list,
+                seat_numbers,
+                options,
+            };
 
             let Some(candidate_drawn) = candidates_drawn.next() else {
                 return Ok(PreferentialCandidateNomination::DrawingLotsRequired(
@@ -1222,6 +1232,7 @@ mod tests {
             variant_one,
             CandidateDrawingLotsVariant {
                 list: 2,
+                seat_numbers: vec![2, 3],
                 options: vec![2, 3, 4, 5, 6]
             }
         );
@@ -1241,6 +1252,7 @@ mod tests {
             variant_two,
             CandidateDrawingLotsVariant {
                 list: 2,
+                seat_numbers: vec![3],
                 options: vec![2, 3, 4, 6]
             }
         );
@@ -1326,6 +1338,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawnMock {
                     variant: CandidateDrawingLotsVariant {
                         list: 1,
+                        seat_numbers: vec![2],
                         options: vec![3, 4],
                     },
                     drawn: 4,
@@ -1339,6 +1352,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawnMock {
                     variant: CandidateDrawingLotsVariant {
                         list: 1,
+                        seat_numbers: vec![1, 2],
                         options: vec![1, 3],
                     },
                     drawn: 3,
@@ -1353,6 +1367,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            seat_numbers: vec![2, 3],
                             options: vec![3, 4, 5],
                         },
                         drawn: 4,
@@ -1360,6 +1375,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            seat_numbers: vec![3],
                             options: vec![3, 5],
                         },
                         drawn: 3,
@@ -1382,6 +1398,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            seat_numbers: vec![1, 2, 3, 4],
                             options: vec![1, 3, 4, 5],
                         },
                         drawn: 1,
@@ -1389,6 +1406,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            seat_numbers: vec![2, 3, 4],
                             options: vec![3, 4, 5],
                         },
                         drawn: 5,
@@ -1396,6 +1414,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            seat_numbers: vec![3, 4],
                             options: vec![3, 4],
                         },
                         drawn: 3,

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -310,6 +310,7 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
 
             let variant = CandidateDrawingLotsVariant {
                 list,
+                total_seats,
                 number_of_votes: same_votes_candidates_remaining[0].votes(),
                 seat_numbers,
                 options,
@@ -1233,6 +1234,7 @@ mod tests {
             variant_one,
             CandidateDrawingLotsVariant {
                 list: 2,
+                total_seats: 3,
                 number_of_votes: 400,
                 seat_numbers: vec![2, 3],
                 options: vec![2, 3, 4, 5, 6]
@@ -1254,6 +1256,7 @@ mod tests {
             variant_two,
             CandidateDrawingLotsVariant {
                 list: 2,
+                total_seats: 3,
                 number_of_votes: 400,
                 seat_numbers: vec![3],
                 options: vec![2, 3, 4, 6]
@@ -1341,6 +1344,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawnMock {
                     variant: CandidateDrawingLotsVariant {
                         list: 1,
+                        total_seats: 2,
                         number_of_votes: 900,
                         seat_numbers: vec![2],
                         options: vec![3, 4],
@@ -1356,6 +1360,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawnMock {
                     variant: CandidateDrawingLotsVariant {
                         list: 1,
+                        total_seats: 2,
                         number_of_votes: 1000,
                         seat_numbers: vec![1, 2],
                         options: vec![1, 3],
@@ -1372,6 +1377,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            total_seats: 3,
                             number_of_votes: 900,
                             seat_numbers: vec![2, 3],
                             options: vec![3, 4, 5],
@@ -1381,6 +1387,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            total_seats: 3,
                             number_of_votes: 900,
                             seat_numbers: vec![3],
                             options: vec![3, 5],
@@ -1405,6 +1412,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            total_seats: 4,
                             number_of_votes: 1000,
                             seat_numbers: vec![1, 2, 3, 4],
                             options: vec![1, 3, 4, 5],
@@ -1414,6 +1422,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            total_seats: 4,
                             number_of_votes: 1000,
                             seat_numbers: vec![2, 3, 4],
                             options: vec![3, 4, 5],
@@ -1423,6 +1432,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            total_seats: 4,
                             number_of_votes: 1000,
                             seat_numbers: vec![3, 4],
                             options: vec![3, 4],

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -310,6 +310,7 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
 
             let variant = CandidateDrawingLotsVariant {
                 list,
+                number_of_votes: same_votes_candidates_remaining[0].votes(),
                 seat_numbers,
                 options,
             };
@@ -1232,6 +1233,7 @@ mod tests {
             variant_one,
             CandidateDrawingLotsVariant {
                 list: 2,
+                number_of_votes: 400,
                 seat_numbers: vec![2, 3],
                 options: vec![2, 3, 4, 5, 6]
             }
@@ -1252,6 +1254,7 @@ mod tests {
             variant_two,
             CandidateDrawingLotsVariant {
                 list: 2,
+                number_of_votes: 400,
                 seat_numbers: vec![3],
                 options: vec![2, 3, 4, 6]
             }
@@ -1338,6 +1341,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawnMock {
                     variant: CandidateDrawingLotsVariant {
                         list: 1,
+                        number_of_votes: 900,
                         seat_numbers: vec![2],
                         options: vec![3, 4],
                     },
@@ -1352,6 +1356,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawnMock {
                     variant: CandidateDrawingLotsVariant {
                         list: 1,
+                        number_of_votes: 1000,
                         seat_numbers: vec![1, 2],
                         options: vec![1, 3],
                     },
@@ -1367,6 +1372,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            number_of_votes: 900,
                             seat_numbers: vec![2, 3],
                             options: vec![3, 4, 5],
                         },
@@ -1375,6 +1381,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            number_of_votes: 900,
                             seat_numbers: vec![3],
                             options: vec![3, 5],
                         },
@@ -1398,6 +1405,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            number_of_votes: 1000,
                             seat_numbers: vec![1, 2, 3, 4],
                             options: vec![1, 3, 4, 5],
                         },
@@ -1406,6 +1414,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            number_of_votes: 1000,
                             seat_numbers: vec![2, 3, 4],
                             options: vec![3, 4, 5],
                         },
@@ -1414,6 +1423,7 @@ mod tests {
                     CandidateDrawnMock {
                         variant: CandidateDrawingLotsVariant {
                             list: 1,
+                            number_of_votes: 1000,
                             seat_numbers: vec![3, 4],
                             options: vec![3, 4],
                         },

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -129,6 +129,7 @@ pub trait ListDrawn<LN> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandidateDrawingLotsVariant<LN: PartialEq, CN: PartialEq> {
     pub list: LN,
+    pub number_of_votes: u32,
     pub seat_numbers: Vec<u32>,
     pub options: Vec<CN>,
 }

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -129,6 +129,7 @@ pub trait ListDrawn<LN> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandidateDrawingLotsVariant<LN: PartialEq, CN: PartialEq> {
     pub list: LN,
+    pub seat_numbers: Vec<u32>,
     pub options: Vec<CN>,
 }
 

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -129,6 +129,7 @@ pub trait ListDrawn<LN> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandidateDrawingLotsVariant<LN: PartialEq, CN: PartialEq> {
     pub list: LN,
+    pub total_seats: u32,
     pub number_of_votes: u32,
     pub seat_numbers: Vec<u32>,
     pub options: Vec<CN>,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5977,6 +5977,7 @@
         "type": "object",
         "required": [
           "list",
+          "total_seats",
           "number_of_votes",
           "seat_numbers",
           "options"
@@ -6007,6 +6008,12 @@
               "minimum": 0
             },
             "description": "The seat numbers that the candidates can be drawn for"
+          },
+          "total_seats": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The total number of seats for the list",
+            "minimum": 0
           }
         }
       },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5977,6 +5977,7 @@
         "type": "object",
         "required": [
           "list",
+          "seat_numbers",
           "options"
         ],
         "properties": {
@@ -5990,6 +5991,15 @@
               "$ref": "#/components/schemas/CandidateNumber"
             },
             "description": "The candidates that lots are drawn for"
+          },
+          "seat_numbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "The seat numbers that the candidates can be drawn for"
           }
         }
       },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5977,6 +5977,7 @@
         "type": "object",
         "required": [
           "list",
+          "number_of_votes",
           "seat_numbers",
           "options"
         ],
@@ -5984,6 +5985,12 @@
           "list": {
             "$ref": "#/components/schemas/PGNumber",
             "description": "The list the candidate needs to be drawn from"
+          },
+          "number_of_votes": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of votes, equal for these candidates",
+            "minimum": 0
           },
           "options": {
             "type": "array",

--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -90,6 +90,7 @@ mod tests {
         let drawing_lots_required =
             DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
                 list: PGNumber::from(3),
+                number_of_votes: 200,
                 seat_numbers: vec![1, 2],
                 options: CandidateNumber::from_values(vec![1, 2]),
             });
@@ -110,6 +111,7 @@ mod tests {
         let candidate_drawn = CandidateDrawn {
             variant: CandidateDrawingLotsVariant {
                 list: PGNumber::from(3),
+                number_of_votes: 200,
                 seat_numbers: vec![2],
                 options: CandidateNumber::from_values(vec![1, 2]),
             },

--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -90,6 +90,7 @@ mod tests {
         let drawing_lots_required =
             DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
                 list: PGNumber::from(3),
+                seat_numbers: vec![1, 2],
                 options: CandidateNumber::from_values(vec![1, 2]),
             });
 
@@ -109,6 +110,7 @@ mod tests {
         let candidate_drawn = CandidateDrawn {
             variant: CandidateDrawingLotsVariant {
                 list: PGNumber::from(3),
+                seat_numbers: vec![2],
                 options: CandidateNumber::from_values(vec![1, 2]),
             },
             drawn: CandidateNumber::from(2),

--- a/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
+++ b/backend/src/api/apportionment/handlers/add_candidate_drawn.rs
@@ -90,6 +90,7 @@ mod tests {
         let drawing_lots_required =
             DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
                 list: PGNumber::from(3),
+                total_seats: 2,
                 number_of_votes: 200,
                 seat_numbers: vec![1, 2],
                 options: CandidateNumber::from_values(vec![1, 2]),
@@ -111,6 +112,7 @@ mod tests {
         let candidate_drawn = CandidateDrawn {
             variant: CandidateDrawingLotsVariant {
                 list: PGNumber::from(3),
+                total_seats: 2,
                 number_of_votes: 200,
                 seat_numbers: vec![2],
                 options: CandidateNumber::from_values(vec![1, 2]),

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -182,12 +182,14 @@ impl From<CandidateDrawingLotsVariant>
     fn from(
         CandidateDrawingLotsVariant {
             list,
+            number_of_votes,
             seat_numbers,
             options,
         }: CandidateDrawingLotsVariant,
     ) -> Self {
         Self {
             list,
+            number_of_votes,
             seat_numbers,
             options,
         }

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -182,6 +182,7 @@ impl From<CandidateDrawingLotsVariant>
     fn from(
         CandidateDrawingLotsVariant {
             list,
+            total_seats,
             number_of_votes,
             seat_numbers,
             options,
@@ -189,6 +190,7 @@ impl From<CandidateDrawingLotsVariant>
     ) -> Self {
         Self {
             list,
+            total_seats,
             number_of_votes,
             seat_numbers,
             options,

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -179,8 +179,18 @@ impl apportionment::ListDrawn<PGNumber> for ListDrawn {
 impl From<CandidateDrawingLotsVariant>
     for apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>
 {
-    fn from(CandidateDrawingLotsVariant { list, options }: CandidateDrawingLotsVariant) -> Self {
-        Self { list, options }
+    fn from(
+        CandidateDrawingLotsVariant {
+            list,
+            seat_numbers,
+            options,
+        }: CandidateDrawingLotsVariant,
+    ) -> Self {
+        Self {
+            list,
+            seat_numbers,
+            options,
+        }
     }
 }
 

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -421,6 +421,8 @@ pub struct ListDrawn {
 pub struct CandidateDrawingLotsVariant {
     /// The list the candidate needs to be drawn from
     pub list: PGNumber,
+    /// The number of votes, equal for these candidates
+    pub number_of_votes: u32,
     /// The seat numbers that the candidates can be drawn for
     pub seat_numbers: Vec<u32>,
     /// The candidates that lots are drawn for

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -421,6 +421,8 @@ pub struct ListDrawn {
 pub struct CandidateDrawingLotsVariant {
     /// The list the candidate needs to be drawn from
     pub list: PGNumber,
+    /// The total number of seats for the list
+    pub total_seats: u32,
     /// The number of votes, equal for these candidates
     pub number_of_votes: u32,
     /// The seat numbers that the candidates can be drawn for

--- a/backend/src/domain/apportionment.rs
+++ b/backend/src/domain/apportionment.rs
@@ -421,6 +421,8 @@ pub struct ListDrawn {
 pub struct CandidateDrawingLotsVariant {
     /// The list the candidate needs to be drawn from
     pub list: PGNumber,
+    /// The seat numbers that the candidates can be drawn for
+    pub seat_numbers: Vec<u32>,
     /// The candidates that lots are drawn for
     pub options: Vec<CandidateNumber>,
 }

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -330,6 +330,7 @@ mod tests {
     fn candidate_required() -> DrawingLotsRequired {
         DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
             list: PGNumber::from(1),
+            total_seats: 2,
             number_of_votes: 1000,
             seat_numbers: vec![1, 2, 3],
             options: CandidateNumber::from_values(vec![3, 4, 5]),
@@ -448,6 +449,7 @@ mod tests {
                     state.clone().add_candidate_drawn(CandidateDrawn {
                         variant: CandidateDrawingLotsVariant {
                             list: PGNumber::from(1),
+                            total_seats: 2,
                             number_of_votes: 1000,
                             seat_numbers: vec![1, 2, 3],
                             options: CandidateNumber::from_values(vec![3, 4, 5]),

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -330,6 +330,7 @@ mod tests {
     fn candidate_required() -> DrawingLotsRequired {
         DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
             list: PGNumber::from(1),
+            number_of_votes: 1000,
             seat_numbers: vec![1, 2, 3],
             options: CandidateNumber::from_values(vec![3, 4, 5]),
         })
@@ -447,6 +448,7 @@ mod tests {
                     state.clone().add_candidate_drawn(CandidateDrawn {
                         variant: CandidateDrawingLotsVariant {
                             list: PGNumber::from(1),
+                            number_of_votes: 1000,
                             seat_numbers: vec![1, 2, 3],
                             options: CandidateNumber::from_values(vec![3, 4, 5]),
                         },

--- a/backend/src/domain/apportionment_state.rs
+++ b/backend/src/domain/apportionment_state.rs
@@ -330,6 +330,7 @@ mod tests {
     fn candidate_required() -> DrawingLotsRequired {
         DrawingLotsRequired::CandidateDrawingLotsRequired(CandidateDrawingLotsVariant {
             list: PGNumber::from(1),
+            seat_numbers: vec![1, 2, 3],
             options: CandidateNumber::from_values(vec![3, 4, 5]),
         })
     }
@@ -446,6 +447,7 @@ mod tests {
                     state.clone().add_candidate_drawn(CandidateDrawn {
                         variant: CandidateDrawingLotsVariant {
                             list: PGNumber::from(1),
+                            seat_numbers: vec![1, 2, 3],
                             options: CandidateNumber::from_values(vec![3, 4, 5]),
                         },
                         drawn: CandidateNumber::from(4),

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -112,6 +112,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawn {
                     variant: CandidateDrawingLotsVariant {
                         list: PGNumber::from(1),
+                        seat_numbers: vec![1, 2, 3],
                         options: CandidateNumber::from_values(vec![2, 3, 4]),
                     },
                     drawn: CandidateNumber::from(1),

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -112,6 +112,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawn {
                     variant: CandidateDrawingLotsVariant {
                         list: PGNumber::from(1),
+                        total_seats: 3,
                         number_of_votes: 1000,
                         seat_numbers: vec![1, 2, 3],
                         options: CandidateNumber::from_values(vec![2, 3, 4]),

--- a/backend/src/repository/apportionment_state_repo.rs
+++ b/backend/src/repository/apportionment_state_repo.rs
@@ -112,6 +112,7 @@ mod tests {
                 candidates_drawn: vec![CandidateDrawn {
                     variant: CandidateDrawingLotsVariant {
                         list: PGNumber::from(1),
+                        number_of_votes: 1000,
                         seat_numbers: vec![1, 2, 3],
                         options: CandidateNumber::from_values(vec![2, 3, 4]),
                     },

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -135,6 +135,7 @@ impl From<apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>>
     fn from(value: apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>) -> Self {
         CandidateDrawingLotsVariant {
             list: value.list,
+            number_of_votes: value.number_of_votes,
             seat_numbers: value.seat_numbers,
             options: value.options,
         }

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -135,6 +135,7 @@ impl From<apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>>
     fn from(value: apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>) -> Self {
         CandidateDrawingLotsVariant {
             list: value.list,
+            total_seats: value.total_seats,
             number_of_votes: value.number_of_votes,
             seat_numbers: value.seat_numbers,
             options: value.options,

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -135,6 +135,7 @@ impl From<apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>>
     fn from(value: apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>) -> Self {
         CandidateDrawingLotsVariant {
             list: value.list,
+            seat_numbers: value.seat_numbers,
             options: value.options,
         }
     }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -624,6 +624,8 @@ export interface CandidateDrawingLotsVariant {
   options: CandidateNumber[];
   /** The seat numbers that the candidates can be drawn for */
   seat_numbers: number[];
+  /** The total number of seats for the list */
+  total_seats: number;
 }
 
 /**

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -620,6 +620,8 @@ export interface CandidateDrawingLotsVariant {
   list: PGNumber;
   /** The candidates that lots are drawn for */
   options: CandidateNumber[];
+  /** The seat numbers that the candidates can be drawn for */
+  seat_numbers: number[];
 }
 
 /**

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -618,6 +618,8 @@ export interface Candidate {
 export interface CandidateDrawingLotsVariant {
   /** The list the candidate needs to be drawn from */
   list: PGNumber;
+  /** The number of votes, equal for these candidates */
+  number_of_votes: number;
   /** The candidates that lots are drawn for */
   options: CandidateNumber[];
   /** The seat numbers that the candidates can be drawn for */


### PR DESCRIPTION
## What & why

Resolves #3513

Adds three fields to `CandidateDrawingLotsVariant`:
- `total_seats`: The total number of seats for the list
- `number_of_votes`: The number of votes, equal for these candidates
- `seat_numbers`: The seat numbers that the candidates can be drawn for

## How to test

- Check if tests succeed
- Validate if the `seat_numbers` are calculated correctly

## Reviewer notes

`seat_numbers` is calculated by taking:
- The `current_seat_number`, which is the current loop `index + 1`
- Until `current_seat_number + MIN(amount_of_options, number_of_seats_remaining)`

If we have more or equal number of seats than the options, it will only take as many seats as there are options.
If we have less number of seats than the options, take the amount of seats left.