### PR TITLE
Update EML_NL crate to v0.6.1

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -726,7 +726,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756ff1e3d43a9ecc8183932fb4d9fd3971236f3ce4acb62fe51d1cd43297547d"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "serde_path_to_error",
 ]
@@ -1167,12 +1167,12 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142068a435989dcdc985d6a0a7cd701e87c3b6eb79c24ae8f94c0ccc4900c675"
+checksum = "c2e44b143a6a48317033079275252e49eb0da3214728b16e3e61144d43eadd39"
 dependencies = [
  "chrono",
- "quick-xml",
+ "quick-xml 0.41.0",
  "regex",
  "thiserror 2.0.18",
  "tracing",
@@ -2962,7 +2962,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3086,6 +3086,15 @@ checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,7 +77,7 @@ axum.workspace = true
 axum-extra.workspace = true
 chrono.workspace = true
 clap = { version = "4.6", default-features = false, features = ["derive", "std", "help", "env"] }
-eml-nl = { version = "0.6.0" }
+eml-nl = { version = "0.6.1" }
 hyper = { version = "1", features = ["full"] }
 tokio.workspace = true
 memory-serve = { version = "2.1.0", optional = true, features = ["force-embed"] }

--- a/backend/tests/election_admin_integration_tests.rs
+++ b/backend/tests/election_admin_integration_tests.rs
@@ -210,6 +210,29 @@ async fn test_election_validate_missing_election_domain(pool: SqlitePool) {
 }
 
 #[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
+async fn test_gsb_election_validate_hash_file_instead_of_election_definition(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+
+    let url = format!("http://{addr}/api/elections/import/validate");
+    let admin_cookie = login(&addr, Admin).await;
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("cookie", admin_cookie)
+        .json(&serde_json::json!({
+          "committee_category": "GSB",
+          "election_data": "5738 d520 a7f2 89b8 8875 ebfe cfc8 6012 d7b6 f65f 3271 d0e1 180b ccdd 8134 cd5d",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Ensure the response is what we expect
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["reference"], "EmlImportError");
+}
+
+#[test(sqlx::test(fixtures(path = "../fixtures", scripts("users"))))]
 async fn test_election_candidates_validate_valid(pool: SqlitePool) {
     let addr = serve_api(pool).await;
     let admin_cookie = login(&addr, Admin).await;


### PR DESCRIPTION
## What & why

Update EML_NL crate to v0.6.1 to resolve #3582. Also updates quick-xml to v0.41.0, related to #3581.

## How to test

Try to reproduce #3582 by uploading a non-XML file in the election creation flow. It should now display "Ongeldige verkiezingsdefinitie" right away.

Can also be verified using the integration test: first commit fails, second commit with crate update passes.

## Reviewer notes

None.