### PR TITLE
Corrected `is_municipality` function and added `is_local_election` function

### DIFF
--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -3,6 +3,11 @@
   location in public_bodies
 ) { public_body } else { municipal }
 
+// In the future category == "Island" will also be added
+#let is_local_election = (category, local, other) => if (
+  category == "Municipal"
+) { local } else { other }
+
 // A paragraph with a vertical line on the left
 #let emph_block(content) = {
   block(width: 75%, above: 3em, below: 1.5em, outset: (left: 6pt, top: 3pt, bottom: 3pt), stroke: (left: 1pt), text(

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -1,3 +1,8 @@
+#let public_bodies = ("Bonaire", "Saba", "Sint Eustatius");
+#let is_municipality = (location, municipal, public_body) => if (
+  location in public_bodies
+) { public_body } else { municipal }
+
 // A paragraph with a vertical line on the left
 #let emph_block(content) = {
   block(width: 75%, above: 3em, below: 1.5em, outset: (left: 6pt, top: 3pt, bottom: 3pt), stroke: (left: 1pt), text(

--- a/backend/templates/model-n-10-2.typ
+++ b/backend/templates/model-n-10-2.typ
@@ -2,16 +2,12 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-n-10-2.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
 #let is_mobile = "polling_station_type" in input.polling_station and input.polling_station.polling_station_type == "Mobile"
 
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
-#let this_location = is_municipality[deze gemeente][dit openbaar lichaam]
-#let location = is_municipality[gemeente][openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
+#let location = is_municipality[#input.election.location][gemeente][openbaar lichaam]
 
 #let header-right = [Stembureau #input.polling_station.number]
 
@@ -159,10 +155,10 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
 == Toegelaten kiezers
 
-#is_municipality[
-  Tel het aantal geldige stempassen en volmachtbewijzen
+#if input.election.category == "Municipal" {
+  [Tel het aantal geldige stempassen en volmachtbewijzen]
 
-  #sum(
+  sum(
     empty_letterbox("A")[Stempassen],
     empty_letterbox("B")[Volmachtbewijzen (schriftelijk of via ingevulde stempas)],
     empty_letterbox(
@@ -170,10 +166,10 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
       light: false,
     )[Totaal toegelaten kiezers (A+B)],
   )
-][
-  Tel het aantal geldige stempassen, volmachtbewijzen en kiezerspassen
+} else {
+  [Tel het aantal geldige stempassen, volmachtbewijzen en kiezerspassen]
 
-  #sum(
+  sum(
     empty_letterbox("A")[Stempassen],
     empty_letterbox(
       "B",
@@ -184,7 +180,7 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
       light: false,
     )[Totaal toegelaten kiezers (A+B+C)],
   )
-]
+}
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-n-10-2.typ
+++ b/backend/templates/model-n-10-2.typ
@@ -2,12 +2,15 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-n-10-2.json")
 
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let is_local_election = (local, other) => is_local_election(input.election.category, local, other)
+
 #let is_mobile = "polling_station_type" in input.polling_station and input.polling_station.polling_station_type == "Mobile"
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
-#let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
-#let location = is_municipality[#input.election.location][gemeente][openbaar lichaam]
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let this_location = is_municipality[deze gemeente][dit openbaar lichaam]
+#let location = is_municipality[gemeente][openbaar lichaam]
 
 #let header-right = [Stembureau #input.polling_station.number]
 
@@ -155,7 +158,7 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
 == Toegelaten kiezers
 
-#is_local_election(input.election.category)[
+#is_local_election[
   Tel het aantal geldige stempassen en volmachtbewijzen
 
   #sum(

--- a/backend/templates/model-n-10-2.typ
+++ b/backend/templates/model-n-10-2.typ
@@ -155,10 +155,10 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
 == Toegelaten kiezers
 
-#if input.election.category == "Municipal" {
-  [Tel het aantal geldige stempassen en volmachtbewijzen]
+#is_local_election(input.election.category)[
+  Tel het aantal geldige stempassen en volmachtbewijzen
 
-  sum(
+  #sum(
     empty_letterbox("A")[Stempassen],
     empty_letterbox("B")[Volmachtbewijzen (schriftelijk of via ingevulde stempas)],
     empty_letterbox(
@@ -166,10 +166,10 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
       light: false,
     )[Totaal toegelaten kiezers (A+B)],
   )
-} else {
-  [Tel het aantal geldige stempassen, volmachtbewijzen en kiezerspassen]
+][
+  Tel het aantal geldige stempassen, volmachtbewijzen en kiezerspassen
 
-  sum(
+  #sum(
     empty_letterbox("A")[Stempassen],
     empty_letterbox(
       "B",
@@ -180,7 +180,7 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
       light: false,
     )[Totaal toegelaten kiezers (A+B+C)],
   )
-}
+]
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-14-2-bijlage1.typ
+++ b/backend/templates/model-na-14-2-bijlage1.typ
@@ -2,8 +2,9 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-14-2-bijlage1.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(
   doc,

--- a/backend/templates/model-na-14-2-bijlage1.typ
+++ b/backend/templates/model-na-14-2-bijlage1.typ
@@ -2,12 +2,8 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-14-2-bijlage1.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(
   doc,
@@ -59,7 +55,7 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
     checkbox[Ja #sym.arrow.r *Ga verder met B1 - #ref(<corrected_results>)*]
   }
 )
-  
+
 #pagebreak(weak: true)
 
 = Gecorrigeerde telresultaten <corrected_results>

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -2,12 +2,8 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-14-2.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
@@ -17,8 +13,8 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
-  is_municipality[Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
+  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[#input.election.location][Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
   [#input.election.name - #format_date(input.election.election_date)],
   [
     Gecorrigeerde telresultaten per lijst en kandidaat –
@@ -34,7 +30,7 @@
 
 == Corrigendum
 
-#is_municipality[Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was. In dat proces-verbaal kunnen fouten staan. Het corrigendum
+#is_municipality[#input.election.location][Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was. In dat proces-verbaal kunnen fouten staan. Het corrigendum
 corrigeert de fouten in het proces-verbaal. De aantallen in het corrigendum vervangen
 de aantallen in het proces-verbaal.
 
@@ -46,7 +42,7 @@ de aantallen in het proces-verbaal.
 
 == Inhoudsopgave
 
-- Deel 1 - *Gecorrigeerde telresultaten* van #is_municipality[de hele gemeente][het hele openbaar lichaam]
+- Deel 1 - *Gecorrigeerde telresultaten* van #is_municipality[#input.election.location][de hele gemeente][het hele openbaar lichaam]
 - Deel 2 - *Ondertekening* door de leden van het #location_type
 
 \
@@ -57,7 +53,7 @@ de aantallen in het proces-verbaal.
 
 #show: doc => document_numbering(doc)
 
-= Gecorrigeerde telresultaten van #is_municipality[de gemeente][het openbaar lichaam]
+= Gecorrigeerde telresultaten van #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn
 veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen
@@ -116,7 +112,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 
 == Verschillen tussen aantal kiezers en uitgebrachte stemmen
 
-=== Is bij *alle afzonderlijke stembureaus* in #is_municipality[deze gemeente][dit openbaar lichaam] het aantal uitgebrachte stemmen en het aantal toegelaten kiezers gelijk?
+=== Is bij *alle afzonderlijke stembureaus* in #is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam] het aantal uitgebrachte stemmen en het aantal toegelaten kiezers gelijk?
 
 #let differences = input.summary.differences_counts.more_ballots_count.count > 0 or input.summary.differences_counts.fewer_ballots_count.count > 0
 
@@ -181,21 +177,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_municipality[twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_municipality[#input.election.location][twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_municipality[2][4] leden van het #location_type:
+=== #is_municipality[#input.election.location][2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -177,21 +177,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_municipality[#input.election.location][twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_local_election(input.election.category)[twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_municipality[#input.election.location][2][4] leden van het #location_type:
+=== #is_local_election(input.election.category)[2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -2,8 +2,10 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-14-2.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let is_local_election = (local, other) => is_local_election(input.election.category, local, other)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
@@ -13,8 +15,8 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
-  is_municipality[#input.election.location][Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
+  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
   [#input.election.name - #format_date(input.election.election_date)],
   [
     Gecorrigeerde telresultaten per lijst en kandidaat –
@@ -30,7 +32,7 @@
 
 == Corrigendum
 
-#is_municipality[#input.election.location][Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was. In dat proces-verbaal kunnen fouten staan. Het corrigendum
+#is_municipality[Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was. In dat proces-verbaal kunnen fouten staan. Het corrigendum
 corrigeert de fouten in het proces-verbaal. De aantallen in het corrigendum vervangen
 de aantallen in het proces-verbaal.
 
@@ -42,7 +44,7 @@ de aantallen in het proces-verbaal.
 
 == Inhoudsopgave
 
-- Deel 1 - *Gecorrigeerde telresultaten* van #is_municipality[#input.election.location][de hele gemeente][het hele openbaar lichaam]
+- Deel 1 - *Gecorrigeerde telresultaten* van #is_municipality[de hele gemeente][het hele openbaar lichaam]
 - Deel 2 - *Ondertekening* door de leden van het #location_type
 
 \
@@ -53,7 +55,7 @@ de aantallen in het proces-verbaal.
 
 #show: doc => document_numbering(doc)
 
-= Gecorrigeerde telresultaten van #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
+= Gecorrigeerde telresultaten van #is_municipality[de gemeente][het openbaar lichaam]
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn
 veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen
@@ -112,7 +114,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 
 == Verschillen tussen aantal kiezers en uitgebrachte stemmen
 
-=== Is bij *alle afzonderlijke stembureaus* in #is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam] het aantal uitgebrachte stemmen en het aantal toegelaten kiezers gelijk?
+=== Is bij *alle afzonderlijke stembureaus* in #is_municipality[deze gemeente][dit openbaar lichaam] het aantal uitgebrachte stemmen en het aantal toegelaten kiezers gelijk?
 
 #let differences = input.summary.differences_counts.more_ballots_count.count > 0 or input.summary.differences_counts.fewer_ballots_count.count > 0
 
@@ -177,21 +179,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_local_election(input.election.category)[twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_local_election[twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_local_election(input.election.category)[2][4] leden van het #location_type:
+=== #is_local_election[2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-31-2-bijlage1.typ
+++ b/backend/templates/model-na-31-2-bijlage1.typ
@@ -2,8 +2,10 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2-bijlage1.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let is_local_election = (local, other) => is_local_election(input.election.category, local, other)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(
   doc,
@@ -56,7 +58,7 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Was er in de telresultaten van het *stembureau* (rubriek 2.3 van het proces-verbaal van het stembureau) een onverklaard verschil tussen het totaal aantal getelde stembiljetten en het aantal toegelaten kiezers?
 
-#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#is_local_election(input.election.category)[stempassen en volmachten][stempassen, kiezerspassen en volmachten])*, en noteer de uitkomsten bij rubriek 3.1]
+#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#is_local_election[stempassen en volmachten][stempassen, kiezerspassen en volmachten])*, en noteer de uitkomsten bij rubriek 3.1]
 #checkbox[Nee]
 
 == Tel de stembiljetten
@@ -109,7 +111,7 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Heeft het #location_type het aantal toegelaten kiezers opnieuw geteld? Schrijf dan die aantallen op. Neem anders de aantallen over die het stembureau heeft opgeschreven in het proces-verbaal.
 
-#is_local_election(input.election.category)[
+#is_local_election[
   #sum(
     empty_letterbox("A")[Stempassen], 
     empty_letterbox("B")[Volmachtbewijzen], 

--- a/backend/templates/model-na-31-2-bijlage1.typ
+++ b/backend/templates/model-na-31-2-bijlage1.typ
@@ -56,7 +56,7 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Was er in de telresultaten van het *stembureau* (rubriek 2.3 van het proces-verbaal van het stembureau) een onverklaard verschil tussen het totaal aantal getelde stembiljetten en het aantal toegelaten kiezers?
 
-#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#if input.election.category == "Municipal" {[stempassen en volmachten]} else {[stempassen, kiezerspassen en volmachten]})*, en noteer de uitkomsten bij rubriek 3.1]
+#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#is_local_election(input.election.category)[stempassen en volmachten][stempassen, kiezerspassen en volmachten])*, en noteer de uitkomsten bij rubriek 3.1]
 #checkbox[Nee]
 
 == Tel de stembiljetten

--- a/backend/templates/model-na-31-2-bijlage1.typ
+++ b/backend/templates/model-na-31-2-bijlage1.typ
@@ -2,12 +2,8 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2-bijlage1.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(
   doc,
@@ -60,7 +56,7 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Was er in de telresultaten van het *stembureau* (rubriek 2.3 van het proces-verbaal van het stembureau) een onverklaard verschil tussen het totaal aantal getelde stembiljetten en het aantal toegelaten kiezers?
 
-#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#is_municipality[stempassen en volmachten][stempassen, kiezerspassen en volmachten])*, en noteer de uitkomsten bij rubriek 3.1]
+#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#if input.election.category == "Municipal" {[stempassen en volmachten]} else {[stempassen, kiezerspassen en volmachten]})*, en noteer de uitkomsten bij rubriek 3.1]
 #checkbox[Nee]
 
 == Tel de stembiljetten
@@ -113,19 +109,20 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Heeft het #location_type het aantal toegelaten kiezers opnieuw geteld? Schrijf dan die aantallen op. Neem anders de aantallen over die het stembureau heeft opgeschreven in het proces-verbaal.
 
-#is_municipality[
-  #sum(empty_letterbox("A")[Stempassen], empty_letterbox("B")[Volmachtbewijzen], empty_letterbox(
-    "D",
-    light: false,
-  )[Totaal toegelaten kiezers (A+B)])
-][
-  #sum(
+#if input.election.category == "Municipal" {
+  sum(
+    empty_letterbox("A")[Stempassen], 
+    empty_letterbox("B")[Volmachtbewijzen], 
+    empty_letterbox("D", light: false)[Totaal toegelaten kiezers (A+B)],
+  )
+} else {
+  sum(
     empty_letterbox("A")[Stempassen],
     empty_letterbox("B")[Volmachtbewijzen],
     empty_letterbox("C")[Kiezerspassen],
     empty_letterbox("D", light: false)[Totaal toegelaten kiezers (A+B+C)],
   )
-]
+}
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-31-2-bijlage1.typ
+++ b/backend/templates/model-na-31-2-bijlage1.typ
@@ -109,20 +109,20 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Heeft het #location_type het aantal toegelaten kiezers opnieuw geteld? Schrijf dan die aantallen op. Neem anders de aantallen over die het stembureau heeft opgeschreven in het proces-verbaal.
 
-#if input.election.category == "Municipal" {
-  sum(
+#is_local_election(input.election.category)[
+  #sum(
     empty_letterbox("A")[Stempassen], 
     empty_letterbox("B")[Volmachtbewijzen], 
     empty_letterbox("D", light: false)[Totaal toegelaten kiezers (A+B)],
   )
-} else {
-  sum(
+][
+  #sum(
     empty_letterbox("A")[Stempassen],
     empty_letterbox("B")[Volmachtbewijzen],
     empty_letterbox("C")[Kiezerspassen],
     empty_letterbox("D", light: false)[Totaal toegelaten kiezers (A+B+C)],
   )
-}
+]
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-31-2-inlegvel.typ
+++ b/backend/templates/model-na-31-2-inlegvel.typ
@@ -2,12 +2,8 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2-inlegvel.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(
   doc,

--- a/backend/templates/model-na-31-2-inlegvel.typ
+++ b/backend/templates/model-na-31-2-inlegvel.typ
@@ -2,8 +2,9 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2-inlegvel.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 
 #show: doc => conf(
   doc,

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -2,13 +2,9 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
-#let this_location = is_municipality[deze gemeente][dit openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
@@ -18,8 +14,8 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
-  is_municipality[Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
+  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[#input.election.location][Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
   [#input.election.name - #format_date(input.election.election_date)],
   [
     Verslag en telresultaten per lijst en kandidaat -
@@ -35,7 +31,7 @@
 
 == Proces-verbaal
 
-Elke #is_municipality[gemeente][openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
+Elke #is_municipality[#input.election.location][gemeente][openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
 
 #emph_block[
   In #this_location is gekozen voor *centrale stemopneming*.
@@ -46,12 +42,12 @@ Elke #is_municipality[gemeente][openbaar lichaam] maakt bij een verkiezing een v
 == Inhoudsopgave
 
 - Deel 1 - *Verslag van de zitting* (het verloop van het tellen en optellen)
-- Deel 2 - *Telresultaten* van #is_municipality[de hele gemeente][het hele openbaar lichaam]
+- Deel 2 - *Telresultaten* van #is_municipality[#input.election.location][de hele gemeente][het hele openbaar lichaam]
 - Deel 3 - *Ondertekening* door de leden van het #location_type
 
 \
 
-- Bijlage 1: Telresultaten van alle stembureaus in #is_municipality[de gemeente][het openbaar lichaam]
+- Bijlage 1: Telresultaten van alle stembureaus in #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
 - Bijlage 2: Overzicht van alle bezwaren die op de stembureaus zijn gemaakt
 
 #pagebreak(weak: true)
@@ -77,7 +73,7 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter of lid
 
 == Getelde stembureaus
 
-=== De resultaten van onderstaande stembureaus zijn door het #location_type gecontroleerd en opgeteld tot het totaal van #is_municipality[de gemeente][het openbaar lichaam]. Als er extra onderzoeken hebben plaatsgevonden, dan kan dat in de laatste drie kolommen worden aangegeven.
+=== De resultaten van onderstaande stembureaus zijn door het #location_type gecontroleerd en opgeteld tot het totaal van #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]. Als er extra onderzoeken hebben plaatsgevonden, dan kan dat in de laatste drie kolommen worden aangegeven.
 
 #light_table(
   columns: (5em, 1fr, 1fr, 6em, 6em, 6em),
@@ -148,7 +144,7 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
 
 #pagebreak(weak: true)
 
-= Telresultaten van #is_municipality[de gemeente][het openbaar lichaam]
+= Telresultaten van #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
 
 == Aantal kiesgerechtigden
 
@@ -295,21 +291,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_municipality[twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_municipality[#input.election.location][twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_municipality[2][4] leden van het #location_type:
+=== #is_municipality[#input.election.location][2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -291,21 +291,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_municipality[#input.election.location][twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_local_election(input.election.category)[twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_municipality[#input.election.location][2][4] leden van het #location_type:
+=== #is_local_election(input.election.category)[2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -5,6 +5,7 @@
 #let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
 #let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
 #let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
+#let the_location = is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
@@ -47,7 +48,7 @@ Elke #is_municipality[#input.election.location][gemeente][openbaar lichaam] maak
 
 \
 
-- Bijlage 1: Telresultaten van alle stembureaus in #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
+- Bijlage 1: Telresultaten van alle stembureaus in #the_location
 - Bijlage 2: Overzicht van alle bezwaren die op de stembureaus zijn gemaakt
 
 #pagebreak(weak: true)
@@ -73,7 +74,7 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter of lid
 
 == Getelde stembureaus
 
-=== De resultaten van onderstaande stembureaus zijn door het #location_type gecontroleerd en opgeteld tot het totaal van #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]. Als er extra onderzoeken hebben plaatsgevonden, dan kan dat in de laatste drie kolommen worden aangegeven.
+=== De resultaten van onderstaande stembureaus zijn door het #location_type gecontroleerd en opgeteld tot het totaal van #the_location. Als er extra onderzoeken hebben plaatsgevonden, dan kan dat in de laatste drie kolommen worden aangegeven.
 
 #light_table(
   columns: (5em, 1fr, 1fr, 6em, 6em, 6em),
@@ -144,7 +145,7 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
 
 #pagebreak(weak: true)
 
-= Telresultaten van #is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
+= Telresultaten van #the_location
 
 == Aantal kiesgerechtigden
 

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -2,10 +2,12 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-na-31-2.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
-#let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
-#let the_location = is_municipality[#input.election.location][de gemeente][het openbaar lichaam]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let is_local_election = (local, other) => is_local_election(input.election.category, local, other)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let this_location = is_municipality[deze gemeente][dit openbaar lichaam]
+#let the_location = is_municipality[de gemeente][het openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   #input.creation_date_time. Digitale vingerafdruk van EML-telbestand bij dit proces-verbaal (SHA-256): \
@@ -15,8 +17,8 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
-  is_municipality[#input.election.location][Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
+  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
   [#input.election.name - #format_date(input.election.election_date)],
   [
     Verslag en telresultaten per lijst en kandidaat -
@@ -32,7 +34,7 @@
 
 == Proces-verbaal
 
-Elke #is_municipality[#input.election.location][gemeente][openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
+Elke #is_municipality[gemeente][openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
 
 #emph_block[
   In #this_location is gekozen voor *centrale stemopneming*.
@@ -43,7 +45,7 @@ Elke #is_municipality[#input.election.location][gemeente][openbaar lichaam] maak
 == Inhoudsopgave
 
 - Deel 1 - *Verslag van de zitting* (het verloop van het tellen en optellen)
-- Deel 2 - *Telresultaten* van #is_municipality[#input.election.location][de hele gemeente][het hele openbaar lichaam]
+- Deel 2 - *Telresultaten* van #is_municipality[de hele gemeente][het hele openbaar lichaam]
 - Deel 3 - *Ondertekening* door de leden van het #location_type
 
 \
@@ -292,21 +294,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_local_election(input.election.category)[twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_local_election[twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_local_election(input.election.category)[2][4] leden van het #location_type:
+=== #is_local_election[2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -2,11 +2,7 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-p-22-2.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
 #let location_type = [centraal stembureau]
 #let subcommittee_type = [gemeentelijk stembureau]
 #let LARGE_COUNCIL_THRESHOLD = 19
@@ -26,7 +22,7 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
   [Centraal Stembureau],
   [#input.election.name - #format_date(input.election.election_date)],
   [

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -2,7 +2,8 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-p-22-2.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
 #let location_type = [centraal stembureau]
 #let subcommittee_type = [gemeentelijk stembureau]
 #let LARGE_COUNCIL_THRESHOLD = 19
@@ -22,7 +23,7 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
   [Centraal Stembureau],
   [#input.election.name - #format_date(input.election.election_date)],
   [

--- a/backend/templates/model-p-2a.typ
+++ b/backend/templates/model-p-2a.typ
@@ -148,21 +148,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_municipality[#input.election.location][twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_local_election(input.election.category)[twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_municipality[#input.election.location][2][4] leden van het #location_type:
+=== #is_local_election(input.election.category)[2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-p-2a.typ
+++ b/backend/templates/model-p-2a.typ
@@ -2,9 +2,11 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-p-2a.json")
 
-#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
-#let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
+#let is_municipality = (municipal, public_body) => is_municipality(input.election.location, municipal, public_body)
+#let is_local_election = (local, other) => is_local_election(input.election.category, local, other)
+#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let this_location = is_municipality[deze gemeente][dit openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   Proces-verbaal van een #location_type (nieuwe zitting)\
@@ -14,8 +16,8 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
-  is_municipality[#input.election.location][Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
+  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
   [#input.election.name - #format_date(input.election.election_date)],
   [
     Verslag en gecorrigeerde telresultaten per lijst en
@@ -31,7 +33,7 @@
 
 == Proces-verbaal
 
-#is_municipality[#input.election.location][Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
+#is_municipality[Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
 
 #emph_block[
   Het centraal stembureau vermoedt dat er één of meer fouten staan in het
@@ -148,21 +150,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_local_election(input.election.category)[twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_local_election[twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_local_election(input.election.category)[2][4] leden van het #location_type:
+=== #is_local_election[2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_local_election(input.election.category, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_local_election(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-p-2a.typ
+++ b/backend/templates/model-p-2a.typ
@@ -2,13 +2,9 @@
 #import "common/scripts.typ": *
 #let input = json("inputs/model-p-2a.json")
 
-#let is_municipality = (municipal, public_body) => if (
-  input.election.category == "Municipal"
-) { municipal } else { public_body }
-
-#let location_name = is_municipality[Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
-#let location_type = is_municipality[gemeentelijk stembureau][stembureau voor het openbaar lichaam]
-#let this_location = is_municipality[deze gemeente][dit openbaar lichaam]
+#let location_name = is_municipality[#input.election.location][Gemeente #input.election.domain_id #input.election.location][Openbaar lichaam #input.election.location]
+#let location_type = is_municipality[#input.election.location][gemeentelijk stembureau][stembureau voor het openbaar lichaam]
+#let this_location = is_municipality[#input.election.location][deze gemeente][dit openbaar lichaam]
 
 #show: doc => conf(doc, header-right: location_name, footer: [
   Proces-verbaal van een #location_type (nieuwe zitting)\
@@ -18,8 +14,8 @@
 #set heading(numbering: none)
 
 #title_page(
-  is_municipality[#input.election.domain_id #input.election.location][#input.election.location],
-  is_municipality[Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
+  is_municipality[#input.election.location][#input.election.domain_id #input.election.location][#input.election.location],
+  is_municipality[#input.election.location][Gemeentelijk stembureau][Stembureau voor het openbaar lichaam],
   [#input.election.name - #format_date(input.election.election_date)],
   [
     Verslag en gecorrigeerde telresultaten per lijst en
@@ -35,7 +31,7 @@
 
 == Proces-verbaal
 
-#is_municipality[Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
+#is_municipality[#input.election.location][Elke gemeente][Elk openbaar lichaam] maakt bij een verkiezing een verslag: het proces-verbaal. Hierin staat hoe het tellen van de stemmen is verlopen en wat de uitslag van de stemming was.
 
 #emph_block[
   Het centraal stembureau vermoedt dat er één of meer fouten staan in het
@@ -152,21 +148,21 @@ Zo komt het handtekeningen-blad altijd op een losse pagina, ook als het verslag 
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_municipality[twee][vier] leden van het #location_type
+== Verplicht: voorzitter en #is_municipality[#input.election.location][twee][vier] leden van het #location_type
 
 === Voorzitter van het #location_type:
 
 #textbox[Naam:][Handtekening:]
 
-=== #is_municipality[2][4] leden van het #location_type:
+=== #is_municipality[#input.election.location][2][4] leden van het #location_type:
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(2, 4)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 2, 4)).map(_ => textbox[Naam:][Handtekening:]))
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
 === Extra ondertekening: (niet verplicht)
 
-#stack(spacing: 0.5em, ..range(0, is_municipality(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
+#stack(spacing: 0.5em, ..range(0, is_municipality(input.election.location, 3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 
 #pagebreak(weak: true)
 


### PR DESCRIPTION
 Closes #3633 

## What & why

- Corrected `is_municipality` function and moved to scripts
- Added `is_local_election` function to scripts
- Use `is_local_election` function where kiezerspassen are involved
- Use `is_local_election` function on the signature pages

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- PDF diff should not show any changes
- Adjust one of the `election.location`s in one of the input json files to "Bonaire", "Saba" or "Sint Eustatius" and check that you get the "openbaar lichaam" version of the document (as discussed with @jschuurk-kr I didn't add any separate diffs for the public bodies yet, since they will not be using Abacus for now)

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->