### PR TITLE
Test data generator for GSB PS/WS

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7514,6 +7514,7 @@
         "description": "Abacus API and asset server",
         "required": [
           "committee_category",
+          "election_category",
           "political_groups",
           "candidates_per_group",
           "polling_stations",
@@ -7543,6 +7544,10 @@
           "custom_name": {
             "type": "string",
             "description": "Custom election name"
+          },
+          "election_category": {
+            "$ref": "#/components/schemas/ElectionCategory",
+            "description": "Municipal, Provincial or WaterAuthority"
           },
           "first_data_entry": {
             "$ref": "#/components/schemas/RandomRange",

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -8,7 +8,7 @@ use abacus::{
     domain::{
         committee_session::CommitteeSession,
         data_entry::DataEntrySource,
-        election::{CommitteeCategory, ElectionWithPoliticalGroups},
+        election::{CommitteeCategory, ElectionCategory, ElectionWithPoliticalGroups},
         models::{ModelNa31_2Input, ToPdfFileModel, votes_table::VotesTables},
         polling_station::PollingStation,
         report::DEFAULT_DATE_TIME_FORMAT,
@@ -28,6 +28,10 @@ struct Args {
     /// The committee category
     #[arg(value_enum)]
     committee_category: CommitteeCategory,
+
+    /// The election category
+    #[arg(value_enum)]
+    election_category: ElectionCategory,
 
     /// Location of the database file, will be created if it doesn't exist
     #[arg(short, long, default_value = "db.sqlite")]
@@ -107,6 +111,7 @@ impl From<Args> for GenerateElectionArgs {
         GenerateElectionArgs {
             custom_name: args.custom_name,
             committee_category: args.committee_category,
+            election_category: args.election_category,
             political_groups: RandomRange(args.political_groups),
             candidates_per_group: RandomRange(args.candidates_per_group),
             polling_stations: RandomRange(args.polling_stations),

--- a/backend/src/domain/election.rs
+++ b/backend/src/domain/election.rs
@@ -174,7 +174,18 @@ pub struct ElectionNumberOfVotersChangeRequest {
 
 /// Election category (limited for now)
 #[derive(
-    Serialize, Deserialize, strum::Display, ToSchema, Clone, Copy, Debug, PartialEq, Eq, Hash, Type,
+    Serialize,
+    Deserialize,
+    strum::Display,
+    strum::EnumString,
+    ToSchema,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Type,
 )]
 #[strum(serialize_all = "lowercase")]
 pub enum ElectionCategory {

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -16,7 +16,7 @@ use crate::{
         election::{
             self, CandidateGender, CandidateNumber, CommitteeCategory, ElectionCategory,
             ElectionSubCategory, ElectionWithPoliticalGroups, NewElection, PGNumber,
-            PoliticalGroup, RegisteredPoliticalGroup, VoteCountingMethod,
+            RegisteredPoliticalGroup, VoteCountingMethod,
         },
         field_path::FieldPath,
         polling_station::{PollingStation, PollingStationRequest, PollingStationType},
@@ -254,6 +254,39 @@ pub async fn create_test_election(
     })
 }
 
+fn format_election_name(election_category: ElectionCategory, locality: &str, year: i32) -> String {
+    let election_type = match election_category {
+        ElectionCategory::Municipal => "Gemeenteraadsverkiezing",
+        ElectionCategory::Provincial => "Provinciale Statenverkiezing",
+        ElectionCategory::WaterAuthority => "Waterschapsverkiezing",
+    };
+    format!("{election_type} {locality} {year}")
+}
+
+fn get_election_sub_category(
+    election_category: ElectionCategory,
+    number_of_seats: u32,
+) -> ElectionSubCategory {
+    match election_category {
+        ElectionCategory::Municipal => {
+            if number_of_seats < 19 {
+                ElectionSubCategory::GR1
+            } else {
+                ElectionSubCategory::GR2
+            }
+        }
+        // Default to PS1
+        ElectionCategory::Provincial => ElectionSubCategory::PS1,
+        ElectionCategory::WaterAuthority => {
+            if number_of_seats < 19 {
+                ElectionSubCategory::AB1
+            } else {
+                ElectionSubCategory::AB2
+            }
+        }
+    }
+}
+
 /// Generate a random election using the limits from args.
 fn generate_election(
     rng: &mut impl rand::RngExt,
@@ -287,18 +320,18 @@ fn generate_election(
     let election_date =
         super::data::date_between(rng, nomination_date, nomination_date + Days::new(63));
 
-    // extract the year from the election date, generate the locality where this election would be
+    let category = args.election_category.to_eml_code();
     let year = election_date.year();
     let locality = super::data::locality(rng).to_owned();
 
     // use the previous data to generate some identifiers and names
-    let name: String = args
-        .custom_name
-        .clone()
-        .unwrap_or(format!("Gemeenteraad {locality} {year}"));
-
+    let name: String = args.custom_name.clone().unwrap_or(format_election_name(
+        args.election_category,
+        &locality,
+        year,
+    ));
     let cleaned_up_locality = locality.replace(" ", "_").replace("'", "");
-    let election_id = format!("GR{year}_{cleaned_up_locality}");
+    let election_id = format!("{category}{year}_{cleaned_up_locality}");
 
     info!("Election has name '{name}'");
 
@@ -316,12 +349,8 @@ fn generate_election(
         domain_id: super::data::domain_id(rng),
         election_id,
         location: locality,
-        category: ElectionCategory::Municipal,
-        sub_category: if number_of_seats < 19 {
-            ElectionSubCategory::GR1
-        } else {
-            ElectionSubCategory::GR2
-        },
+        category: args.election_category,
+        sub_category: get_election_sub_category(args.election_category, number_of_seats),
         number_of_seats,
         number_of_voters: if args.committee_category == CommitteeCategory::GSB {
             rng.random_range(args.voters.clone())
@@ -483,7 +512,7 @@ async fn generate_gsb_data_entry(
                 rng.random_range(args.candidate_distribution_slope.clone()) as f64 / 1000.0;
             let results = Results::CSOFirstSession(generate_cso_first_session_results(
                 rng,
-                &election.political_groups,
+                election,
                 voters_turned_out,
                 &group_weights,
                 candidate_slope,
@@ -577,7 +606,7 @@ async fn generate_csb_data_entry(
         let results = if let Some(v) = votes {
             let total_votes: u32 = v.iter().flatten().sum();
             Results::GSB(generate_gsb_results_from_votes(
-                &election.political_groups,
+                election,
                 rng.random_range(total_votes..=total_votes * 2),
                 v,
             ))
@@ -590,7 +619,7 @@ async fn generate_csb_data_entry(
 
             Results::GSB(generate_gsb_results(
                 rng,
-                &election.political_groups,
+                election,
                 number_of_eligible_voters,
                 voters_turned_out,
                 &group_weights,
@@ -652,7 +681,7 @@ async fn generate_csb_data_entry(
 #[allow(clippy::too_many_lines)]
 fn generate_cso_first_session_results(
     rng: &mut impl rand::RngExt,
-    political_groups: &[PoliticalGroup],
+    election: &ElectionWithPoliticalGroups,
     number_of_votes: u32,
     group_weights: &[f64],
     candidate_distribution_slope: f64,
@@ -707,10 +736,10 @@ fn generate_cso_first_session_results(
     ];
 
     let extra_investigation = extra_investigation_options
-	.choose_weighted(rng, |item| item.0)
-	.expect("Weighted random selection for extra_investigation should never fail with valid weights")
-	.1
-	.clone();
+        .choose_weighted(rng, |item| item.0)
+        .expect("Weighted random selection for extra_investigation should never fail with valid weights")
+        .1
+        .clone();
 
     CSOFirstSessionResults {
         extra_investigation,
@@ -730,11 +759,12 @@ fn generate_cso_first_session_results(
         voters_counts: VotersCounts {
             poll_card_count: number_of_votes,
             proxy_certificate_count: 0,
-            voter_card_count: None,
+            voter_card_count: (election.category != ElectionCategory::Municipal).then_some(0),
             total_admitted_voters_count: number_of_votes,
         },
         votes_counts: VotesCounts {
-            political_group_total_votes: political_groups
+            political_group_total_votes: election
+                .political_groups
                 .iter()
                 .zip(pg_votes.clone())
                 .map(|(pg, votes)| PoliticalGroupTotalVotes {
@@ -757,7 +787,8 @@ fn generate_cso_first_session_results(
             fewer_ballots_count: 0,
             difference_completely_accounted_for: YesNo::default(),
         },
-        political_group_votes: political_groups
+        political_group_votes: election
+            .political_groups
             .iter()
             .zip(pg_votes)
             .map(|(pg, votes)| {
@@ -787,9 +818,10 @@ fn generate_cso_first_session_results(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn generate_gsb_results(
     rng: &mut impl rand::RngExt,
-    political_groups: &[PoliticalGroup],
+    election: &ElectionWithPoliticalGroups,
     number_of_voters: u32,
     number_of_votes: u32,
     group_weights: &[f64],
@@ -813,11 +845,12 @@ fn generate_gsb_results(
         voters_counts: VotersCounts {
             poll_card_count: number_of_votes,
             proxy_certificate_count: 0,
-            voter_card_count: None,
+            voter_card_count: (election.category != ElectionCategory::Municipal).then_some(0),
             total_admitted_voters_count: number_of_votes,
         },
         votes_counts: VotesCounts {
-            political_group_total_votes: political_groups
+            political_group_total_votes: election
+                .political_groups
                 .iter()
                 .zip(pg_votes.clone())
                 .map(|(pg, votes)| PoliticalGroupTotalVotes {
@@ -834,7 +867,8 @@ fn generate_gsb_results(
             more_ballots_count: 0,
             fewer_ballots_count: 0,
         },
-        political_group_votes: political_groups
+        political_group_votes: election
+            .political_groups
             .iter()
             .zip(pg_votes)
             .map(|(pg, votes)| {
@@ -865,7 +899,7 @@ fn generate_gsb_results(
 }
 
 fn generate_gsb_results_from_votes(
-    political_groups: &[PoliticalGroup],
+    election: &ElectionWithPoliticalGroups,
     number_of_voters: u32,
     pg_votes: Vec<Vec<u32>>,
 ) -> GSBResults {
@@ -876,11 +910,12 @@ fn generate_gsb_results_from_votes(
         voters_counts: VotersCounts {
             poll_card_count: number_of_votes,
             proxy_certificate_count: 0,
-            voter_card_count: None,
+            voter_card_count: (election.category != ElectionCategory::Municipal).then_some(0),
             total_admitted_voters_count: number_of_votes,
         },
         votes_counts: VotesCounts {
-            political_group_total_votes: political_groups
+            political_group_total_votes: election
+                .political_groups
                 .iter()
                 .zip(pg_votes.clone())
                 .map(|(pg, votes)| PoliticalGroupTotalVotes {
@@ -897,7 +932,8 @@ fn generate_gsb_results_from_votes(
             more_ballots_count: 0,
             fewer_ballots_count: 0,
         },
-        political_group_votes: political_groups
+        political_group_votes: election
+            .political_groups
             .iter()
             .zip(pg_votes)
             .map(|(pg, votes)| {
@@ -1008,6 +1044,7 @@ mod tests {
         let args = GenerateElectionArgs {
             custom_name: None,
             committee_category: CommitteeCategory::GSB,
+            election_category: ElectionCategory::Municipal,
             political_groups: RandomRange(20..50),
             candidates_per_group: RandomRange(10..50),
             polling_stations: RandomRange(50..200),

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -256,9 +256,9 @@ pub async fn create_test_election(
 
 fn format_election_name(election_category: ElectionCategory, locality: &str, year: i32) -> String {
     let election_type = match election_category {
-        ElectionCategory::Municipal => "Gemeenteraadsverkiezing",
-        ElectionCategory::Provincial => "Provinciale Statenverkiezing",
-        ElectionCategory::WaterAuthority => "Waterschapsverkiezing",
+        ElectionCategory::Municipal => "Gemeenteraad",
+        ElectionCategory::Provincial => "Provinciale Staten",
+        ElectionCategory::WaterAuthority => "Algemeen bestuur van het waterschap",
     };
     format!("{election_type} {locality} {year}")
 }

--- a/backend/src/test_data_gen/mod.rs
+++ b/backend/src/test_data_gen/mod.rs
@@ -11,7 +11,7 @@ mod generators;
 pub use api::router;
 pub use generators::create_test_election;
 
-use crate::domain::election::CommitteeCategory;
+use crate::domain::election::{CommitteeCategory, ElectionCategory};
 
 #[derive(Clone, Debug)]
 pub struct RandomRange(pub Range<u32>);
@@ -26,6 +26,9 @@ pub struct GenerateElectionArgs {
 
     /// GSB or CSB
     pub committee_category: CommitteeCategory,
+
+    /// Municipal, Provincial or WaterAuthority
+    pub election_category: ElectionCategory,
 
     /// Number of political groups to create
     pub political_groups: RandomRange,

--- a/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
+++ b/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
@@ -8,7 +8,8 @@ import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { InputField } from "@/components/ui/InputField/InputField";
-import { type CommitteeCategory, committeeCategoryValues } from "@/types/generated/openapi";
+import { t } from "@/i18n/translate";
+import { type CommitteeCategory, committeeCategoryValues, electionCategoryValues } from "@/types/generated/openapi";
 import { StringFormData } from "@/utils/stringFormData";
 
 const RANGE_HINT = "Gebruik notatie zoals 10..50 of 9..=45 of een enkel getal zoals 40";
@@ -75,12 +76,17 @@ export function GenerateTestElectionForm() {
       formState.generate_p22_2_variants || formState.generate_drawing_lots
         ? "CSB"
         : formData.getString("committee_category");
+    const election_category =
+      formState.generate_p22_2_variants || formState.generate_drawing_lots
+        ? "Municipal"
+        : formData.getString("election_category");
 
     const payload = RANGE_FIELDS.reduce<Record<string, string | boolean>>(
       (acc, field) =>
         Object.assign(acc, { [field.key]: formState[field.key] ? formState[field.key] : field.placeholder }),
       {
         committee_category,
+        election_category,
         generate_p22_2_variants: formState.generate_p22_2_variants,
         generate_drawing_lots: formState.generate_drawing_lots,
         with_data_entry: formState.with_data_entry,
@@ -112,20 +118,21 @@ export function GenerateTestElectionForm() {
         <Checkbox
           id="generate-p22-2-variants"
           name="generate_p22_2_variants"
-          label="Genereer meerdere verkiezingen voor P 22-2 varianten (CSB)"
+          label="Genereer meerdere verkiezingen voor P 22-2 varianten (CSB GR)"
           checked={formState.generate_p22_2_variants}
           onChange={handleBooleanChange}
         />
         <Checkbox
           id="generate-drawing-lots"
           name="generate_drawing_lots"
-          label="Genereer meerdere verkiezingen met verschillende vormen van loting"
+          label="Genereer meerdere verkiezingen met verschillende vormen van loting (CSB GR)"
           checked={formState.generate_drawing_lots}
           onChange={handleBooleanChange}
         />
         {formState.generate_p22_2_variants || formState.generate_drawing_lots || (
           <>
             <ChoiceList>
+              <ChoiceList.Legend>{t("election.committee_category.title")}</ChoiceList.Legend>
               {committeeCategoryValues.map((committeeCategory, index) => (
                 <ChoiceList.Radio
                   id={committeeCategory}
@@ -133,7 +140,20 @@ export function GenerateTestElectionForm() {
                   name={"committee_category"}
                   defaultChecked={index === 0}
                   defaultValue={committeeCategory}
-                  label={committeeCategory}
+                  label={t(`committee_category.${committeeCategory}.full`)}
+                />
+              ))}
+            </ChoiceList>
+            <ChoiceList>
+              <ChoiceList.Legend>{t("election.election_category.title")}</ChoiceList.Legend>
+              {electionCategoryValues.map((electionCategory, index) => (
+                <ChoiceList.Radio
+                  id={electionCategory}
+                  key={electionCategory}
+                  name={"election_category"}
+                  defaultChecked={index === 0}
+                  defaultValue={electionCategory}
+                  label={t(`election_category.${electionCategory}`)}
                 />
               ))}
             </ChoiceList>

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -29,9 +29,17 @@
     "list_name": "{location}, kandidatenlijsten {name}",
     "polling_station_title": "Controleer stembureaus"
   },
+  "committee_category": {
+    "choose": "Kies het type stembureau",
+    "description": "Voor welk stembureau wil je deze verkiezing nu klaarzetten? Ga je Abacus voor GSB én CSB gebruiken? Zet dan eerst het GSB klaar, en doe daarna hetzelfde voor het CSB.",
+    "title": "Type stembureau"
+  },
   "configuration_not_finished": "De configuratie van Abacus is nog niet afgerond.",
   "create": "Verkiezing toevoegen",
   "dso_not_supported": "Niet ondersteund in deze versie van Abacus",
+  "election_category": {
+    "title": "Type verkiezing"
+  },
   "import_candidates_eml": "Importeer kandidatenlijsten",
   "import_election_eml": "Importeer verkiezingsdefinitie",
   "import_polling_station_eml": "Importeer stembureaus gemeente {location}",
@@ -48,15 +56,11 @@
     "title": "Ongeldig stembureaubestand"
   },
   "invalid_committee_category": "Ongeldig type stembureau",
+  "location": "Gebied",
+  "manage": "Verkiezingen beheren",
   "message": {
     "election_created": "Verkiezing {committee_category} {name} toegevoegd"
   },
-  "polling_station_definition_does_not_match_election": {
-    "title": "Afwijkende verkiezing",
-    "description": "Het bestand <file>filename</file> bevat stembureaus voor een andere verkiezing. Controleer voor je verder gaat of de stembureaus juist zijn."
-  },
-  "location": "Gebied",
-  "manage": "Verkiezingen beheren",
   "no_elections_added": "Nog geen verkiezingen ingesteld",
   "not_ready_for_use": "Abacus is nog niet klaar voor gebruik",
   "number_of_voters": {
@@ -64,6 +68,10 @@
     "hint": "Ingelezen uit bestand met stembureaus"
   },
   "please_wait_for_coordinator": "Je kan als invoerder nog niks doen. Wacht tot de coördinator het systeem openstelt voor het invoeren van telresultaten.",
+  "polling_station_definition_does_not_match_election": {
+    "description": "Het bestand <file>filename</file> bevat stembureaus voor een andere verkiezing. Controleer voor je verder gaat of de stembureaus juist zijn.",
+    "title": "Afwijkende verkiezing"
+  },
   "polling_stations": {
     "added": "{num} stembureaus toegevoegd",
     "check": {
@@ -94,11 +102,6 @@
     "dso_description": "Op de verkiezingsdag tellen de stembureaus de stemmen per kandidaat",
     "dso_not_supported": "Niet ondersteund in deze versie van Abacus",
     "title": "Type stemopneming in"
-  },
-  "committee_category": {
-    "title": "Type stembureau",
-    "description": "Voor welk stembureau wil je deze verkiezing nu klaarzetten? Ga je Abacus voor GSB én CSB gebruiken? Zet dan eerst het GSB klaar, en doe daarna hetzelfde voor het CSB.",
-    "choose": "Kies het type stembureau"
   },
   "you_cannot_start_data_entry_yet": "Je kan nog geen telresultaten invoeren."
 }

--- a/frontend/src/i18n/locales/nl/election_category.json
+++ b/frontend/src/i18n/locales/nl/election_category.json
@@ -1,0 +1,5 @@
+{
+  "Municipal": "Gemeenteraadsverkiezing (GR)",
+  "Provincial": "Provinciale Statenverkiezing (PS)",
+  "WaterAuthority": "Waterschapverkiezing (WS/AB)"
+}

--- a/frontend/src/i18n/locales/nl/nl.ts
+++ b/frontend/src/i18n/locales/nl/nl.ts
@@ -12,6 +12,7 @@ import data_entry_detail from "./data_entry_detail.json";
 import data_entry_home from "./data_entry_home.json";
 import differences_counts from "./differences_counts.json";
 import election from "./election.json";
+import election_category from "./election_category.json";
 import election_management from "./election_management.json";
 import election_report from "./election_report.json";
 import election_status from "./election_status.json";
@@ -48,6 +49,7 @@ const nl = {
   data_entry_detail,
   differences_counts,
   election,
+  election_category,
   election_management,
   extra_investigation,
   election_report,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1170,6 +1170,8 @@ export interface GenerateElectionArgs {
   committee_category: CommitteeCategory;
   /** Custom election name */
   custom_name?: string;
+  /** Municipal, Provincial or WaterAuthority */
+  election_category: ElectionCategory;
   /** Percentage of the first data entry to complete if data entry is included */
   first_data_entry: RandomRange;
   /** Generate multiple elections, each resulting in drawing lots */


### PR DESCRIPTION
Closes #3616 

## What & why

- Make gen test election work for PS and WS elections as well
- Alphabetically ordered `election.json` i18n file

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Create GSB election for Provincial and Water Authority elections, check that `with data entry` also works and that they can be viewed by a coordinator

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->