### PR TITLE
Add playwright tests for drawing lots flow and 2 small fixes

### DIFF
--- a/backend/src/eml/tests/eml110a_test_less_than_19_seats.eml.xml
+++ b/backend/src/eml/tests/eml110a_test_less_than_19_seats.eml.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2022-02-04</IssueDate>
+    <kr:CreationDateTime>2022-02-04T11:16:26.827</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="GR2022_Test">
+                <ElectionName>Gemeenteraad Test 2022</ElectionName>
+                <ElectionCategory>GR</ElectionCategory>
+                <kr:ElectionSubcategory>GR1</kr:ElectionSubcategory>
+                <kr:ElectionDomain Id="0000">Test</kr:ElectionDomain>
+                <kr:ElectionDate>2022-03-16</kr:ElectionDate>
+                <kr:NominationDate>2022-01-31</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="geen"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>15</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>50</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="000" RegionCategory="GEMEENTE">
+                    <kr:RegionName>Test</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partijdige Partij</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Stemmer</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Stemmmers 22</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>STEM</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>De Stemunie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Stemalliantie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -3,11 +3,18 @@ import { type APIRequestContext, test as base, expect, type Page } from "@playwr
 import { DataEntryApiClient } from "e2e-tests/helpers-utils/api-clients";
 import { completeDataEntries } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import { createRandomUsername } from "e2e-tests/helpers-utils/e2e-test-utils";
-import { type Eml230b, eml110a, eml230b, eml230b_more_than_45_candidates } from "e2e-tests/test-data/eml-files";
+import {
+  type Eml230b,
+  eml110a,
+  eml110a_less_than_19_seats,
+  eml230b,
+  eml230b_more_than_45_candidates,
+} from "e2e-tests/test-data/eml-files";
 import {
   dataEntryRequest,
   dataEntryRequestGSB,
-  dataEntryRequestGSBTriggeringDrawingLots,
+  dataEntryRequestGSBTriggeringDrawingLotsForListAndCandidate,
+  dataEntryRequestGSBTriggeringDrawingLotsForP9,
   dataEntryWithDifferencesRequest,
   dataEntryWithErrorRequest,
   pollingStationRequests,
@@ -59,12 +66,16 @@ type Fixtures = {
   eml230b_more_than_45_candidates: Eml230b;
   // GSB election without polling stations
   emptyElectionGSB: Election;
-  // CSB election
-  emptyElectionCSB: Election;
+  // CSB election with >= 19 seats
+  emptyElectionCSBLargeCouncil: Election;
+  // CSB election with < 19 seats
+  emptyElectionCSBSmallCouncil: Election;
   // GSB election with two polling stations
   electionGSB: ElectionDetailsResponse;
-  // CSB election with one subcommittee
-  electionCSB: ElectionDetailsResponse;
+  // CSB election with >= 19 seats and one subcommittee
+  electionCSBLargeCouncil: ElectionDetailsResponse;
+  // CSB election with < 19 seats and one subcommittee
+  electionCSBSmallCouncil: ElectionDetailsResponse;
   // First data entry of the GSB election
   dataEntryGSB: DataEntry;
   // First data entry of the GSB election with entry claimed by typist one
@@ -81,10 +92,12 @@ type Fixtures = {
   dataEntryGSBEntriesDifferentWithErrors: DataEntry;
   // GSB election with polling stations and two completed data entries for each
   completedElectionGSB: Election;
-  // CSB election with subcommittee and two completed data entries
+  // CSB election with >= 19 seats, one subcommittee and two completed data entries
   completedElectionCSB: Election;
-  // CSB election with subcommittee and two completed data entries that triggers drawing lots for lists and candidates
-  completedElectionCSBWithDrawingLots: Election;
+  // CSB election with >= 19 seats, one subcommittee and two completed data entries that triggers drawing lots for lists and candidates
+  completedElectionCSBWithDrawingLotsForListAndCandidate: Election;
+  // CSB election with < 19 seats, one subcommittee and two completed data entries that triggers drawing lots for P 9
+  completedElectionCSBWithDrawingLotsForP9: Election;
   // The current committee session for the GSB election
   currentCommitteeSessionElectionGSB: CommitteeSession;
   // Newly created GSB User
@@ -157,7 +170,7 @@ export const test = base.extend<Fixtures>({
 
     await use(election);
   },
-  emptyElectionCSB: async ({ adminOne, eml230b_more_than_45_candidates }, use) => {
+  emptyElectionCSBLargeCouncil: async ({ adminOne, eml230b_more_than_45_candidates }, use) => {
     const { request } = adminOne;
     const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
     const election_data = await readFile(eml110a.path, "utf8");
@@ -167,6 +180,25 @@ export const test = base.extend<Fixtures>({
         committee_category: "CSB",
         election_data,
         election_hash: eml110a.fullHash,
+        candidate_data,
+        candidate_hash: eml230b_more_than_45_candidates.fullHash,
+      },
+    });
+    expect(electionResponse.ok()).toBeTruthy();
+    const election = (await electionResponse.json()) as Election;
+
+    await use(election);
+  },
+  emptyElectionCSBSmallCouncil: async ({ adminOne, eml230b_more_than_45_candidates }, use) => {
+    const { request } = adminOne;
+    const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
+    const election_data = await readFile(eml110a_less_than_19_seats.path, "utf8");
+    const candidate_data = await readFile(eml230b_more_than_45_candidates.path, "utf8");
+    const electionResponse = await request.post(url, {
+      data: {
+        committee_category: "CSB",
+        election_data,
+        election_hash: eml110a_less_than_19_seats.fullHash,
         candidate_data,
         candidate_hash: eml230b_more_than_45_candidates.fullHash,
       },
@@ -208,9 +240,34 @@ export const test = base.extend<Fixtures>({
 
     await use(response);
   },
-  electionCSB: async ({ adminOne, coordinatorOneCSB, emptyElectionCSB }, use) => {
+  electionCSBLargeCouncil: async ({ adminOne, coordinatorOneCSB, emptyElectionCSBLargeCouncil }, use) => {
     // get election details
-    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionCSB.id}`;
+    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionCSBLargeCouncil.id}`;
+    const electionResponse = await adminOne.request.get(electionUrl);
+    expect(electionResponse.ok()).toBeTruthy();
+    const response = (await electionResponse.json()) as ElectionDetailsResponse;
+
+    // Set committee session status to DataEntry
+    const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}/status`;
+    const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status: "data_entry" };
+    const statusChangeResponse = await coordinatorOneCSB.request.put(statusChangeUrl, { data: statusChangeData });
+    expect(statusChangeResponse.ok()).toBeTruthy();
+
+    // Fill in committee session details
+    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}`;
+    const detailsUpdateData: COMMITTEE_SESSION_UPDATE_REQUEST_BODY = {
+      location: "Den Haag",
+      start_date: "2026-03-18",
+      start_time: "21:45",
+    };
+    const detailsUpdateResponse = await coordinatorOneCSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
+    expect(detailsUpdateResponse.ok()).toBeTruthy();
+
+    await use(response);
+  },
+  electionCSBSmallCouncil: async ({ adminOne, coordinatorOneCSB, emptyElectionCSBSmallCouncil }, use) => {
+    // get election details
+    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionCSBSmallCouncil.id}`;
     const electionResponse = await adminOne.request.get(electionUrl);
     expect(electionResponse.ok()).toBeTruthy();
     const response = (await electionResponse.json()) as ElectionDetailsResponse;
@@ -308,10 +365,10 @@ export const test = base.extend<Fixtures>({
 
     await use(electionGSB.election);
   },
-  completedElectionCSB: async ({ electionCSB, typistOneCSB, typistTwoCSB }, use) => {
+  completedElectionCSB: async ({ electionCSBLargeCouncil, typistOneCSB, typistTwoCSB }, use) => {
     const { request } = typistOneCSB;
     // get the existing election statuses
-    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSB.election.id}/status`;
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSBLargeCouncil.election.id}/status`;
     const response = await request.get(url);
     expect(response.ok()).toBeTruthy();
     const electionStatus = (await response.json()) as ElectionStatusResponse;
@@ -326,12 +383,15 @@ export const test = base.extend<Fixtures>({
       dataEntryRequestGSB,
     );
 
-    await use(electionCSB.election);
+    await use(electionCSBLargeCouncil.election);
   },
-  completedElectionCSBWithDrawingLots: async ({ electionCSB, typistOneCSB, typistTwoCSB }, use) => {
+  completedElectionCSBWithDrawingLotsForListAndCandidate: async (
+    { electionCSBLargeCouncil, typistOneCSB, typistTwoCSB },
+    use,
+  ) => {
     const { request } = typistOneCSB;
     // get the existing election statuses
-    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSB.election.id}/status`;
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSBLargeCouncil.election.id}/status`;
     const response = await request.get(url);
     expect(response.ok()).toBeTruthy();
     const electionStatus = (await response.json()) as ElectionStatusResponse;
@@ -342,11 +402,31 @@ export const test = base.extend<Fixtures>({
       dataEntryId,
       typistOneCSB.request,
       typistTwoCSB.request,
-      dataEntryRequestGSBTriggeringDrawingLots,
-      dataEntryRequestGSBTriggeringDrawingLots,
+      dataEntryRequestGSBTriggeringDrawingLotsForListAndCandidate,
+      dataEntryRequestGSBTriggeringDrawingLotsForListAndCandidate,
     );
 
-    await use(electionCSB.election);
+    await use(electionCSBLargeCouncil.election);
+  },
+  completedElectionCSBWithDrawingLotsForP9: async ({ electionCSBSmallCouncil, typistOneCSB, typistTwoCSB }, use) => {
+    const { request } = typistOneCSB;
+    // get the existing election statuses
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSBSmallCouncil.election.id}/status`;
+    const response = await request.get(url);
+    expect(response.ok()).toBeTruthy();
+    const electionStatus = (await response.json()) as ElectionStatusResponse;
+    const dataEntryId = electionStatus.statuses[0]!.data_entry_id;
+
+    // finalise both data entries for the subcommittee
+    await completeDataEntries(
+      dataEntryId,
+      typistOneCSB.request,
+      typistTwoCSB.request,
+      dataEntryRequestGSBTriggeringDrawingLotsForP9,
+      dataEntryRequestGSBTriggeringDrawingLotsForP9,
+    );
+
+    await use(electionCSBSmallCouncil.election);
   },
   currentCommitteeSessionElectionGSB: async ({ electionGSB }, use) => {
     await use(electionGSB.current_committee_session);

--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -7,6 +7,7 @@ import { type Eml230b, eml110a, eml230b, eml230b_more_than_45_candidates } from 
 import {
   dataEntryRequest,
   dataEntryRequestGSB,
+  dataEntryRequestGSBTriggeringDrawingLots,
   dataEntryWithDifferencesRequest,
   dataEntryWithErrorRequest,
   pollingStationRequests,
@@ -82,6 +83,8 @@ type Fixtures = {
   completedElectionGSB: Election;
   // CSB election with subcommittee and two completed data entries
   completedElectionCSB: Election;
+  // CSB election with subcommittee and two completed data entries that triggers drawing lots for lists and candidates
+  completedElectionCSBWithDrawingLots: Election;
   // The current committee session for the GSB election
   currentCommitteeSessionElectionGSB: CommitteeSession;
   // Newly created GSB User
@@ -321,6 +324,26 @@ export const test = base.extend<Fixtures>({
       typistTwoCSB.request,
       dataEntryRequestGSB,
       dataEntryRequestGSB,
+    );
+
+    await use(electionCSB.election);
+  },
+  completedElectionCSBWithDrawingLots: async ({ electionCSB, typistOneCSB, typistTwoCSB }, use) => {
+    const { request } = typistOneCSB;
+    // get the existing election statuses
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionCSB.election.id}/status`;
+    const response = await request.get(url);
+    expect(response.ok()).toBeTruthy();
+    const electionStatus = (await response.json()) as ElectionStatusResponse;
+    const dataEntryId = electionStatus.statuses[0]!.data_entry_id;
+
+    // finalise both data entries for the subcommittee
+    await completeDataEntries(
+      dataEntryId,
+      typistOneCSB.request,
+      typistTwoCSB.request,
+      dataEntryRequestGSBTriggeringDrawingLots,
+      dataEntryRequestGSBTriggeringDrawingLots,
     );
 
     await use(electionCSB.election);

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
@@ -55,7 +55,7 @@ export class Apportionment {
     this.manageDeceasedCandidates = page.getByRole("link", { name: "Beheer overleden kandidaten" });
   }
 
-  getAlert(text: string) {
+  getAlertByText(text: string) {
     return this.page.getByRole("alert").filter({
       hasText: text,
     });

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
@@ -8,6 +8,8 @@ export class Apportionment {
   readonly drawingLotsForListNeededAlert: Locator;
   readonly toDrawingLots: Locator;
   readonly toResidualSeatAllocationDetails: Locator;
+  private readonly drawingLotsForP9Needed: Locator;
+  readonly drawingLotsForP9NeededAlert: Locator;
   private readonly drawingLotsForCandidateNeeded: Locator;
   readonly drawingLotsForCandidateNeededAlert: Locator;
   readonly preliminaryResult: Locator;
@@ -33,14 +35,18 @@ export class Apportionment {
       hasText: /Loting noodzakelijk voor toekennen restzetel \d/,
     });
     this.drawingLotsForListNeededAlert = page.getByRole("alert").filter({ has: this.drawingLotsForListNeeded });
-    this.toDrawingLots = page.getByRole("link", { name: "Naar loting" });
-    this.toResidualSeatAllocationDetails = page.getByRole("link", { name: "Details restzetelverdeling" });
+    this.drawingLotsForP9Needed = page.getByRole("strong").filter({
+      hasText: "Loting noodzakelijk vanwege volstrekte meerderheid",
+    });
+    this.drawingLotsForP9NeededAlert = page.getByRole("alert").filter({ has: this.drawingLotsForP9Needed });
     this.drawingLotsForCandidateNeeded = page.getByRole("strong").filter({
       hasText: "Loting noodzakelijk voor kandidaten met gelijk aantal voorkeursstemmen",
     });
     this.drawingLotsForCandidateNeededAlert = page
       .getByRole("alert")
       .filter({ has: this.drawingLotsForCandidateNeeded });
+    this.toDrawingLots = page.getByRole("link", { name: /Naar loting/ });
+    this.toResidualSeatAllocationDetails = page.getByRole("link", { name: "Details restzetelverdeling" });
 
     this.preliminaryResult = page.getByRole("heading", { level: 2, name: "Voorlopig resultaat" });
     this.apportionment = page.getByRole("heading", { level: 2, name: "Zetelverdeling" });

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
@@ -3,9 +3,17 @@ import type { Locator, Page } from "@playwright/test";
 export class Apportionment {
   readonly allSeatsAssigned: Locator;
   readonly allSeatsAssignedAlert: Locator;
+  readonly toReport: Locator;
+  readonly drawingLotsForListNeeded: Locator;
+  readonly drawingLotsForListNeededAlert: Locator;
+  readonly toDrawingLots: Locator;
+  readonly toResidualSeatAllocationDetails: Locator;
+  readonly drawingLotsForCandidateNeeded: Locator;
+  readonly drawingLotsForCandidateNeededAlert: Locator;
+  readonly preliminaryResult: Locator;
+  readonly apportionment: Locator;
   readonly apportionmentTable: Locator;
   readonly header: Locator;
-  readonly toReport: Locator;
   readonly fullSeatInformation: Locator;
   readonly fullSeatsPageLink: Locator;
   readonly residualSeatInformation: Locator;
@@ -18,11 +26,25 @@ export class Apportionment {
     this.allSeatsAssigned = page.getByRole("strong").filter({
       hasText: "Alle zetels zijn toegewezen",
     });
-
-    this.apportionmentTable = page.getByTestId("apportionment-table");
-
     this.allSeatsAssignedAlert = page.getByRole("alert").filter({ has: this.allSeatsAssigned });
     this.toReport = page.getByRole("link", { name: "Naar proces-verbaal" });
+
+    this.drawingLotsForListNeeded = page.getByRole("strong").filter({
+      hasText: /Loting noodzakelijk voor toekennen restzetel \d/,
+    });
+    this.drawingLotsForListNeededAlert = page.getByRole("alert").filter({ has: this.drawingLotsForListNeeded });
+    this.toDrawingLots = page.getByRole("link", { name: "Naar loting" });
+    this.toResidualSeatAllocationDetails = page.getByRole("link", { name: "Details restzetelverdeling" });
+    this.drawingLotsForCandidateNeeded = page.getByRole("strong").filter({
+      hasText: "Loting noodzakelijk voor kandidaten met gelijk aantal voorkeursstemmen",
+    });
+    this.drawingLotsForCandidateNeededAlert = page
+      .getByRole("alert")
+      .filter({ has: this.drawingLotsForCandidateNeeded });
+
+    this.preliminaryResult = page.getByRole("heading", { level: 2, name: "Voorlopig resultaat" });
+    this.apportionment = page.getByRole("heading", { level: 2, name: "Zetelverdeling" });
+    this.apportionmentTable = page.getByTestId("apportionment-table");
 
     this.fullSeatInformation = page.getByText(/\d+ zetels werden als volle zetel toegewezen/);
     this.fullSeatsPageLink = this.fullSeatInformation.getByRole("link", { name: "bekijk details" });
@@ -31,6 +53,12 @@ export class Apportionment {
     this.residualSeatsPageLink = this.residualSeatInformation.getByRole("link", { name: "bekijk details" });
 
     this.manageDeceasedCandidates = page.getByRole("link", { name: "Beheer overleden kandidaten" });
+  }
+
+  getAlert(text: string) {
+    return this.page.getByRole("alert").filter({
+      hasText: text,
+    });
   }
 
   async clickList(listNumber: number) {

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentPgObj.ts
@@ -1,14 +1,14 @@
 import type { Locator, Page } from "@playwright/test";
 
 export class Apportionment {
-  readonly allSeatsAssigned: Locator;
+  private readonly allSeatsAssigned: Locator;
   readonly allSeatsAssignedAlert: Locator;
   readonly toReport: Locator;
-  readonly drawingLotsForListNeeded: Locator;
+  private readonly drawingLotsForListNeeded: Locator;
   readonly drawingLotsForListNeededAlert: Locator;
   readonly toDrawingLots: Locator;
   readonly toResidualSeatAllocationDetails: Locator;
-  readonly drawingLotsForCandidateNeeded: Locator;
+  private readonly drawingLotsForCandidateNeeded: Locator;
   readonly drawingLotsForCandidateNeededAlert: Locator;
   readonly preliminaryResult: Locator;
   readonly apportionment: Locator;

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj.ts
@@ -5,15 +5,21 @@ export class ApportionmentResidualSeats {
 
   private readonly drawingLotsForListNeeded: Locator;
   readonly drawingLotsForListNeededAlert: Locator;
+  private readonly drawingLotsForP9Needed: Locator;
+  readonly drawingLotsForP9NeededAlert: Locator;
   readonly toDrawingLots: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1, name: "Verdeling van de restzetels" });
 
     this.drawingLotsForListNeeded = page.getByRole("strong").filter({
-      hasText: /Er is nog \d restzetel te verdelen/,
+      hasText: "Er is nog 1 restzetel te verdelen.",
     });
     this.drawingLotsForListNeededAlert = page.getByRole("alert").filter({ has: this.drawingLotsForListNeeded });
+    this.drawingLotsForP9Needed = page.getByRole("strong").filter({
+      hasText: "Er moet 1 restzetel worden afgestaan.",
+    });
+    this.drawingLotsForP9NeededAlert = page.getByRole("alert").filter({ has: this.drawingLotsForP9Needed });
     this.toDrawingLots = page.getByRole("link", { name: "Ga naar loting" });
   }
 }

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj.ts
@@ -3,7 +3,17 @@ import type { Locator, Page } from "@playwright/test";
 export class ApportionmentResidualSeats {
   readonly header: Locator;
 
+  readonly drawingLotsForListNeeded: Locator;
+  readonly drawingLotsForListNeededAlert: Locator;
+  readonly toDrawingLots: Locator;
+
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1, name: "Verdeling van de restzetels" });
+
+    this.drawingLotsForListNeeded = page.getByRole("strong").filter({
+      hasText: /Er is nog \d restzetel te verdelen/,
+    });
+    this.drawingLotsForListNeededAlert = page.getByRole("alert").filter({ has: this.drawingLotsForListNeeded });
+    this.toDrawingLots = page.getByRole("link", { name: "Ga naar loting" });
   }
 }

--- a/frontend/e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj.ts
@@ -3,7 +3,7 @@ import type { Locator, Page } from "@playwright/test";
 export class ApportionmentResidualSeats {
   readonly header: Locator;
 
-  readonly drawingLotsForListNeeded: Locator;
+  private readonly drawingLotsForListNeeded: Locator;
   readonly drawingLotsForListNeededAlert: Locator;
   readonly toDrawingLots: Locator;
 

--- a/frontend/e2e-tests/page-objects/apportionment/DrawingLotsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/DrawingLotsPgObj.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from "@playwright/test";
+
+export class DrawingLots {
+  readonly title: Locator;
+  readonly list: Locator;
+  readonly instructions: Locator;
+  readonly result: Locator;
+  readonly next: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.title = page.getByRole("heading", { level: 2, name: "Loting noodzakelijk" });
+    this.list = page.getByRole("list", { name: "drawing-lots-information" });
+    this.instructions = page.getByRole("heading", { level: 3, name: "Instructies voor loting" });
+    this.result = page.getByRole("heading", { level: 3, name: "Resultaat loting" });
+    this.next = page.getByRole("button", { name: "Volgende" });
+  }
+
+  getHeaderByName(name: string) {
+    return this.page.getByRole("heading", { level: 1, name: name });
+  }
+
+  getListItemByText(text: string) {
+    return this.list.getByRole("listitem").filter({ hasText: text });
+  }
+
+  getOptionByName(name: string) {
+    return this.page.getByRole("radio", { name: name });
+  }
+}

--- a/frontend/e2e-tests/page-objects/apportionment/DrawingLotsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/DrawingLotsPgObj.ts
@@ -9,7 +9,7 @@ export class DrawingLots {
 
   constructor(protected readonly page: Page) {
     this.title = page.getByRole("heading", { level: 2, name: "Loting noodzakelijk" });
-    this.list = page.getByRole("list", { name: "drawing-lots-information" });
+    this.list = page.getByTestId("drawing-lots-information");
     this.instructions = page.getByRole("heading", { level: 3, name: "Instructies voor loting" });
     this.result = page.getByRole("heading", { level: 3, name: "Resultaat loting" });
     this.next = page.getByRole("button", { name: "Volgende" });

--- a/frontend/e2e-tests/page-objects/apportionment/IncludeAllCandidatesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/apportionment/IncludeAllCandidatesPgObj.ts
@@ -2,7 +2,7 @@ import type { Locator, Page } from "@playwright/test";
 
 export class IncludeAllCandidates {
   readonly header: Locator;
-  readonly dataEntryFinished: Locator;
+  private readonly dataEntryFinished: Locator;
   readonly dataEntryFinishedAlert: Locator;
   readonly title: Locator;
   readonly noDeceased: Locator;

--- a/frontend/e2e-tests/test-data/eml-files.ts
+++ b/frontend/e2e-tests/test-data/eml-files.ts
@@ -25,6 +25,33 @@ export const eml110a = {
   ],
 };
 
+export const eml110a_less_than_19_seats = {
+  filename: "eml110a_test_less_than_19_seats.eml.xml",
+  path: "../backend/src/eml/tests/eml110a_test_less_than_19_seats.eml.xml",
+  electionName: "Gemeenteraad Test 2022",
+  electionDate: "woensdag 16 maart 2022",
+  hashInput1: "f369",
+  hashInput2: "2efd",
+  fullHash: [
+    "f369",
+    "ea57",
+    "0b45",
+    "a68e",
+    "416e",
+    "a6a3",
+    "1a39",
+    "91ec",
+    "5a33",
+    "0785",
+    "ee27",
+    "2efd",
+    "c376",
+    "e869",
+    "e3c3",
+    "9848",
+  ],
+};
+
 export const eml110b = {
   filename: "eml110b_test.eml.xml",
   path: "../backend/src/eml/tests/eml110b_test.eml.xml",

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -591,7 +591,7 @@ export const noRecountNoDifferencesDataEntryGSB: GSBResults & { model: "GSB" } =
   ],
 };
 
-export const noRecountNoDifferencesDrawingLotsDataEntryGSB: GSBResults & { model: "GSB" } = {
+export const noRecountNoDifferencesDrawingLotsForListAndCandidateDataEntryGSB: GSBResults & { model: "GSB" } = {
   model: "GSB",
   number_of_voters: 612694,
   voters_counts: {
@@ -894,6 +894,309 @@ export const noRecountNoDifferencesDrawingLotsDataEntryGSB: GSBResults & { model
   ],
 };
 
+export const noRecountNoDifferencesDrawingLotsForP9DataEntryGSB: GSBResults & { model: "GSB" } = {
+  model: "GSB",
+  number_of_voters: 8000,
+  voters_counts: {
+    poll_card_count: 5103,
+    proxy_certificate_count: 500,
+    total_admitted_voters_count: 5603,
+  },
+  votes_counts: {
+    political_group_total_votes: [
+      { number: 1, total: 2552 },
+      { number: 2, total: 511 },
+      { number: 3, total: 511 },
+      { number: 4, total: 511 },
+      { number: 5, total: 509 },
+      { number: 6, total: 509 },
+      { number: 7, total: 0 },
+      { number: 8, total: 0 },
+      { number: 9, total: 0 },
+    ],
+    total_votes_candidates_count: 5103,
+    blank_votes_count: 300,
+    invalid_votes_count: 200,
+    total_votes_cast_count: 5603,
+  },
+  differences_counts: {
+    more_ballots_count: 0,
+    fewer_ballots_count: 0,
+  },
+  political_group_votes: [
+    {
+      number: 1,
+      total: 2552,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 1000,
+        },
+        {
+          number: 2,
+          votes: 400,
+        },
+        {
+          number: 3,
+          votes: 300,
+        },
+        {
+          number: 4,
+          votes: 200,
+        },
+        {
+          number: 5,
+          votes: 100,
+        },
+        {
+          number: 6,
+          votes: 50,
+        },
+        {
+          number: 7,
+          votes: 2,
+        },
+        {
+          number: 8,
+          votes: 0,
+        },
+        {
+          number: 9,
+          votes: 0,
+        },
+        {
+          number: 10,
+          votes: 0,
+        },
+        {
+          number: 11,
+          votes: 0,
+        },
+        {
+          number: 12,
+          votes: 500,
+        },
+      ],
+    },
+    {
+      number: 2,
+      total: 511,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 500,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+        {
+          number: 3,
+          votes: 0,
+        },
+        {
+          number: 4,
+          votes: 11,
+        },
+      ],
+    },
+    {
+      number: 3,
+      total: 511,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 400,
+        },
+        {
+          number: 2,
+          votes: 111,
+        },
+      ],
+    },
+    {
+      number: 4,
+      total: 511,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 300,
+        },
+        {
+          number: 2,
+          votes: 100,
+        },
+        {
+          number: 3,
+          votes: 0,
+        },
+        {
+          number: 4,
+          votes: 0,
+        },
+        {
+          number: 5,
+          votes: 0,
+        },
+        {
+          number: 6,
+          votes: 0,
+        },
+        {
+          number: 7,
+          votes: 0,
+        },
+        {
+          number: 8,
+          votes: 0,
+        },
+        {
+          number: 9,
+          votes: 0,
+        },
+        {
+          number: 10,
+          votes: 0,
+        },
+        {
+          number: 11,
+          votes: 0,
+        },
+        {
+          number: 12,
+          votes: 111,
+        },
+      ],
+    },
+    {
+      number: 5,
+      total: 509,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 500,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+        {
+          number: 3,
+          votes: 0,
+        },
+        {
+          number: 4,
+          votes: 9,
+        },
+      ],
+    },
+    {
+      number: 6,
+      total: 509,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 450,
+        },
+        {
+          number: 2,
+          votes: 59,
+        },
+      ],
+    },
+    {
+      number: 7,
+      total: 0,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 0,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+        {
+          number: 3,
+          votes: 0,
+        },
+        {
+          number: 4,
+          votes: 0,
+        },
+        {
+          number: 5,
+          votes: 0,
+        },
+        {
+          number: 6,
+          votes: 0,
+        },
+        {
+          number: 7,
+          votes: 0,
+        },
+        {
+          number: 8,
+          votes: 0,
+        },
+        {
+          number: 9,
+          votes: 0,
+        },
+        {
+          number: 10,
+          votes: 0,
+        },
+        {
+          number: 11,
+          votes: 0,
+        },
+        {
+          number: 12,
+          votes: 0,
+        },
+      ],
+    },
+    {
+      number: 8,
+      total: 0,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 0,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+        {
+          number: 3,
+          votes: 0,
+        },
+        {
+          number: 4,
+          votes: 0,
+        },
+      ],
+    },
+    {
+      number: 9,
+      total: 0,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 0,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+      ],
+    },
+  ],
+};
+
 export const dataEntryRequest: DataEntry = {
   progress: 87,
   data: noRecountNoDifferencesDataEntry,
@@ -916,9 +1219,20 @@ export const dataEntryRequestGSB: DataEntry = {
   },
 };
 
-export const dataEntryRequestGSBTriggeringDrawingLots: DataEntry = {
+export const dataEntryRequestGSBTriggeringDrawingLotsForListAndCandidate: DataEntry = {
   progress: 100,
-  data: noRecountNoDifferencesDrawingLotsDataEntryGSB,
+  data: noRecountNoDifferencesDrawingLotsForListAndCandidateDataEntryGSB,
+  client_state: {
+    furthest: "political_group_votes_9",
+    current: "political_group_votes_9",
+    acceptedErrorsAndWarnings: [],
+    continue: true,
+  },
+};
+
+export const dataEntryRequestGSBTriggeringDrawingLotsForP9: DataEntry = {
+  progress: 100,
+  data: noRecountNoDifferencesDrawingLotsForP9DataEntryGSB,
   client_state: {
     furthest: "political_group_votes_9",
     current: "political_group_votes_9",

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -916,6 +916,17 @@ export const dataEntryRequestGSB: DataEntry = {
   },
 };
 
+export const dataEntryRequestGSBTriggeringDrawingLots: DataEntry = {
+  progress: 100,
+  data: noRecountNoDifferencesDrawingLotsDataEntryGSB,
+  client_state: {
+    furthest: "political_group_votes_9",
+    current: "political_group_votes_9",
+    acceptedErrorsAndWarnings: [],
+    continue: true,
+  },
+};
+
 export const dataEntryWithErrorRequest: DataEntry = {
   progress: 86,
   data: {

--- a/frontend/e2e-tests/tests/apportionment/drawing-lots-for-list-and-candidate.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/drawing-lots-for-list-and-candidate.e2e.ts
@@ -1,0 +1,132 @@
+import { expect } from "@playwright/test";
+import { ApportionmentListDetails } from "e2e-tests/page-objects/apportionment/ApportionmentListDetailsPgObj";
+import { Apportionment } from "e2e-tests/page-objects/apportionment/ApportionmentPgObj";
+import { ApportionmentResidualSeats } from "e2e-tests/page-objects/apportionment/ApportionmentResidualSeatsPgObj";
+import { DrawingLots } from "e2e-tests/page-objects/apportionment/DrawingLotsPgObj";
+import { IncludeAllCandidates } from "e2e-tests/page-objects/apportionment/IncludeAllCandidatesPgObj";
+import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
+import { FinishDataEntry } from "e2e-tests/page-objects/election/FinishDataEntryPgObj";
+import { test } from "../../fixtures";
+
+test.describe("CSB election apportionment", () => {
+  test("is calculated after drawing lots for lists and candidates", async ({
+    coordinatorOneCSB,
+    completedElectionCSBWithDrawingLots,
+  }) => {
+    const page = coordinatorOneCSB.page;
+    await page.goto(`/elections/${completedElectionCSBWithDrawingLots.id}/status`);
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.finish.click();
+
+    const finishDataEntryPage = new FinishDataEntry(page);
+    await finishDataEntryPage.finishDataEntry.click();
+
+    const includeAllCandidatesPage = new IncludeAllCandidates(page);
+    await expect(includeAllCandidatesPage.header).toBeVisible();
+    await expect(includeAllCandidatesPage.dataEntryFinishedAlert).toBeVisible();
+    await expect(includeAllCandidatesPage.title).toBeVisible();
+    await expect(includeAllCandidatesPage.noDeceased).toBeVisible();
+    await expect(includeAllCandidatesPage.hasDeceased).toBeVisible();
+    await includeAllCandidatesPage.noDeceased.check();
+    await includeAllCandidatesPage.next.click();
+
+    const apportionmentPage = new Apportionment(page);
+    await expect(apportionmentPage.header).toBeVisible();
+    await expect(apportionmentPage.preliminaryResult).toBeVisible();
+    await expect(apportionmentPage.drawingLotsForListNeededAlert).toBeVisible();
+    await expect(apportionmentPage.toResidualSeatAllocationDetails).toBeVisible();
+    await apportionmentPage.toResidualSeatAllocationDetails.click();
+    const apportionmentResidualSeatsPage = new ApportionmentResidualSeats(page);
+    await expect(apportionmentResidualSeatsPage.header).toBeVisible();
+    await expect(apportionmentResidualSeatsPage.drawingLotsForListNeededAlert).toBeVisible();
+    await expect(apportionmentResidualSeatsPage.toDrawingLots).toBeVisible();
+
+    await page.goBack();
+
+    await expect(apportionmentPage.toDrawingLots).toBeVisible();
+    await apportionmentPage.toDrawingLots.click();
+    const drawingLotsPage = new DrawingLots(page);
+    await expect(drawingLotsPage.getHeaderByName("Loting voor restzetel 6")).toBeVisible();
+    await expect(drawingLotsPage.title).toBeVisible();
+    await expect(drawingLotsPage.list).toBeVisible();
+    await expect(drawingLotsPage.getListItemByText("Er zijn 6 restzetels te verdelen")).toBeVisible();
+    await expect(drawingLotsPage.getListItemByText("Restzetel 6 kan niet automatisch worden toegewezen")).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText(
+        "De partij met het hoogste gemiddeld aantal stemmen bij het toewijzen van de restzetel krijgt de restzetel",
+      ),
+    ).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText(
+        "Lijst 2 – Partij voor de Stemmer en Lijst 3 – Stemmmers 22 hebben samen het hoogste gemiddeld aantal stemmen per zetel (5.000 stemmen)",
+      ),
+    ).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText("Daarom moet er geloot worden welke lijst de restzetel krijgt"),
+    ).toBeVisible();
+    await expect(drawingLotsPage.instructions).toBeVisible();
+    await expect(drawingLotsPage.result).toBeVisible();
+    const listOption1 = drawingLotsPage.getOptionByName("Lijst 2 – Partij voor de Stemmer");
+    const listOption2 = drawingLotsPage.getOptionByName("Lijst 3 – Stemmmers 22");
+    await expect(listOption1).toBeVisible();
+    await expect(listOption2).toBeVisible();
+    await listOption2.check();
+    await drawingLotsPage.next.click();
+
+    await expect(apportionmentPage.header).toBeVisible();
+    await expect(apportionmentPage.preliminaryResult).toBeVisible();
+    await expect(
+      apportionmentPage.getAlert(
+        "Restzetel 6 kon niet automatisch worden toegewezen en is na loting toegekend aan Lijst 3 – Stemmmers 22 (er is geloot tussen lijst 2 en 3).",
+      ),
+    ).toBeVisible();
+
+    await expect(apportionmentPage.drawingLotsForCandidateNeededAlert).toBeVisible();
+    await expect(apportionmentPage.toDrawingLots).toBeVisible();
+    await apportionmentPage.toDrawingLots.click();
+
+    await expect(drawingLotsPage.getHeaderByName("Loting voor kandidaten met evenveel stemmen")).toBeVisible();
+    await expect(drawingLotsPage.title).toBeVisible();
+    await expect(drawingLotsPage.list).toBeVisible();
+    await expect(drawingLotsPage.getListItemByText("Lijst 2 – Partij voor de Stemmer heeft 1 zetel")).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText(
+        "Er zijn 4 kandidaten die op basis van hun voorkeursstemmen in aanmerking komen voor zetel 1. Zij hebben allen 2500 stemmen. Het gaat om de kandidaten:",
+      ),
+    ).toBeVisible();
+    await expect(drawingLotsPage.getListItemByText("Daarom moet er geloot worden wie zetel 1 krijgt")).toBeVisible();
+    await expect(drawingLotsPage.instructions).toBeVisible();
+    await expect(drawingLotsPage.result).toBeVisible();
+    const candidateOption1 = drawingLotsPage.getOptionByName("1. Van der Spek, C.P.M. (Charèl)");
+    const candidateOption2 = drawingLotsPage.getOptionByName("2. Arets, W.P. (Tjeu)");
+    const candidateOption3 = drawingLotsPage.getOptionByName("3. Van den Arets, X.T. (Xuan)");
+    const candidateOption4 = drawingLotsPage.getOptionByName("4. Van den Eijnden, F.M. (Frédérique)");
+    await expect(candidateOption1).toBeVisible();
+    await expect(candidateOption2).toBeVisible();
+    await expect(candidateOption3).toBeVisible();
+    await expect(candidateOption4).toBeVisible();
+    await candidateOption3.check();
+    await drawingLotsPage.next.click();
+
+    await expect(apportionmentPage.header).toBeVisible();
+    await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
+    await expect(apportionmentPage.apportionment).toBeVisible();
+    // Alert with drawing lots for list result is still visible
+    await expect(
+      apportionmentPage.getAlert(
+        "Restzetel 6 kon niet automatisch worden toegewezen en is na loting toegekend aan Lijst 3 – Stemmmers 22 (er is geloot tussen lijst 2 en 3).",
+      ),
+    ).toBeVisible();
+    await expect(apportionmentPage.apportionmentTable).toBeVisible();
+    await apportionmentPage.clickList(2);
+
+    const listDetailsPage = new ApportionmentListDetails(page);
+    await expect(listDetailsPage.header).toBeVisible();
+    await expect(listDetailsPage.header).toContainText("Lijst 2 – Partij voor de Stemmer");
+    await expect(listDetailsPage.alert).toBeVisible();
+    await expect(listDetailsPage.alert).toContainText(
+      "Zetel 1 is na loting toegewezen aan Kandidaat 3 – Van den Arets, X.T. (Xuan) (er is geloot tussen kandidaat 1, 2, 3 en 4)",
+    );
+  });
+});

--- a/frontend/e2e-tests/tests/apportionment/drawing-lots-for-list-and-candidate.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/drawing-lots-for-list-and-candidate.e2e.ts
@@ -77,7 +77,7 @@ test.describe("CSB election apportionment", () => {
     await expect(apportionmentPage.header).toBeVisible();
     await expect(apportionmentPage.preliminaryResult).toBeVisible();
     await expect(
-      apportionmentPage.getAlert(
+      apportionmentPage.getAlertByText(
         "Restzetel 6 kon niet automatisch worden toegewezen en is na loting toegekend aan Lijst 3 – Stemmmers 22 (er is geloot tussen lijst 2 en 3).",
       ),
     ).toBeVisible();
@@ -114,7 +114,7 @@ test.describe("CSB election apportionment", () => {
     await expect(apportionmentPage.apportionment).toBeVisible();
     // Alert with drawing lots for list result is still visible
     await expect(
-      apportionmentPage.getAlert(
+      apportionmentPage.getAlertByText(
         "Restzetel 6 kon niet automatisch worden toegewezen en is na loting toegekend aan Lijst 3 – Stemmmers 22 (er is geloot tussen lijst 2 en 3).",
       ),
     ).toBeVisible();

--- a/frontend/e2e-tests/tests/apportionment/drawing-lots-for-list-and-candidate.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/drawing-lots-for-list-and-candidate.e2e.ts
@@ -111,6 +111,7 @@ test.describe("CSB election apportionment", () => {
 
     await expect(apportionmentPage.header).toBeVisible();
     await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
+    await expect(apportionmentPage.toReport).toBeVisible();
     await expect(apportionmentPage.apportionment).toBeVisible();
     // Alert with drawing lots for list result is still visible
     await expect(

--- a/frontend/e2e-tests/tests/apportionment/drawing-lots.e2e.ts
+++ b/frontend/e2e-tests/tests/apportionment/drawing-lots.e2e.ts
@@ -11,10 +11,10 @@ import { test } from "../../fixtures";
 test.describe("CSB election apportionment", () => {
   test("is calculated after drawing lots for lists and candidates", async ({
     coordinatorOneCSB,
-    completedElectionCSBWithDrawingLots,
+    completedElectionCSBWithDrawingLotsForListAndCandidate,
   }) => {
     const page = coordinatorOneCSB.page;
-    await page.goto(`/elections/${completedElectionCSBWithDrawingLots.id}/status`);
+    await page.goto(`/elections/${completedElectionCSBWithDrawingLotsForListAndCandidate.id}/status`);
 
     const electionStatusPage = new ElectionStatus(page);
     await electionStatusPage.finish.click();
@@ -129,5 +129,88 @@ test.describe("CSB election apportionment", () => {
     await expect(listDetailsPage.alert).toContainText(
       "Zetel 1 is na loting toegewezen aan Kandidaat 3 – Van den Arets, X.T. (Xuan) (er is geloot tussen kandidaat 1, 2, 3 en 4)",
     );
+  });
+
+  test("is calculated after drawing lots for absolute majority reassignment", async ({
+    coordinatorOneCSB,
+    completedElectionCSBWithDrawingLotsForP9,
+  }) => {
+    const page = coordinatorOneCSB.page;
+    await page.goto(`/elections/${completedElectionCSBWithDrawingLotsForP9.id}/status`);
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.finish.click();
+
+    const finishDataEntryPage = new FinishDataEntry(page);
+    await finishDataEntryPage.finishDataEntry.click();
+
+    const includeAllCandidatesPage = new IncludeAllCandidates(page);
+    await expect(includeAllCandidatesPage.header).toBeVisible();
+    await expect(includeAllCandidatesPage.dataEntryFinishedAlert).toBeVisible();
+    await expect(includeAllCandidatesPage.title).toBeVisible();
+    await expect(includeAllCandidatesPage.noDeceased).toBeVisible();
+    await expect(includeAllCandidatesPage.hasDeceased).toBeVisible();
+    await includeAllCandidatesPage.noDeceased.check();
+    await includeAllCandidatesPage.next.click();
+
+    const apportionmentPage = new Apportionment(page);
+    await expect(apportionmentPage.header).toBeVisible();
+    await expect(apportionmentPage.preliminaryResult).toBeVisible();
+    await expect(
+      apportionmentPage.getAlertByText("Lijst 2, 3 of 4 moet een zetel afstaan aan lijst 1. Ga naar loting"),
+    ).toBeVisible();
+    await expect(apportionmentPage.drawingLotsForP9NeededAlert).toBeVisible();
+    await expect(apportionmentPage.toResidualSeatAllocationDetails).toBeVisible();
+    await apportionmentPage.toResidualSeatAllocationDetails.click();
+    const apportionmentResidualSeatsPage = new ApportionmentResidualSeats(page);
+    await expect(apportionmentResidualSeatsPage.header).toBeVisible();
+    await expect(apportionmentResidualSeatsPage.drawingLotsForP9NeededAlert).toBeVisible();
+    await expect(apportionmentResidualSeatsPage.toDrawingLots).toBeVisible();
+
+    await page.goBack();
+
+    await expect(apportionmentPage.toDrawingLots).toBeVisible();
+    await apportionmentPage.toDrawingLots.click();
+    const drawingLotsPage = new DrawingLots(page);
+    await expect(drawingLotsPage.getHeaderByName("Loting voor afstaan restzetel aan lijst 1")).toBeVisible();
+    await expect(drawingLotsPage.title).toBeVisible();
+    await expect(drawingLotsPage.list).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText(
+        "Lijst 1 heeft de volstrekte meerderheid van stemmen gekregen, maar heeft niet de volstrekte meerderheid aan zetels.",
+      ),
+    ).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText("De laatste restzetel moet worden afgestaan aan lijst 1."),
+    ).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText(
+        "Lijst 2, 3 en 4 hebben met hetzelfde overschot aan stemmen de laatste restzetels gekregen.",
+      ),
+    ).toBeVisible();
+    await expect(
+      drawingLotsPage.getListItemByText("Daarom moet er geloot worden welke lijst de restzetel moet afstaan"),
+    ).toBeVisible();
+    await expect(drawingLotsPage.instructions).toBeVisible();
+    await expect(drawingLotsPage.result).toBeVisible();
+    const listOption1 = drawingLotsPage.getOptionByName("Lijst 2 – Partij voor de Stemmer");
+    const listOption2 = drawingLotsPage.getOptionByName("Lijst 3 – Stemmmers 22");
+    const listOption3 = drawingLotsPage.getOptionByName("Lijst 4 – STEM");
+    await expect(listOption1).toBeVisible();
+    await expect(listOption2).toBeVisible();
+    await expect(listOption3).toBeVisible();
+    await listOption3.check();
+    await drawingLotsPage.next.click();
+
+    await expect(apportionmentPage.header).toBeVisible();
+    await expect(apportionmentPage.allSeatsAssignedAlert).toBeVisible();
+    await expect(apportionmentPage.toReport).toBeVisible();
+    await expect(apportionmentPage.apportionment).toBeVisible();
+    await expect(
+      apportionmentPage.getAlertByText(
+        "De laatste restzetel voor lijst 1 (artikel P 9) is na loting afgestaan door Lijst 4 – STEM (er is geloot tussen lijst 2, 3 en 4)",
+      ),
+    ).toBeVisible();
+    await expect(apportionmentPage.apportionmentTable).toBeVisible();
   });
 });

--- a/frontend/src/components/ui/Alert/Alert.module.css
+++ b/frontend/src/components/ui/Alert/Alert.module.css
@@ -60,6 +60,7 @@
     p {
       margin: 0;
       max-width: 40rem;
+      color: var(--base-black);
     }
 
     > ul {

--- a/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsForP9.stories.tsx
+++ b/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsForP9.stories.tsx
@@ -20,7 +20,7 @@ export const AbsoluteMajorityHighestAverage: StoryObj = {
     await expect(listitems[2]).toHaveTextContent(
       "Lijst 6 en 7 hebben met hetzelfde gemiddeld aantal stemmen de laatste restzetels gekregen.",
     );
-    await expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel krijgt");
+    await expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel moet afstaan");
   },
 };
 
@@ -40,7 +40,7 @@ export const AbsoluteMajorityLargestRemainder: StoryObj = {
     await expect(listitems[2]).toHaveTextContent(
       "Lijst 2, 3 en 4 hebben met hetzelfde overschot aan stemmen de laatste restzetels gekregen.",
     );
-    await expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel krijgt");
+    await expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel moet afstaan");
   },
 };
 

--- a/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsForP9.tsx
+++ b/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsForP9.tsx
@@ -34,7 +34,7 @@ export function DrawingLotsForP9({ drawingLotsRequired }: DrawingLotsForListProp
               : t("apportionment.remainder_of"),
         })}
       </li>
-      <li>{t("apportionment.drawing_lots_for_list.hence_drawing_lots_is_needed")}</li>
+      <li>{t("apportionment.drawing_lots_for_p9.hence_drawing_lots_is_needed")}</li>
     </ul>
   );
 }

--- a/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsPage.test.tsx
@@ -352,7 +352,7 @@ describe("DrawingLotsPage", () => {
     expect(listitems[2]).toHaveTextContent(
       "Lijst 6 en 7 hebben met hetzelfde gemiddeld aantal stemmen de laatste restzetels gekregen.",
     );
-    expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel krijgt");
+    expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel moet afstaan");
 
     expect(await screen.findByRole("heading", { level: 3, name: "Instructies voor loting" })).toBeVisible();
     expect(
@@ -443,7 +443,7 @@ describe("DrawingLotsPage", () => {
     expect(listitems[2]).toHaveTextContent(
       "Lijst 2, 3 en 4 hebben met hetzelfde overschot aan stemmen de laatste restzetels gekregen.",
     );
-    expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel krijgt");
+    expect(listitems[3]).toHaveTextContent("Daarom moet er geloot worden welke lijst de restzetel moet afstaan");
 
     expect(await screen.findByRole("heading", { level: 3, name: "Instructies voor loting" })).toBeVisible();
     expect(


### PR DESCRIPTION
Closes #1267 

## What & why

- Adds playwright test for drawing lots for list and candidate
- Adds playwright test for drawing lots for p9

### Fixes
- Incorrect copy for drawing lots for P9 (last list item)
- Font color of paragraphs in Alert (was dark grey, is now black)

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Run the new tests (for example by running (`pnpm run test:e2e-ui tests/apportionment`, select only `initialisation-test' and 'setup-test-users', run all, when done, select only one or more browsers and then run all)
- Verify the fixes by checking the stories and/or checking on an AbsoluteMajority drawing lots election from gen-test-election

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->