### PR TITLE
Clarify discard and reset in data entry state doc

### DIFF
--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -4,6 +4,10 @@ This document describes the states a data entry can have.
 The transition labels describe the endpoint that is used for performing the transition.
 The "save" endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
 
+Note the difference between `discard` and `reset`:
+- `discard` is a typist removing their own _in-progress_ entry (the `data_entry_discard` endpoint). Discarding an in-progress second entry keeps the finalised first entry. 
+- `reset` is a coordinator clearing the whole data entry back to `Empty` (the `data_entry_reset` endpoint). It always removes _both_ entries.
+
 ```mermaid
 stateDiagram-v2
   [*] --> Empty
@@ -35,10 +39,10 @@ stateDiagram-v2
   EntriesDifferent --> resolve: resolve differences
   resolve --> first_has_errors: keep one entry
   resolve --> Empty: discard both entries
-  FirstEntryInProgress --> Empty: delete
-  FirstEntryFinalised --> Empty: delete
-  SecondEntryInProgress --> FirstEntryFinalised: delete
-  Definitive --> Empty: delete
+  FirstEntryInProgress --> Empty: reset
+  FirstEntryFinalised --> Empty: reset
+  SecondEntryInProgress --> Empty: reset
+  Definitive --> Empty: reset
 
   Definitive --> [*]
 ```
@@ -47,5 +51,5 @@ When resolving differences between the first and second entry (`EntriesDifferent
 keep one of the entries or discard both. If one of the entries is kept, the other entry is discarded. The remaining entry
 will from then on be the first entry, and the data entry is open for a new second entry.
 
-When the coordinator decides to delete the entry when there's a second entry (`SecondEntryInProgress` &
+When the coordinator resets the data entry while there's a second entry (`SecondEntryInProgress` &
 `Definitive` state), both entries will be deleted.


### PR DESCRIPTION
## What & why

Clarify discard and reset in data entry state doc, discovered when refining #3381.
- The coordinator can only reset to `Empty`, not `SecondEntryInProgress` → `FirstEntryFinalised` 
- The `delete` transition is renamed to `reset` to match the API endpoint name.