### PR TITLE
Pin Rust versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,15 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "axum-extra"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - package-ecosystem: "rust-toolchain"
+    directories: ["/backend", "backend/fuzz", "backend/apportionment/fuzz"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    groups:
+      rust-toolchain:
+        patterns: ["*"]
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Setup Rust
         shell: bash
         run: >
-          rustup update stable &&
-          rustup default stable &&
+          rustup toolchain install &&
           rustup target add x86_64-unknown-linux-musl
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
@@ -110,10 +109,8 @@ jobs:
       - name: Setup Rust
         shell: bash
         run: >
-          rustup update stable &&
-          rustup default stable &&
-          rustup target add x86_64-unknown-linux-musl &&
-          rustup component add --toolchain stable clippy rustfmt
+          rustup toolchain install &&
+          rustup target add x86_64-unknown-linux-musl
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
@@ -267,11 +264,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
       - name: Setup Rust Nightly
-        shell: bash
-        run: >
-          rustup update nightly &&
-          rustup default nightly &&
-          rustup component add clippy
+        working-directory: ./backend/fuzz
+        run: rustup toolchain install
+      - name: Setup Rust Nightly (apportionment)
+        working-directory: ./backend/apportionment/fuzz
+        run: rustup toolchain install
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
@@ -280,6 +277,7 @@ jobs:
             backend/apportionment/fuzz -> target
           shared-key: "fuzzer"
       - name: Install cargo fuzz
+        working-directory: ./backend/fuzz
         run: cargo install cargo-fuzz
       - name: Check Clippy for ./backend/fuzz
         run: cargo --verbose --locked clippy -- -D warnings
@@ -288,9 +286,10 @@ jobs:
         run: cargo --verbose --locked clippy -- -D warnings
         working-directory: ./backend/apportionment/fuzz
       - name: Run data entry fuzzer
+        working-directory: ./backend/fuzz
         run: cargo fuzz run data_entry_status -- -max_total_time=60
       - name: Run simple apportionment fuzzer
-        working-directory: ./backend/apportionment
+        working-directory: ./backend/apportionment/fuzz
         run: cargo fuzz run simple_apportionment -- -max_total_time=60
 
   rustdoc:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,6 +26,8 @@ jobs:
       CARGO_TERM_COLOR: always
       SQLX_OFFLINE: "true"
       BINSTALL_DISABLE_TELEMETRY: "true"
+      # Branch coverage requires Rust nightly: https://github.com/taiki-e/cargo-llvm-cov/issues/8
+      RUSTUP_TOOLCHAIN: nightly-2026-07-10
     steps:
       # Free up runner disk space, so that our job has enough space to run
       # https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
@@ -56,12 +58,9 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-      # Branch coverage requires Rust nightly: https://github.com/taiki-e/cargo-llvm-cov/issues/8
       - name: Setup Rust Nightly
         shell: bash
-        run: >
-          rustup update nightly-2026-02-21 &&
-          rustup default nightly-2026-02-21
+        run: rustup toolchain install "$RUSTUP_TOOLCHAIN"
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:

--- a/.github/workflows/pdf-diff.yml
+++ b/.github/workflows/pdf-diff.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.base_ref || 'main' }}
+      # The base ref may not have a rust-toolchain.toml yet, so fall back to stable.
       - name: Setup Rust
-        run: >
-          rustup update stable &&
-          rustup default stable
+        shell: bash
+        run: if [ -f rust-toolchain.toml ]; then rustup toolchain install; else rustup update stable && rustup default stable; fi
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
@@ -38,6 +38,8 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           clean: false
+      - name: Setup Rust for current branch
+        run: rustup toolchain install
       - name: Generate PDFs on the current branch
         run: cargo run --bin gen-pdf --features embed-typst -- --directory head
       - name: Install diff-pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           name: frontend-production-build
           path: frontend/dist
       - name: Setup Rust
-        run: rustup update stable && rustup default stable
+        run: rustup toolchain install
       - name: Install target
         run: rustup target add ${{ matrix.target.name }}
       - name: Install musl

--- a/.github/workflows/weekly-e2e-tests.yml
+++ b/.github/workflows/weekly-e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
           name: frontend-weekly-build
           path: frontend/dist
       - name: Setup Rust
-        run: rustup update stable && rustup default stable
+        run: rustup toolchain install
       - name: Install target
         run: rustup target add ${{ matrix.target.name }}
       - name: Install musl

--- a/backend/apportionment/fuzz/README.md
+++ b/backend/apportionment/fuzz/README.md
@@ -8,7 +8,7 @@ The Abacus apportionment crate has several fuzz targets that check our implement
 
 ## Running
 
-[cargo fuzz](https://rust-fuzz.github.io/book/cargo-fuzz/tutorial.html) is used as a fuzzing tool. A nightly version of the Rust toolchain is required; when using `rustup` this should get taken care of automatically because of the `rust-toolchain` file in this directory.
+[cargo fuzz](https://rust-fuzz.github.io/book/cargo-fuzz/tutorial.html) is used as a fuzzing tool. A nightly version of the Rust toolchain is required; when using `rustup` this should get taken care of automatically because of the `rust-toolchain.toml` file in this directory. Run the commands below from within this directory, so that the pinned nightly toolchain is used.
 
 Basic commands:
 - Installation: `cargo install cargo-fuzz`

--- a/backend/apportionment/fuzz/rust-toolchain
+++ b/backend/apportionment/fuzz/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/backend/apportionment/fuzz/rust-toolchain.toml
+++ b/backend/apportionment/fuzz/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-07-10"
+components = ["clippy"]

--- a/backend/fuzz/README.md
+++ b/backend/fuzz/README.md
@@ -8,17 +8,17 @@ The `data_entry_status` fuzz test tests that the data entry system matches the s
 
 This fuzz test covers all possible states and all possible `DataEntryTransitionError` errors, except for the `FirstEntryAlreadyClaimed`, `ValidatorError` and `ValidationError` errors. The `FirstEntryAlreadyClaimed` error is not triggered by the fuzzer for simplicity, but this error is explicitly tested by the `first_entry_in_progress_claim_first_entry_other_user_error` unit test. The `ValidatorError` and `ValidationError` errors are not triggered by the fuzzer because the fuzzer does not test the API directly. Instead, the fuzzer only tests the internal functions to focus on verifying the data entry state machine. This fuzz test can be seen as a more complete extension of the unit tests that test individual transitions, which shows that no unexpected errors or transition can happen.
 
-To run the fuzzer, first install the nightly compiler and cargo fuzz if you haven't already:
+To run the fuzzer, first install cargo-fuzz if you haven't already:
 
 ```
-rustup install nightly
-cargo +nightly install cargo-fuzz
+cargo install cargo-fuzz
 ```
 
-Then, run the fuzzer with the following command from within the `/backend` folder:
+Then, run the fuzzer with the following command from within the `/backend/fuzz` folder
+(the pinned nightly toolchain from `rust-toolchain.toml` is installed automatically):
 
 ```
-cargo +nightly fuzz run data_entry_status
+cargo fuzz run data_entry_status
 ```
 
 The output of the fuzzer should look something like:

--- a/backend/fuzz/rust-toolchain
+++ b/backend/fuzz/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/backend/fuzz/rust-toolchain.toml
+++ b/backend/fuzz/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-07-10"
+components = ["clippy"]

--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## What & why

Pin Rust versions used in Abacus to prevent breakage like #3554, especially during the release cycle.

## How to test

CI should pass and local builds should still work.

## Reviewer notes

The code coverage workflow was pinned to Rust Nightly 2026-02-21 in #2931 and never updated, this PR does update it.