### PR TITLE
Apportionment fix standings, added assertions

### DIFF
--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -133,11 +133,18 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
     };
     if let Some(assigned_seat) = assigned_seat {
         // add the absolute majority change to the remainder assignment steps
-        steps.push(SeatChangeStep {
+        let step = SeatChangeStep {
             standings: current_standings,
             residual_seat_number: None,
             change: assigned_seat,
-        });
+        };
+        if let Some(last_step) = steps.last() {
+            assert_ne!(
+                last_step.standings, step.standings,
+                "standings should be different"
+            );
+        }
+        steps.push(step);
     }
 
     // [Artikel P 19a Kieswet](https://wetten.overheid.nl/BWBR0004627/2026-01-01/#AfdelingII_HoofdstukP_Paragraaf3_ArtikelP19a)
@@ -189,6 +196,13 @@ pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmen
         .iter()
         .map(|list| list.residual_seats())
         .sum::<u32>();
+
+    if let Some(last_step) = final_steps.last() {
+        assert_ne!(
+            last_step.standings, final_standing,
+            "standings should be different"
+        );
+    }
 
     Ok(SeatAssignment::Completed(SeatAssignmentDetails {
         seats: input.number_of_seats(),
@@ -382,6 +396,9 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
             seats_to_reassign += seats;
             let mut full_seat: bool = false;
             for _ in 1..=seats {
+                // Clone standings for returned step as they are before changes
+                let standings = current_standings.clone();
+
                 let list_standing = current_standings
                     .iter_mut()
                     .find(|list_standing| list_standing.list_number() == list_number)
@@ -398,14 +415,20 @@ fn reassign_residual_seats_for_exhausted_lists<'a, T: ListVotes>(
                     "Seat first assigned to list {:?} has been removed and will be assigned to another list in accordance with Article P 10 Kieswet",
                     list_number
                 );
-                list_exhaustion_steps.push(SeatChangeStep {
-                    standings: current_standings.clone(),
+
+                let step = SeatChangeStep {
+                    standings,
                     residual_seat_number: None,
                     change: SeatChange::ListExhaustionRemoval(ListExhaustionRemovedSeat {
                         list_retracted_seat: list_number,
                         full_seat,
                     }),
-                });
+                };
+                assert_ne!(
+                    step.standings, current_standings,
+                    "standings should be different"
+                );
+                list_exhaustion_steps.push(step);
             }
         }
         let mut current_steps = previous_steps.to_owned();

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -86,11 +86,16 @@ pub fn assign_remainder<'b, T: ListVotes>(
         list_standing.add_residual_seat();
 
         // add the update to the remainder assignment steps
-        steps.push(SeatChangeStep {
+        let step = SeatChangeStep {
             standings,
             residual_seat_number: Some(residual_seat_number),
             change,
-        });
+        };
+        assert_ne!(
+            step.standings, current_standings,
+            "standings should be different"
+        );
+        steps.push(step);
     }
 
     Ok(RemainderAssignment::Completed(steps, current_standings))


### PR DESCRIPTION
## What & why

Related to #788 

Noticed that the absolute majority step did not contain the standings **before** the change. This has been fixed and assertions have been added in the code where steps get added. At the end of the `seat_assignment` function we also assert that the `final_standings` are different than the last step.

## How to test

Tests should succeed. See if all places are covered.

## Reviewer notes

N/A