### PR TITLE
Update to React Router 7.18.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "lightningcss": "1.32.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-router": "7.17.0",
+    "react-router": "7.18.1",
     "vite": "8.1.4"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-router:
-        specifier: 7.17.0
-        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       vite:
         specifier: 8.1.4
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)
@@ -2582,8 +2582,8 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-router@7.17.0:
-    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -5281,7 +5281,7 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7


### PR DESCRIPTION
## What & why

Update to [React Router 7.18.1](https://github.com/remix-run/react-router/blob/v7/CHANGELOG.md#v7181) to fix: GHSA-h8fp-f39c-q6mh / https://github.com/kiesraad/abacus/security/dependabot/121.

## How to test

Tests pass.

## Reviewer notes

React Router 8 has also been released, created #3680 for that.