### PR TITLE
Create and trust CA in Windows installer

### DIFF
--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -99,6 +99,11 @@ struct Args {
     #[arg(long, default_value_t = default_http_port(), env = "ABACUS_HTTP_PORT")]
     http_port: u16,
 
+    /// Create the TLS directory and CA certificate (if missing) and exit without starting the server
+    #[cfg(feature = "tls")]
+    #[arg(long)]
+    init_tls: bool,
+
     /// Seed the database with initial data using the fixtures
     #[cfg(feature = "dev-database")]
     #[arg(short, long, env = "ABACUS_SEED_DATA")]
@@ -129,6 +134,25 @@ async fn main() {
     }
 }
 
+/// Create the CA in `tls_dir` (if missing) and print its location and SHA-256
+/// fingerprint. Used for the `--init-tls` CLI flag.
+#[cfg(feature = "tls")]
+fn init_tls(tls_dir: &std::path::Path) -> Result<(), AppError> {
+    use abacus::infra::tls;
+    let ca = tls::init_ca(tls_dir)?;
+    let tls_dir = std::path::absolute(tls_dir)?;
+    println!(
+        "CA certificate (PEM): {}",
+        tls_dir.join(tls::CA_CERT_PEM).display()
+    );
+    println!(
+        "CA certificate (DER): {}",
+        tls_dir.join(tls::CA_CERT_DER).display()
+    );
+    println!("CA SHA-256 fingerprint: {}", ca.sha256_fingerprint());
+    Ok(())
+}
+
 async fn run() -> Result<(), AppError> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -142,6 +166,12 @@ async fn run() -> Result<(), AppError> {
     if args.version {
         println!(env!("ABACUS_GIT_VERSION"));
         return Ok(());
+    }
+
+    // Create the CA and exit, without touching the database or starting the server.
+    #[cfg(feature = "tls")]
+    if args.init_tls {
+        return init_tls(&args.tls_dir);
     }
 
     let pool = create_sqlite_pool(

--- a/backend/src/infra/tls.rs
+++ b/backend/src/infra/tls.rs
@@ -14,8 +14,8 @@ use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, pem::P
 
 use crate::AppError;
 
-const CA_CERT_PEM: &str = "ca.pem";
-const CA_CERT_DER: &str = "ca.cer";
+pub const CA_CERT_PEM: &str = "ca.pem";
+pub const CA_CERT_DER: &str = "ca.cer";
 const CA_KEY_DER: &str = "ca-key.der";
 
 fn tls_err<E: core::fmt::Debug>(e: E) -> AppError {
@@ -28,6 +28,13 @@ fn tls_err<E: core::fmt::Debug>(e: E) -> AppError {
 pub struct CaCertificate {
     pub pem: String,
     pub der: Vec<u8>,
+}
+
+impl CaCertificate {
+    /// SHA-256 fingerprint of the CA certificate (colon-separated hex).
+    pub fn sha256_fingerprint(&self) -> String {
+        fingerprint(&self.der)
+    }
 }
 
 /// TLS certificates: the local CA and leaf certificate and the leaf private key
@@ -51,14 +58,20 @@ impl TlsCertificates {
     }
 }
 
-/// Load or generate the CA and create a new leaf certificate
-pub fn load_or_generate(tls_dir: &Path) -> Result<TlsCertificates, AppError> {
+/// Create the TLS directory (if missing) and lock it down to the owner on unix.
+fn ensure_tls_dir(tls_dir: &Path) -> Result<(), AppError> {
     fs::create_dir_all(tls_dir)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(tls_dir, fs::Permissions::from_mode(0o700))?;
     }
+    Ok(())
+}
+
+/// Load or generate the CA and create a new leaf certificate
+pub fn load_or_generate(tls_dir: &Path) -> Result<TlsCertificates, AppError> {
+    ensure_tls_dir(tls_dir)?;
 
     let (issuer, ca) = load_or_generate_ca(tls_dir)?;
     let (leaf_cert, leaf_key) = create_leaf(&issuer, &get_subjects())?;
@@ -67,6 +80,14 @@ pub fn load_or_generate(tls_dir: &Path) -> Result<TlsCertificates, AppError> {
         leaf_cert,
         leaf_key,
     })
+}
+
+/// Ensure the TLS directory and persisted CA exist, without creating a leaf certificate.
+/// Used by `--init-tls`, the Windows installer runs this before importing the CA.
+pub fn init_ca(tls_dir: &Path) -> Result<CaCertificate, AppError> {
+    ensure_tls_dir(tls_dir)?;
+    let (_issuer, ca) = load_or_generate_ca(tls_dir)?;
+    Ok(ca)
 }
 
 /// Load the persisted local CA or generate and persist a new one.
@@ -299,8 +320,54 @@ mod tests {
             second.leaf_cert.as_ref(),
             "each call creates a fresh leaf"
         );
+    }
 
-        // clean up
-        dir.close().expect("temporary directory is cleaned up");
+    /// Test that `init_ca` persists the CA (and only the CA, no leaf) and reuses it on a second call
+    #[test]
+    fn init_ca_persists_and_reuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let tls_dir = dir.path().join("tls");
+
+        let first = init_ca(&tls_dir).unwrap();
+
+        // exactly the three CA files exist; no leaf certificate was persisted
+        for file in [CA_CERT_PEM, CA_CERT_DER, CA_KEY_DER] {
+            assert!(tls_dir.join(file).exists(), "{file} should be persisted");
+        }
+        assert_eq!(
+            fs::read_dir(&tls_dir).unwrap().count(),
+            3,
+            "only the three CA files should exist, no leaf"
+        );
+
+        // ca.cer matches the returned DER
+        assert_eq!(fs::read(tls_dir.join(CA_CERT_DER)).unwrap(), first.der);
+
+        // fingerprint: 64 hex chars + 31 colons = 95 chars
+        let fp = first.sha256_fingerprint();
+        assert_eq!(fp.len(), 95, "fingerprint should be 95 chars");
+        assert!(
+            fp.chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == ':'),
+            "fingerprint should be uppercase colon-separated hex, got {fp}"
+        );
+
+        // check file permissions
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let key_mode = fs::metadata(tls_dir.join(CA_KEY_DER))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(key_mode, 0o600, "the CA private key must be private");
+            let dir_mode = fs::metadata(&tls_dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(dir_mode, 0o700, "the tls directory must be private");
+        }
+
+        // a second call reuses the same persisted CA
+        let second = init_ca(&tls_dir).unwrap();
+        assert_eq!(first.der, second.der, "CA persists across runs");
     }
 }

--- a/backend/tests/init_tls_test.rs
+++ b/backend/tests/init_tls_test.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "tls")]
+
+use std::process::Command;
+
+#[test]
+fn init_tls_creates_ca_and_exits_without_database() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_abacus"))
+        .current_dir(dir.path())
+        .args(["--init-tls", "--tls-dir", "tls"])
+        .output()
+        .expect("failed to run abacus --init-tls");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert!(
+        dir.path().join("tls/ca.pem").exists(),
+        "ca.pem should be created"
+    );
+    assert!(
+        dir.path().join("tls/ca.cer").exists(),
+        "ca.cer should be created"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("CA SHA-256 fingerprint:"),
+        "stdout should include the fingerprint line, got:\n{stdout}"
+    );
+
+    assert!(
+        !dir.path().join("db.sqlite").exists(),
+        "--init-tls must not create a database"
+    );
+}

--- a/packaging/windows/.gitignore
+++ b/packaging/windows/.gitignore
@@ -1,0 +1,2 @@
+Output/
+*.exe

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -4,5 +4,5 @@ Follow the next steps to compile the installer:
 
 1. Download and install [Inno Setup 6.7](https://jrsoftware.org/). Use this version to get the same result.
 2. [Download Visual C++ Redistributable v14 installer](https://aka.ms/vc14/vc_redist.x64.exe) to this folder and save it as `VC_redist.x64.exe`.
-3. Place a recent Abacus build for Windows in this folder under the name `abacus.exe`.
+3. Place a recent Abacus release build for Windows (with TLS enabled) in this folder under the name `abacus.exe`.
 4. Open `abacus.iss` with Inno Setup and select `Build -> Compile` in the menu or use the keyboard shortcut Ctrl+F9.

--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -78,15 +78,16 @@ Name: "{app}\{#MyBackupDirName}"
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppIcon}"
 Name: "{autodesktop}\1. Start {#MyAppName} server"; Filename: "{sys}\cmd.exe"; Parameters: "/k ""{app}\{#MyAppExeName}"""; WorkingDir: "{app}"; IconFilename: "{app}\{#MyAppIcon}"
-Name: "{autodesktop}\2. Open {#MyAppName} in browser"; Filename: "http://localhost"; IconFilename: "{app}\{#MyAppIcon}"
+Name: "{autodesktop}\2. Open {#MyAppName} in browser"; Filename: "https://localhost"; IconFilename: "{app}\{#MyAppIcon}"
 Name: "{autodesktop}\{#MyAppName} backups"; Filename: "{app}\{#MyBackupDirName}"; IconFilename: "{sys}\shell32.dll"; IconIndex: 3
 
 [Run]
 Filename: "{tmp}\VC_redist.x64.exe"; Parameters: "/install /passive /norestart"; StatusMsg: "Visual C++ Redistributable installeren..."
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-Filename: "http://localhost"; Description: "Open Abacus Interface"; Flags: shellexec postinstall skipifsilent
+Filename: "https://localhost"; Description: "Open Abacus Interface"; Flags: shellexec postinstall skipifsilent
 
 [UninstallRun]
+Filename: "{sys}\certutil.exe"; Parameters: "-delstore root ""Abacus Local CA"""; Flags: runhidden; RunOnceId: "RemoveCaCert"
 Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Abacus server"" "; Flags: runhidden; RunOnceId: "RemoveFirewallExc"
 
 [Messages]
@@ -139,15 +140,32 @@ end;
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   CmdLine: String;
+  CaCertPath: String;
+  ResultCode: Integer;
 begin
   if CurStep = ssPostInstall then
     begin
+      // Generate the CA by running non-elevated with `--init-tls`
+      if (not Exec(ExpandConstant('{app}\{#MyAppExeName}'),
+          '--init-tls --tls-dir "' + ExpandConstant('{app}\tls') + '"',
+          ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode))
+         or (ResultCode <> 0) then
+        MsgBox('Het aanmaken van het beveiligingscertificaat is mislukt (foutcode: '
+          + IntToStr(ResultCode) + ').'#13#10#13#10
+          + 'Installeer het beveiligingscertificaat handmatig volgens de gebruikershandleiding.',
+          mbError, MB_OK);
+
+      // Create firewall rule and import CA into machine root store.
+      CaCertPath := ExpandConstant('{app}\tls\ca.cer');
       CmdLine :=
         'netsh advfirewall firewall delete rule name="Abacus server" >nul 2>&1 & ' +
         'netsh advfirewall firewall add rule name="Abacus server" ' +
         'program="' + ExpandConstant('{app}\{#MyAppExeName}') + '" ' +
-        'protocol=TCP dir=in localport=80 action=allow';
-      RunElevatedCommandWithRetry(CmdLine, 'Het toevoegen van de firewallregel');
+        'protocol=TCP dir=in localport=80,443 action=allow';
+      // Import the CA only if it was generated.
+      if FileExists(CaCertPath) then
+        CmdLine := CmdLine + ' && certutil -f -addstore root "' + CaCertPath + '"';
+      RunElevatedCommandWithRetry(CmdLine, 'Het instellen van de firewall en het beveiligingscertificaat');
     end;
 end;
 
@@ -163,11 +181,12 @@ begin
                     0) of
         IDYES: begin
           DelTree(ExpandConstant('{userappdata}\{#MyAppName}'), True, True, True);
-          MsgBox('Database en backups zijn verwijderd', mbInformation, MB_OK);
+          MsgBox('Database en backups zijn verwijderd.', mbInformation, MB_OK);
         end;
-        IDNO: MsgBox('Database en backups worden behouden', mbInformation, MB_OK);
+        IDNO: MsgBox('Database en backups worden behouden.', mbInformation, MB_OK);
       end;
 
-      RunElevatedCommandWithRetry('netsh advfirewall firewall delete rule name="Abacus server"', 'Het verwijderen van de firewallregel');
+      // delete Abacus CA from the machine root store by name and delete firewall rule
+      RunElevatedCommandWithRetry('certutil -delstore root "Abacus Local CA" >nul 2>&1 & netsh advfirewall firewall delete rule name="Abacus server"', 'Het verwijderen van de firewallregel en het beveiligingscertificaat');
     end;
 end;


### PR DESCRIPTION
## What & why

Update the Windows installer to create the TLS CA certificate and add it to the system root trust store. To let the installer create the certificate without starting the full Abacus server, the `--init-tls` CLI option was added. The firewall rule now also opens TCP port 443 (HTTPS) in addition to TCP port 80 (HTTP). Resolves #3510.

## How to test

- The new `--init-tls` option should create the TLS CA certificate in the backend directory: `cargo run --features tls -- --init-tls` (and not recreate it when the CA certificate already exists)
- Run the Windows installer to verify that the TLS CA certificate gets created and added to the trust store.

## Reviewer notes

I can provide you with a built Windows installer if needed.