### PR TITLE
Fix P 22-2 rendering with zero votes cast

### DIFF
--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -807,6 +807,97 @@ async fn test_p_22_2() {
     test_pdf(model).await;
 }
 
+/// Regression test for #3669, "number must be positive" error from Typst.
+/// This reproduces the issue with a large council GR election and zero votes cast.
+#[test(tokio::test)]
+async fn test_p_22_2_no_votes_cast_regression_3669() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(791397299);
+
+    let (parties, candidates, string_length, none_where_possible) = (10, 10, 10, false);
+
+    let mut election = random_election(
+        &mut rng,
+        parties,
+        candidates,
+        string_length,
+        none_where_possible,
+    );
+    // Use large council so residual seats are distributed via the highest-averages method
+    election.number_of_seats = 29;
+    election.sub_category = ElectionSubCategory::GR2;
+
+    let committee_session = random_committee_session(&mut rng, election.id, string_length);
+    let polling_stations = random_polling_stations(&mut rng, string_length, none_where_possible);
+    let data_sources = ps_as_first_data_entry_sources(&polling_stations);
+    let summary = random_election_summary_csb(&mut rng, &election, &data_sources, string_length);
+
+    // Zero votes cast on any candidate/list
+    let political_group_votes: Vec<PoliticalGroupCandidateVotes> = election
+        .political_groups
+        .iter()
+        .map(|group| PoliticalGroupCandidateVotes {
+            number: group.number,
+            total: 0,
+            candidate_votes: group
+                .candidates
+                .iter()
+                .map(|candidate| CandidateVotes {
+                    number: candidate.number,
+                    votes: 0,
+                })
+                .collect(),
+        })
+        .collect();
+
+    let apportionment_input = ApportionmentInputData::new(
+        election.number_of_seats,
+        &political_group_votes,
+        &[],
+        &[],
+        &[],
+    );
+    let apportionment_result = apportionment::process(&apportionment_input);
+    let Ok(ApportionmentOutput::Completed(apportionment)) = apportionment_result else {
+        panic!("apportionment should be Completed");
+    };
+
+    let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
+    assert!(
+        seat_assignment.steps.is_empty(),
+        "expected no seat assignment steps when zero votes are cast"
+    );
+
+    let enriched_seat_assignment =
+        EnrichedSeatAssignment::new(election.number_of_seats, &summary, &seat_assignment).unwrap();
+    let candidate_nomination = map_candidate_nomination(
+        &apportionment.candidate_nomination,
+        &election.political_groups,
+    );
+    let enriched_candidate_nomination =
+        EnrichedCandidateNomination::new(&election, &candidate_nomination).unwrap();
+    let footnotes =
+        ApportionmentFootnotes::new(&election.political_groups, &seat_assignment.steps).unwrap();
+
+    let hash = random_string(&mut rng, 64);
+    let creation_date_time = random_date_time(&mut rng)
+        .format(DEFAULT_DATE_TIME_FORMAT)
+        .to_string();
+
+    let model = PdfModel::ModelP22_2(Box::new(ModelP22_2Input {
+        committee_session,
+        election: election.into(),
+        summary,
+        footnotes,
+        seat_assignment: enriched_seat_assignment,
+        candidate_nomination: enriched_candidate_nomination,
+        hash,
+        creation_date_time,
+    }));
+
+    test_pdf(model).await;
+}
+
 #[test(tokio::test)]
 async fn test_p_22_2_bijlage_1() {
     let mut rng = rand::rng();

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -738,21 +738,7 @@
   steps,
   list_seat_assignments,
 ) = {
-  let steps_copy = steps
-  let slices = ()
-  if steps_copy.len() > 6 {
-    let slice = ()
-    while steps_copy.len() > 0 {
-      slice.push(steps_copy.remove(0))
-      if slice.len() == 6 {
-        slices.push(slice)
-        slice = ()
-      }
-    }
-    slices.push(slice)
-  } else {
-    slices.push(steps_copy)
-  }
+  let slices = steps.chunks(6)
   for slice in slices {
     table(
       columns: (1fr,) + slice.len() * (6em,) + (6em,),


### PR DESCRIPTION
## What & why

Fix P 22-2 rendering with zero votes cast by replacing the custom, buggy array slicing code in the `highest_averages_table` with the Typst built-in [`chunks` function](https://typst.app/docs/reference/foundations/array/#definitions-chunks). Resolves #3669.

## How to test

Check scenario in #3669 or see that regression test fails in 557faf4c6a61f810c7b9f6d594a4482a77f9b40b and gets fixed by eb17415cc52cb947f2355e212087875699da9f33.
