### PR TITLE
Added extra tests to prevent missed mutants

### DIFF
--- a/backend/apportionment/src/candidate_nomination/structs.rs
+++ b/backend/apportionment/src/candidate_nomination/structs.rs
@@ -121,3 +121,36 @@ pub struct Candidate<T: ListVotes> {
     pub list_number: ListNumber<T>,
     pub candidate_number: CandidateNumber<T>,
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::CandidateRanking;
+
+    #[test]
+    fn test_candidate_ranking_functions() {
+        let original_candidate_ranking = CandidateRanking::Original(vec![1, 2, 3]);
+        let updated_candidate_ranking = CandidateRanking::Updated(vec![1, 3, 2]);
+
+        assert_eq!(original_candidate_ranking.as_slice(), &[1, 2, 3]);
+        assert_eq!(updated_candidate_ranking.as_slice(), &[1, 3, 2]);
+
+        assert_eq!(original_candidate_ranking.as_updated_slice(), []);
+        assert_eq!(updated_candidate_ranking.as_updated_slice(), &[1, 3, 2]);
+
+        assert!(original_candidate_ranking.iter().eq([1, 2, 3].iter()));
+        assert!(updated_candidate_ranking.iter().eq([1, 3, 2].iter()));
+
+        assert!(original_candidate_ranking.iter_updated().eq([].iter()));
+        assert!(
+            updated_candidate_ranking
+                .iter_updated()
+                .eq([1, 3, 2].iter())
+        );
+
+        assert!(original_candidate_ranking.is_original());
+        assert!(!updated_candidate_ranking.is_original());
+
+        assert!(!original_candidate_ranking.is_updated());
+        assert!(updated_candidate_ranking.is_updated());
+    }
+}

--- a/backend/apportionment/src/candidate_nomination/structs.rs
+++ b/backend/apportionment/src/candidate_nomination/structs.rs
@@ -124,7 +124,10 @@ pub struct Candidate<T: ListVotes> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::CandidateRanking;
+    use crate::{
+        CandidateRanking, ListCandidateNomination,
+        test_helpers::{CandidateVotesMock, ListVotesMock},
+    };
 
     #[test]
     fn test_candidate_ranking_functions() {
@@ -152,5 +155,25 @@ pub(crate) mod tests {
 
         assert!(!original_candidate_ranking.is_updated());
         assert!(updated_candidate_ranking.is_updated());
+    }
+
+    #[test]
+    fn test_list_candidate_nomination_function() {
+        let list_candidate_nomination: ListCandidateNomination<ListVotesMock> =
+            ListCandidateNomination {
+                list_number: 1,
+                list_seats: 4,
+                preferential_candidate_nomination: vec![
+                    &CandidateVotesMock(1, 500),
+                    &CandidateVotesMock(5, 400),
+                    &CandidateVotesMock(3, 400),
+                ],
+                other_candidate_nomination: vec![&CandidateVotesMock(2, 300)],
+                candidate_ranking: CandidateRanking::Updated(vec![1, 5, 3, 2, 4, 6]),
+            };
+        assert_eq!(
+            list_candidate_nomination.nominated_candidate_ranking(),
+            &[1, 5, 3, 2]
+        );
     }
 }

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -890,19 +890,34 @@ pub(crate) mod tests {
             assert!(result.warnings().is_empty());
         }
 
-        /// Article P 9 Kieswet requires a strict majority of votes (> 50%), so exactly 50% should not trigger it.
+        /// Apportionment with residual seats assigned with largest remainders method  
+        /// This test does not trigger Kieswet Article P 9, since this requires a
+        /// strict majority of votes (> 50%), so exactly 50% does not trigger it.
+        ///
+        /// Full seats: [7, 2, 1, 1, 1] - Remainder seats: 3  
+        /// Remainders: [170 2/15, 306 7/15, 229 11/15, 198 11/15, 115 11/15]  
+        /// 1 - largest remainder: seat assigned to list 2  
+        /// 2 - largest remainder: seat assigned to list 3  
+        /// 3 - largest remainder: seat assigned to list 4
         #[test]
         fn test_exactly_half_of_votes_should_not_trigger_absolute_majority_reassignment() {
-            let input = seat_assignment_fixture_with_default_50_candidates(7, vec![500, 300, 200]);
+            let input = seat_assignment_fixture_with_default_50_candidates(
+                15,
+                vec![2552, 987, 570, 539, 456],
+            );
             let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
                 panic!("should be Completed");
             };
-            assert!(
-                !result
-                    .steps
-                    .iter()
-                    .any(|step| step.change.is_changed_by_absolute_majority_reassignment())
-            );
+
+            assert_eq!(result.full_seats, 12);
+            assert_eq!(result.residual_seats, 3);
+            assert_eq!(result.steps.len(), 3);
+            assert_eq!(result.steps[0].change.list_number_assigned(), 2);
+            assert_eq!(result.steps[1].change.list_number_assigned(), 3);
+            assert_eq!(result.steps[2].change.list_number_assigned(), 4);
+            let total_seats = get_total_seats_from_apportionment_result(&result);
+            assert_eq!(total_seats, vec![7, 3, 2, 2, 1]);
+            assert!(result.warnings().is_empty());
         }
 
         mod drawing_of_lots {

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -407,3 +407,77 @@ pub enum AbsoluteMajority<LN> {
     Completed(Vec<ListStanding<LN>>, Option<SeatChange<LN>>),
     DrawingLotsRequired(ListDrawingLotsVariant<LN>),
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::{Fraction, seat_assignment::ListStanding, test_helpers::ListVotesMock};
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_list_standing_functions() {
+        let candidate_votes: Vec<u32> = vec![100, 100, 100];
+        let votes_cast: u64 = candidate_votes.iter().sum::<u32>() as u64;
+        let mut standing = ListStanding::new(
+            &ListVotesMock::from_test_data_auto(1, candidate_votes),
+            Fraction {
+                numerator: 50,
+                denominator: 1,
+            },
+        );
+        assert_eq!(standing.full_seats(), 6);
+        assert_eq!(standing.residual_seats(), 0);
+        assert_eq!(
+            standing.total_seats(),
+            standing.full_seats() + standing.residual_seats()
+        );
+        assert_eq!(
+            standing.next_votes_per_seat,
+            Fraction {
+                numerator: votes_cast,
+                denominator: (standing.total_seats() + 1) as u64
+            }
+        );
+        standing.add_residual_seat();
+        assert_eq!(standing.full_seats(), 6);
+        assert_eq!(standing.residual_seats(), 1);
+        assert_eq!(
+            standing.total_seats(),
+            standing.full_seats() + standing.residual_seats()
+        );
+        assert_eq!(
+            standing.next_votes_per_seat,
+            Fraction {
+                numerator: votes_cast,
+                denominator: (standing.total_seats() + 1) as u64
+            }
+        );
+        standing.remove_residual_seat();
+        assert_eq!(standing.full_seats(), 6);
+        assert_eq!(standing.residual_seats(), 0);
+        assert_eq!(
+            standing.total_seats(),
+            standing.full_seats() + standing.residual_seats()
+        );
+        assert_eq!(
+            standing.next_votes_per_seat,
+            Fraction {
+                numerator: votes_cast,
+                denominator: (standing.total_seats() + 1) as u64
+            }
+        );
+        standing.remove_full_seat();
+        assert_eq!(standing.full_seats(), 5);
+        assert_eq!(standing.residual_seats(), 0);
+        assert_eq!(
+            standing.total_seats(),
+            standing.full_seats() + standing.residual_seats()
+        );
+        assert_eq!(
+            standing.next_votes_per_seat,
+            Fraction {
+                numerator: votes_cast,
+                denominator: (standing.total_seats() + 1) as u64
+            }
+        );
+    }
+}

--- a/backend/apportionment/src/structs.rs
+++ b/backend/apportionment/src/structs.rs
@@ -228,7 +228,7 @@ mod tests {
     use super::*;
     use crate::{
         seat_assignment::{LargestRemainderAssignedSeat, ListExhaustionRemovedSeat},
-        test_helpers::ListDrawnMock,
+        test_helpers::{CandidateDrawnMock, ListDrawnMock},
     };
 
     #[test]
@@ -304,5 +304,52 @@ mod tests {
         );
 
         assert_eq!(variant.validate(&ListDrawnMock::new(&variant, 2)), Ok(()));
+    }
+
+    #[test]
+    fn test_candidate_drawing_lots_variant_validate() {
+        let variant = CandidateDrawingLotsVariant {
+            list: 2,
+            total_seats: 3,
+            number_of_votes: 400,
+            seat_numbers: vec![2, 3],
+            options: vec![2, 3, 4, 5, 6],
+        };
+
+        let another_variant = CandidateDrawingLotsVariant {
+            list: 1,
+            total_seats: 3,
+            number_of_votes: 400,
+            seat_numbers: vec![2, 3],
+            options: vec![2, 3, 4, 5, 6],
+        };
+
+        assert_eq!(
+            variant.validate(&CandidateDrawnMock {
+                variant: another_variant,
+                drawn: 3
+            }),
+            Err(ApportionmentError::InvalidLotDrawing(
+                "Variant mismatch".to_string()
+            ))
+        );
+
+        assert_eq!(
+            variant.validate(&CandidateDrawnMock {
+                variant: variant.clone(),
+                drawn: 7
+            }),
+            Err(ApportionmentError::InvalidLotDrawing(
+                "Invalid number drawn".to_string()
+            ))
+        );
+
+        assert_eq!(
+            variant.validate(&CandidateDrawnMock {
+                variant: variant.clone(),
+                drawn: 2
+            }),
+            Ok(())
+        );
     }
 }


### PR DESCRIPTION
Closes #3492

## What & why

- Corrected existing test to work correctly to prevent missed mutant in `reassign_residual_seat_for_absolute_majority`
- Added test for list standing functions
- Added test for candidate ranking functions
- Added test for list candidate nomination function
- Added test for candidate drawing lots variant validate function

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Verify that the updated test and added tests do what they are supposed to
- Verify that the mutants are not missed anymore by running `cargo mutants -d apportionment/`
- Verify that the mutants that are left do not need more tests, see https://github.com/kiesraad/abacus/issues/3492#issuecomment-5005510173

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->