### PR TITLE
Fix ApportionmentTable does not count full seats + residual seats but uses council seats

### DIFF
--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -10,7 +10,6 @@ import { getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import {
   GetApportionmentStateRequestHandler,
   RegisterDeceasedCandidatesRequestHandler,
-  ResetApportionmentStateRequestHandler,
 } from "@/testing/api-mocks/RequestHandlers";
 import { Providers } from "@/testing/Providers";
 import type { Router } from "@/testing/router";
@@ -30,6 +29,7 @@ import { apportionmentRoutes } from "../routes";
 import * as gte19SeatsAndP7DrawingLots from "../testing/gte-19-seats-and-p7-drawing-lots";
 import * as gte19SeatsAndP9DrawingLots from "../testing/gte-19-seats-and-p9-drawing-lots-and-deceased-candidates";
 import * as lt19Seats from "../testing/lt-19-seats";
+import * as lt19SeatsAndNotAllSeatsAssigned from "../testing/lt-19-seats-and-not-all-seats-assigned";
 import * as lt19SeatsAndP7DrawingLots from "../testing/lt-19-seats-and-p7-drawing-lots";
 import * as lt19SeatsAndP9DrawingLots from "../testing/lt-19-seats-and-p9-drawing-lots";
 import * as lt19SeatsAndP15DrawingLots from "../testing/lt-19-seats-and-p15-drawing-lots";
@@ -297,32 +297,40 @@ describe("ApportionmentPage", () => {
 
   test("Renders yellow warning when finalised but not all seats assigned and clicks reset button", async () => {
     const user = userEvent.setup();
-    server.use(GetApportionmentStateRequestHandler);
-    server.use(ResetApportionmentStateRequestHandler);
-    const resetApportionmentState = spyOnHandler(ResetApportionmentStateRequestHandler);
-    const getApportionmentState = spyOnHandler(GetApportionmentStateRequestHandler);
-    overrideOnce("get", "/api/elections/3", 200, getElectionMockData(lt19Seats.election, lt19Seats.committee_session));
+    const resetApportionmentStateRequestHandler = http.post("/api/elections/13/apportionment/reset", () =>
+      HttpResponse.json({ type: "Uninitialised" } satisfies ApportionmentState, {
+        status: 200,
+      }),
+    );
+    server.use(resetApportionmentStateRequestHandler);
+    const resetApportionmentState = spyOnHandler(resetApportionmentStateRequestHandler);
+    const getApportionmentStateRequestHandler = http.get("/api/elections/13/apportionment/state", () =>
+      HttpResponse.json(gte19SeatsAndP7DrawingLots.state, { status: 200 }),
+    );
+    server.use(getApportionmentStateRequestHandler);
+    const getApportionmentState = spyOnHandler(getApportionmentStateRequestHandler);
+    overrideOnce(
+      "get",
+      "/api/elections/13",
+      200,
+      getElectionMockData(lt19SeatsAndNotAllSeatsAssigned.election, lt19SeatsAndNotAllSeatsAssigned.committee_session),
+    );
     server.use(
-      http.post("/api/elections/3/apportionment", () =>
+      http.post("/api/elections/13/apportionment", () =>
         HttpResponse.json(
           {
-            seat_assignment: lt19Seats.seat_assignment,
-            candidate_nomination: lt19Seats.candidate_nomination,
-            election_summary: lt19Seats.election_summary,
-            warnings: ["NotAllSeatsAssigned"],
+            seat_assignment: lt19SeatsAndNotAllSeatsAssigned.seat_assignment,
+            candidate_nomination: lt19SeatsAndNotAllSeatsAssigned.candidate_nomination,
+            election_summary: lt19SeatsAndNotAllSeatsAssigned.election_summary,
+            warnings: lt19SeatsAndNotAllSeatsAssigned.warnings,
           } satisfies ElectionApportionmentResponse,
           { status: 200 },
         ),
       ),
     );
-    overrideOnce("get", "/api/elections/3/apportionment/state", 200, {
-      deceased_candidates: [],
-      lists_drawn: [],
-      candidates_drawn: [],
-      type: "Finalised",
-    } satisfies ApportionmentState);
+    overrideOnce("get", "/api/elections/13/apportionment/state", 200, lt19SeatsAndNotAllSeatsAssigned.state);
 
-    renderApportionmentPage(3, false);
+    renderApportionmentPage(13, false);
 
     const alerts = await screen.findAllByRole("alert");
     expect(alerts).toHaveLength(2);
@@ -330,6 +338,32 @@ describe("ApportionmentPage", () => {
     alerts.forEach((alert) => {
       expect(alert).not.toHaveTextContent("Alle zetels zijn toegewezen");
     });
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Kengetallen" })).toBeVisible();
+    const election_summary_table = await screen.findByTestId("election-summary-table");
+    expect(election_summary_table).toBeVisible();
+    expect(election_summary_table).toHaveTableContent([
+      ["Kiesgerechtigden", "91", ""],
+      ["Getelde stembiljetten", "60", "Opkomst: 65,93%"],
+      ["Blanco stemmen", "0", ""],
+      ["Ongeldige stemmen", "0", ""],
+      ["Totaal stemmen op kandidaten", "60", ""],
+      ["Aantal raadszetels", "6", ""],
+      ["Kiesdeler", "10", "Benodigde stemmen per volle zetel"],
+      ["Voorkeursdrempel", "5", "50% van de kiesdeler"],
+      ["Kandidaten voor zetelverdeling", "6 - 1 † = 5", "Beheer overleden kandidaten"],
+    ]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Zetelverdeling" })).toBeVisible();
+    const apportionment_table = await screen.findByTestId("apportionment-table");
+    expect(apportionment_table).toBeVisible();
+    expect(apportionment_table).toHaveTableContent([
+      ["Lijst", "Lijstnaam", "Volle zetels", "Restzetels", "Totaal zetels"],
+      ["1", "Political Group A", "-", "1", "1"],
+      ["2", "Political Group B", "-", "2", "2"],
+      ["3", "Blanco (Smit, G.)", "2", "-", "2"],
+      ["", "Totaal", "2", "3", "5"],
+    ]);
 
     const finalisedAlert = alerts[1] as HTMLElement;
     await user.click(within(finalisedAlert).getByRole("button", { name: "Zetelverdeling opnieuw doen" }));

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -363,7 +363,6 @@ function ApportionmentTableSection({ state, seatAssignment, election }: Apportio
           politicalGroups={election.political_groups}
           fullSeats={seatAssignment.full_seats}
           residualSeats={seatAssignment.residual_seats}
-          seats={seatAssignment.seats}
           notAssignedSeats={notAssignedSeats}
           withoutLinks={state.type === "DrawingLots"}
         />

--- a/frontend/src/features/apportionment/components/ApportionmentTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentTable.stories.tsx
@@ -2,6 +2,7 @@ import type { StoryObj } from "@storybook/react-vite";
 import { expect } from "storybook/test";
 import * as gte19Seats from "../testing/gte-19-seats";
 import * as gte19SeatsAndP7DrawingLots from "../testing/gte-19-seats-and-p7-drawing-lots";
+import * as lt19SeatsAndNotAllSeatsAssigned from "../testing/lt-19-seats-and-not-all-seats-assigned";
 import { getNotAssignedSeats } from "../utils/utils";
 import { ApportionmentTable } from "./ApportionmentTable";
 
@@ -13,7 +14,6 @@ export const Default: StoryObj = {
         politicalGroups={gte19Seats.election.political_groups}
         fullSeats={gte19Seats.seat_assignment.full_seats}
         residualSeats={gte19Seats.seat_assignment.residual_seats}
-        seats={gte19Seats.seat_assignment.seats}
         notAssignedSeats={0}
         withoutLinks={false}
       />
@@ -42,7 +42,6 @@ export const NotAssignedSeats: StoryObj = {
         politicalGroups={gte19SeatsAndP7DrawingLots.election.political_groups}
         fullSeats={gte19SeatsAndP7DrawingLots.seat_assignment.full_seats}
         residualSeats={gte19SeatsAndP7DrawingLots.seat_assignment.residual_seats}
-        seats={gte19SeatsAndP7DrawingLots.seat_assignment.seats}
         notAssignedSeats={getNotAssignedSeats(gte19SeatsAndP7DrawingLots.state)}
         withoutLinks={true}
       />
@@ -61,6 +60,32 @@ export const NotAssignedSeats: StoryObj = {
       ["5", "Unie van kandidaten", "2", "-", "2"],
       ["6", "Lijst van stemmers", "2", "-", "2"],
       ["", "Totaal", "19", "4", "23"],
+    ]);
+  },
+};
+
+export const NotAllSeatsAssigned: StoryObj = {
+  render: () => {
+    return (
+      <ApportionmentTable
+        standings={lt19SeatsAndNotAllSeatsAssigned.seat_assignment.standings}
+        politicalGroups={lt19SeatsAndNotAllSeatsAssigned.election.political_groups}
+        fullSeats={lt19SeatsAndNotAllSeatsAssigned.seat_assignment.full_seats}
+        residualSeats={lt19SeatsAndNotAllSeatsAssigned.seat_assignment.residual_seats}
+        notAssignedSeats={getNotAssignedSeats(lt19SeatsAndNotAllSeatsAssigned.state)}
+        withoutLinks={true}
+      />
+    );
+  },
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table");
+    await expect(table).toBeVisible();
+    expect(table).toHaveTableContent([
+      ["Lijst", "Lijstnaam", "Volle zetels", "Restzetels", "Totaal zetels"],
+      ["1", "Political Group A", "-", "1", "1"],
+      ["2", "Political Group B", "-", "2", "2"],
+      ["3", "Blanco (Smit, G.)", "2", "-", "2"],
+      ["", "Totaal", "2", "3", "5"],
     ]);
   },
 };

--- a/frontend/src/features/apportionment/components/ApportionmentTable.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentTable.tsx
@@ -10,7 +10,6 @@ interface ApportionmentTableProps {
   politicalGroups: PoliticalGroup[];
   fullSeats: number;
   residualSeats: number;
-  seats: number;
   notAssignedSeats: number;
   withoutLinks: boolean;
 }
@@ -27,7 +26,6 @@ export function ApportionmentTable({
   politicalGroups,
   fullSeats,
   residualSeats,
-  seats,
   notAssignedSeats,
   withoutLinks,
 }: ApportionmentTableProps) {
@@ -76,7 +74,7 @@ export function ApportionmentTable({
           <Table.Cell className="text-align-r bold">{t("apportionment.total")}</Table.Cell>
           <Table.NumberCell>{fullSeats}</Table.NumberCell>
           <Table.NumberCell>{residualSeats}</Table.NumberCell>
-          <Table.NumberCell className="link-cell-padding">{seats}</Table.NumberCell>
+          <Table.NumberCell className="link-cell-padding">{fullSeats + residualSeats}</Table.NumberCell>
         </Table.TotalRow>
       </Table.Body>
     </Table>

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-not-all-seats-assigned.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-not-all-seats-assigned.ts
@@ -1,0 +1,887 @@
+import type {
+  ApportionmentState,
+  ApportionmentWarning,
+  CandidateNomination,
+  CommitteeSession,
+  ElectionSummary,
+  ElectionWithPoliticalGroups,
+  SeatAssignment,
+} from "@/types/generated/openapi";
+
+export const state: ApportionmentState = {
+  type: "Finalised",
+  deceased_candidates: [
+    {
+      pg_number: 1,
+      candidate_number: 1,
+    },
+  ],
+  lists_drawn: [],
+  candidates_drawn: [],
+};
+
+export const seat_assignment: SeatAssignment = {
+  seats: 6,
+  full_seats: 2,
+  residual_seats: 3,
+  quota: {
+    integer: 10,
+    numerator: 0,
+    denominator: 6,
+  },
+  steps: [
+    {
+      residual_seat_number: 1,
+      change: {
+        changed_by: "LargestRemainderAssignment",
+        selected_list_number: 3,
+        list_options: [3],
+        list_assigned: [3],
+        remainder_votes: {
+          integer: 0,
+          numerator: 0,
+          denominator: 6,
+        },
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 6,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 8,
+            numerator: 2,
+            denominator: 6,
+          },
+          full_seats: 5,
+          residual_seats: 0,
+        },
+      ],
+    },
+    {
+      change: {
+        changed_by: "ListExhaustionRemoval",
+        list_retracted_seat: 3,
+        full_seat: false,
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 6,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 7,
+            numerator: 1,
+            denominator: 7,
+          },
+          full_seats: 5,
+          residual_seats: 1,
+        },
+      ],
+    },
+    {
+      change: {
+        changed_by: "ListExhaustionRemoval",
+        list_retracted_seat: 3,
+        full_seat: true,
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 6,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 8,
+            numerator: 2,
+            denominator: 6,
+          },
+          full_seats: 5,
+          residual_seats: 0,
+        },
+      ],
+    },
+    {
+      change: {
+        changed_by: "ListExhaustionRemoval",
+        list_retracted_seat: 3,
+        full_seat: true,
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 6,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 10,
+            numerator: 0,
+            denominator: 5,
+          },
+          full_seats: 4,
+          residual_seats: 0,
+        },
+      ],
+    },
+    {
+      change: {
+        changed_by: "ListExhaustionRemoval",
+        list_retracted_seat: 3,
+        full_seat: true,
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 6,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 12,
+            numerator: 2,
+            denominator: 4,
+          },
+          full_seats: 3,
+          residual_seats: 0,
+        },
+      ],
+    },
+    {
+      residual_seat_number: 2,
+      change: {
+        changed_by: "UniqueHighestAverageAssignment",
+        selected_list_number: 1,
+        list_options: [1],
+        list_assigned: [1],
+        list_exhausted: [3],
+        votes_per_seat: {
+          integer: 6,
+          numerator: 0,
+          denominator: 1,
+        },
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 6,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 16,
+            numerator: 2,
+            denominator: 3,
+          },
+          full_seats: 2,
+          residual_seats: 0,
+        },
+      ],
+    },
+    {
+      residual_seat_number: 3,
+      change: {
+        changed_by: "UniqueHighestAverageAssignment",
+        selected_list_number: 2,
+        list_options: [2],
+        list_assigned: [2],
+        list_exhausted: [1, 3],
+        votes_per_seat: {
+          integer: 4,
+          numerator: 0,
+          denominator: 1,
+        },
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 3,
+            numerator: 0,
+            denominator: 2,
+          },
+          full_seats: 0,
+          residual_seats: 1,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 4,
+            numerator: 0,
+            denominator: 1,
+          },
+          full_seats: 0,
+          residual_seats: 0,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 16,
+            numerator: 2,
+            denominator: 3,
+          },
+          full_seats: 2,
+          residual_seats: 0,
+        },
+      ],
+    },
+    {
+      residual_seat_number: 4,
+      change: {
+        changed_by: "HighestAverageAssignment",
+        selected_list_number: 2,
+        list_options: [2],
+        list_assigned: [2],
+        list_exhausted: [1, 3],
+        votes_per_seat: {
+          integer: 2,
+          numerator: 0,
+          denominator: 2,
+        },
+      },
+      standings: [
+        {
+          list_number: 1,
+          votes_cast: 6,
+          remainder_votes: {
+            integer: 6,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 3,
+            numerator: 0,
+            denominator: 2,
+          },
+          full_seats: 0,
+          residual_seats: 1,
+        },
+        {
+          list_number: 2,
+          votes_cast: 4,
+          remainder_votes: {
+            integer: 4,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: false,
+          next_votes_per_seat: {
+            integer: 2,
+            numerator: 0,
+            denominator: 2,
+          },
+          full_seats: 0,
+          residual_seats: 1,
+        },
+        {
+          list_number: 3,
+          votes_cast: 50,
+          remainder_votes: {
+            integer: 0,
+            numerator: 0,
+            denominator: 6,
+          },
+          meets_remainder_threshold: true,
+          next_votes_per_seat: {
+            integer: 16,
+            numerator: 2,
+            denominator: 3,
+          },
+          full_seats: 2,
+          residual_seats: 0,
+        },
+      ],
+    },
+  ],
+  standings: [
+    {
+      list_number: 1,
+      votes_cast: 6,
+      remainder_votes: {
+        integer: 6,
+        numerator: 0,
+        denominator: 6,
+      },
+      meets_remainder_threshold: false,
+      full_seats: 0,
+      residual_seats: 1,
+      total_seats: 1,
+    },
+    {
+      list_number: 2,
+      votes_cast: 4,
+      remainder_votes: {
+        integer: 4,
+        numerator: 0,
+        denominator: 6,
+      },
+      meets_remainder_threshold: false,
+      full_seats: 0,
+      residual_seats: 2,
+      total_seats: 2,
+    },
+    {
+      list_number: 3,
+      votes_cast: 50,
+      remainder_votes: {
+        integer: 0,
+        numerator: 0,
+        denominator: 6,
+      },
+      meets_remainder_threshold: true,
+      full_seats: 2,
+      residual_seats: 0,
+      total_seats: 2,
+    },
+  ],
+};
+
+export const candidate_nomination: CandidateNomination = {
+  preference_threshold: {
+    percentage: 50,
+    number_of_votes: {
+      integer: 5,
+      numerator: 0,
+      denominator: 600,
+    },
+  },
+  chosen_candidates: [
+    {
+      number: 2,
+      initials: "D.",
+      first_name: "Damian",
+      last_name: "Born",
+      locality: "Hovenerwoud",
+      gender: "Female",
+      list_number: 1,
+      list_name: "Voorkeurskeuzepartij",
+    },
+    {
+      number: 1,
+      initials: "İ.",
+      first_name: "İlknur",
+      last_name: "Cornelis",
+      locality: "Heemdamseburg",
+      gender: "X",
+      list_number: 2,
+      list_name: "Het Stembiljet",
+    },
+    {
+      number: 2,
+      initials: "N.",
+      last_name_prefix: "van",
+      last_name: "Jaspers-Gezen",
+      locality: "Sluisdam",
+      gender: "Female",
+      list_number: 3,
+      list_name: "Politieke Groep de Partij",
+    },
+    {
+      number: 1,
+      initials: "N.",
+      last_name: "Katsma",
+      locality: "Hoek van Zoom",
+      gender: "X",
+      list_number: 3,
+      list_name: "Politieke Groep de Partij",
+    },
+    {
+      number: 2,
+      initials: "S.",
+      first_name: "Sibel",
+      last_name: "Titulaer",
+      locality: "Bloemstede",
+      gender: "Female",
+      list_number: 2,
+      list_name: "Het Stembiljet",
+    },
+  ],
+  list_candidate_nomination: [
+    {
+      list_number: 1,
+      list_name: "Voorkeurskeuzepartij",
+      list_seats: 1,
+      preferential_candidate_nomination: [],
+      other_candidate_nomination: [
+        {
+          number: 2,
+          votes: 3,
+        },
+      ],
+      updated_candidate_ranking: [
+        {
+          number: 2,
+          initials: "D.",
+          first_name: "Damian",
+          last_name: "Born",
+          locality: "Hovenerwoud",
+          gender: "Female",
+        },
+      ],
+    },
+    {
+      list_number: 2,
+      list_name: "Het Stembiljet",
+      list_seats: 2,
+      preferential_candidate_nomination: [],
+      other_candidate_nomination: [
+        {
+          number: 1,
+          votes: 2,
+        },
+        {
+          number: 2,
+          votes: 2,
+        },
+      ],
+      updated_candidate_ranking: [],
+    },
+    {
+      list_number: 3,
+      list_name: "Politieke Groep de Partij",
+      list_seats: 2,
+      preferential_candidate_nomination: [
+        {
+          number: 1,
+          votes: 25,
+        },
+        {
+          number: 2,
+          votes: 25,
+        },
+      ],
+      other_candidate_nomination: [],
+      updated_candidate_ranking: [],
+    },
+  ],
+};
+
+export const election_summary: ElectionSummary = {
+  voters_counts: {
+    poll_card_count: 60,
+    proxy_certificate_count: 0,
+    total_admitted_voters_count: 60,
+  },
+  votes_counts: {
+    political_group_total_votes: [
+      {
+        number: 1,
+        total: 6,
+      },
+      {
+        number: 2,
+        total: 4,
+      },
+      {
+        number: 3,
+        total: 50,
+      },
+    ],
+    total_votes_candidates_count: 60,
+    blank_votes_count: 0,
+    invalid_votes_count: 0,
+    total_votes_cast_count: 60,
+  },
+  differences_counts: {
+    more_ballots_count: {
+      count: 0,
+      data_entry_sources: [],
+    },
+    fewer_ballots_count: {
+      count: 0,
+      data_entry_sources: [],
+    },
+  },
+  political_group_votes: [
+    {
+      number: 1,
+      total: 6,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 3,
+        },
+        {
+          number: 2,
+          votes: 3,
+        },
+      ],
+    },
+    {
+      number: 2,
+      total: 4,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 2,
+        },
+        {
+          number: 2,
+          votes: 2,
+        },
+      ],
+    },
+    {
+      number: 3,
+      total: 50,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 25,
+        },
+        {
+          number: 2,
+          votes: 25,
+        },
+      ],
+    },
+  ],
+  polling_station_investigations: {
+    admitted_voters_recounted: [],
+    investigated_other_reason: [],
+    ballots_recounted: [],
+  },
+  number_of_voters: 91,
+};
+
+export const warnings: ApportionmentWarning[] = ["NotAllSeatsAssigned"];
+
+export const committee_session: CommitteeSession = {
+  id: 13,
+  number: 1,
+  election_id: 13,
+  status: "completed",
+  location: "",
+  start_date_time: "",
+};
+
+export const election: ElectionWithPoliticalGroups = {
+  id: 13,
+  name: "Election < 19 seats & Not All Seats Assigned",
+  committee_category: "CSB",
+  election_id: "GR2026_Juinen",
+  location: "Juinen",
+  domain_id: "0035",
+  category: "Municipal",
+  number_of_seats: 6,
+  number_of_voters: 1,
+  election_date: "2026-03-18",
+  nomination_date: "2026-02-02",
+  political_groups: [
+    {
+      number: 1,
+      name: "Political Group A",
+      candidates: [
+        {
+          number: 1,
+          initials: "L.",
+          first_name: "Lidewij",
+          last_name: "Oud",
+          locality: "Test Location",
+          gender: "Female",
+        },
+        {
+          number: 2,
+          initials: "J.",
+          first_name: "Johan",
+          last_name: "Oud",
+          locality: "Test Location",
+          gender: "Male",
+        },
+      ],
+    },
+    {
+      number: 2,
+      name: "Political Group B",
+      candidates: [
+        {
+          number: 1,
+          initials: "T.",
+          first_name: "Tinus",
+          last_name: "Bakker",
+          locality: "Test Location",
+          gender: "Male",
+          country_code: "BE",
+        },
+        {
+          number: 2,
+          initials: "D.",
+          last_name: "Po",
+          locality: "Test Location",
+          gender: "X",
+        },
+      ],
+    },
+    {
+      number: 3,
+      name: "Blanco (Smit, G.)",
+      candidates: [
+        {
+          number: 1,
+          initials: "G.",
+          first_name: "Gert",
+          last_name: "Smit",
+          locality: "Test Location",
+          gender: "Male",
+        },
+        {
+          number: 2,
+          initials: "E.",
+          first_name: "Eva",
+          last_name: "Koster",
+          locality: "Test Location",
+          gender: "Female",
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Closes #3593 

## What & why

ApportionmentTable does not count full seats + residual seats but uses council seats, in case of not all seats assigned, this calculation does not add up. This is now fixed.

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Run gen-test-election with P 22-2 variants
- Select Election < 19 seats & List Exhaustion
- Mark 1 candidate deceased (from any list)
- Check that the calculation is now correct and compare with main on abacus-test

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->