### PR TITLE
Add checks to ensure input is sorted

### DIFF
--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -50,6 +50,20 @@ pub enum ApportionmentOutput<'a, T: ApportionmentInput> {
 pub fn process<T: ApportionmentInput>(
     input: &T,
 ) -> Result<ApportionmentOutput<'_, T>, ApportionmentError> {
+    // Check if all list votes are sorted by number
+    if !input.list_votes().is_sorted_by_key(|lv| lv.number()) {
+        return Err(ApportionmentError::UnsortedInput);
+    }
+
+    // Check if all candidate votes are sorted by number
+    if input
+        .list_votes()
+        .iter()
+        .any(|lv| !lv.candidate_votes().is_sorted_by_key(|cv| cv.number()))
+    {
+        return Err(ApportionmentError::UnsortedInput);
+    }
+
     let seat_assignment = match seat_assignment(input)? {
         SeatAssignment::Completed(seat_assignment) => seat_assignment,
         SeatAssignment::DrawingLotsRequired(variant, seat_assignment) => {
@@ -80,11 +94,14 @@ pub fn process<T: ApportionmentInput>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        assert_matches,
+        collections::{HashMap, HashSet},
+    };
 
     use super::{ApportionmentOutput, process};
     use crate::{
-        Fraction,
+        ApportionmentError, Fraction,
         test_helpers::{
             check_chosen_candidates, check_list_candidate_nomination,
             get_total_seats_from_apportionment_result,
@@ -408,5 +425,31 @@ mod tests {
                 case.name, result.seat_assignment.steps,
             );
         }
+    }
+
+    #[test]
+    fn test_apportionment_process_unsorted_list_number_fails() {
+        let mut input = seat_assignment_fixture_with_default_50_candidates(
+            15,
+            vec![540, 160, 160, 80, 80, 80, 60, 40],
+        );
+
+        input.list_votes.reverse();
+
+        assert_matches!(process(&input), Err(ApportionmentError::UnsortedInput));
+    }
+
+    #[test]
+    fn test_apportionment_process_unsorted_list_candidate_number_fails() {
+        let mut input = seat_assignment_fixture_with_default_50_candidates(
+            15,
+            vec![540, 160, 160, 80, 80, 80, 60, 40],
+        );
+
+        input.list_votes.iter_mut().for_each(|lv| {
+            lv.candidate_votes.reverse();
+        });
+
+        assert_matches!(process(&input), Err(ApportionmentError::UnsortedInput));
     }
 }

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -446,9 +446,7 @@ mod tests {
             vec![540, 160, 160, 80, 80, 80, 60, 40],
         );
 
-        input.list_votes.iter_mut().for_each(|lv| {
-            lv.candidate_votes.reverse();
-        });
+        input.list_votes[1].candidate_votes.reverse();
 
         assert_matches!(process(&input), Err(ApportionmentError::UnsortedInput));
     }

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -21,6 +21,7 @@ pub type CandidateNumber<LV> = <<LV as ListVotes>::Cv as CandidateVotes>::Candid
 pub enum ApportionmentError {
     InvalidLotDrawing(String),
     InvalidState(String),
+    UnsortedInput,
 }
 
 /// Different variants of drawing lots for lists, with all the information needed to do the drawing
@@ -192,7 +193,7 @@ pub struct ApportionmentDetails<'a, T: ListVotes> {
 
 pub trait ListVotes: PartialEq + Debug {
     type Cv: CandidateVotes;
-    type ListNumber: Copy + Debug + Eq + Hash;
+    type ListNumber: Copy + Debug + Eq + PartialOrd + Hash;
 
     fn number(&self) -> Self::ListNumber;
     fn total_votes(&self) -> u32 {
@@ -205,7 +206,7 @@ pub trait ListVotes: PartialEq + Debug {
 }
 
 pub trait CandidateVotes: PartialEq + Debug {
-    type CandidateNumber: Copy + Debug + Eq + Hash;
+    type CandidateNumber: Copy + Debug + Eq + PartialOrd + Hash;
 
     fn number(&self) -> Self::CandidateNumber;
     fn votes(&self) -> u32;

--- a/backend/apportionment/src/test_helpers.rs
+++ b/backend/apportionment/src/test_helpers.rs
@@ -11,6 +11,7 @@ use crate::{
     structs::{CandidateDrawn, ListDrawingLotsVariant, ListDrawn},
 };
 
+#[derive(Debug)]
 pub struct ApportionmentInputMock {
     pub number_of_seats: u32,
     pub list_votes: Vec<ListVotesMock>,
@@ -92,6 +93,7 @@ impl ListVotesMock {
     }
 }
 
+#[derive(Debug)]
 pub struct ListDrawnMock {
     pub variant: ListDrawingLotsVariant<u32>,
     pub drawn: u32,

--- a/backend/src/api/apportionment/mod.rs
+++ b/backend/src/api/apportionment/mod.rs
@@ -26,6 +26,7 @@ pub enum ApportionmentApiError {
     InvalidLotDrawing(String),
     InvalidState(String),
     NotCSBElection,
+    UnsortedInput,
 }
 
 impl ApiErrorResponse for ApportionmentApiError {
@@ -75,6 +76,14 @@ impl ApiErrorResponse for ApportionmentApiError {
                     true,
                 ),
             ),
+            ApportionmentApiError::UnsortedInput => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::new(
+                    "Apportionment expects lists and candidates to be sorted",
+                    ErrorReference::InternalServerError,
+                    true,
+                ),
+            ),
         }
     }
 }
@@ -87,6 +96,9 @@ impl From<apportionment::ApportionmentError> for APIError {
             }
             apportionment::ApportionmentError::InvalidState(message) => {
                 ApportionmentApiError::InvalidState(message).into()
+            }
+            apportionment::ApportionmentError::UnsortedInput => {
+                ApportionmentApiError::UnsortedInput.into()
             }
         }
     }


### PR DESCRIPTION
## What & why

Closes #3478
The apportionment crate expects sorted input. Abacus currently does this correctly, but because it is a separate crate and can be used as a library, we should ensure that it is sorted.

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test
Check out the unit tests added in lib.rs. You can remove the `reverse()` calls and see that the unit tests fail.

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes


I've opted to simply add `is_sorted_*` checks and return an `ApportionmentError` when the checks fail.

Currently, the `process` function passes in an immutable reference to the input. Sorting the input in the input crate itself would require to either pass in a mutable reference, or cloning the data, creating multiple sources of the input.
Both solutions decrease type safety and maintainability, while we gain nothing, since Abacus already passes in sorted input correctly.
<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->