### PR TITLE
Fixed copy mistake in P 22-2 drawing lots footnote

### DIFF
--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -353,7 +353,7 @@ Na toewijzing van de volle zetels blijft een aantal te verdelen zetels over. Dit
       let lot_variant = if drawn_lot.variant == "HighestAverageResidualSeat" { [gemiddelden] } else { [overschotten] };
       let list_names = drawn_lot.lists.map((list) => format_political_group_name(list.number, list.name, with_prefix: "with_list_prefix"));
       let list_names_formatted = comma_list(list_names, last_separator: "en");
-      [+ De lijsten #list_names_formatted hebben gelijke #lot_variant, maar er zijn niet voldoende restzetels voor toekenning ervan aan die lijst. Er is daarom geloot welke lijst de restzetel krijgt.]
+      [+ De lijsten #list_names_formatted hebben gelijke #lot_variant, maar er zijn niet voldoende restzetels voor toekenning ervan aan die lijsten. Er is daarom geloot welke lijst de restzetel krijgt.]
     }
     if absolute_majority != none {
       [+ #format_political_group_name(absolute_majority.number, absolute_majority.name, with_prefix: "with_list_prefix") heeft meer dan de helft van de stemmen behaald en heeft daardoor een volstrekte meerderheid. Omdat de lijst op basis van de zetelverdeling niet meer dan de helft van de zetels heeft gekregen, heeft de lijst via de restzetelverdeling een extra (rest)zetel gekregen.]


### PR DESCRIPTION
## What & why

Found in https://github.com/kiesraad/abacus/issues/3547

Screenshot from the drawing lots footnote in the P 22-2 model:
<img width="542" height="62" alt="image" src="https://github.com/user-attachments/assets/872baa76-6b02-4656-92e7-c39bb87db9f5" />

Changed "aan die lijst" to "aan die lijsten" to make sure it's correct as in the model.

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Verify the PDF diff changes

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->