### PR TITLE
Change shortcut back to data folder in Windows installer

### DIFF
--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -80,7 +80,7 @@ Name: "{app}\{#MyBackupDirName}"
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppIcon}"
 Name: "{autodesktop}\1. Start {#MyAppName} server"; Filename: "{sys}\cmd.exe"; Parameters: "/k ""{app}\{#MyAppExeName}"""; WorkingDir: "{app}"; IconFilename: "{app}\{#MyAppIcon}"
 Name: "{autodesktop}\2. Open {#MyAppName} in browser"; Filename: "https://localhost"; IconFilename: "{app}\{#MyAppIcon}"
-Name: "{autodesktop}\{#MyAppName} backups"; Filename: "{app}\{#MyBackupDirName}"; IconFilename: "{sys}\shell32.dll"; IconIndex: 3
+Name: "{autodesktop}\{#MyAppName} data"; Filename: "{app}"; IconFilename: "{sys}\shell32.dll"; IconIndex: 3
 
 [Run]
 Filename: "{tmp}\VC_redist.x64.exe"; Parameters: "/install /passive /norestart"; StatusMsg: "Visual C++ Redistributable installeren..."


### PR DESCRIPTION
## What & why

Change shortcut back to data folder in Windows installer, so that the database and TLS certificates can be found more easily. See https://github.com/kiesraad/abacus/issues/3629#issuecomment-5043230749.

## How to test

Build and run Windows installer, or just trust the diff :)

## Reviewer notes

@marjoleintamis this might impact user documentation