### PR TITLE
Remove direct dependency on quick-xml

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -21,7 +21,6 @@ dependencies = [
  "if-addrs",
  "memory-serve",
  "pdf_gen",
- "quick-xml 0.39.2",
  "rand 0.10.1",
  "rcgen",
  "reqwest",
@@ -727,7 +726,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756ff1e3d43a9ecc8183932fb4d9fd3971236f3ce4acb62fe51d1cd43297547d"
 dependencies = [
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "serde_path_to_error",
 ]
@@ -1173,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142068a435989dcdc985d6a0a7cd701e87c3b6eb79c24ae8f94c0ccc4900c675"
 dependencies = [
  "chrono",
- "quick-xml 0.38.4",
+ "quick-xml",
  "regex",
  "thiserror 2.0.18",
  "tracing",
@@ -2963,7 +2962,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3084,16 +3083,6 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -91,7 +91,6 @@ tower = "0.5"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing.workspace = true
 tower-http = { version = "0.6", features = ["set-header", "trace"] }
-quick-xml = { version = "0.39.2", features = ["serialize"] }
 sha2 = "0.11.0"
 argon2 = { version = "0.5.3", features = ["std"] }
 rand.workspace = true

--- a/backend/README.md
+++ b/backend/README.md
@@ -177,7 +177,6 @@ The following dependencies (crates) are used:
 - `hyper`: fast and correct HTTP implementation.
 - `memory-serve`: serves frontend assets from memory, but ad-hoc from disk during development.
 - `password_hash`: password hashing interfaces.
-- `quick-xml`: reading and writing EML_NL XML files.
 - `rand`: create a random session key.
 - `serde_json`: JSON support for Serde.
 - `serde`: framework for serializing and deserializing data structures.

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -16,7 +16,6 @@ dependencies = [
  "eml-nl",
  "hyper",
  "pdf_gen",
- "quick-xml 0.39.2",
  "rand",
  "serde",
  "serde_json",
@@ -614,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142068a435989dcdc985d6a0a7cd701e87c3b6eb79c24ae8f94c0ccc4900c675"
 dependencies = [
  "chrono",
- "quick-xml 0.38.4",
+ "quick-xml",
  "regex",
  "thiserror",
  "tracing",
@@ -1507,16 +1506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7251,7 +7251,6 @@
           "InvalidUsernameOrPassword",
           "InvalidVoteCandidate",
           "InvalidVoteGroup",
-          "InvalidXml",
           "InvestigationHasDataEntryOrResult",
           "InvestigationRequiresCorrectedResults",
           "NotInitialised",

--- a/backend/src/api/election.rs
+++ b/backend/src/api/election.rs
@@ -5,7 +5,6 @@ use axum::{
 };
 use chrono::NaiveDate;
 use eml_nl::EMLError;
-use quick_xml::{DeError, SeError};
 use serde::{Deserialize, Serialize};
 use sqlx::{SqliteConnection, SqlitePool};
 use strum::VariantArray;
@@ -713,18 +712,6 @@ async fn create_sub_committees(
         (CommitteeCategory::GSB, _) => {}
     }
     Ok(())
-}
-
-impl From<DeError> for APIError {
-    fn from(err: DeError) -> Self {
-        APIError::XmlDeError(err)
-    }
-}
-
-impl From<SeError> for APIError {
-    fn from(err: SeError) -> Self {
-        APIError::XmlError(err)
-    }
 }
 
 impl From<EMLImportError> for APIError {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -9,7 +9,6 @@ use axum::{
 use eml_nl::EMLError;
 use hyper::header::InvalidHeaderValue;
 use pdf_gen::{PdfGenError, zip::ZipResponseError};
-use quick_xml::{DeError, SeError};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 use utoipa::ToSchema;
@@ -72,7 +71,6 @@ pub enum ErrorReference {
     InvalidUsernameOrPassword,
     InvalidVoteCandidate,
     InvalidVoteGroup,
-    InvalidXml,
     InvestigationHasDataEntryOrResult,
     InvestigationRequiresCorrectedResults,
     NotInitialised,
@@ -136,8 +134,6 @@ pub enum APIError {
     SerdeJsonError(serde_json::Error),
     SqlxError(sqlx::Error),
     StdError(Box<dyn Error>),
-    XmlDeError(DeError),
-    XmlError(SeError),
     ZipError(ZipResponseError),
 }
 
@@ -256,24 +252,6 @@ impl APIError {
                 (
                     StatusCode::BAD_REQUEST,
                     ErrorResponse::new("Invalid hash", ErrorReference::InvalidHash, false),
-                )
-            }
-            APIError::XmlError(err) => {
-                error!("Could not serialize XML: {:?}", err);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    ErrorResponse::new(
-                        "Internal server error",
-                        ErrorReference::InternalServerError,
-                        false,
-                    ),
-                )
-            }
-            APIError::XmlDeError(err) => {
-                error!("Could not deserialize XML: {:?}", err);
-                (
-                    StatusCode::BAD_REQUEST,
-                    ErrorResponse::new("Invalid XML", ErrorReference::InvalidXml, false),
                 )
             }
             APIError::ZipError(err) => {

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
@@ -47,9 +47,9 @@ describe("UploadCandidatesDefinition component", () => {
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     overrideOnce("post", "/api/elections/import/validate", 400, {
-      error: "Invalid XML",
+      error: "EML import error",
       fatal: false,
-      reference: "InvalidXml",
+      reference: "EmlImportError",
     });
 
     await renderPage();

--- a/frontend/src/features/election_create/components/UploadElectionDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadElectionDefinition.test.tsx
@@ -127,9 +127,9 @@ describe("UploadElectionDefinition component", () => {
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     overrideOnce("post", "/api/elections/import/validate", 400, {
-      error: "Invalid XML",
+      error: "EML import error",
       fatal: false,
-      reference: "InvalidXml",
+      reference: "EmlImportError",
     });
 
     await renderPage();

--- a/frontend/src/features/election_create/components/UploadPollingStationDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadPollingStationDefinition.test.tsx
@@ -49,9 +49,9 @@ describe("UploadPollingStationDefinition component", () => {
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     overrideOnce("post", "/api/elections/import/validate", 400, {
-      error: "Invalid XML",
+      error: "EML import error",
       fatal: false,
-      reference: "InvalidXml",
+      reference: "EmlImportError",
     });
 
     await renderPage();

--- a/frontend/src/features/polling_stations/components/PollingStationImportPage.test.tsx
+++ b/frontend/src/features/polling_stations/components/PollingStationImportPage.test.tsx
@@ -48,9 +48,9 @@ describe("PollingStationImportPage", () => {
 
   test("Shows an error when uploading invalid polling stations file", async () => {
     overrideOnce("post", "/api/elections/1/polling_stations/validate-import", 400, {
-      error: "Invalid XML",
+      error: "EML import error",
       fatal: false,
-      reference: "InvalidXml",
+      reference: "EmlImportError",
     });
 
     await renderPage();

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -37,7 +37,6 @@
     "InvalidUsernameOrPassword": "De gebruikersnaam of het wachtwoord is onjuist",
     "InvalidVoteCandidate": "De kandidaat van de stem is niet geldig",
     "InvalidVoteGroup": "De politieke partij van de stem is niet geldig",
-    "InvalidXml": "De XML is niet geldig",
     "InvestigationHasDataEntryOrResult": "Er zijn al gecorrigeerde telresultaten ingevoerd",
     "InvestigationRequiresCorrectedResults": "Er zijn gecorrigeerde telresultaten vereist voor dit onderzoek",
     "NotInitialised": "De applicatie is nog niet klaar voor gebruik.",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1052,7 +1052,6 @@ export const errorReferenceValues = [
   "InvalidUsernameOrPassword",
   "InvalidVoteCandidate",
   "InvalidVoteGroup",
-  "InvalidXml",
   "InvestigationHasDataEntryOrResult",
   "InvestigationRequiresCorrectedResults",
   "NotInitialised",


### PR DESCRIPTION
## What & why

Remove direct dependency on quick-xml. All XML operations go through the eml-nl crate, which has its own dependency on quick-xml, so we don't need to use quick-xml directly any more. The errors and `From<..>` implementations were left over from before the migration to the eml-nl crate.

Relates to #3581.

## How to test

No visible changes expected, check CI and review diff.

## Reviewer notes

None.