### PR TITLE
Resolving differences for second entry with errors

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6412,6 +6412,7 @@
           "first_entry",
           "second_entry_user_id",
           "second_entry",
+          "second_entry_has_errors",
           "source"
         ],
         "properties": {
@@ -6423,6 +6424,9 @@
           },
           "second_entry": {
             "$ref": "#/components/schemas/Results"
+          },
+          "second_entry_has_errors": {
+            "type": "boolean"
           },
           "second_entry_user_id": {
             "$ref": "#/components/schemas/UserId"

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -824,6 +824,7 @@ pub struct DataEntryGetDifferencesResponse {
     pub first_entry: Results,
     pub second_entry_user_id: UserId,
     pub second_entry: Results,
+    pub second_entry_has_errors: bool,
     pub source: DataEntrySource,
 }
 
@@ -859,13 +860,19 @@ async fn data_entry_get_differences(
             second_entry_user_id,
             second_entry,
             ..
-        }) => Ok(Json(DataEntryGetDifferencesResponse {
-            first_entry_user_id,
-            first_entry,
-            second_entry_user_id,
-            second_entry,
-            source: context.source,
-        })),
+        }) => {
+            let second_entry_has_errors =
+                second_entry.start_validate(&context.election)?.has_errors();
+
+            Ok(Json(DataEntryGetDifferencesResponse {
+                first_entry_user_id,
+                first_entry,
+                second_entry_user_id,
+                second_entry,
+                second_entry_has_errors,
+                source: context.source,
+            }))
+        }
         _ => Err(APIError::NotFound(
             "No data entry with differences found".to_string(),
             ErrorReference::EntryNotFound,
@@ -908,9 +915,11 @@ async fn data_entry_resolve_differences(
         | ResolveDifferencesAction::KeepFirstAndCorrectSecond => {
             state.keep_first_entry(&context.election)?
         }
-        ResolveDifferencesAction::KeepSecondAndDiscardFirst
-        | ResolveDifferencesAction::KeepSecondAndCorrectFirst => {
+        ResolveDifferencesAction::KeepSecondAndDiscardFirst => {
             state.keep_second_entry(&context.election)?
+        }
+        ResolveDifferencesAction::KeepSecondAndCorrectFirst => {
+            state.keep_second_and_correct_first(&context.election)?
         }
         ResolveDifferencesAction::DiscardBoth => state.delete_entries()?,
     };
@@ -1212,7 +1221,8 @@ mod tests {
         .into_response()
     }
 
-    async fn finalise_different_entries(pool: SqlitePool) {
+    /// Finalise the example first entry and the given, different second entry.
+    async fn finalise_different_entries_with(pool: SqlitePool, second_entry: DataEntry) {
         // Save and finalise the first data entry
         let request_body = example_data_entry();
         let data_entry_id = DataEntryId::from(201);
@@ -1229,18 +1239,12 @@ mod tests {
         let response = finalise(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        // Save and finalise a different second data entry
-        let mut request_body = example_data_entry();
-        request_body.data.voters_counts_mut().poll_card_count = 100;
-        request_body
-            .data
-            .voters_counts_mut()
-            .proxy_certificate_count = 0;
+        // Save and finalise the different second data entry
         let response = claim(pool.clone(), data_entry_id, EntryNumber::SecondEntry).await;
         assert_eq!(response.status(), StatusCode::OK);
         let response = save(
             pool.clone(),
-            request_body.clone(),
+            second_entry,
             data_entry_id,
             EntryNumber::SecondEntry,
         )
@@ -1253,6 +1257,25 @@ mod tests {
         let DataEntryStatusResponse { status } = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(status, DataEntryStatusName::EntriesDifferent);
+    }
+
+    async fn finalise_different_entries(pool: SqlitePool) {
+        let mut second_entry = example_data_entry();
+        second_entry.data.voters_counts_mut().poll_card_count = 100;
+        second_entry
+            .data
+            .voters_counts_mut()
+            .proxy_certificate_count = 0;
+
+        finalise_different_entries_with(pool, second_entry).await;
+    }
+
+    /// Like `finalise_different_entries`, but the second entry has an error.
+    async fn finalise_different_entries_second_entry_has_errors(pool: SqlitePool) {
+        let mut second_entry = example_data_entry();
+        second_entry.data.voters_counts_mut().poll_card_count = 100;
+
+        finalise_different_entries_with(pool, second_entry).await;
     }
 
     async fn finalise_with_errors(pool: SqlitePool) {
@@ -2387,6 +2410,55 @@ mod tests {
             };
 
             assert_eq!(first_entry.voters_counts.poll_card_count, 100);
+        }
+
+        async fn get_differences(
+            pool: SqlitePool,
+            data_entry_id: DataEntryId,
+        ) -> DataEntryGetDifferencesResponse {
+            let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+            let response = data_entry_get_differences(user, State(pool), Path(data_entry_id))
+                .await
+                .into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            serde_json::from_slice(&body).unwrap()
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_get_differences_second_entry_has_errors(pool: SqlitePool) {
+            let data_entry_id = DataEntryId::from(201);
+            finalise_different_entries_second_entry_has_errors(pool.clone()).await;
+
+            let differences = get_differences(pool.clone(), data_entry_id).await;
+            assert!(differences.second_entry_has_errors);
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_keep_second_has_errors_rejects_correction(pool: SqlitePool) {
+            let polling_station_id = PollingStationId::from(211);
+            let data_entry_id = DataEntryId::from(201);
+            finalise_different_entries_second_entry_has_errors(pool.clone()).await;
+
+            let response = resolve_differences(
+                pool.clone(),
+                data_entry_id,
+                ResolveDifferencesAction::KeepSecondAndCorrectFirst,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            let result: ErrorResponse = serde_json::from_slice(&body).unwrap();
+            assert_eq!(result.reference, ErrorReference::InvalidStateTransition);
+
+            // The state must be unchanged
+            let mut conn = pool.acquire().await.unwrap();
+            let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+            assert!(matches!(
+                data_entry.state.0,
+                DataEntryStatus::EntriesDifferent(_)
+            ));
         }
 
         #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -36,6 +36,8 @@ pub enum DataEntryTransitionError {
     CannotTransitionUsingDifferentUser,
     /// The second data entry needs to be claimed by a user other than the one who claimed the first entry
     SecondEntryNeedsDifferentUser,
+    /// Correction is not allowed because the second entry has errors
+    CorrectionNotAllowed,
     ValidatorError(DataError),
     ValidationError(ValidationResults),
 }
@@ -745,6 +747,21 @@ impl DataEntryStatus {
         }
     }
 
+    /// Keep second entry and let original typist correct first entry.
+    /// This is only allowed when the second entry has no errors.
+    pub fn keep_second_and_correct_first(
+        self,
+        election: &ElectionWithPoliticalGroups,
+    ) -> Result<Self, DataEntryTransitionError> {
+        if let DataEntryStatus::EntriesDifferent(state) = &self
+            && state.second_entry.start_validate(election)?.has_errors()
+        {
+            return Err(DataEntryTransitionError::CorrectionNotAllowed);
+        }
+
+        self.keep_second_entry(election)
+    }
+
     /// Get the progress of the first entry (if there is a first entry), from 0 to 100
     pub fn get_first_entry_progress(&self) -> Option<u8> {
         match self {
@@ -888,6 +905,9 @@ impl Display for DataEntryTransitionError {
                 )
             }
             DataEntryTransitionError::Invalid => write!(f, "Invalid state transition"),
+            DataEntryTransitionError::CorrectionNotAllowed => {
+                write!(f, "Correction not allowed: second entry has errors")
+            }
             DataEntryTransitionError::ValidatorError(data_error) => {
                 write!(f, "Validator error: {data_error}")
             }
@@ -1628,6 +1648,26 @@ mod tests {
         } else {
             panic!("{next:?}")
         };
+    }
+
+    #[test]
+    fn entries_different_keep_second_and_correct_first_with_errors_is_rejected() {
+        let first_entry = example_results();
+        let second_entry = example_results().with_error();
+
+        let initial = DataEntryStatus::EntriesDifferent(EntriesDifferent {
+            first_entry,
+            first_entry_user_id: UserId::from(0),
+            second_entry,
+            second_entry_user_id: UserId::from(0),
+            first_entry_finished_at: Utc::now(),
+            second_entry_finished_at: Utc::now(),
+        });
+
+        assert_eq!(
+            initial.keep_second_and_correct_first(&election()),
+            Err(DataEntryTransitionError::CorrectionNotAllowed)
+        );
     }
 
     #[test]

--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -14,6 +14,14 @@ Note the difference between `discard` and `reset`:
 When resolving differences between the first and second data entry (`EntriesDifferent` state), one of the options for the coordinator is to
 discard one entry. In this case, the remaining entry will from then on be the first entry, and the data entry is open for a new second entry.
 
+Instead of discarding an entry, the coordinator can also have it corrected by
+the typist who entered it. That is only possible when the entry that is kept has
+no errors. The first entry never has errors at this point, so keeping the first
+entry and correcting the second is always allowed. Keeping the second entry
+while it has errors is not allowed: the coordinator has to resolve errors first,
+so the only option is to discard the first entry, which transitions the state to
+`FirstEntryHasErrors`.
+
 ```mermaid
 stateDiagram-v2
   [*] --> Empty
@@ -42,7 +50,7 @@ stateDiagram-v2
   EntriesDifferent --> resolve_differences: resolve differences
   resolve_differences --> Empty: discard both entries
   resolve_differences --> first_has_errors: discard one entry
-  resolve_differences --> FirstEntryCorrection: correct first entry
+  resolve_differences --> FirstEntryCorrection: correct first entry<br>(only without errors in second entry)
   resolve_differences --> SecondEntryCorrection: correct second entry
 
   FirstEntryCorrection --> is_different: finalise

--- a/frontend/e2e-tests/page-objects/election/ResolveDifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/ResolveDifferencesPgObj.ts
@@ -11,7 +11,9 @@ export class ResolveDifferencesPgObj {
   readonly wrongEntryQuestion: Locator;
   readonly correctWrongEntry: Locator;
   readonly discardWrongEntry: Locator;
+  readonly correctionBlocked: Locator;
   readonly save: Locator;
+  readonly continueToResolveErrors: Locator;
 
   constructor(protected readonly page: Page) {
     this.title = this.page.getByRole("heading", { name: "Verschil tussen eerste en tweede invoer" });
@@ -24,6 +26,8 @@ export class ResolveDifferencesPgObj {
     this.wrongEntryQuestion = page.getByRole("heading", { name: /Wat wil je doen/ });
     this.correctWrongEntry = page.getByRole("radio", { name: /Laten herstellen/ });
     this.discardWrongEntry = page.getByRole("radio", { name: /Opnieuw laten invoeren/ });
+    this.correctionBlocked = page.getByText(/Uit de tweede invoer blijkt/);
     this.save = page.getByRole("button", { name: "Opslaan" });
+    this.continueToResolveErrors = page.getByRole("button", { name: "Verder naar fouten oplossen" });
   }
 }

--- a/frontend/e2e-tests/tests/data-entry-GSB/resolve-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/resolve-differences.e2e.ts
@@ -138,8 +138,14 @@ test.describe("resolve differences then errors", () => {
     const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
     await expect(resolveDifferencesPage.title).toBeVisible();
     await resolveDifferencesPage.keepSecondEntry.click();
-    await resolveDifferencesPage.discardWrongEntry.click();
-    await resolveDifferencesPage.save.click();
+
+    // The kept second entry has errors, so the first entry cannot be corrected
+    await expect(resolveDifferencesPage.correctionBlocked).toBeVisible();
+    await expect(resolveDifferencesPage.correctWrongEntry).toBeDisabled();
+    await expect(resolveDifferencesPage.correctWrongEntry).not.toBeChecked();
+    await expect(resolveDifferencesPage.discardWrongEntry).toBeDisabled();
+    await expect(resolveDifferencesPage.discardWrongEntry).toBeChecked();
+    await resolveDifferencesPage.continueToResolveErrors.click();
 
     const resolveErrorsPage = new ResolveErrorsPgObj(page);
     await expect(resolveErrorsPage.title).toBeVisible();

--- a/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferences.module.css
@@ -1,21 +1,31 @@
 .resolveDifferences {
+  > aside {
+    flex: 0 0 19.5rem;
+    display: flex;
+  }
+
   article {
-    section {
+    section:not([role="alert"] section) {
       margin-top: 2.5rem;
       display: flex;
       flex-direction: column;
       gap: 1rem;
     }
 
+    [role="alert"] {
+      width: calc(37.5rem + 4px);
+      align-items: flex-start;
+    }
+
     p {
-      max-width: 37.5rem;
+      max-width: 32rem;
       color: var(--text-color-header);
       margin-bottom: 0;
     }
 
-    aside {
-      flex: 0 0 19.5rem;
-      display: flex;
+    form p:global(.md) {
+      width: 40rem;
+      max-width: 40rem;
     }
   }
 

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.stories.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.stories.tsx
@@ -15,6 +15,7 @@ const meta = {
     setCorrectEntry: fn(),
     wrongEntryAction: undefined,
     setWrongEntryAction: fn(),
+    correctionBlocked: false,
     correctEntryError: undefined,
     wrongEntryError: undefined,
     onSubmit: fn(),
@@ -22,6 +23,7 @@ const meta = {
   argTypes: {
     correctEntry: { control: false },
     wrongEntryAction: { control: false },
+    correctionBlocked: { control: false },
     correctEntryError: { control: "text" },
     wrongEntryError: { control: "text" },
   },
@@ -44,6 +46,7 @@ export const Default: Story = {
             setCorrectEntry={(next) => {
               args.setCorrectEntry(next);
               setCorrectEntry(next);
+              setWrongEntryAction(undefined);
             }}
             wrongEntryAction={wrongEntryAction}
             setWrongEntryAction={(next) => {
@@ -87,13 +90,13 @@ export const Default: Story = {
     await expect(args.setWrongEntryAction).toHaveBeenLastCalledWith("discard");
     await expect(discardWrongEntry).toBeChecked();
 
-    // Choosing "neither" disables the second question again and clears its answer
+    // Choosing "neither" disables the second question again and sets discarding as the (disabled) answer
     await userEvent.click(discardBoth);
     await expect(args.setCorrectEntry).toHaveBeenLastCalledWith("neither");
-    await expect(args.setWrongEntryAction).toHaveBeenLastCalledWith(undefined);
     await expect(correctWrongEntry).toBeDisabled();
+    await expect(correctWrongEntry).not.toBeChecked();
     await expect(discardWrongEntry).toBeDisabled();
-    await expect(discardWrongEntry).not.toBeChecked();
+    await expect(discardWrongEntry).toBeChecked();
 
     // Submitting the form calls onSubmit
     await userEvent.click(canvas.getByRole("button", { name: "Opslaan" }));
@@ -112,6 +115,34 @@ export const FirstEntrySelected: Story = {
     // The second question is enabled once an entry is chosen
     await expect(canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" })).toBeEnabled();
     await expect(canvas.getByRole("radio", { name: "Opnieuw laten invoeren" })).toBeEnabled();
+  },
+};
+
+export const SecondEntryHasErrors: Story = {
+  ...Default,
+  args: {
+    correctEntry: "second",
+    correctionBlocked: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText(
+        "Uit de tweede invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. " +
+          "Daarom kan je de eerste invoer nu niet laten herstellen door de oorspronkelijke invoerder. " +
+          "Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. " +
+          "De eerste invoer wordt verwijderd.",
+      ),
+    ).toBeVisible();
+
+    const correctWrongEntry = canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" });
+    const discardWrongEntry = canvas.getByRole("radio", { name: "Opnieuw laten invoeren" });
+    await expect(correctWrongEntry).toBeDisabled();
+    await expect(correctWrongEntry).not.toBeChecked();
+    await expect(discardWrongEntry).toBeDisabled();
+    await expect(discardWrongEntry).toBeChecked();
+
+    // The submit button announces that resolving the errors is the next step
+    await expect(canvas.getByRole("button", { name: "Verder naar fouten oplossen" })).toBeVisible();
   },
 };
 

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.tsx
@@ -1,10 +1,11 @@
+import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
 import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { t, tx } from "@/i18n/translate";
 
-import type { ResolveDifferencesFormState } from "../utils/differences";
+import { effectiveWrongEntryAction, type ResolveDifferencesFormState } from "../utils/differences";
 
 export interface ResolveDifferencesFormProps extends ResolveDifferencesFormState {
   firstEntryName: string;
@@ -19,12 +20,13 @@ export function ResolveDifferencesForm({
   setCorrectEntry,
   wrongEntryAction,
   setWrongEntryAction,
+  correctionBlocked,
   correctEntryError,
   wrongEntryError,
   onSubmit,
 }: ResolveDifferencesFormProps) {
-  // The second question only applies when one of the two entries is kept.
-  const wrongEntryDisabled = correctEntry !== "first" && correctEntry !== "second";
+  const wrongEntryDisabled = (correctEntry !== "first" && correctEntry !== "second") || correctionBlocked;
+  const checkedAction = effectiveWrongEntryAction(correctEntry, wrongEntryAction, correctionBlocked);
 
   return (
     <Form
@@ -65,12 +67,16 @@ export function ResolveDifferencesForm({
               checked={correctEntry === "neither"}
               onChange={() => {
                 setCorrectEntry("neither");
-                setWrongEntryAction(undefined);
               }}
             />
           </ChoiceList>
         </FormLayout.Section>
         <FormLayout.Section title={tx("resolve_differences.wrong_entry_question")}>
+          {correctionBlocked && (
+            <Alert type="notify" small>
+              {t("resolve_differences.correction_blocked")}
+            </Alert>
+          )}
           <ChoiceList disabled={wrongEntryDisabled}>
             {wrongEntryError && (
               <ChoiceList.Error id="resolve-differences-wrong-entry-error">{wrongEntryError}</ChoiceList.Error>
@@ -79,7 +85,7 @@ export function ResolveDifferencesForm({
               id="correct_wrong_entry"
               name="wrong_entry_action"
               label={t("resolve_differences.wrong_entry_options.correct")}
-              checked={wrongEntryAction === "correct"}
+              checked={checkedAction === "correct"}
               onChange={() => {
                 setWrongEntryAction("correct");
               }}
@@ -88,7 +94,7 @@ export function ResolveDifferencesForm({
               id="discard_wrong_entry"
               name="wrong_entry_action"
               label={t("resolve_differences.wrong_entry_options.discard")}
-              checked={wrongEntryAction === "discard"}
+              checked={checkedAction === "discard"}
               onChange={() => {
                 setWrongEntryAction("discard");
               }}
@@ -96,7 +102,9 @@ export function ResolveDifferencesForm({
           </ChoiceList>
         </FormLayout.Section>
         <FormLayout.Controls>
-          <Button type="submit">{t("save")}</Button>
+          <Button type="submit">
+            {correctionBlocked ? t("resolve_differences.continue_to_resolve_errors") : t("save")}
+          </Button>
         </FormLayout.Controls>
       </FormLayout>
     </Form>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -8,6 +8,7 @@ import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
 import * as useMessages from "@/hooks/messages/useMessages";
 import { UsersProvider } from "@/hooks/user/UsersProvider";
+import { dataEntryStatusDifferences } from "@/testing/api-mocks/DataEntryMockData";
 import {
   DataEntryGetDifferencesHandler,
   DataEntryResolveDifferencesHandler,
@@ -142,8 +143,9 @@ describe("ResolveDifferencesPage", () => {
 
     await user.click(await screen.findByRole("radio", { name: "Geen van beide: alles opnieuw invoeren" }));
     expect(correctWrongEntry).toBeDisabled();
+    expect(correctWrongEntry).not.toBeChecked();
     expect(discardWrongEntry).toBeDisabled();
-    expect(discardWrongEntry).not.toBeChecked();
+    expect(discardWrongEntry).toBeChecked();
   });
 
   test("should validate both questions before submitting", async () => {
@@ -324,5 +326,33 @@ describe("ResolveDifferencesPage", () => {
       text: "Let op: het proces-verbaal bevat fouten die moeten worden opgelost",
     });
     expect(navigate).toHaveBeenCalledWith("/elections/1/status/3/detail");
+  });
+
+  test("should block correcting the first entry when the kept second entry has errors", async () => {
+    const user = userEvent.setup();
+    const resolve = spyOnHandler(DataEntryResolveDifferencesHandler);
+    overrideOnce("get", "/api/data_entries/3/resolve_differences", 200, {
+      ...dataEntryStatusDifferences,
+      second_entry_has_errors: true,
+    });
+
+    await renderPage();
+    overrideResponseStatus("first_entry_has_errors");
+    await user.click(await screen.findByRole("radio", { name: "Tweede invoer (Gebruiker02)" }));
+
+    expect(
+      await screen.findByText(
+        "Uit de tweede invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. " +
+          "Daarom kan je de eerste invoer nu niet laten herstellen door de oorspronkelijke invoerder. " +
+          "Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. " +
+          "De eerste invoer wordt verwijderd.",
+      ),
+    ).toBeVisible();
+    expect(
+      await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }),
+    ).toBeDisabled();
+
+    await user.click(await screen.findByRole("button", { name: "Verder naar fouten oplossen" }));
+    expect(resolve).toHaveBeenCalledWith("keep_second_and_discard_first");
   });
 });

--- a/frontend/src/features/resolve_differences/hooks/useDataEntryDifferences.ts
+++ b/frontend/src/features/resolve_differences/hooks/useDataEntryDifferences.ts
@@ -5,7 +5,6 @@ import { useApiClient } from "@/api/useApiClient";
 import { useInitialApiGet } from "@/api/useInitialApiGet";
 import { ElectionStatusProviderContext } from "@/hooks/election/ElectionStatusProviderContext";
 import { useElection } from "@/hooks/election/useElection";
-import { t } from "@/i18n/translate";
 import type {
   DATA_ENTRY_GET_DIFFERENCES_REQUEST_PATH,
   DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY,
@@ -20,8 +19,9 @@ import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 
 import {
   type CorrectEntry,
+  effectiveWrongEntryAction,
+  getQuestionErrors,
   getResolveDifferencesAction,
-  getUnansweredQuestions,
   type ResolveDifferencesFormState,
   type WrongEntryAction,
 } from "../utils/differences";
@@ -62,7 +62,7 @@ export function useDataEntryDifferences(
 ): DataEntryDifferences {
   const client = useApiClient();
   const { election } = useElection();
-  const [correctEntry, setCorrectEntry] = useState<CorrectEntry>();
+  const [correctEntry, setCorrectEntryAnswer] = useState<CorrectEntry>();
   const [wrongEntryAction, setWrongEntryAction] = useState<WrongEntryAction>();
   const electionContext = useContext(ElectionStatusProviderContext);
   const [error, setError] = useState<AnyApiError | null>(null);
@@ -88,13 +88,16 @@ export function useDataEntryDifferences(
     dataEntryStructure = getDataEntryStructure(differences.first_entry.model, election);
   }
 
-  const unanswered = getUnansweredQuestions(correctEntry, wrongEntryAction);
-  const requiredError = t("resolve_differences.required_error");
+  // Block correction of first entry when second entry has errors
+  const correctionBlocked = correctEntry === "second" && (differences?.second_entry_has_errors ?? false);
+  const effectiveAction = effectiveWrongEntryAction(correctEntry, wrongEntryAction, correctionBlocked);
+
+  const questionErrors = getQuestionErrors(correctEntry, effectiveAction, submitted);
 
   const onSubmit = async () => {
     setSubmitted(true);
 
-    const action = getResolveDifferencesAction(correctEntry, wrongEntryAction);
+    const action = getResolveDifferencesAction(correctEntry, effectiveAction);
     if (action === undefined) {
       return;
     }
@@ -107,7 +110,7 @@ export function useDataEntryDifferences(
       // reload the election status data then navigate according to new status
       await electionContext?.refetch();
       afterSave(response.data.status, {
-        wrongEntryAction,
+        wrongEntryAction: effectiveAction,
         ...resolvedUserIds(differences, correctEntry),
       });
     } else {
@@ -118,11 +121,15 @@ export function useDataEntryDifferences(
   return {
     formState: {
       correctEntry,
-      setCorrectEntry,
+      // Answering the first question clears the second question
+      setCorrectEntry: (next) => {
+        setCorrectEntryAnswer(next);
+        setWrongEntryAction(undefined);
+      },
       wrongEntryAction,
       setWrongEntryAction,
-      correctEntryError: submitted && unanswered.correctEntry ? requiredError : undefined,
-      wrongEntryError: submitted && unanswered.wrongEntry ? requiredError : undefined,
+      correctionBlocked,
+      ...questionErrors,
     },
     election,
     loading: requestState.status === "loading",

--- a/frontend/src/features/resolve_differences/utils/differences.ts
+++ b/frontend/src/features/resolve_differences/utils/differences.ts
@@ -1,3 +1,4 @@
+import { t } from "@/i18n/translate";
 import type { ResolveDifferencesAction } from "@/types/generated/openapi";
 import type { DataEntryResults, DataEntrySection } from "@/types/types";
 import { mapResultsToSectionValues } from "@/utils/dataEntryMapping";
@@ -13,9 +14,18 @@ export interface ResolveDifferencesFormState {
   correctEntry: CorrectEntry | undefined;
   setCorrectEntry: (correctEntry: CorrectEntry) => void;
   wrongEntryAction: WrongEntryAction | undefined;
-  setWrongEntryAction: (wrongEntryAction: WrongEntryAction | undefined) => void;
+  setWrongEntryAction: (wrongEntryAction: WrongEntryAction) => void;
+  correctionBlocked: boolean;
   correctEntryError: string | undefined;
   wrongEntryError: string | undefined;
+}
+
+export function effectiveWrongEntryAction(
+  correctEntry: CorrectEntry | undefined,
+  wrongEntryAction: WrongEntryAction | undefined,
+  correctionBlocked: boolean,
+): WrongEntryAction | undefined {
+  return correctEntry === "neither" || correctionBlocked ? "discard" : wrongEntryAction;
 }
 
 const KEEP_ENTRY_ACTIONS = {
@@ -37,14 +47,19 @@ export function getResolveDifferencesAction(
   return KEEP_ENTRY_ACTIONS[correctEntry][wrongEntryAction];
 }
 
-/** Which of the two questions still need an answer at submit time. */
-export function getUnansweredQuestions(
+/** The error to show for each of the two questions at submit time. */
+export function getQuestionErrors(
   correctEntry: CorrectEntry | undefined,
   wrongEntryAction: WrongEntryAction | undefined,
-): { correctEntry: boolean; wrongEntry: boolean } {
+  submitted: boolean,
+): Pick<ResolveDifferencesFormState, "correctEntryError" | "wrongEntryError"> {
+  const requiredError = submitted ? t("resolve_differences.required_error") : undefined;
+  const wrongEntryUnanswered =
+    (correctEntry === "first" || correctEntry === "second") && wrongEntryAction === undefined;
+
   return {
-    correctEntry: correctEntry === undefined,
-    wrongEntry: (correctEntry === "first" || correctEntry === "second") && wrongEntryAction === undefined,
+    correctEntryError: correctEntry === undefined ? requiredError : undefined,
+    wrongEntryError: wrongEntryUnanswered ? requiredError : undefined,
   };
 }
 

--- a/frontend/src/i18n/locales/nl/resolve_differences.json
+++ b/frontend/src/i18n/locales/nl/resolve_differences.json
@@ -1,4 +1,6 @@
 {
+  "continue_to_resolve_errors": "Verder naar fouten oplossen",
+  "correction_blocked": "Uit de tweede invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. Daarom kan je de eerste invoer nu niet laten herstellen door de oorspronkelijke invoerder. Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. De eerste invoer wordt verwijderd.",
   "form_content": "De resultaten van dit stembureau zijn pas definitief als er twee gelijke invoeren zijn. Kies de invoer die overeenkomt met het papieren proces-verbaal.",
   "form_question": "Welke invoer klopt?",
   "headers": {

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -230,6 +230,7 @@ export const dataEntryStatusDifferences: DataEntryGetDifferencesResponse = {
       },
     ],
   },
+  second_entry_has_errors: false,
   source: source(3),
 };
 

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -790,6 +790,7 @@ export interface DataEntryGetDifferencesResponse {
   first_entry: Results;
   first_entry_user_id: UserId;
   second_entry: Results;
+  second_entry_has_errors: boolean;
   second_entry_user_id: UserId;
   source: DataEntrySource;
 }


### PR DESCRIPTION
## What & why

Add special case for resolving differences for second entry with errors: only discarding the first entry should be allowed. Resolves #3675.

## How to test

Create a data entry with differences using two different typist users, and make sure the second data entry contains errors. Then check the resolve differences page using the coordinator user.

It should look like this:
<img width="1002" height="926" alt="image" src="https://github.com/user-attachments/assets/4a226ef6-3295-4084-82c9-db7dd1bd79eb" />

