### PR TITLE
Allow improper EML polling station files to be imported when possible

### DIFF
--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -868,7 +868,7 @@ fn add_reporting_unit_investigations(
 pub fn parse_polling_stations_eml_str(
     polling_stations_data: &str,
 ) -> Result<PollingStations, EMLImportError> {
-    Ok(PollingStations::parse_eml(polling_stations_data, EMLParsingMode::Strict).ok()?)
+    Ok(PollingStations::parse_eml(polling_stations_data, EMLParsingMode::StrictFallback).ok()?)
 }
 
 pub fn polling_stations_from_eml_str(


### PR DESCRIPTION
## What & why

The parsing mode is changed from strict to strict-fallback to allow continuing of parsing when the EML file does not fully comply with the standard.

## How to test

During the creation of an election, try importing a polling stations file with some warnings from the EML validator (an example file from Hilversum is shared in the chat). This should succeed unless one of the polling stations themselves has an error.

## Reviewer notes

Note that this still gives errors in case one of the polling stations in the imported file is invalid. We could also filter these out, but we don't have any UI for this currently. The behavior in this PR is similar to how we parsed EML files with Abacus 1.0

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->