### PR TITLE
Update Rust to v1.97.1

### DIFF
--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## What & why

Rust 1.97.1 fixes a miscompilation in an LLVM optimization: https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/

## How to test

CI pass should be enough.