### PR TITLE
Always remove empty app dir in Windows installer

### DIFF
--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -73,6 +73,7 @@ Source: ".\VC_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
 Source: ".\{#MyAppIcon}"; DestDir: "{app}"
 
 [Dirs]
+Name: "{app}"; Flags: uninsalwaysuninstall
 Name: "{app}\{#MyBackupDirName}"
 
 [Icons]


### PR DESCRIPTION
## What & why

Always remove empty app dir in Windows installer. Resolves #3567.

## How to test

Run installer/uninstaller:
- Install
- Uninstall - select 'keep database and backups'
- Reinstall
- Uninstall - select 'remove database and backups'
- Abacus directory should be removed

## Reviewer notes

None.