### PR TITLE
Ensure TypeScript imports do not contain unnecessary file extensions 

### DIFF
--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -8,7 +8,7 @@ import { AbortModalPgObj } from "e2e-tests/page-objects/election/create/AbortMod
 import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckAndSavePgObj";
 import { CheckCandidateDefinitionPgObj } from "e2e-tests/page-objects/election/create/CheckCandidateDefinitionPgObj";
 import { CheckElectionDefinitionPgObj } from "e2e-tests/page-objects/election/create/CheckElectionDefinitionPgObj";
-import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj.ts";
+import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj";
 import { CountingMethodTypePgObj } from "e2e-tests/page-objects/election/create/CountingMethodTypePgObj";
 import { NumberOfVotersPgObj } from "e2e-tests/page-objects/election/create/NumberOfVotersPgObj";
 import { UploadCandidateDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadCandidateDefinitionPgObj";

--- a/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow-CSB.e2e.ts
@@ -16,7 +16,7 @@ import { AccountSetupPgObj } from "e2e-tests/page-objects/authentication/Account
 import { LoginPgObj } from "e2e-tests/page-objects/authentication/LoginPgObj";
 import { DataEntryHomePage } from "e2e-tests/page-objects/data_entry/DataEntryHomePgObj";
 import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckAndSavePgObj";
-import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj.ts";
+import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj";
 import { ElectionDetailsPgObj } from "e2e-tests/page-objects/election/ElectionDetailsPgObj";
 import { ElectionHome } from "e2e-tests/page-objects/election/ElectionHomePgObj";
 import { ElectionReport } from "e2e-tests/page-objects/election/ElectionReportPgObj";

--- a/frontend/e2e-tests/tests/full-flow-GSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow-GSB.e2e.ts
@@ -21,7 +21,7 @@ import { ExtraInvestigationPage } from "e2e-tests/page-objects/data_entry/ExtraI
 import { ProgressList } from "e2e-tests/page-objects/data_entry/ProgressListPgObj";
 import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
 import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckAndSavePgObj";
-import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj.ts";
+import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj";
 import { CountingMethodTypePgObj } from "e2e-tests/page-objects/election/create/CountingMethodTypePgObj";
 import { NumberOfVotersPgObj } from "e2e-tests/page-objects/election/create/NumberOfVotersPgObj";
 import { ElectionDetailsPgObj } from "e2e-tests/page-objects/election/ElectionDetailsPgObj";

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -36,6 +36,19 @@ export default defineConfig(
     ],
     rules: {
       "import-x/namespace": "off",
+      "import-x/extensions": [
+        "error",
+        "never",
+        {
+          pattern: {
+            css: "always",
+            json: "always",
+            webp: "always",
+          },
+          checkTypeImports: true,
+          fix: true,
+        },
+      ],
       "@typescript-eslint/no-unsafe-type-assertion": "error",
       "@typescript-eslint/restrict-template-expressions": [
         "error",

--- a/frontend/src/components/data_entry/CommitteeSessionPausedModal.tsx
+++ b/frontend/src/components/data_entry/CommitteeSessionPausedModal.tsx
@@ -2,7 +2,7 @@ import { CommitteeSessionStatusWithRightIcon } from "@/components/committee_sess
 import { Button } from "@/components/ui/Button/Button";
 import { Modal } from "@/components/ui/Modal/Modal";
 import { t } from "@/i18n/translate";
-import type { CommitteeCategory } from "@/types/generated/openapi.ts";
+import type { CommitteeCategory } from "@/types/generated/openapi";
 
 interface CommitteeSessionPausedModalProps {
   showUnsavedChanges?: boolean;

--- a/frontend/src/features/apportionment/components/list_details/CandidatesWithVotesTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/list_details/CandidatesWithVotesTable.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from "@storybook/react-vite";
 import { expect } from "storybook/test";
-import type { Candidate } from "@/types/generated/openapi.ts";
+import type { Candidate } from "@/types/generated/openapi";
 import * as lt19Seats from "../../testing/lt-19-seats";
 import { CandidatesWithVotesTable } from "./CandidatesWithVotesTable";
 

--- a/frontend/src/features/backups/components/BackupsPage.test.tsx
+++ b/frontend/src/features/backups/components/BackupsPage.test.tsx
@@ -12,7 +12,7 @@ import type {
 } from "@/types/generated/openapi";
 import { formatTime } from "@/utils/dateTime";
 
-import { BackupsPage } from "./BackupsPage.tsx";
+import { BackupsPage } from "./BackupsPage";
 
 const createdAt = new Date(2026, 6, 7, 0, 0).toISOString();
 

--- a/frontend/src/features/backups/components/BackupsPage.tsx
+++ b/frontend/src/features/backups/components/BackupsPage.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { type AnyApiError, isSuccess } from "@/api/ApiResult.ts";
-import { useApiClient } from "@/api/useApiClient.ts";
-import { PageTitle } from "@/components/page_title/PageTitle.tsx";
+import { type AnyApiError, isSuccess } from "@/api/ApiResult";
+import { useApiClient } from "@/api/useApiClient";
+import { PageTitle } from "@/components/page_title/PageTitle";
 import { t } from "@/i18n/translate";
-import type { BackupResponse, CREATE_BACKUP_REQUEST_PATH } from "@/types/generated/openapi.ts";
-import { BackupsPageContent } from "./BackupsPageContent.tsx";
+import type { BackupResponse, CREATE_BACKUP_REQUEST_PATH } from "@/types/generated/openapi";
+import { BackupsPageContent } from "./BackupsPageContent";
 
 const MIN_LOADING_MS = 1000; // Time the loading state should at least remain visible
 const BACKUP_PATH: CREATE_BACKUP_REQUEST_PATH = `/api/backup`;

--- a/frontend/src/features/backups/components/BackupsPageContent.tsx
+++ b/frontend/src/features/backups/components/BackupsPageContent.tsx
@@ -1,8 +1,8 @@
 import { Alert } from "@/components/ui/Alert/Alert";
-import { Button } from "@/components/ui/Button/Button.tsx";
-import { Spinner } from "@/components/ui/Spinner/Spinner.tsx";
+import { Button } from "@/components/ui/Button/Button";
+import { Spinner } from "@/components/ui/Spinner/Spinner";
 import { t, tx } from "@/i18n/translate";
-import { formatTime } from "@/utils/dateTime.ts";
+import { formatTime } from "@/utils/dateTime";
 import cls from "./BackupsPageContent.module.css";
 
 interface BackupsPageContentProps {

--- a/frontend/src/features/backups/routes.tsx
+++ b/frontend/src/features/backups/routes.tsx
@@ -1,6 +1,6 @@
 import type { RouteObject } from "react-router";
 
-import { BackupsPage } from "./components/BackupsPage.tsx";
+import { BackupsPage } from "./components/BackupsPage";
 
 export const backupsRoutes: RouteObject[] = [
   { index: true, Component: BackupsPage, handle: { roles: ["administrator", "coordinator_csb", "coordinator_gsb"] } },

--- a/frontend/src/features/data_entry/components/DataEntryPage.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryPage.tsx
@@ -5,7 +5,7 @@ import { StickyNav } from "@/components/ui/AppLayout/StickyNav";
 import { DataEntryHeader } from "@/features/data_entry/components/DataEntryHeader";
 import { useElection } from "@/hooks/election/useElection";
 import { useNumericParam } from "@/hooks/useNumericParam";
-import { useUser } from "@/hooks/user/useUser.ts";
+import { useUser } from "@/hooks/user/useUser";
 import type { FormSectionId } from "@/types/types";
 import { CheckAndSaveForm } from "./check_and_save/CheckAndSaveForm";
 import { DataEntryProgress } from "./DataEntryProgress";

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -14,7 +14,7 @@ import { Form } from "@/components/ui/Form/Form";
 import { KeyboardKeys } from "@/components/ui/KeyboardKeys/KeyboardKeys";
 import { useUser } from "@/hooks/user/useUser";
 import { t } from "@/i18n/translate";
-import type { CommitteeCategory } from "@/types/generated/openapi.ts";
+import type { CommitteeCategory } from "@/types/generated/openapi";
 import { KeyboardKey } from "@/types/ui";
 import { getTranslations } from "@/utils/ValidationResults";
 import { useDataEntryFormSection } from "../hooks/useDataEntryFormSection";

--- a/frontend/src/features/data_entry_detail/components/DetailLayout.tsx
+++ b/frontend/src/features/data_entry_detail/components/DetailLayout.tsx
@@ -12,7 +12,7 @@ import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { useElection } from "@/hooks/election/useElection";
 import { useMessages } from "@/hooks/messages/useMessages";
 import { useNumericParam } from "@/hooks/useNumericParam";
-import { useUser } from "@/hooks/user/useUser.ts";
+import { useUser } from "@/hooks/user/useUser";
 import { t } from "@/i18n/translate";
 import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 import { useDataEntryErrors } from "../hooks/useDataEntryErrors";

--- a/frontend/src/features/data_entry_home/components/DataEntrySourceNumberInput.tsx
+++ b/frontend/src/features/data_entry_home/components/DataEntrySourceNumberInput.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/Badge/Badge";
 import { Icon } from "@/components/ui/Icon/Icon";
 import { InputField } from "@/components/ui/InputField/InputField";
 import { Spinner } from "@/components/ui/Spinner/Spinner";
-import { useUser } from "@/hooks/user/useUser.ts";
+import { useUser } from "@/hooks/user/useUser";
 import { t, tx } from "@/i18n/translate";
 import { cn } from "@/utils/classnames";
 import { removeLeadingZeros } from "@/utils/strings";

--- a/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
+++ b/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
@@ -9,7 +9,7 @@ import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { InputField } from "@/components/ui/InputField/InputField";
 import { type CommitteeCategory, committeeCategoryValues } from "@/types/generated/openapi";
-import { StringFormData } from "@/utils/stringFormData.ts";
+import { StringFormData } from "@/utils/stringFormData";
 
 const RANGE_HINT = "Gebruik notatie zoals 10..50 of 9..=45 of een enkel getal zoals 40";
 

--- a/frontend/src/features/election_create/components/CommitteeCategory.test.tsx
+++ b/frontend/src/features/election_create/components/CommitteeCategory.test.tsx
@@ -3,12 +3,12 @@ import { describe, expect, test, vi } from "vitest";
 import {
   csbElectionImportValidateMockResponse,
   gsbElectionImportValidateMockResponse,
-} from "@/testing/api-mocks/ElectionMockData.ts";
-import { overrideOnce } from "@/testing/server.ts";
+} from "@/testing/api-mocks/ElectionMockData";
+import { overrideOnce } from "@/testing/server";
 import { renderReturningRouter, screen } from "@/testing/test-utils";
-import type { CommitteeCategory as CommitteeCategoryType, NewElection } from "@/types/generated/openapi.ts";
+import type { CommitteeCategory as CommitteeCategoryType, NewElection } from "@/types/generated/openapi";
 import * as useElectionCreateContext from "../hooks/useElectionCreateContext";
-import { CommitteeCategory } from "./CommitteeCategory.tsx";
+import { CommitteeCategory } from "./CommitteeCategory";
 import { ElectionCreateContextProvider } from "./ElectionCreateContextProvider";
 
 const election = { name: "Naam", location: "Plek", committee_category: "GSB" } as NewElection;

--- a/frontend/src/features/election_create/components/CommitteeCategory.tsx
+++ b/frontend/src/features/election_create/components/CommitteeCategory.tsx
@@ -1,12 +1,12 @@
 import { type ReactNode, type SubmitEvent, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
-import { Alert } from "@/components/ui/Alert/Alert.tsx";
+import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { t } from "@/i18n/translate";
-import { StringFormData } from "@/utils/stringFormData.ts";
+import { StringFormData } from "@/utils/stringFormData";
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 
 export function CommitteeCategory() {

--- a/frontend/src/features/election_create/routes.tsx
+++ b/frontend/src/features/election_create/routes.tsx
@@ -1,7 +1,7 @@
 import type { RouteObject } from "react-router";
 
 import { CheckAndSave } from "./components/CheckAndSave";
-import { CommitteeCategory } from "./components/CommitteeCategory.tsx";
+import { CommitteeCategory } from "./components/CommitteeCategory";
 import { CountingMethodType } from "./components/CountingMethodType";
 import { ElectionCreateLayout } from "./components/ElectionCreateLayout";
 import { NumberOfVoters } from "./components/NumberOfVoters";

--- a/frontend/src/features/election_management/components/ElectionInformationTable.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionInformationTable.test.tsx
@@ -3,7 +3,7 @@ import * as ReactRouter from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { committeeSessionMockData } from "@/testing/api-mocks/CommitteeSessionMockData";
-import { getCSBElectionMockData } from "@/testing/api-mocks/ElectionMockData.ts";
+import { getCSBElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { TestUserProvider } from "@/testing/TestUserProvider";
 import { render, screen, within } from "@/testing/test-utils";
 import type { CommitteeSessionStatus, Role } from "@/types/generated/openapi";

--- a/frontend/src/features/election_status/components/CategoryRow.tsx
+++ b/frontend/src/features/election_status/components/CategoryRow.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/Badge/Badge";
 import { Icon } from "@/components/ui/Icon/Icon";
 import { ProgressBar } from "@/components/ui/ProgressBar/ProgressBar";
 import { Table } from "@/components/ui/Table/Table";
-import { useUser } from "@/hooks/user/useUser.ts";
+import { useUser } from "@/hooks/user/useUser";
 import { t } from "@/i18n/translate";
 import type { DataEntryStatusName, ElectionStatusResponseEntry } from "@/types/generated/openapi";
 import { formatDateTime } from "@/utils/dateTime";

--- a/frontend/src/i18n/feedback-structure.test.tsx
+++ b/frontend/src/i18n/feedback-structure.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { type CommitteeCategory, committeeCategoryValues } from "@/types/generated/openapi";
-import translations from "./locales/nl/nl.ts";
+import translations from "./locales/nl/nl";
 
 describe("feedback translations structure", () => {
   test.each(committeeCategoryValues)("validate feedback_%s.json", (cat: CommitteeCategory) => {

--- a/frontend/src/utils/committeeSession.ts
+++ b/frontend/src/utils/committeeSession.ts
@@ -1,5 +1,5 @@
 import { hasTranslation, t } from "@/i18n/translate";
-import type { CommitteeCategory } from "@/types/generated/openapi.ts";
+import type { CommitteeCategory } from "@/types/generated/openapi";
 
 export function committeeSessionLabel(
   committeeCategory: CommitteeCategory,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,4 +44,5 @@ pre-commit:
     frontend-lint-eslint:
       root: "frontend/"
       glob: "*.{ts,tsx}"
-      run: pnpm lint:eslint
+      run: pnpm lint:eslint --fix
+      stage_fixed: true


### PR DESCRIPTION
## What & why

Resolves https://github.com/kiesraad/abacus/issues/3576

Opted for a solution via linting (`eslint.config.js`) rather than enforcing the rule via the compiler (`tsconfig.json`), because:
- eslint does auto-fix
- eslint allows imports to keep the extension when there are several assets with the same basename


## How to test

Introduce an import that uses an extension:

e.g.:

```
import { formatVoteCount } from "@/utils/number.ts";
```

run 

```
pnpm lint:eslint --fix
```

and see that we saved 3 chars:

```
import { formatVoteCount } from "@/utils/number";
```
 

## Reviewer notes
Except `eslint.config.js` and `lefthook.yml` the changed source files should only contain automatic removal of extensions.