### PR TITLE
Test data generator fictional provinces/water authorities

### DIFF
--- a/backend/src/test_data_gen/data.rs
+++ b/backend/src/test_data_gen/data.rs
@@ -175,7 +175,7 @@ const WATER_AUTHORITIES: &[&str] = &[
     "Hoogwaard en Delta",
     "Duin en Diep",
     "De Kleiwaarden",
-    "Aqua Delta",
+    "Rivier en Polder",
     "Waterkring",
     "Noorderwater",
     "De Oude Beek",

--- a/backend/src/test_data_gen/data.rs
+++ b/backend/src/test_data_gen/data.rs
@@ -149,6 +149,45 @@ pub fn locality(rng: &mut impl rand::RngExt) -> &'static str {
     LOCALITIES.choose(rng).expect("Missing test data")
 }
 
+const PROVINCES: &[&str] = &[
+    "Oost-Holland",
+    "Westmark",
+    "Middenland",
+    "Eikenwoud",
+    "Zuiderwaard",
+    "Bloemmark",
+    "Duinrand",
+    "Kleipolder",
+    "Stormwaard",
+    "Klompenwaard",
+    "Maaszoom",
+];
+
+/// Generate a random province, using the random number generator given
+pub fn province(rng: &mut impl rand::RngExt) -> &'static str {
+    PROVINCES.choose(rng).expect("Missing test data")
+}
+
+const WATER_AUTHORITIES: &[&str] = &[
+    "Groot Heemland",
+    "Vliet en Veenstreek",
+    "Sluisland",
+    "Hoogwaard en Delta",
+    "Duin en Diep",
+    "De Kleiwaarden",
+    "Aqua Delta",
+    "Waterkring",
+    "Noorderwater",
+    "De Oude Beek",
+    "Hollands Middenwater",
+    "Rijn en Zand",
+];
+
+/// Generate a random water authority, using the random number generator given
+pub fn water_authority(rng: &mut impl rand::RngExt) -> &'static str {
+    WATER_AUTHORITIES.choose(rng).expect("Missing test data")
+}
+
 const STREETNAMES: &[&str] = &[
     "Dorpsstraat",
     "Kerkstraat",

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -263,7 +263,15 @@ fn format_election_name(
     let (election_type, election_locality) = match election_category {
         ElectionCategory::Municipal => ("Gemeenteraad", locality),
         ElectionCategory::Provincial => ("Provinciale Staten", super::data::province(rng)),
-        ElectionCategory::WaterAuthority => ("Waterschap", super::data::water_authority(rng)),
+        ElectionCategory::WaterAuthority => (
+            *[
+                "Algemeen bestuur van het waterschap",
+                "Algemeen bestuur van het hoogheemraadschap",
+            ]
+            .choose(rng)
+            .expect("Missing test data"),
+            super::data::water_authority(rng),
+        ),
     };
     format!("{election_type} {election_locality} {year}")
 }

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -264,12 +264,9 @@ fn format_election_name(
         ElectionCategory::Municipal => ("Gemeenteraad", locality),
         ElectionCategory::Provincial => ("Provinciale Staten", super::data::province(rng)),
         ElectionCategory::WaterAuthority => (
-            *[
-                "Algemeen bestuur van het waterschap",
-                "Algemeen bestuur van het hoogheemraadschap",
-            ]
-            .choose(rng)
-            .expect("Missing test data"),
+            *["Waterschap", "Hoogheemraadschap"]
+                .choose(rng)
+                .expect("Missing test data"),
             super::data::water_authority(rng),
         ),
     };

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -254,22 +254,18 @@ pub async fn create_test_election(
     })
 }
 
-fn format_election_name(election_category: ElectionCategory, locality: &str, year: i32) -> String {
-    let election_type = match election_category {
-        ElectionCategory::Municipal => "Gemeenteraad",
-        ElectionCategory::Provincial => "Provinciale Staten",
-        ElectionCategory::WaterAuthority => "Waterschap",
+fn format_election_name(
+    rng: &mut impl rand::RngExt,
+    election_category: ElectionCategory,
+    locality: &str,
+    year: i32,
+) -> String {
+    let (election_type, election_locality) = match election_category {
+        ElectionCategory::Municipal => ("Gemeenteraad", locality),
+        ElectionCategory::Provincial => ("Provinciale Staten", super::data::province(rng)),
+        ElectionCategory::WaterAuthority => ("Waterschap", super::data::water_authority(rng)),
     };
-    format!("{election_type} {locality} {year}")
-}
-
-fn generate_locality(rng: &mut impl rand::RngExt, election_category: ElectionCategory) -> String {
-    match election_category {
-        ElectionCategory::Municipal => super::data::locality(rng),
-        ElectionCategory::Provincial => super::data::province(rng),
-        ElectionCategory::WaterAuthority => super::data::water_authority(rng),
-    }
-    .to_owned()
+    format!("{election_type} {election_locality} {year}")
 }
 
 fn get_election_sub_category(
@@ -331,14 +327,13 @@ fn generate_election(
 
     let category = args.election_category.to_eml_code();
     let year = election_date.year();
-    let locality = generate_locality(rng, args.election_category);
+    let locality = super::data::locality(rng).to_owned();
 
     // use the previous data to generate some identifiers and names
-    let name: String = args.custom_name.clone().unwrap_or(format_election_name(
-        args.election_category,
-        &locality,
-        year,
-    ));
+    let name: String = args
+        .custom_name
+        .clone()
+        .unwrap_or_else(|| format_election_name(rng, args.election_category, &locality, year));
     let cleaned_up_locality = locality.replace(" ", "_").replace("'", "");
     let election_id = format!("{category}{year}_{cleaned_up_locality}");
 

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -258,9 +258,18 @@ fn format_election_name(election_category: ElectionCategory, locality: &str, yea
     let election_type = match election_category {
         ElectionCategory::Municipal => "Gemeenteraad",
         ElectionCategory::Provincial => "Provinciale Staten",
-        ElectionCategory::WaterAuthority => "Algemeen bestuur van het waterschap",
+        ElectionCategory::WaterAuthority => "Waterschap",
     };
     format!("{election_type} {locality} {year}")
+}
+
+fn generate_locality(rng: &mut impl rand::RngExt, election_category: ElectionCategory) -> String {
+    match election_category {
+        ElectionCategory::Municipal => super::data::locality(rng),
+        ElectionCategory::Provincial => super::data::province(rng),
+        ElectionCategory::WaterAuthority => super::data::water_authority(rng),
+    }
+    .to_owned()
 }
 
 fn get_election_sub_category(
@@ -322,7 +331,7 @@ fn generate_election(
 
     let category = args.election_category.to_eml_code();
     let year = election_date.year();
-    let locality = super::data::locality(rng).to_owned();
+    let locality = generate_locality(rng, args.election_category);
 
     // use the previous data to generate some identifiers and names
     let name: String = args.custom_name.clone().unwrap_or(format_election_name(


### PR DESCRIPTION
## What & why

Resolves #3700 

Adds fictional provinces and water authorities to test data generator.

## How to test

Generate some test elections through `/dev` and see that the new names are being assigned to the election name.

## Reviewer notes

Validate if the names are fictional enough.