### PR TITLE
Include unnamed political groups in generated elections

### DIFF
--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -365,9 +365,17 @@ fn generate_political_party(
             .copied(),
         })
     }
+
+    // Include some unnamed political groups.
+    let registered_name = if rng.random_ratio(1, 5) {
+        String::new()
+    } else {
+        super::data::political_group_name(rng)
+    };
+
     RegisteredPoliticalGroup {
         number: pg_number,
-        registered_name: super::data::political_group_name(rng),
+        registered_name,
         candidates,
     }
 }


### PR DESCRIPTION
## What & why

See title ⬆️ (initially used for testing: https://github.com/kiesraad/abacus/issues/3547)

## How to test

Generate an election; see that it contains unnamed groups (`Blanco (achternaam, initialen)`).

## Reviewer notes

None.