### PR TITLE
Improve HighestAveragesTable with fraction aligned number cells

### DIFF
--- a/frontend/src/components/ui/Table/Table.stories.tsx
+++ b/frontend/src/components/ui/Table/Table.stories.tsx
@@ -284,6 +284,33 @@ export const TotalTableWithFractions: StoryObj = {
             </Table.TotalRow>
           </Table.Body>
         </Table>
+
+        <h2>Table with fraction aligned number</h2>
+        <Table id="total_table_with_fraction_aligned_number">
+          <Table.Header>
+            <Table.HeaderCell className="text-align-r">Number</Table.HeaderCell>
+            <Table.HeaderCell className="w-full">List name</Table.HeaderCell>
+            <Table.HeaderCell span={2} className="text-align-r">
+              Fractions
+            </Table.HeaderCell>
+          </Table.Header>
+          <Table.Body>
+            {data.map((row) => {
+              return (
+                <Table.Row key={row[0]}>
+                  <Table.NumberCell>{row[0]}</Table.NumberCell>
+                  <Table.Cell>{row[1]}</Table.Cell>
+                  <Table.DisplayFractionCells>{row[2]}</Table.DisplayFractionCells>
+                </Table.Row>
+              );
+            })}
+            <Table.TotalRow>
+              <Table.Cell />
+              <Table.Cell className="text-align-r">Fraction aligned number:</Table.Cell>
+              <Table.FractionAlignedNumberCells>{2}</Table.FractionAlignedNumberCells>
+            </Table.TotalRow>
+          </Table.Body>
+        </Table>
       </>
     );
   },
@@ -303,6 +330,14 @@ export const TotalTableWithFractions: StoryObj = {
       ["2", "Political Group B", "5", "", "11"],
       ["3", "Political Group C", "8", "", "4"],
       ["", "", "Total", "60"],
+    ]);
+    const fractionAlignedNumberTable = canvas.getByTestId("total_table_with_fraction_aligned_number");
+    await expect(fractionAlignedNumberTable).toHaveTableContent([
+      ["Number", "List name", "Fractions"],
+      ["1", "Political Group A", "3", "149/150"],
+      ["2", "Political Group B", "5", ""],
+      ["3", "Political Group C", "8", "1/150"],
+      ["", "Fraction aligned number:", "2", ""],
     ]);
   },
 };

--- a/frontend/src/components/ui/Table/Table.tsx
+++ b/frontend/src/components/ui/Table/Table.tsx
@@ -26,6 +26,7 @@ Table.TotalRow = TotalRow;
 Table.Cell = Cell;
 Table.NumberCell = NumberCell;
 Table.DisplayFractionCells = DisplayFractionCells;
+Table.FractionAlignedNumberCells = FractionAlignedNumberCells;
 
 function Header({ children, className }: { children: ReactNode; className?: string }) {
   return (
@@ -135,6 +136,15 @@ function DisplayFractionCells({ children, className }: { children: DisplayFracti
       <td className={cn(cls.fractionCell, "font-number", className)}>
         {children && getFractionWithoutInteger(children)}
       </td>
+    </>
+  );
+}
+
+function FractionAlignedNumberCells({ children, className }: { children: number; className?: string }) {
+  return (
+    <>
+      <td className={cn(cls.integerCell, "font-number", className)}>{children}</td>
+      <td className={cn(cls.fractionCell, "font-number", className)}></td>
     </>
   );
 }

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -141,7 +141,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ["3", "Political Group C", "49", "", "49", "", "49", "", "49", "", "0"],
         ["4", "Political Group D", "49", "1/2", "49", "1/2", "49", "1/2", "49", "1/2", "1"],
         ["5", "Blanco (Smit, G.)", "50", "1/2", "33", "2/3", "33", "2/3", "33", "2/3", "1"],
-        ["", "Restzetel toegekend aan lijst", "5", "2", "1", "4", ""],
+        ["", "Restzetel toegekend aan lijst", "5", "", "2", "", "1", "", "4", "", ""],
       ]);
 
       expect(screen.queryByTestId("largest-remainders-table")).not.toBeInTheDocument();
@@ -266,7 +266,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ],
         ["7", "Political Group G", "624", "", "624", "", "624", "", "624", "", "624", "", "624", "", "1 0"],
         ["8", "Political Group H", "7", "", "7", "", "7", "", "7", "", "7", "", "7", "", "0"],
-        ["", "Restzetel toegekend aan lijst", "2", "3", "4", "5", "6", "7", ""],
+        ["", "Restzetel toegekend aan lijst", "2", "", "3", "", "4", "", "5", "", "6", "", "7", "", ""],
       ]);
 
       expect(await screen.findByTestId("footnotes-list")).toHaveTextContent(
@@ -319,7 +319,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ["3", "Political Group C", "320", "", "0"],
         ["4", "Political Group D", "320", "", "0"],
         ["5", "Political Group E", "266", "2/3", "0"],
-        ["", "Restzetel toegekend aan lijst", "2", ""],
+        ["", "Restzetel toegekend aan lijst", "2", "", ""],
       ]);
       expect(screen.queryByTestId("largest-remainders-table")).not.toBeInTheDocument();
       expect(screen.queryByTestId("unique-highest-averages-table")).not.toBeInTheDocument();
@@ -651,7 +651,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ["1", "Political Group A", "2", "1/2", "", "", "1"],
         ["2", "Political Group B", "2", "1/2", "2", "1/2", "1"],
         ["3", "Blanco (Smit, G.)", "", "", "", "", "0"],
-        ["", "Restzetel toegekend aan lijst", "1", "2", ""],
+        ["", "Restzetel toegekend aan lijst", "1", "", "2", "", ""],
       ]);
 
       expect(await screen.findByTestId("footnotes-list")).toHaveTextContent(
@@ -757,7 +757,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ["4", "Algemene Lijst", "46", "2/3", "46", "2/3", "0"],
         ["5", "Unie van kandidaten", "46", "2/3", "46", "2/3", "0"],
         ["6", "Lijst van stemmers", "46", "2/3", "46", "2/3", "0"],
-        ["", "Restzetel toegekend aan lijst", "1", "Loting nodig", ""],
+        ["", "Restzetel toegekend aan lijst", "1", "", "Loting nodig", ""],
       ]);
 
       // Check that the "Loting nodig" link links to the drawing lots page
@@ -921,7 +921,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ["6", "Altijd van de Partij", "624", "", "624", "", "624", "", "624", "", "624", "", "416", "", "1 1"],
         ["7", "Partij van de Keuze", "624", "", "624", "", "624", "", "624", "", "624", "", "624", "", "1 1"],
         ["8", "Stemmersgroep", "8", "", "8", "", "8", "", "8", "", "8", "", "8", "", "0"],
-        ["", "Restzetel toegekend aan lijst", "2", "3", "4", "5", "6", "7", ""],
+        ["", "Restzetel toegekend aan lijst", "2", "", "3", "", "4", "", "5", "", "6", "", "7", "", ""],
       ]);
 
       expect(await screen.findByTestId("footnotes-list")).toHaveTextContent(
@@ -1020,7 +1020,7 @@ describe("ApportionmentResidualSeatsPage", () => {
         ["6", "Altijd van de Partij", "624", "", "624", "", "624", "", "624", "", "624", "", "416", "", "1"],
         ["7", "Partij van de Keuze", "624", "", "624", "", "624", "", "624", "", "624", "", "624", "", "1 0"],
         ["8", "Stemmersgroep", "8", "", "8", "", "8", "", "8", "", "8", "", "8", "", "0"],
-        ["", "Restzetel toegekend aan lijst", "2", "3", "4", "5", "6", "7", ""],
+        ["", "Restzetel toegekend aan lijst", "2", "", "3", "", "4", "", "5", "", "6", "", "7", "", ""],
       ]);
 
       expect(await screen.findByTestId("footnotes-list")).toHaveTextContent(

--- a/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.stories.tsx
@@ -31,7 +31,7 @@ export const Default: StoryObj = {
       ["3", "Political Group C", "49", "", "49", "", "49", "", "49", "", "0"],
       ["4", "Political Group D", "49", "1/2", "49", "1/2", "49", "1/2", "49", "1/2", "1"],
       ["5", "Blanco (Smit, G.)", "50", "1/2", "33", "2/3", "33", "2/3", "33", "2/3", "1"],
-      ["", "Restzetel toegekend aan lijst", "5", "2", "1", "4", ""],
+      ["", "Restzetel toegekend aan lijst", "5", "", "2", "", "1", "", "4", "", ""],
     ]);
   },
 };
@@ -143,7 +143,7 @@ export const AbsoluteMajorityReassignment: StoryObj = {
       ],
       ["7", "Political Group G", "624", "", "624", "", "624", "", "624", "", "624", "", "624", "", "1 0"],
       ["8", "Political Group H", "7", "", "7", "", "7", "", "7", "", "7", "", "7", "", "0"],
-      ["", "Restzetel toegekend aan lijst", "2", "3", "4", "5", "6", "7", ""],
+      ["", "Restzetel toegekend aan lijst", "2", "", "3", "", "4", "", "5", "", "6", "", "7", "", ""],
     ]);
   },
 };
@@ -176,7 +176,7 @@ export const DrawingLotsForList: StoryObj = {
       ["4", "Algemene Lijst", "46", "2/3", "46", "2/3", "0"],
       ["5", "Unie van kandidaten", "46", "2/3", "46", "2/3", "0"],
       ["6", "Lijst van stemmers", "46", "2/3", "46", "2/3", "0"],
-      ["", "Restzetel toegekend aan lijst", "1", "Loting nodig", ""],
+      ["", "Restzetel toegekend aan lijst", "1", "", "Loting nodig", ""],
     ]);
   },
 };
@@ -259,7 +259,7 @@ export const P9BeforeDrawingLots: StoryObj = {
       ["6", "Altijd van de Partij", "624", "", "624", "", "624", "", "624", "", "624", "", "416", "", "1 1"],
       ["7", "Partij van de Keuze", "624", "", "624", "", "624", "", "624", "", "624", "", "624", "", "1 1"],
       ["8", "Stemmersgroep", "8", "", "8", "", "8", "", "8", "", "8", "", "8", "", "0"],
-      ["", "Restzetel toegekend aan lijst", "2", "3", "4", "5", "6", "7", ""],
+      ["", "Restzetel toegekend aan lijst", "2", "", "3", "", "4", "", "5", "", "6", "", "7", "", ""],
     ]);
   },
 };
@@ -342,7 +342,7 @@ export const P9AfterDrawingLots: StoryObj = {
       ["6", "Altijd van de Partij", "624", "", "624", "", "624", "", "624", "", "624", "", "416", "", "1"],
       ["7", "Partij van de Keuze", "624", "", "624", "", "624", "", "624", "", "624", "", "624", "", "1 0"],
       ["8", "Stemmersgroep", "8", "", "8", "", "8", "", "8", "", "8", "", "8", "", "0"],
-      ["", "Restzetel toegekend aan lijst", "2", "3", "4", "5", "6", "7", ""],
+      ["", "Restzetel toegekend aan lijst", "2", "", "3", "", "4", "", "5", "", "6", "", "7", "", ""],
     ]);
   },
 };

--- a/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/HighestAveragesTable.tsx
@@ -122,9 +122,9 @@ export function HighestAveragesTable({
               {t("apportionment.residual_seat_assigned_to_list")}
             </Table.Cell>
             {steps.map((step) => (
-              <Table.NumberCell key={step.residual_seat_number} colSpan={2}>
+              <Table.FractionAlignedNumberCells key={step.residual_seat_number}>
                 {step.change.selected_list_number}
-              </Table.NumberCell>
+              </Table.FractionAlignedNumberCells>
             ))}
             {addDrawingLotsRound && (
               <Table.Cell className={cn(cls.sticky, "text-align-r")} colSpan={2}>


### PR DESCRIPTION
## What & why

Improve the alignment of content in the footer row in the `HighestAveragesTable`. See the following screenshots, note the rows with 'nieuw' & 'origineel'):

<img width="2464" height="378" alt="image" src="https://github.com/user-attachments/assets/54d31489-4ee5-451b-bf45-4bc272ab9468" />

<br><br>

<img width="1704" height="346" alt="image" src="https://github.com/user-attachments/assets/cf9ed6ac-fabe-411a-9206-40da0a0cbc9c" />

Introduced a new `FractionAlignedNumberCells` component to render this correctly (and decided not to reuse `DisplayFractionCells` for non-fractions like 'lijstnumer').

Initially found in https://github.com/kiesraad/abacus/issues/3547#issuecomment-5002448393

## How to test

Storybook: [Table with fraction aligned number](https://afwijking-kiezer-digitale.abacus-test.nl/storybook/?path=/story/components-ui-table--total-table-with-fractions)

## Reviewer notes
None.