### PR TITLE
Update undici

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2831,12 +2831,12 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   universal-user-agent@7.0.3:
@@ -3079,17 +3079,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -4946,7 +4946,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5520,9 +5520,9 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   universal-user-agent@7.0.3: {}
 


### PR DESCRIPTION
## What & why

Update undici dependency to fix security vulnerabilities (Dependabot, `pnpm audit`). Because the undici versions with fixes are in range for the packages requiring it, `pnpm update --depth Infinity undici` was enough to update the lockfile and update to a versions of undici with fixes for the vulnerabilities.

Related Dependabot alerts:
- https://github.com/kiesraad/abacus/security/dependabot/110
- https://github.com/kiesraad/abacus/security/dependabot/111
- https://github.com/kiesraad/abacus/security/dependabot/112
- https://github.com/kiesraad/abacus/security/dependabot/113
- https://github.com/kiesraad/abacus/security/dependabot/114
- https://github.com/kiesraad/abacus/security/dependabot/115
- https://github.com/kiesraad/abacus/security/dependabot/116
- https://github.com/kiesraad/abacus/security/dependabot/117
- https://github.com/kiesraad/abacus/security/dependabot/118
- https://github.com/kiesraad/abacus/security/dependabot/119
- https://github.com/kiesraad/abacus/security/dependabot/120

## How to test

Test that frontend dev server still works.

## Reviewer notes

None.