### PR TITLE
Add candidate nomination to differential fuzzer

### DIFF
--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -125,10 +125,12 @@ fn parse_last_bracketed_list_numbers(log: &str, prefix: &str) -> Option<BTreeSet
 }
 
 /// Parse the list numbers from Abacus's
-/// "Drawing of lots is required for lists: [..]" log line.
-/// Returns None when there is no drawing of lots for lists.
+/// "Drawing of lots is required for {lists|candidates}: [..]" log line.
+/// Returns None when there is no drawing of lots for lists or candidates.
 fn parse_abacus_lots_options(abacus_log: &str) -> Option<BTreeSet<u32>> {
-    parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for lists: [")
+    parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for lists: [").or_else(|| {
+	parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for candidates: [")
+    })
 }
 
 /// Parse the list numbers from OSV2020's
@@ -222,7 +224,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
     {
         return;
     }
-
+    
     match abacus_result {
         Ok(ApportionmentOutput::Completed(ref output)) => {
             let abacus_seats = get_total_seats(&output.seat_assignment);
@@ -303,10 +305,10 @@ fn fuzz(data: FuzzedApportionmentInput) {
                 }
             }
         }
-        Ok(
-            e @ ApportionmentOutput::ListDrawingLotsRequired(..)
-            | e @ ApportionmentOutput::CandidateDrawingLotsRequired(..),
-        ) => {
+	Ok(
+            e @ ApportionmentOutput::ListDrawingLotsRequired(..) |
+	    e @ ApportionmentOutput::CandidateDrawingLotsRequired(..)
+	) => {
             match osv2020_result {
                 Osv2020Result::Allocated {
                     seats: osv2020_seats,

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -142,6 +142,7 @@ fn abacus_lots_options(
 /// Parse the lots options from OSV2020
 /// - For lists: "... Alternativen: List2, List3."
 /// - For candidates: "... Alternativen: List1_2, List1_3."
+///
 /// Returns None if the prefix is not found in the log
 fn parse_osv2020_lots_options(osv2020_log: &[String]) -> Option<LotsOptions> {
     let prefix = "Alternativen: ";
@@ -306,10 +307,6 @@ fn fuzz(data: FuzzedApportionmentInput) {
                             "candidate nomination mismatch",
                         );
                     }
-
-                    eprintln!(
-                        "Abacus and OSV2020 agree on seat allocation and candidate nomination (1)"
-                    );
                 }
                 Osv2020Result::Conflict => {
                     // OSV2020 can require a drawing lots for a residual seat while
@@ -342,10 +339,6 @@ fn fuzz(data: FuzzedApportionmentInput) {
                             "OSV2020 has conflict where Abacus has allocation",
                         );
                     }
-
-                    eprintln!(
-                        "Abacus and OSV2020 agree on seat allocation and candidate nomination (2)"
-                    );
                 }
             }
         }
@@ -391,10 +384,6 @@ fn fuzz(data: FuzzedApportionmentInput) {
                                 &format!("OSV2020 lots options: {osv2020_options:?}"),
                                 &osv2020_log,
                                 "OSV2020 and Abacus require drawing lots, but the options do not match",
-                            );
-                        } else {
-                            eprintln!(
-                                "OSV2020 and Abacus require drawing lots, and the options match: {abacus_options:?}"
                             );
                         }
                     }

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -232,7 +232,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
                     seats: osv2020_seats,
                     candidates: osv2020_candidates,
                 } => {
-		    // Compare seat allocation
+                    // Compare seat allocation
                     if abacus_seats != osv2020_seats {
                         report_mismatch(
                             &data,

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -24,6 +24,7 @@ struct ApportionmentRequest {
 enum ApportionmentResponse {
     Seats {
         seats: Vec<u32>,
+        candidates: Vec<[u32; 2]>,
         log: Vec<String>,
     },
     Conflict {
@@ -43,7 +44,10 @@ static OSV2020_WRAPPER: OnceLock<Mutex<Osv2020WrapperProcess>> = OnceLock::new()
 
 #[derive(Debug)]
 enum Osv2020Result {
-    Allocated(Vec<u32>),
+    Allocated {
+        seats: Vec<u32>,
+        candidates: Vec<[u32; 2]>,
+    },
     Conflict,
 }
 
@@ -72,7 +76,11 @@ fn osv2020_apportionment(
 
     let resp: ApportionmentResponse = serde_json::from_str(&response).unwrap();
     match resp {
-        ApportionmentResponse::Seats { seats, log } => (Osv2020Result::Allocated(seats), log),
+        ApportionmentResponse::Seats {
+            seats,
+            candidates,
+            log,
+        } => (Osv2020Result::Allocated { seats, candidates }, log),
         ApportionmentResponse::Conflict { log, .. } => (Osv2020Result::Conflict, log),
     }
 }
@@ -220,7 +228,11 @@ fn fuzz(data: FuzzedApportionmentInput) {
             let abacus_seats = get_total_seats(&output.seat_assignment);
 
             match osv2020_result {
-                Osv2020Result::Allocated(osv2020_seats) => {
+                Osv2020Result::Allocated {
+                    seats: osv2020_seats,
+                    candidates: osv2020_candidates,
+                } => {
+		    // Compare seat allocation
                     if abacus_seats != osv2020_seats {
                         report_mismatch(
                             &data,
@@ -229,6 +241,31 @@ fn fuzz(data: FuzzedApportionmentInput) {
                             &format!("seats: {:?}", osv2020_seats),
                             &osv2020_log,
                             "seat allocation mismatch",
+                        );
+                    }
+
+                    // Compare candidate nomination
+                    let abacus_candidates: Vec<[u32; 2]> = output
+                        .candidate_nomination
+                        .list_candidate_nomination
+                        .iter()
+                        .flat_map(|nomination| {
+                            nomination
+                                .preferential_candidate_nomination
+                                .iter()
+                                .chain(&nomination.other_candidate_nomination)
+                                .map(|cv| [nomination.list_number, cv.number()])
+                        })
+                        .collect();
+
+                    if abacus_candidates != osv2020_candidates {
+                        report_mismatch(
+                            &data,
+                            &format!("candidates: {abacus_candidates:?}"),
+                            &abacus_log,
+                            &format!("candidates: {osv2020_candidates:?}"),
+                            &osv2020_log,
+                            "candidate nomination mismatch",
                         );
                     }
                 }
@@ -271,7 +308,10 @@ fn fuzz(data: FuzzedApportionmentInput) {
             | e @ ApportionmentOutput::CandidateDrawingLotsRequired(..),
         ) => {
             match osv2020_result {
-                Osv2020Result::Allocated(osv2020_seats) => {
+                Osv2020Result::Allocated {
+                    seats: osv2020_seats,
+                    ..
+                } => {
                     report_mismatch(
                         &data,
                         &format!("Err({e:?})"),

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use std::{
-    collections::BTreeSet,
+    collections::HashSet,
     io::{BufRead, BufReader, Write},
     process::{Command, Stdio},
     sync::{Mutex, OnceLock},
@@ -111,68 +111,82 @@ fn report_mismatch(
     panic!("{message}");
 }
 
-/// Parse a bracketed list of numbers (e.g. `[1, 2, 3]`) that follows `prefix`.
-/// Returns None when the prefix or no valid list is not found.
-fn parse_last_bracketed_list_numbers(log: &str, prefix: &str) -> Option<BTreeSet<u32>> {
-    let line = log.lines().rev().find(|l| l.contains(prefix))?;
-    let start = line.find(prefix)? + prefix.len();
-    let lists = &line[start..line[start..].find(']')? + start];
-    lists
-        .split(',')
-        .map(|s| s.trim().parse::<u32>())
-        .collect::<Result<BTreeSet<u32>, _>>()
-        .ok()
+/// The options for a required drawing of lots
+#[derive(Debug, PartialEq, Eq)]
+enum LotsOptions {
+    /// List numbers
+    Lists(Vec<u32>),
+    /// (list number, candidate number) pairs
+    Candidates { list: u32, options: Vec<u32> },
 }
 
-/// Parse the list numbers from Abacus's
-/// "Drawing of lots is required for {lists|candidates}: [..]" log line.
-/// Returns None when there is no drawing of lots for lists or candidates.
-fn parse_abacus_lots_options(abacus_log: &str) -> Option<BTreeSet<u32>> {
-    parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for lists: [")
-        .or_else(|| {
-            parse_last_bracketed_list_numbers(
-                abacus_log,
-                "Drawing of lots is required for candidates: [",
-            )
-        })
+/// Extract the drawing of lots options from Abacus's apportionment output.
+/// Returns None when the output does not require a drawing of lots.
+fn abacus_lots_options(
+    output: &ApportionmentOutput<'_, FuzzedApportionmentInput>,
+) -> Option<LotsOptions> {
+    match output {
+        ApportionmentOutput::Completed(_) => None,
+        ApportionmentOutput::ListDrawingLotsRequired(variant, _) => {
+            Some(LotsOptions::Lists(variant.options().to_vec()))
+        }
+        ApportionmentOutput::CandidateDrawingLotsRequired(variant, _) => {
+            Some(LotsOptions::Candidates {
+                list: variant.list,
+                options: variant.options.clone(),
+            })
+        }
+    }
 }
 
-/// Parse the list numbers from OSV2020's
-/// "... Alternativen: List2, List3." log line
-/// Returns None when there is no drawing of lots for lists.
-fn parse_osv2020_list_alternatives(lists: &str) -> Option<BTreeSet<u32>> {
-    lists
-        .split(", ")
-        .map(|name| {
-            name.rsplit_once('_')
-                .and_then(|(_, n)| n.parse::<u32>().ok())
-        })
-        .collect::<Option<BTreeSet<u32>>>()
-}
-
-/// Parse the candidate numbers from OSV2020's
-/// "... Alternativen: List2_1, List2_2." log line
-/// Returns None when there is no drawing of candidates for lists.
-fn parse_osv2020_candidate_alternatives(lists: &str) -> Option<BTreeSet<u32>> {
-    lists
-        .split(", ")
-        .map(|name| {
-            name.strip_prefix("List")
-                .and_then(|n| n.parse::<u32>().ok())
-        })
-        .collect::<Option<BTreeSet<u32>>>()
-}
-
-fn parse_osv2020_lots_options(osv2020_log: &[String]) -> Option<BTreeSet<u32>> {
+/// Parse the lots options from OSV2020
+/// - For lists: "... Alternativen: List2, List3."
+/// - For candidates: "... Alternativen: List1_2, List1_3."
+/// Returns None if the prefix is not found in the log
+fn parse_osv2020_lots_options(osv2020_log: &[String]) -> Option<LotsOptions> {
     let prefix = "Alternativen: ";
     let line = osv2020_log.iter().rev().find(|l| l.contains(prefix))?;
     let start = line.find(prefix)? + prefix.len();
-    let lists = line[start..]
-        .trim()
-        .strip_suffix('.')
-        .unwrap_or(line[start..].trim());
+    let names = line[start..].trim();
+    let names = names.strip_suffix('.').unwrap_or(names);
 
-    parse_osv2020_list_alternatives(lists).or_else(|| parse_osv2020_candidate_alternatives(lists))
+    if names.contains('_') {
+        // Format "List<list>_<candidate>, List<list>_<candidate>, ..."
+        let options = names
+            .split(", ")
+            .map(|name| {
+                let (list, candidate) = name.strip_prefix("List")?.split_once('_')?;
+                Some((list.parse().ok()?, candidate.parse().ok()?))
+            })
+            .collect::<Option<Vec<(u32, u32)>>>()?;
+
+        let lists = options
+            .iter()
+            .map(|(list, _)| *list)
+            .collect::<HashSet<u32>>();
+
+        // Assert same list
+        assert!(
+            lists.len() == 1,
+            "OSV2020 drawing of lots for candidates has multiple lists: {names}"
+        );
+
+        Some(LotsOptions::Candidates {
+            list: lists.into_iter().next().unwrap(),
+            options: options
+                .into_iter()
+                .map(|(_, candidate)| candidate)
+                .collect(),
+        })
+    } else {
+        // Format "List<list>, List<list>, ..."
+        let options = names
+            .split(", ")
+            .map(|name| name.strip_prefix("List")?.parse().ok())
+            .collect::<Option<Vec<u32>>>()?;
+
+        Some(LotsOptions::Lists(options))
+    }
 }
 
 /// Whether Abacus hit Article P 10 (list exhaustion) during seat assignment.
@@ -292,6 +306,10 @@ fn fuzz(data: FuzzedApportionmentInput) {
                             "candidate nomination mismatch",
                         );
                     }
+
+                    eprintln!(
+                        "Abacus and OSV2020 agree on seat allocation and candidate nomination (1)"
+                    );
                 }
                 Osv2020Result::Conflict => {
                     // OSV2020 can require a drawing lots for a residual seat while
@@ -324,6 +342,10 @@ fn fuzz(data: FuzzedApportionmentInput) {
                             "OSV2020 has conflict where Abacus has allocation",
                         );
                     }
+
+                    eprintln!(
+                        "Abacus and OSV2020 agree on seat allocation and candidate nomination (2)"
+                    );
                 }
             }
         }
@@ -359,7 +381,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
                         // accept, do nothing
                     } else {
                         // No exhaustion: the options for drawing lots must match.
-                        let abacus_options = parse_abacus_lots_options(&abacus_log);
+                        let abacus_options = abacus_lots_options(&e);
                         let osv2020_options = parse_osv2020_lots_options(&osv2020_log);
                         if abacus_options != osv2020_options {
                             report_mismatch(
@@ -369,6 +391,10 @@ fn fuzz(data: FuzzedApportionmentInput) {
                                 &format!("OSV2020 lots options: {osv2020_options:?}"),
                                 &osv2020_log,
                                 "OSV2020 and Abacus require drawing lots, but the options do not match",
+                            );
+                        } else {
+                            eprintln!(
+                                "OSV2020 and Abacus require drawing lots, and the options match: {abacus_options:?}"
                             );
                         }
                     }

--- a/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
+++ b/backend/apportionment/fuzz/fuzz_targets/differential_osv2020.rs
@@ -128,14 +128,41 @@ fn parse_last_bracketed_list_numbers(log: &str, prefix: &str) -> Option<BTreeSet
 /// "Drawing of lots is required for {lists|candidates}: [..]" log line.
 /// Returns None when there is no drawing of lots for lists or candidates.
 fn parse_abacus_lots_options(abacus_log: &str) -> Option<BTreeSet<u32>> {
-    parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for lists: [").or_else(|| {
-	parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for candidates: [")
-    })
+    parse_last_bracketed_list_numbers(abacus_log, "Drawing of lots is required for lists: [")
+        .or_else(|| {
+            parse_last_bracketed_list_numbers(
+                abacus_log,
+                "Drawing of lots is required for candidates: [",
+            )
+        })
 }
 
 /// Parse the list numbers from OSV2020's
 /// "... Alternativen: List2, List3." log line
 /// Returns None when there is no drawing of lots for lists.
+fn parse_osv2020_list_alternatives(lists: &str) -> Option<BTreeSet<u32>> {
+    lists
+        .split(", ")
+        .map(|name| {
+            name.rsplit_once('_')
+                .and_then(|(_, n)| n.parse::<u32>().ok())
+        })
+        .collect::<Option<BTreeSet<u32>>>()
+}
+
+/// Parse the candidate numbers from OSV2020's
+/// "... Alternativen: List2_1, List2_2." log line
+/// Returns None when there is no drawing of candidates for lists.
+fn parse_osv2020_candidate_alternatives(lists: &str) -> Option<BTreeSet<u32>> {
+    lists
+        .split(", ")
+        .map(|name| {
+            name.strip_prefix("List")
+                .and_then(|n| n.parse::<u32>().ok())
+        })
+        .collect::<Option<BTreeSet<u32>>>()
+}
+
 fn parse_osv2020_lots_options(osv2020_log: &[String]) -> Option<BTreeSet<u32>> {
     let prefix = "Alternativen: ";
     let line = osv2020_log.iter().rev().find(|l| l.contains(prefix))?;
@@ -144,13 +171,8 @@ fn parse_osv2020_lots_options(osv2020_log: &[String]) -> Option<BTreeSet<u32>> {
         .trim()
         .strip_suffix('.')
         .unwrap_or(line[start..].trim());
-    lists
-        .split(", ")
-        .map(|name| {
-            name.strip_prefix("List")
-                .and_then(|n| n.parse::<u32>().ok())
-        })
-        .collect::<Option<BTreeSet<u32>>>()
+
+    parse_osv2020_list_alternatives(lists).or_else(|| parse_osv2020_candidate_alternatives(lists))
 }
 
 /// Whether Abacus hit Article P 10 (list exhaustion) during seat assignment.
@@ -224,7 +246,7 @@ fn fuzz(data: FuzzedApportionmentInput) {
     {
         return;
     }
-    
+
     match abacus_result {
         Ok(ApportionmentOutput::Completed(ref output)) => {
             let abacus_seats = get_total_seats(&output.seat_assignment);
@@ -305,10 +327,10 @@ fn fuzz(data: FuzzedApportionmentInput) {
                 }
             }
         }
-	Ok(
-            e @ ApportionmentOutput::ListDrawingLotsRequired(..) |
-	    e @ ApportionmentOutput::CandidateDrawingLotsRequired(..)
-	) => {
+        Ok(
+            e @ ApportionmentOutput::ListDrawingLotsRequired(..)
+            | e @ ApportionmentOutput::CandidateDrawingLotsRequired(..),
+        ) => {
             match osv2020_result {
                 Osv2020Result::Allocated {
                     seats: osv2020_seats,

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -119,13 +119,29 @@ impl<'a> Arbitrary<'a> for FuzzedApportionmentInput {
         for list_idx in 0..list_count {
             // Generate candidates for each list
             let candidate_count = u.int_in_range(1..=80)?;
-            let mut candidate_votes = Vec::with_capacity(candidate_count);
+            let mut candidate_votes: Vec<u32> = Vec::with_capacity(candidate_count);
 
             // Generate votes for each candidate
             for _ in 0..candidate_count {
                 // Limit votes to ensure total doesn't exceed 100 million to prevent overflows
                 let max_votes_per_candidate = 100_000_000u32.saturating_sub(total_votes);
-                let votes: u32 = u.int_in_range(0..=max_votes_per_candidate)?;
+                // Generating two random numbers in a large range makes the chances of a
+                // tie very low. To bias more towards drawing of lots for candidates,
+                // sometimes copy an earlier candidate's votes (a guaranteed tie),
+                // and sometimes pick a small value, which keeps the quota (and thus the
+                // preference threshold) low enough for tied candidates to still reach
+                // the candidate drawing of lots.
+                let votes: u32 = match u.int_in_range(0..=3u8)? {
+                    // Copy the votes of an earlier candidate on this list, producing an exact tie
+                    0 if !candidate_votes.is_empty() => {
+                        let index = u.int_in_range(0..=candidate_votes.len() - 1)?;
+                        candidate_votes[index].min(max_votes_per_candidate)
+                    }
+                    // Small values keep the quota low, so tied candidates can still meet the
+                    // preference threshold
+                    1 => u.int_in_range(0..=100u32)?.min(max_votes_per_candidate),
+                    _ => u.int_in_range(0..=max_votes_per_candidate)?,
+                };
                 candidate_votes.push(votes);
                 // Ensure total_votes does not overflow, which would cause a panic in the apportionment code (#3179)
                 total_votes = total_votes

--- a/backend/apportionment/fuzz/src/apportionment_input.rs
+++ b/backend/apportionment/fuzz/src/apportionment_input.rs
@@ -173,11 +173,7 @@ impl apportionment::ApportionmentInput for FuzzedApportionmentInput {
 }
 
 pub fn get_total_seats(result: &apportionment::SeatAssignmentDetails<u32>) -> Vec<u32> {
-    result
-        .standings
-        .iter()
-        .map(|p| p.total_seats)
-        .collect()
+    result.standings.iter().map(|p| p.total_seats).collect()
 }
 
 impl fmt::Debug for FuzzedApportionmentInput {

--- a/backend/apportionment/fuzz/src/logging.rs
+++ b/backend/apportionment/fuzz/src/logging.rs
@@ -46,7 +46,9 @@ pub fn init_tracing() {
         .with_target(true)
         .with_level(true)
         .with_filter(
-            Targets::new().with_target("apportionment::seat_assignment", LevelFilter::TRACE),
+            Targets::new()
+		.with_target("apportionment::seat_assignment", LevelFilter::TRACE)
+		.with_target("apportionment::candidate_nomination", LevelFilter::TRACE),
         );
     tracing_subscriber::registry().with(layer).init();
 }

--- a/backend/apportionment/fuzz/src/logging.rs
+++ b/backend/apportionment/fuzz/src/logging.rs
@@ -47,8 +47,8 @@ pub fn init_tracing() {
         .with_level(true)
         .with_filter(
             Targets::new()
-		.with_target("apportionment::seat_assignment", LevelFilter::TRACE)
-		.with_target("apportionment::candidate_nomination", LevelFilter::TRACE),
+                .with_target("apportionment::seat_assignment", LevelFilter::TRACE)
+                .with_target("apportionment::candidate_nomination", LevelFilter::TRACE),
         );
     tracing_subscriber::registry().with(layer).init();
 }

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -304,7 +304,6 @@ fn preferential_candidate_nomination<'a, LV: ListVotes>(
             info!(
                 "Drawing of lots is required for candidates: {options:?}, only {seats_remaining} seat(s) available",
             );
-
             let current_seat_number = index + 1;
             let nr_of_seats = options.len().min(seats_remaining as usize);
             let seat_numbers = (current_seat_number..current_seat_number + nr_of_seats)


### PR DESCRIPTION
# NOTE: 

## ~~The fuzzer CI will fail until https://github.com/kiesraad/osv2020-apportionment-wrapper/pull/2 is merged!~~
The differential fuzzer is not run in CI, so this is no issue. Just make sure to checkout and build the `candidate-nomination` branch in the `osv2020-apportionment-wrapper` when testing locally.

## What & why
Adds a comparison for the candidate nomination in the differential fuzzer

## How to test
Run the fuzzer locally, it is not run in CI. See instructions in the [apportionment fuzzer README](https://github.com/kiesraad/abacus/tree/main/backend/apportionment/fuzz)

## Reviewer notes
Make sure the input and checks are correct

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->