### PR TITLE
Add correction states to data-entry-state.md

### DIFF
--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -2,12 +2,17 @@
 
 This document describes the states a data entry can have.
 The transition labels describe the endpoint that is used for performing the transition.
+
 The `save` endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
+
 All states except for `FirstEntryHasErrors` and `EntriesDifferent` also have a `reset` endpoint which transitions to the `Empty` state. 
 
 Note the difference between `discard` and `reset`:
 - `discard` is a typist removing their own _in-progress_ entry (the `data_entry_discard` endpoint). Discarding an in-progress second entry keeps the finalised first entry. 
 - `reset` is a coordinator clearing the whole data entry back to `Empty` (the `data_entry_reset` endpoint). It always removes _both_ entries.
+
+When resolving differences between the first and second entry (`EntriesDifferent` state), the coordinator can choose to
+discard one of the two data entries. The remaining entry will from then on be the first entry, and the data entry is open for a new second entry.
 
 ```mermaid
 stateDiagram-v2
@@ -48,9 +53,4 @@ stateDiagram-v2
   Definitive --> [*]
 ```
 
-When resolving differences between the first and second entry (`EntriesDifferent` state), the coordinator can choose to
-keep one of the entries or discard both. If one of the entries is kept, the other entry is discarded. The remaining entry
-will from then on be the first entry, and the data entry is open for a new second entry.
 
-When the coordinator resets the data entry while there's a second entry (`SecondEntryInProgress` &
-`Definitive` state), both entries will be deleted.

--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -5,7 +5,7 @@ The transition labels describe the endpoint that is used for performing the tran
 
 The `save` endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
 
-All states also have a `reset` endpoint which transitions to the `Empty` state, which is not shown in the diagram below. For the states `FirstEntryHasErrors` and `EntriesDifferent`, the `reset` is more explicitly called `discard first entry` resp. `discard both entries` and shown in the diagram.
+All states also have a `reset` endpoint which transitions to the `Empty` state, which is not shown in the diagram below. For the states `FirstEntryHasErrors` and `EntriesDifferent`, the `reset` is more explicitly called `discard first entry` and `discard both entries`, and shown in the diagram.
 
 Note the difference between `discard` and `reset`:
 - `discard` is a typist removing their own _in-progress_ entry (the `data_entry_discard` endpoint). Discarding an in-progress second entry keeps the finalised first entry. 

--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -5,14 +5,14 @@ The transition labels describe the endpoint that is used for performing the tran
 
 The `save` endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
 
-All states except for `FirstEntryHasErrors` and `EntriesDifferent` also have a `reset` endpoint which transitions to the `Empty` state. 
+All states also have a `reset` endpoint which transitions to the `Empty` state, which is not shown in the diagram below. For the states `FirstEntryHasErrors` and `EntriesDifferent`, the `reset` is more explicitly called `discard first entry` resp. `discard both entries` and shown in the diagram.
 
 Note the difference between `discard` and `reset`:
 - `discard` is a typist removing their own _in-progress_ entry (the `data_entry_discard` endpoint). Discarding an in-progress second entry keeps the finalised first entry. 
 - `reset` is a coordinator clearing the whole data entry back to `Empty` (the `data_entry_reset` endpoint). It always removes _both_ entries.
 
-When resolving differences between the first and second entry (`EntriesDifferent` state), the coordinator can choose to
-discard one of the two data entries. The remaining entry will from then on be the first entry, and the data entry is open for a new second entry.
+When resolving differences between the first and second data entry (`EntriesDifferent` state), one of the options for the coordinator is to
+discard one entry. In this case, the remaining entry will from then on be the first entry, and the data entry is open for a new second entry.
 
 ```mermaid
 stateDiagram-v2
@@ -28,22 +28,22 @@ stateDiagram-v2
   FirstEntryFinalised --> SecondEntryInProgress: claim
   SecondEntryInProgress --> FirstEntryFinalised: discard
 
-  state first_resolve_errors <<choice>>
-  FirstEntryHasErrors --> first_resolve_errors: resolve errors
-  first_resolve_errors --> FirstEntryInProgress: resume first entry
-  first_resolve_errors --> Empty: discard first entry
+  state resolve_errors <<choice>>
+  FirstEntryHasErrors --> resolve_errors: resolve errors
+  resolve_errors --> FirstEntryInProgress: resume first entry
+  resolve_errors --> Empty: discard first entry
   
   state is_different <<choice>>
   SecondEntryInProgress --> is_different: finalise
   is_different --> EntriesDifferent: different? yes
   is_different --> Definitive: different? no
   
-  state resolve <<choice>>
-  EntriesDifferent --> resolve: resolve differences
-  resolve --> Empty: discard both entries
-  resolve --> first_has_errors: keep one entry
-  resolve --> FirstEntryCorrection: correct first entry
-  resolve --> SecondEntryCorrection: correct second entry
+  state resolve_differences <<choice>>
+  EntriesDifferent --> resolve_differences: resolve differences
+  resolve_differences --> Empty: discard both entries
+  resolve_differences --> first_has_errors: discard one entry
+  resolve_differences --> FirstEntryCorrection: correct first entry
+  resolve_differences --> SecondEntryCorrection: correct second entry
 
   FirstEntryCorrection --> is_different: finalise
   FirstEntryCorrection --> FirstEntryFinalised: discard

--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -2,7 +2,8 @@
 
 This document describes the states a data entry can have.
 The transition labels describe the endpoint that is used for performing the transition.
-The "save" endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
+The `save` endpoint which is used for [First/Second]EntryInProgress states is kept out, because Mermaid doesn't render self-loops too well.
+All states except for `FirstEntryHasErrors` and `EntriesDifferent` also have a `reset` endpoint which transitions to the `Empty` state. 
 
 Note the difference between `discard` and `reset`:
 - `discard` is a typist removing their own _in-progress_ entry (the `data_entry_discard` endpoint). Discarding an in-progress second entry keeps the finalised first entry. 
@@ -12,17 +13,14 @@ Note the difference between `discard` and `reset`:
 stateDiagram-v2
   [*] --> Empty
   Empty --> FirstEntryInProgress: claim
-  %% FirstEntryInProgress --> FirstEntryInProgress: save
 
   state first_has_errors <<choice>>
   FirstEntryInProgress --> first_has_errors: finalise
   FirstEntryInProgress --> Empty: discard
-  
   first_has_errors --> FirstEntryFinalised: errors? no
   first_has_errors --> FirstEntryHasErrors: errors? yes
 
   FirstEntryFinalised --> SecondEntryInProgress: claim
-  %% SecondEntryInProgress --> SecondEntryInProgress: save
   SecondEntryInProgress --> FirstEntryFinalised: discard
 
   state first_resolve_errors <<choice>>
@@ -37,12 +35,15 @@ stateDiagram-v2
   
   state resolve <<choice>>
   EntriesDifferent --> resolve: resolve differences
-  resolve --> first_has_errors: keep one entry
   resolve --> Empty: discard both entries
-  FirstEntryInProgress --> Empty: reset
-  FirstEntryFinalised --> Empty: reset
-  SecondEntryInProgress --> Empty: reset
-  Definitive --> Empty: reset
+  resolve --> first_has_errors: keep one entry
+  resolve --> FirstEntryCorrection: correct first entry
+  resolve --> SecondEntryCorrection: correct second entry
+
+  FirstEntryCorrection --> is_different: finalise
+  FirstEntryCorrection --> FirstEntryFinalised: discard
+  SecondEntryCorrection --> FirstEntryFinalised: discard
+  SecondEntryCorrection --> is_different: finalise
 
   Definitive --> [*]
 ```


### PR DESCRIPTION
## What & why

Resolves https://github.com/kiesraad/abacus/issues/3656
- Update the diagram with the new states for streamlining resolving data entry differences and their transitions
- Remove `reset` transitions to try to prevent one big ball of transitions

## How to test

Check that the necessary transitions for the new states have been added and go to the correct states.

## Reviewer notes


<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->