### PR TITLE
Print SHA-1 fingerprint for CA certificate

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "socket2",
  "sqlx",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -94,6 +94,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing.workspace = true
 tower-http = { version = "0.6", features = ["set-header", "trace"] }
 sha2 = "0.11.0"
+sha1 = "0.11.0"
 argon2 = { version = "0.5.3", features = ["std"] }
 rand.workspace = true
 cookie = { version = "0.18.1", features = ["percent-encode"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -117,6 +117,12 @@ To trust the server, import the CA into the client trust store: `ca.pem` on
 Linux/macOS/Firefox, `ca.cer` (DER) on Windows. The CA can be downloaded from the
 running server at `/ca.pem` and `/ca.cer`.
 
+Verify that you have the right certificate by comparing its fingerprint. Abacus
+logs both the SHA-256 and SHA-1 fingerprint of the CA on startup. Compare
+against whatever your client shows: browsers and the OpenSSL CLI (`openssl x509
+-in ca.pem -noout -fingerprint -sha256`) show SHA-256, while the Windows
+certificate manager displays the SHA-1 digest as the certificate "thumbprint".
+
 With the `tls` feature enabled, the default port is 8443 in debug builds and 443
 in release builds. Binding to 443 requires elevated privileges (e.g. the
 `CAP_NET_BIND_SERVICE` capability on Linux).

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -15,10 +15,13 @@ dependencies = [
  "cookie",
  "eml-nl",
  "hyper",
+ "icu_collator",
+ "icu_locale_core",
  "pdf_gen",
  "rand",
  "serde",
  "serde_json",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "socket2",
  "sqlx",
@@ -608,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142068a435989dcdc985d6a0a7cd701e87c3b6eb79c24ae8f94c0ccc4900c675"
+checksum = "c2e44b143a6a48317033079275252e49eb0da3214728b16e3e61144d43eadd39"
 dependencies = [
  "chrono",
  "quick-xml",
@@ -1065,6 +1068,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collator"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1107,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,10 +1129,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -1102,6 +1152,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -1139,6 +1192,8 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1471,6 +1526,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -1501,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2123,6 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -2403,6 +2461,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -2749,6 +2813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2877,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -2815,6 +2886,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/backend/src/bin/abacus.rs
+++ b/backend/src/bin/abacus.rs
@@ -134,8 +134,8 @@ async fn main() {
     }
 }
 
-/// Create the CA in `tls_dir` (if missing) and print its location and SHA-256
-/// fingerprint. Used for the `--init-tls` CLI flag.
+/// Create the CA in `tls_dir` (if missing) and print its location and its
+/// SHA-256 and SHA-1 fingerprints. Used for the `--init-tls` CLI flag.
 #[cfg(feature = "tls")]
 fn init_tls(tls_dir: &std::path::Path) -> Result<(), AppError> {
     use abacus::infra::tls;
@@ -150,6 +150,7 @@ fn init_tls(tls_dir: &std::path::Path) -> Result<(), AppError> {
         tls_dir.join(tls::CA_CERT_DER).display()
     );
     println!("CA SHA-256 fingerprint: {}", ca.sha256_fingerprint());
+    println!("CA SHA-1 fingerprint:   {}", ca.sha1_fingerprint());
     Ok(())
 }
 

--- a/backend/src/infra/tls.rs
+++ b/backend/src/infra/tls.rs
@@ -33,7 +33,12 @@ pub struct CaCertificate {
 impl CaCertificate {
     /// SHA-256 fingerprint of the CA certificate (colon-separated hex).
     pub fn sha256_fingerprint(&self) -> String {
-        fingerprint(&self.der)
+        sha256_fingerprint(&self.der)
+    }
+
+    /// SHA-1 fingerprint of the CA certificate (colon-separated hex).
+    pub fn sha1_fingerprint(&self) -> String {
+        sha1_fingerprint(&self.der)
     }
 }
 
@@ -123,9 +128,10 @@ fn load_ca(
     let ca_key = KeyPair::try_from(key_der.as_slice()).map_err(tls_err)?;
     let issuer = Issuer::from_ca_cert_der(&cert_der, ca_key).map_err(tls_err)?;
     tracing::info!(
-        "Loaded the local CA from {:?} (SHA-256 fingerprint {})",
+        "Loaded the local CA from {:?}\n  SHA-256 fingerprint {}\n  SHA-1 fingerprint   {}",
         cert_pem_path,
-        fingerprint(&der),
+        sha256_fingerprint(&der),
+        sha1_fingerprint(&der),
     );
     Ok((issuer, CaCertificate { pem, der }))
 }
@@ -147,9 +153,10 @@ fn generate_ca(
     write_file(key_der_path, &key_der, 0o600)?;
 
     tracing::warn!(
-        "Generated a new local CA at {:?} (SHA-256 fingerprint {}).",
+        "Generated a new local CA at {:?}\n  SHA-256 fingerprint {}\n  SHA-1 fingerprint   {}",
         cert_pem_path,
-        fingerprint(&der),
+        sha256_fingerprint(&der),
+        sha1_fingerprint(&der),
     );
 
     let issuer = Issuer::from_ca_cert_der(ca_cert.der(), ca_key).map_err(tls_err)?;
@@ -191,7 +198,7 @@ fn create_leaf(
     let cert_der = cert.der().clone();
     tracing::info!(
         "Created a new server certificate for {subjects:?} (SHA-256 fingerprint {})",
-        fingerprint(&cert_der),
+        sha256_fingerprint(&cert_der),
     );
     let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(pkcs8));
     Ok((cert_der, key_der))
@@ -240,16 +247,29 @@ fn ymd(dt: DateTime<Utc>) -> Result<(i32, u8, u8), AppError> {
         u8::try_from(dt.day()).map_err(tls_err)?,
     ))
 }
-/// SHA-256 fingerprint of a DER-encoded certificate
-/// Uppercase colon-separated hex is used by most browsers and the OpenSSL CLI.
-fn fingerprint(der: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-
-    Sha256::digest(der)
+/// Format a digest as uppercase colon-separated hex, as used by most browsers
+/// and the OpenSSL CLI.
+fn format_fingerprint(digest: &[u8]) -> String {
+    digest
         .iter()
         .map(|b| format!("{b:02X}"))
         .collect::<Vec<_>>()
         .join(":")
+}
+
+/// SHA-256 fingerprint of a DER-encoded certificate.
+fn sha256_fingerprint(der: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    format_fingerprint(&Sha256::digest(der))
+}
+
+/// SHA-1 fingerprint of a DER-encoded certificate.
+/// Windows shows the SHA-1/ digest as the certificate "thumbprint"
+fn sha1_fingerprint(der: &[u8]) -> String {
+    use sha1::{Digest, Sha1};
+
+    format_fingerprint(&Sha1::digest(der))
 }
 
 /// Write `bytes` to `path` with mode permission bits (only on Unix).
@@ -343,14 +363,22 @@ mod tests {
         // ca.cer matches the returned DER
         assert_eq!(fs::read(tls_dir.join(CA_CERT_DER)).unwrap(), first.der);
 
-        // fingerprint: 64 hex chars + 31 colons = 95 chars
-        let fp = first.sha256_fingerprint();
-        assert_eq!(fp.len(), 95, "fingerprint should be 95 chars");
-        assert!(
-            fp.chars()
-                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == ':'),
-            "fingerprint should be uppercase colon-separated hex, got {fp}"
-        );
+        // fingerprints are uppercase colon-separated hex
+        let assert_fingerprint = |fp: &str, digest_bytes: usize, name: &str| {
+            let expected_len = 3 * digest_bytes - 1;
+            assert_eq!(
+                fp.len(),
+                expected_len,
+                "{name} fingerprint should be {expected_len} chars, got {fp}"
+            );
+            assert!(
+                fp.chars()
+                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == ':'),
+                "{name} fingerprint should be uppercase colon-separated hex, got {fp}"
+            );
+        };
+        assert_fingerprint(&first.sha256_fingerprint(), 32, "SHA-256");
+        assert_fingerprint(&first.sha1_fingerprint(), 20, "SHA-1");
 
         // check file permissions
         #[cfg(unix)]

--- a/backend/tests/init_tls_test.rs
+++ b/backend/tests/init_tls_test.rs
@@ -31,7 +31,11 @@ fn init_tls_creates_ca_and_exits_without_database() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("CA SHA-256 fingerprint:"),
-        "stdout should include the fingerprint line, got:\n{stdout}"
+        "stdout should include the SHA-256 fingerprint line, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CA SHA-1 fingerprint:"),
+        "stdout should include the SHA-1 fingerprint line, got:\n{stdout}"
     );
 
     assert!(


### PR DESCRIPTION
## What & why

Print SHA-1 fingerprint for CA certificate on startup, so that Windows users can verify the fingerprint against the SHA-1 "thumbprint" in the Windows certificate UI.

## How to test

`cargo run --features tls` and see that SHA-1 fingerprint is printed.
