### PR TITLE
Fix `per_page` overflow in audit log pagination

### DIFF
--- a/backend/src/api/audit.rs
+++ b/backend/src/api/audit.rs
@@ -235,6 +235,27 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
+    async fn test_list_paging_no_overflow(pool: SqlitePool) {
+        create_log_entries(pool.clone()).await;
+
+        // (page - 1) * per_page = 9_999_900_000 overflows u32::MAX; must not panic (#3326)
+        let result = get_list(
+            pool.clone(),
+            LogFilterQuery {
+                page: 100_000,
+                per_page: 100_000,
+                level: vec![],
+                event: vec![],
+                user: vec![],
+                since: None,
+            },
+        )
+        .await;
+        assert_eq!(result.events.len(), 0);
+        assert_eq!(result.page, 100_000);
+    }
+
+    #[test(sqlx::test(fixtures("../../fixtures/users.sql")))]
     async fn test_list_filter_event(pool: SqlitePool) {
         create_log_entries(pool.clone()).await;
 

--- a/backend/src/infra/audit_log/audit_log_events.rs
+++ b/backend/src/infra/audit_log/audit_log_events.rs
@@ -112,7 +112,7 @@ pub struct LogFilter {
 
 impl LogFilter {
     pub(crate) fn from_query(query: &LogFilterQuery) -> Self {
-        let offset = (query.page - 1) * query.per_page;
+        let offset = query.page.saturating_sub(1).saturating_mul(query.per_page);
         let limit = query.per_page;
 
         let level = query


### PR DESCRIPTION
## What & why

Fix `per_page` overflow in audit log pagination. Resolves #3326.

## How to test

Regression test is committed before the fix, so it can be tested by checking out b911b071bc4119e6ee4ad40dade5a1625625a459 and then verifying that 95cf98e2eab9ef69151ed56aabf4f256b5c6871c fixes the bug. Another way is checking that the audit log with `page=100000&per_page=100000` does not crash Abacus.
