### PR TITLE
Generate rustdoc for private items

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run tests
         run: cargo --verbose --locked nextest run --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation
-        run: cargo doc --workspace --no-deps --all-features
+        run: cargo doc --workspace --no-deps --all-features --document-private-items
         env:
           RUSTDOCFLAGS: "-D warnings"
       - name: Create documentation artifact

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3359,7 +3359,7 @@
     },
     "/api/elections/{election_id}/polling_stations": {
       "get": {
-        "summary": "Get a list of all [PollingStation]s for an election (administrator, coordinator_gsb, typist_gsb)",
+        "summary": "Get a list of all [PollingStation](crate::domain::polling_station::PollingStation)s for an election (administrator, coordinator_gsb, typist_gsb)",
         "operationId": "polling_station_list",
         "parameters": [
           {
@@ -3425,7 +3425,7 @@
         ]
       },
       "post": {
-        "summary": "Create a new [PollingStation] (administrator, coordinator_gsb)",
+        "summary": "Create a new [PollingStation](crate::domain::polling_station::PollingStation) (administrator, coordinator_gsb)",
         "operationId": "polling_station_create",
         "parameters": [
           {
@@ -3696,7 +3696,7 @@
     },
     "/api/elections/{election_id}/polling_stations/{polling_station_id}": {
       "get": {
-        "summary": "Get a [PollingStation] (administrator, coordinator_gsb, typist_gsb)",
+        "summary": "Get a [PollingStation](crate::domain::polling_station::PollingStation) (administrator, coordinator_gsb, typist_gsb)",
         "operationId": "polling_station_get",
         "parameters": [
           {
@@ -3771,7 +3771,7 @@
         ]
       },
       "put": {
-        "summary": "Update a [PollingStation] (administrator, coordinator_gsb)",
+        "summary": "Update a [PollingStation](crate::domain::polling_station::PollingStation) (administrator, coordinator_gsb)",
         "operationId": "polling_station_update",
         "parameters": [
           {
@@ -3865,7 +3865,7 @@
         ]
       },
       "delete": {
-        "summary": "Delete a [PollingStation] (administrator, coordinator_gsb)",
+        "summary": "Delete a [PollingStation](crate::domain::polling_station::PollingStation) (administrator, coordinator_gsb)",
         "operationId": "polling_station_delete",
         "parameters": [
           {

--- a/backend/pdf_gen/impl/src/lib.rs
+++ b/backend/pdf_gen/impl/src/lib.rs
@@ -36,7 +36,7 @@ fn get_pdf_options() -> PdfOptions {
 }
 
 /// Convert [`chrono::DateTime`] to [`Datetime`]
-/// From https://github.com/typst/typst/blob/96dd67e011bb317cf78683bcf1edfdfca5e7b6b3/crates/typst-cli/src/compile.rs#L305
+/// From <https://github.com/typst/typst/blob/96dd67e011bb317cf78683bcf1edfdfca5e7b6b3/crates/typst-cli/src/compile.rs#L305>
 fn convert_datetime<Tz: chrono::TimeZone>(date_time: &chrono::DateTime<Tz>) -> Option<Datetime> {
     Datetime::from_ymd_hms(
         date_time.year(),

--- a/backend/src/api/middleware/authentication/password.rs
+++ b/backend/src/api/middleware/authentication/password.rs
@@ -43,7 +43,7 @@ impl<'pw> ValidatedPassword<'pw> {
 
 /// Helper newtype indicating the containing string is hashed with `hash_password`.
 /// Note that this newtype doesn't give any guarantees, as it is easily constructible
-/// because of the From<String> impl.
+/// because of the `From<String>` impl.
 #[derive(Deserialize, Default, PartialEq, Eq, Clone, Debug, Hash, Type)]
 #[serde(deny_unknown_fields)]
 #[sqlx(transparent)]

--- a/backend/src/api/polling_station.rs
+++ b/backend/src/api/polling_station.rs
@@ -139,7 +139,7 @@ pub fn authorize_user_and_gsb_election(
     Ok(())
 }
 
-/// Get a list of all [PollingStation]s for an election
+/// Get a list of all [PollingStation](crate::domain::polling_station::PollingStation)s for an election
 #[utoipa::path(
     get,
     path = "/api/elections/{election_id}/polling_stations",
@@ -189,7 +189,7 @@ pub fn validate_user_is_allowed_to_perform_action(
     }
 }
 
-/// Create a new [PollingStation]
+/// Create a new [PollingStation](crate::domain::polling_station::PollingStation)
 #[utoipa::path(
     post,
     path = "/api/elections/{election_id}/polling_stations",
@@ -261,7 +261,7 @@ async fn polling_station_create(
     Ok((StatusCode::CREATED, response))
 }
 
-/// Get a [PollingStation]
+/// Get a [PollingStation](crate::domain::polling_station::PollingStation)
 #[utoipa::path(
     get,
     path = "/api/elections/{election_id}/polling_stations/{polling_station_id}",
@@ -290,7 +290,7 @@ async fn polling_station_get(
     Ok((StatusCode::OK, polling_station.into_response(election_id)))
 }
 
-/// Update a [PollingStation]
+/// Update a [PollingStation](crate::domain::polling_station::PollingStation)
 #[utoipa::path(
     put,
     path = "/api/elections/{election_id}/polling_stations/{polling_station_id}",
@@ -355,7 +355,7 @@ async fn polling_station_update(
     Ok((StatusCode::OK, response))
 }
 
-/// Delete a [PollingStation]
+/// Delete a [PollingStation](crate::domain::polling_station::PollingStation)
 #[utoipa::path(
     delete,
     path = "/api/elections/{election_id}/polling_stations/{polling_station_id}",

--- a/backend/src/infra/router.rs
+++ b/backend/src/infra/router.rs
@@ -188,7 +188,7 @@ fn add_storybook_memory_serve(router: Router<AppState>) -> Router<AppState> {
 }
 
 /// Add headers for security hardening
-/// Best practices according to the OWASP Secure Headers Project, https://owasp.org/www-project-secure-headers/
+/// Best practices according to the OWASP Secure Headers Project, <https://owasp.org/www-project-secure-headers/>
 /// HSTS (Strict-Transport-Security) is not set here because this function is also applied to
 /// the plaintext HTTP server (via `ca_router`). HSTS is added in `start_server_tls` (lib.rs) instead.
 pub(crate) fn add_security_headers<S>(router: Router<S>) -> Router<S>


### PR DESCRIPTION
## What & why

Change the CI workflow to also generate rustdoc for private items, and fix any errors in private Rust doc comments. The documentation for private items will be available at https://kiesraad.github.io/abacus after merging.

## How to test

Check CI or run `cargo doc --workspace --no-deps --all-features --document-private-items` manually

## Reviewer notes

None.