### PR TITLE
Adjust DSOFirstSessionResult sections

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5388,6 +5388,21 @@
   },
   "components": {
     "schemas": {
+      "AboutReport": {
+        "type": "object",
+        "description": "Information about the report (\"Over het proces-verbaal\")",
+        "properties": {
+          "checks_and_corrections_present": {
+            "$ref": "#/components/schemas/ChecksAndCorrectionsPresent",
+            "description": "Whether the extra page \"controles en correcties\" is inserted in the report\n(\"Is voorin het proces-verbaal de extra pagina controles en correcties ingevoegd?\")"
+          },
+          "corrigendum_present": {
+            "$ref": "#/components/schemas/CorrigendumPresent",
+            "description": "Whether a corrigendum accompanies the report\n(\"Is er een corrigendum bij het papieren proces-verbaal aanwezig?\")"
+          }
+        },
+        "additionalProperties": false
+      },
       "AbsoluteMajorityDrawingLots": {
         "type": "object",
         "required": [
@@ -6066,6 +6081,38 @@
         },
         "additionalProperties": false
       },
+      "ChecksAndCorrections": {
+        "type": "object",
+        "description": "Checks and corrections (\"Controles en correcties\")",
+        "required": [
+          "reason_investigation_own_initiative",
+          "corrected_results_own_initiative",
+          "corrected_results_csb_request"
+        ],
+        "properties": {
+          "corrected_results_csb_request": {
+            "$ref": "#/components/schemas/YesNo",
+            "description": "Whether investigation at the request of the central electoral committee\nhas led to corrected results\n(\"Op verzoek van het centraal stembureau: Zijn er gecorrigeerde telresultaten?\")"
+          },
+          "corrected_results_own_initiative": {
+            "$ref": "#/components/schemas/YesNo",
+            "description": "Whether the investigation on its own initiative has led to corrected results\n(\"Op eigen initiatief van het gemeentelijk stembureau: Zijn er gecorrigeerde telresultaten?\")"
+          },
+          "reason_investigation_own_initiative": {
+            "$ref": "#/components/schemas/ReasonInvestigationOwnInitiative",
+            "description": "Whether the GSB investigated the counting results on its own initiative\n(\"Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau\n de telresultaten onderzocht?\")"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChecksAndCorrectionsPresent": {
+        "type": "string",
+        "description": "Whether the extra page \"controles en correcties\" is inserted in the report",
+        "enum": [
+          "PagePresent",
+          "PageMissing"
+        ]
+      },
       "ChosenCandidate": {
         "type": "object",
         "description": "Chosen candidate",
@@ -6275,6 +6322,14 @@
         },
         "additionalProperties": false
       },
+      "CorrigendumPresent": {
+        "type": "string",
+        "description": "Whether a corrigendum accompanies the report",
+        "enum": [
+          "TwoDocuments",
+          "OneDocument"
+        ]
+      },
       "CountingDifferencesPollingStation": {
         "type": "object",
         "description": "Counting Differences Polling Station,\npart of the results (\"B1-2 Verschillen met telresultaten van het stembureau\")",
@@ -6357,25 +6412,25 @@
         "type": "object",
         "description": "DSOFirstSessionResults, following the fields in Model N 10-1\n\nSee: Model N 10-1 (Proces-verbaal van een stembureau) from\n[kiesraad](https://www.kiesraad.nl/documenten/2025/11/27/n-10-1-pv-sb-dso)",
         "required": [
-          "extra_investigation",
-          "counting_differences_polling_station",
+          "about_report",
+          "checks_and_corrections",
           "voters_counts",
           "votes_counts",
           "differences_counts",
           "political_group_votes"
         ],
         "properties": {
-          "counting_differences_polling_station": {
-            "$ref": "#/components/schemas/CountingDifferencesPollingStation",
-            "description": "Counting Differences Polling Station (\"B1-2 Verschillen met telresultaten van het stembureau\")"
+          "about_report": {
+            "$ref": "#/components/schemas/AboutReport",
+            "description": "About report (\"Over het proces-verbaal\")"
+          },
+          "checks_and_corrections": {
+            "$ref": "#/components/schemas/ChecksAndCorrections",
+            "description": "Checks and corrections (\"Controles en correcties\")"
           },
           "differences_counts": {
             "$ref": "#/components/schemas/DifferencesCounts",
             "description": "Differences counts (\"3. Verschil tussen het aantal toegelaten kiezers en het aantal getelde stembiljetten\")"
-          },
-          "extra_investigation": {
-            "$ref": "#/components/schemas/ExtraInvestigation",
-            "description": "Extra investigation (\"B1-1 Alleen bij extra onderzoek\")"
           },
           "political_group_votes": {
             "type": "array",
@@ -8802,6 +8857,25 @@
       },
       "RandomRange": {
         "type": "string"
+      },
+      "ReasonInvestigationOwnInitiative": {
+        "type": "object",
+        "description": "Reason for investigation on own initiative",
+        "required": [
+          "unaccounted_difference",
+          "other_error"
+        ],
+        "properties": {
+          "other_error": {
+            "type": "boolean",
+            "description": "Because of a (suspected) other error\n(\"Vanwege (het vermoeden van) een andere fout\")"
+          },
+          "unaccounted_difference": {
+            "type": "boolean",
+            "description": "Because of an unaccounted difference\n(\"Vanwege een onverklaard verschil\")"
+          }
+        },
+        "additionalProperties": false
       },
       "RedactedEmlHash": {
         "type": "object",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6100,7 +6100,7 @@
           },
           "reason_investigation_own_initiative": {
             "$ref": "#/components/schemas/ReasonInvestigationOwnInitiative",
-            "description": "Whether the GSB investigated the counting results on its own initiative\n(\"Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau\n de telresultaten onderzocht?\")"
+            "description": "Why the GSB investigated the counting results on its own initiative\n(\"Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau\n de telresultaten onderzocht?\")"
           }
         },
         "additionalProperties": false
@@ -8872,7 +8872,7 @@
           },
           "unaccounted_difference": {
             "type": "boolean",
-            "description": "Because of an unaccounted difference\n(\"Vanwege een onverklaard verschil\")"
+            "description": "Because of an unaccounted-for difference\n(\"Vanwege een onverklaard verschil\")"
           }
         },
         "additionalProperties": false

--- a/backend/src/domain/results/about_report.rs
+++ b/backend/src/domain/results/about_report.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::domain::{
+    compare::Compare,
+    election::ElectionWithPoliticalGroups,
+    field_path::FieldPath,
+    validate::{DataError, Validate, ValidationResults},
+};
+
+/// Information about the report ("Over het proces-verbaal")
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[serde(deny_unknown_fields)]
+pub struct AboutReport {
+    /// Whether a corrigendum accompanies the report
+    /// ("Is er een corrigendum bij het papieren proces-verbaal aanwezig?")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub corrigendum_present: Option<CorrigendumPresent>,
+    /// Whether the extra page "controles en correcties" is inserted in the report
+    /// ("Is voorin het proces-verbaal de extra pagina controles en correcties ingevoegd?")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub checks_and_corrections_present: Option<ChecksAndCorrectionsPresent>,
+}
+
+/// Whether a corrigendum accompanies the report
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CorrigendumPresent {
+    /// "Ja, ik heb twee documenten (een proces-verbaal en een corrigendum)"
+    TwoDocuments,
+    /// "Nee, ik heb één document (alleen een proces-verbaal)"
+    OneDocument,
+}
+
+/// Whether the extra page "controles en correcties" is inserted in the report
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ChecksAndCorrectionsPresent {
+    /// "Ja, de pagina 'controles en correcties' is aanwezig"
+    PagePresent,
+    /// "Nee, de pagina ontbreekt"
+    PageMissing,
+}
+
+impl Compare for AboutReport {
+    fn compare(&self, first_entry: &Self, different_fields: &mut Vec<String>, path: &FieldPath) {
+        if self.corrigendum_present != first_entry.corrigendum_present {
+            different_fields.push(path.field("corrigendum_present").to_string());
+        }
+
+        if self.checks_and_corrections_present != first_entry.checks_and_corrections_present {
+            different_fields.push(path.field("checks_and_corrections_present").to_string());
+        }
+    }
+}
+
+impl Validate for AboutReport {
+    fn validate(
+        &self,
+        _election: &ElectionWithPoliticalGroups,
+        _path: &FieldPath,
+    ) -> Result<ValidationResults, DataError> {
+        let validation_results = ValidationResults::default();
+        // TODO: https://github.com/kiesraad/abacus/issues/3687
+
+        Ok(validation_results)
+    }
+}

--- a/backend/src/domain/results/checks_and_corrections.rs
+++ b/backend/src/domain/results/checks_and_corrections.rs
@@ -13,7 +13,7 @@ use crate::domain::{
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct ChecksAndCorrections {
-    /// Whether the GSB investigated the counting results on its own initiative
+    /// Why the GSB investigated the counting results on its own initiative
     /// ("Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau
     ///  de telresultaten onderzocht?")
     pub reason_investigation_own_initiative: ReasonInvestigationOwnInitiative,
@@ -32,7 +32,7 @@ pub struct ChecksAndCorrections {
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct ReasonInvestigationOwnInitiative {
-    /// Because of an unaccounted difference
+    /// Because of an unaccounted-for difference
     /// ("Vanwege een onverklaard verschil")
     pub unaccounted_difference: bool,
     /// Because of a (suspected) other error

--- a/backend/src/domain/results/checks_and_corrections.rs
+++ b/backend/src/domain/results/checks_and_corrections.rs
@@ -1,0 +1,92 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::domain::{
+    compare::Compare,
+    election::ElectionWithPoliticalGroups,
+    field_path::FieldPath,
+    results::yes_no::YesNo,
+    validate::{DataError, Validate, ValidationResults},
+};
+
+/// Checks and corrections ("Controles en correcties")
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[serde(deny_unknown_fields)]
+pub struct ChecksAndCorrections {
+    /// Whether the GSB investigated the counting results on its own initiative
+    /// ("Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau
+    ///  de telresultaten onderzocht?")
+    pub reason_investigation_own_initiative: ReasonInvestigationOwnInitiative,
+
+    /// Whether the investigation on its own initiative has led to corrected results
+    /// ("Op eigen initiatief van het gemeentelijk stembureau: Zijn er gecorrigeerde telresultaten?")
+    pub corrected_results_own_initiative: YesNo,
+
+    /// Whether investigation at the request of the central electoral committee
+    /// has led to corrected results
+    /// ("Op verzoek van het centraal stembureau: Zijn er gecorrigeerde telresultaten?")
+    pub corrected_results_csb_request: YesNo,
+}
+
+/// Reason for investigation on own initiative
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[serde(deny_unknown_fields)]
+pub struct ReasonInvestigationOwnInitiative {
+    /// Because of an unaccounted difference
+    /// ("Vanwege een onverklaard verschil")
+    pub unaccounted_difference: bool,
+    /// Because of a (suspected) other error
+    /// ("Vanwege (het vermoeden van) een andere fout")
+    pub other_error: bool,
+}
+
+impl Compare for ChecksAndCorrections {
+    fn compare(&self, first_entry: &Self, different_fields: &mut Vec<String>, path: &FieldPath) {
+        self.reason_investigation_own_initiative.compare(
+            &first_entry.reason_investigation_own_initiative,
+            different_fields,
+            &path.field("reason_investigation_own_initiative"),
+        );
+
+        self.corrected_results_own_initiative.compare(
+            &first_entry.corrected_results_own_initiative,
+            different_fields,
+            &path.field("corrected_results_own_initiative"),
+        );
+
+        self.corrected_results_csb_request.compare(
+            &first_entry.corrected_results_csb_request,
+            different_fields,
+            &path.field("corrected_results_csb_request"),
+        );
+    }
+}
+
+impl Compare for ReasonInvestigationOwnInitiative {
+    fn compare(&self, first_entry: &Self, different_fields: &mut Vec<String>, path: &FieldPath) {
+        self.unaccounted_difference.compare(
+            &first_entry.unaccounted_difference,
+            different_fields,
+            &path.field("unaccounted_difference"),
+        );
+
+        self.other_error.compare(
+            &first_entry.other_error,
+            different_fields,
+            &path.field("other_error"),
+        );
+    }
+}
+
+impl Validate for ChecksAndCorrections {
+    fn validate(
+        &self,
+        _election: &ElectionWithPoliticalGroups,
+        _path: &FieldPath,
+    ) -> Result<ValidationResults, DataError> {
+        let validation_results = ValidationResults::default();
+        // TODO: https://github.com/kiesraad/abacus/issues/3687
+
+        Ok(validation_results)
+    }
+}

--- a/backend/src/domain/results/dso_first_session_results.rs
+++ b/backend/src/domain/results/dso_first_session_results.rs
@@ -5,8 +5,8 @@ use crate::domain::{
     compare::Compare,
     field_path::FieldPath,
     results::{
-        counting_differences_polling_station::CountingDifferencesPollingStation,
-        differences_counts::DifferencesCounts, extra_investigation::ExtraInvestigation,
+        about_report::AboutReport, checks_and_corrections::ChecksAndCorrections,
+        differences_counts::DifferencesCounts,
         political_group_candidate_votes::PoliticalGroupCandidateVotes, voters_counts::VotersCounts,
         votes_counts::VotesCounts,
     },
@@ -18,10 +18,10 @@ use crate::domain::{
 /// [kiesraad](https://www.kiesraad.nl/documenten/2025/11/27/n-10-1-pv-sb-dso)
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DSOFirstSessionResults {
-    /// Extra investigation ("B1-1 Alleen bij extra onderzoek")
-    pub extra_investigation: ExtraInvestigation,
-    /// Counting Differences Polling Station ("B1-2 Verschillen met telresultaten van het stembureau")
-    pub counting_differences_polling_station: CountingDifferencesPollingStation,
+    /// About report ("Over het proces-verbaal")
+    pub about_report: AboutReport,
+    /// Checks and corrections ("Controles en correcties")
+    pub checks_and_corrections: ChecksAndCorrections,
     /// Voters counts ("1. Aantal toegelaten kiezers")
     pub voters_counts: VotersCounts,
     /// Votes counts ("2. Aantal getelde stembiljetten")
@@ -34,16 +34,16 @@ pub struct DSOFirstSessionResults {
 
 impl Compare for DSOFirstSessionResults {
     fn compare(&self, first_entry: &Self, different_fields: &mut Vec<String>, path: &FieldPath) {
-        self.extra_investigation.compare(
-            &first_entry.extra_investigation,
+        self.about_report.compare(
+            &first_entry.about_report,
             different_fields,
-            &path.field("extra_investigation"),
+            &path.field("about_report"),
         );
 
-        self.counting_differences_polling_station.compare(
-            &first_entry.counting_differences_polling_station,
+        self.checks_and_corrections.compare(
+            &first_entry.checks_and_corrections,
             different_fields,
-            &path.field("counting_differences_polling_station"),
+            &path.field("checks_and_corrections"),
         );
 
         self.voters_counts.compare(

--- a/backend/src/domain/results/mod.rs
+++ b/backend/src/domain/results/mod.rs
@@ -19,6 +19,8 @@ use crate::domain::{
     validate::{DataError, Validate, ValidateRoot, ValidationResults},
 };
 
+pub mod about_report;
+pub mod checks_and_corrections;
 pub mod common_polling_station_results;
 pub mod common_validation;
 pub mod count;

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -666,7 +666,7 @@ has led to corrected results
   /** Whether the investigation on its own initiative has led to corrected results
 ("Op eigen initiatief van het gemeentelijk stembureau: Zijn er gecorrigeerde telresultaten?") */
   corrected_results_own_initiative: YesNo;
-  /** Whether the GSB investigated the counting results on its own initiative
+  /** Why the GSB investigated the counting results on its own initiative
 ("Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau
  de telresultaten onderzocht?") */
   reason_investigation_own_initiative: ReasonInvestigationOwnInitiative;
@@ -1578,7 +1578,7 @@ export interface ReasonInvestigationOwnInitiative {
   /** Because of a (suspected) other error
 ("Vanwege (het vermoeden van) een andere fout") */
   other_error: boolean;
-  /** Because of an unaccounted difference
+  /** Because of an unaccounted-for difference
 ("Vanwege een onverklaard verschil") */
   unaccounted_difference: boolean;
 }

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -403,6 +403,18 @@ export type USER_DELETE_REQUEST_PATH = `/api/users/${UserId}`;
 
 /** TYPES **/
 
+/**
+ * Information about the report ("Over het proces-verbaal")
+ */
+export interface AboutReport {
+  /** Whether the extra page "controles en correcties" is inserted in the report
+("Is voorin het proces-verbaal de extra pagina controles en correcties ingevoegd?") */
+  checks_and_corrections_present?: ChecksAndCorrectionsPresent;
+  /** Whether a corrigendum accompanies the report
+("Is er een corrigendum bij het papieren proces-verbaal aanwezig?") */
+  corrigendum_present?: CorrigendumPresent;
+}
+
 export interface AbsoluteMajorityDrawingLots {
   /** The list where the reassigned residual seat will go to */
   assign_to: PGNumber;
@@ -644,6 +656,29 @@ export interface CandidateVotes {
 }
 
 /**
+ * Checks and corrections ("Controles en correcties")
+ */
+export interface ChecksAndCorrections {
+  /** Whether investigation at the request of the central electoral committee
+has led to corrected results
+("Op verzoek van het centraal stembureau: Zijn er gecorrigeerde telresultaten?") */
+  corrected_results_csb_request: YesNo;
+  /** Whether the investigation on its own initiative has led to corrected results
+("Op eigen initiatief van het gemeentelijk stembureau: Zijn er gecorrigeerde telresultaten?") */
+  corrected_results_own_initiative: YesNo;
+  /** Whether the GSB investigated the counting results on its own initiative
+("Op eigen initiatief van het gemeentelijk stembureau: Waarom heeft het gemeentelijk stembureau
+ de telresultaten onderzocht?") */
+  reason_investigation_own_initiative: ReasonInvestigationOwnInitiative;
+}
+
+/**
+ * Whether the extra page "controles en correcties" is inserted in the report
+ */
+export const checksAndCorrectionsPresentValues = ["PagePresent", "PageMissing"] as const;
+export type ChecksAndCorrectionsPresent = (typeof checksAndCorrectionsPresentValues)[number];
+
+/**
  * Chosen candidate
  */
 export interface ChosenCandidate {
@@ -730,6 +765,12 @@ export interface CommonPollingStationResults {
 }
 
 /**
+ * Whether a corrigendum accompanies the report
+ */
+export const corrigendumPresentValues = ["TwoDocuments", "OneDocument"] as const;
+export type CorrigendumPresent = (typeof corrigendumPresentValues)[number];
+
+/**
  * Counting Differences Polling Station,
  * part of the results ("B1-2 Verschillen met telresultaten van het stembureau")
  */
@@ -767,12 +808,12 @@ export interface Credentials {
  * [kiesraad](https://www.kiesraad.nl/documenten/2025/11/27/n-10-1-pv-sb-dso)
  */
 export interface DSOFirstSessionResults {
-  /** Counting Differences Polling Station ("B1-2 Verschillen met telresultaten van het stembureau") */
-  counting_differences_polling_station: CountingDifferencesPollingStation;
+  /** About report ("Over het proces-verbaal") */
+  about_report: AboutReport;
+  /** Checks and corrections ("Controles en correcties") */
+  checks_and_corrections: ChecksAndCorrections;
   /** Differences counts ("3. Verschil tussen het aantal toegelaten kiezers en het aantal getelde stembiljetten") */
   differences_counts: DifferencesCounts;
-  /** Extra investigation ("B1-1 Alleen bij extra onderzoek") */
-  extra_investigation: ExtraInvestigation;
   /** Vote counts per list and candidate (5. "Aantal stemmen per lijst en kandidaat") */
   political_group_votes: PoliticalGroupCandidateVotes[];
   /** Voters counts ("1. Aantal toegelaten kiezers") */
@@ -1529,6 +1570,18 @@ export type ProcessApportionmentResponse =
   | { election_summary: ElectionSummary; seat_assignment: SeatAssignment; status: "DrawingLotsRequired" };
 
 export type RandomRange = string;
+
+/**
+ * Reason for investigation on own initiative
+ */
+export interface ReasonInvestigationOwnInitiative {
+  /** Because of a (suspected) other error
+("Vanwege (het vermoeden van) een andere fout") */
+  other_error: boolean;
+  /** Because of an unaccounted difference
+("Vanwege een onverklaard verschil") */
+  unaccounted_difference: boolean;
+}
 
 export interface RedactedEmlHash {
   /** Array holding the hash chunks as text */


### PR DESCRIPTION
## What & why

Resolves #3686

- Adjusts first two sections for `DSOFirstSessionResult` struct
- Adds enum for radio button options
  - Note: further implementation will happen in https://github.com/kiesraad/abacus/issues/3684

## How to test

- Compare the fields to [Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=9239-29975&m=dev)
- Check the field names / descriptions and propose better names if necessary

## Reviewer notes

None