### PR TITLE
Update copy for database backups

### DIFF
--- a/frontend/src/components/navbar/NavBar.stories.tsx
+++ b/frontend/src/components/navbar/NavBar.stories.tsx
@@ -77,7 +77,7 @@ export const NavBarWithAdminLinks: Story = {
     const numberOfVerkiezingenLinks = canvas.getAllByRole("link", { name: "Verkiezingen" }).length;
     const numberOfGebruikersLinks = canvas.getAllByRole("link", { name: "Gebruikers" }).length;
     const numberOfLogsLinks = canvas.getAllByRole("link", { name: "Logs" }).length;
-    const numberOfBackupsLinks = canvas.getAllByRole("link", { name: "Backups" }).length;
+    const numberOfBackupsLinks = canvas.getAllByRole("link", { name: "Back-ups" }).length;
     const numberOfLogoutLinks = canvas.getAllByRole("link", { name: "Afmelden" }).length;
 
     await expect(numberOfVerkiezingenLinks, "number of links to 'Verkiezingen' does not match").toEqual(
@@ -85,7 +85,7 @@ export const NavBarWithAdminLinks: Story = {
     );
     await expect(numberOfGebruikersLinks, "number of links to 'Gebruikers' does not match").toEqual(numberOfLocations);
     await expect(numberOfLogsLinks, "number of links to 'Logs' does not match").toEqual(numberOfLocations);
-    await expect(numberOfBackupsLinks, "number of links to 'Backups' does not match").toEqual(numberOfLocations);
+    await expect(numberOfBackupsLinks, "number of links to 'Back-ups' does not match").toEqual(numberOfLocations);
     await expect(numberOfLogoutLinks, "number of links to 'Afmelden' does not match").toEqual(numberOfLocations);
     await expect(totalNumberOfLinks, "sum of number of links does not match total number of links").toEqual(
       numberOfVerkiezingenLinks +

--- a/frontend/src/features/backups/components/BackupsPage.test.tsx
+++ b/frontend/src/features/backups/components/BackupsPage.test.tsx
@@ -32,8 +32,8 @@ describe("BackupsPage", () => {
   test("Shows page content", () => {
     render(<BackupsPage />);
 
-    expect(screen.getByRole("heading", { level: 1, name: "Database backups" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Nu backup maken" })).toBeVisible();
+    expect(screen.getByRole("heading", { level: 1, name: "Back-ups van de database" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Nu back-up maken" })).toBeVisible();
   });
 
   test("Creates a backup: success", async () => {
@@ -43,11 +43,11 @@ describe("BackupsPage", () => {
 
     render(<BackupsPage />);
 
-    const button = await screen.findByRole("button", { name: "Nu backup maken" });
+    const button = await screen.findByRole("button", { name: "Nu back-up maken" });
     await user.click(button);
 
     expect(button).toBeDisabled();
-    expect(screen.getByText("backup aan het maken")).toBeVisible();
+    expect(screen.getByText("back-up aan het maken")).toBeVisible();
 
     await waitFor(() => {
       expect(createBackup).toHaveBeenCalledExactlyOnceWith(null);
@@ -56,8 +56,8 @@ describe("BackupsPage", () => {
     await waitFor(() => {
       expect(button).toBeEnabled();
     });
-    expect(screen.queryByText("backup aan het maken")).not.toBeInTheDocument();
-    expect(screen.getByText(`Laatste backup gemaakt om ${formatTime(new Date(createdAt))}`)).toBeVisible();
+    expect(screen.queryByText("back-up aan het maken")).not.toBeInTheDocument();
+    expect(screen.getByText(`Laatste back-up gemaakt om ${formatTime(new Date(createdAt))}`)).toBeVisible();
   });
 
   test("Creates a backup: error", async () => {
@@ -79,11 +79,11 @@ describe("BackupsPage", () => {
 
     render(<BackupsPage />);
 
-    await user.click(await screen.findByRole("button", { name: "Nu backup maken" }));
+    await user.click(await screen.findByRole("button", { name: "Nu back-up maken" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "De backup met deze naam bestaat al, probeer het later opnieuw",
+      "De back-up met deze naam bestaat al, probeer het later opnieuw",
     );
-    expect(screen.queryByText(/Laatste backup gemaakt om/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Laatste back-up gemaakt om/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/backups/components/BackupsPageContent.stories.tsx
+++ b/frontend/src/features/backups/components/BackupsPageContent.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvas }) => {
-    await expect(canvas.getByRole("button", { name: "Nu backup maken" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Nu back-up maken" })).toBeEnabled();
   },
 };
 
@@ -29,8 +29,8 @@ export const Loading: Story = {
     isLoading: true,
   },
   play: async ({ canvas }) => {
-    await expect(await canvas.findByText("backup aan het maken")).toBeVisible();
-    await expect(canvas.getByRole("button", { name: "Nu backup maken" })).toBeDisabled();
+    await expect(await canvas.findByText("back-up aan het maken")).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Nu back-up maken" })).toBeDisabled();
   },
 };
 
@@ -39,8 +39,8 @@ export const BackupSuccess: Story = {
     lastBackupAt: new Date(2026, 6, 7, 12, 34, 56),
   },
   play: async ({ canvas }) => {
-    await expect(await canvas.findByText("Laatste backup gemaakt om 12:34")).toBeVisible();
-    await expect(canvas.getByRole("button", { name: "Nu backup maken" })).toBeEnabled();
+    await expect(await canvas.findByText("Laatste back-up gemaakt om 12:34")).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Nu back-up maken" })).toBeEnabled();
   },
 };
 
@@ -50,8 +50,8 @@ export const BackupError: Story = {
   },
   play: async ({ canvas }) => {
     await expect(await canvas.findByRole("alert")).toHaveTextContent(
-      "De backup met deze naam bestaat al, probeer het later opnieuw",
+      "De back-up met deze naam bestaat al, probeer het later opnieuw",
     );
-    await expect(canvas.getByRole("button", { name: "Nu backup maken" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Nu back-up maken" })).toBeEnabled();
   },
 };

--- a/frontend/src/features/backups/components/BackupsPageContent.tsx
+++ b/frontend/src/features/backups/components/BackupsPageContent.tsx
@@ -17,7 +17,7 @@ export function BackupsPageContent({ isLoading, errorMessage, lastBackupAt, onCr
     <>
       <h2>{t("backups.subtitle")}</h2>
 
-      <div className="mb-lg">{tx("backups.description")}</div>
+      <section className="md mb-lg">{tx("backups.description")}</section>
 
       {errorMessage && (
         <Alert type="error" small margin="mb-lg">

--- a/frontend/src/i18n/locales/nl/backups.json
+++ b/frontend/src/i18n/locales/nl/backups.json
@@ -1,9 +1,9 @@
 {
-  "backups": "Backups",
-  "title": "Database backups",
+  "backups": "Back-ups",
+  "title": "Back-ups van de database",
   "subtitle": "Handig om te weten",
-  "description": "<ul><li>Backups worden opgeslagen op de server, in de database map.</li><li>Je moet zelf controleren of er voldoende schijfruimte is voor backups.</li><li>Tijdens het maken van een backup kan iedereen gewoon doorwerken.</li><li>Instructies voor het terugzetten van een backup staan in de handleiding.</li></ul>",
-  "create_backup_button": "Nu backup maken",
-  "running": "backup aan het maken",
-  "last": "Laatste backup gemaakt om {time}"
+  "description": "<ul><li>Back-ups worden opgeslagen op de server, in de map voor back-ups.</li><li>Je moet zelf controleren of er voldoende schijfruimte is voor back-ups.</li><li>Tijdens het maken van een back-up kan iedereen gewoon doorwerken.</li><li>Instructies voor het terugzetten van een back-up staan in de documentatie van Abacus.</li></ul>",
+  "create_backup_button": "Nu back-up maken",
+  "running": "back-up aan het maken",
+  "last": "Laatste back-up gemaakt om {time}"
 }

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -10,7 +10,7 @@
     "ApportionmentNotCompleted": "De documenten kunnen pas gedownload worden als de zetelverdeling is afgerond",
     "ApportionmentCommitteeSessionNotCompleted": "De zetelverdeling kan pas gemaakt worden als de zitting is afgerond",
     "ApportionmentInvalidLotDrawing": "Loting is ongeldig",
-    "BackupAlreadyExists": "De backup met deze naam bestaat al, probeer het later opnieuw",
+    "BackupAlreadyExists": "De back-up met deze naam bestaat al, probeer het later opnieuw",
     "CommitteeSessionPaused": "De coördinator heeft het invoeren van stemmen gepauzeerd. Je kan niet meer verder.",
     "DatabaseError": "Er is een fout opgetreden bij het opslaan van de invoer",
     "DataEntryAlreadyClaimed": "Een andere invoerder is bezig met dit stembureau",

--- a/frontend/src/i18n/locales/nl/log.json
+++ b/frontend/src/i18n/locales/nl/log.json
@@ -15,7 +15,7 @@
     "CommitteeSessionCreated": "Zitting aangemaakt",
     "CommitteeSessionDeleted": "Zitting verwijderd",
     "CommitteeSessionUpdated": "Zitting bijgewerkt",
-    "DatabaseBackupCreated": "Databasebackup gemaakt",
+    "DatabaseBackupCreated": "Back-up van de database gemaakt",
     "DataEntryDeleted": "Invoer verwijderd",
     "DataEntryDiscardedBoth": "Beide invoeren verwijderd",
     "DataEntryDiscardedFirst": "Eerste invoer verwijderd",


### PR DESCRIPTION
## What & why

- Closes https://github.com/kiesraad/abacus/issues/3629
- Fix max width for backup description text/list

## How to test

Log in as admin or coordinator, go to backup screen, make a backup and see that the texts are according to the issue and the max width is correct.

## Reviewer notes

None

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->