### PR TITLE
Enable full navigation for data entry corrections

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6153,7 +6153,8 @@
           "client_state",
           "validation_results",
           "source",
-          "status"
+          "status",
+          "is_correction"
         ],
         "properties": {
           "client_state": {
@@ -6161,6 +6162,10 @@
           },
           "data": {
             "$ref": "#/components/schemas/Results"
+          },
+          "is_correction": {
+            "type": "boolean",
+            "description": "Whether the typist is correcting an entry that was completed before"
           },
           "previous_results": {
             "$ref": "#/components/schemas/CommonPollingStationResults"

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -152,6 +152,8 @@ pub struct ClaimDataEntryResponse {
     pub previous_results: Option<CommonPollingStationResults>,
     pub source: DataEntrySource,
     pub status: DataEntryStatusName,
+    /// Whether the typist is correcting an entry that was completed before
+    pub is_correction: bool,
 }
 
 pub fn router() -> OpenApiRouter<AppState> {
@@ -371,6 +373,7 @@ async fn data_entry_claim(
         previous_results,
         source: context.source,
         status: new_state.status_name(),
+        is_correction: new_state.is_correction(),
     }))
 }
 
@@ -1080,6 +1083,17 @@ mod tests {
         )
         .await
         .into_response()
+    }
+
+    /// Claim the first entry and deserialise the response body
+    async fn claim_and_parse(
+        pool: SqlitePool,
+        data_entry_id: DataEntryId,
+    ) -> ClaimDataEntryResponse {
+        let response = claim(pool, data_entry_id, EntryNumber::FirstEntry).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&body).unwrap()
     }
 
     async fn save(
@@ -2490,6 +2504,33 @@ mod tests {
         let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
         let status: DataEntryStatus = data_entry.state.0;
         assert!(matches!(status, DataEntryStatus::FirstEntryInProgress(_)));
+    }
+
+    /// Test that a first entry returned for correction is has is_correction set
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_claim_data_entry_resumed_first_entry_is_correction(pool: SqlitePool) {
+        let data_entry_id = DataEntryId::from(201);
+
+        // check that is_correction is false for a new entry, then finalise with errors
+        let claimed = claim_and_parse(pool.clone(), data_entry_id).await;
+        assert_eq!(claimed.status, DataEntryStatusName::FirstEntryInProgress);
+        assert!(!claimed.is_correction);
+        finalise_with_errors(pool.clone()).await;
+
+        // resolve errors by resuming first entry (return for correction)
+        let response = resolve_errors(
+            pool.clone(),
+            data_entry_id,
+            ResolveErrorsAction::ResumeFirstEntry,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // is_correction is true and client state is empty
+        let claimed = claim_and_parse(pool.clone(), data_entry_id).await;
+        assert_eq!(claimed.status, DataEntryStatusName::FirstEntryInProgress);
+        assert!(claimed.is_correction);
+        assert_eq!(claimed.client_state, None);
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -296,6 +296,9 @@ pub struct FirstEntryInProgress {
     #[schema(value_type = Object)]
     /// Client state for the data entry (arbitrary JSON)
     pub client_state: ClientState,
+    /// Whether this entry was returned for correction
+    #[serde(default)]
+    pub is_correction: bool,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, Type, Eq, PartialEq)]
@@ -451,6 +454,7 @@ impl DataEntryStatus {
                 first_entry_user_id: user_id,
                 first_entry: initial_results,
                 client_state: ClientState::default(),
+                is_correction: false,
             })),
             DataEntryStatus::FirstEntryInProgress(_) | DataEntryStatus::FirstEntryCorrection(_) => {
                 if user_id == self.get_first_entry_user_id().expect("user id is present") {
@@ -811,6 +815,7 @@ impl DataEntryStatus {
                     first_entry_user_id: state.first_entry_user_id,
                     first_entry: state.finalised_first_entry.clone(),
                     client_state: Default::default(),
+                    is_correction: true,
                 }))
             }
             _ => Err(DataEntryTransitionError::Invalid),
@@ -1002,6 +1007,21 @@ impl DataEntryStatus {
         }
     }
 
+    /// Whether the typist is correcting an entry that was completed before
+    pub fn is_correction(&self) -> bool {
+        match self {
+            DataEntryStatus::FirstEntryInProgress(state) => state.is_correction,
+            DataEntryStatus::FirstEntryCorrection(_)
+            | DataEntryStatus::SecondEntryCorrection(_) => true,
+            DataEntryStatus::Empty
+            | DataEntryStatus::SecondEntryInProgress(_)
+            | DataEntryStatus::FirstEntryHasErrors(_)
+            | DataEntryStatus::FirstEntryFinalised(_)
+            | DataEntryStatus::EntriesDifferent(_)
+            | DataEntryStatus::Definitive(_) => false,
+        }
+    }
+
     /// Get the name of the current status
     pub fn status_name(&self) -> DataEntryStatusName {
         match self {
@@ -1160,6 +1180,7 @@ mod tests {
             first_entry_user_id: UserId::from(0),
             first_entry: example_results(),
             client_state: ClientState::new_from_str(Some("{}")).unwrap(),
+            is_correction: false,
         })
     }
 
@@ -1331,6 +1352,7 @@ mod tests {
             first_entry_user_id: UserId::from(0),
             first_entry: invalid_entry,
             client_state: ClientState::new_from_str(Some("{}")).unwrap(),
+            is_correction: false,
         });
         let next = initial
             .finalise_first_entry(&election(), UserId::from(0))
@@ -1673,15 +1695,44 @@ mod tests {
 
     #[test]
     fn has_errors_resume_first() {
-        assert!(matches!(
-            first_entry_has_errors().resume_first_entry_with_errors(),
-            Ok(DataEntryStatus::FirstEntryInProgress(
-                FirstEntryInProgress {
-                    first_entry_user_id,
-                    ..
-                }
-            )) if first_entry_user_id == UserId::from(0)
-        ));
+        let resumed = first_entry_has_errors()
+            .resume_first_entry_with_errors()
+            .expect("should be Ok");
+
+        let DataEntryStatus::FirstEntryInProgress(state) = &resumed else {
+            panic!("expected FirstEntryInProgress, got {resumed:?}");
+        };
+        assert_eq!(state.first_entry_user_id, UserId::from(0));
+        assert!(resumed.is_correction());
+    }
+
+    #[test]
+    fn claimed_first_entry_is_not_a_correction() {
+        assert!(!first_entry_in_progress().is_correction());
+        assert!(
+            !DataEntryStatus::Empty
+                .claim_first_entry(UserId::from(0), example_results())
+                .expect("should be Ok")
+                .is_correction()
+        );
+    }
+
+    #[test]
+    fn correction_survives_saving_the_first_entry() {
+        let resumed = first_entry_has_errors()
+            .resume_first_entry_with_errors()
+            .expect("should be Ok");
+
+        let saved = resumed
+            .update_first_entry(DataEntryUpdate {
+                progress: 60,
+                user_id: UserId::from(0),
+                entry: example_results(),
+                client_state: ClientState::new_from_str(Some(r#"{"furthest":"save"}"#)).unwrap(),
+            })
+            .expect("should be Ok");
+
+        assert!(saved.is_correction());
     }
 
     #[test]
@@ -1856,6 +1907,28 @@ mod tests {
         assert!(first_entry_finalised().get_client_state().is_none());
         assert!(second_entry_in_progress().get_client_state().is_some());
         assert!(entries_different().get_client_state().is_none());
+    }
+
+    #[test]
+    fn check_is_correction_return_values() {
+        assert!(!DataEntryStatus::Empty.is_correction());
+        assert!(!first_entry_in_progress().is_correction());
+        assert!(!second_entry_in_progress().is_correction());
+        assert!(!entries_different().is_correction());
+
+        // an entry corrected to resolve differences is also a correction
+        assert!(
+            entries_different()
+                .correct_first_entry(&election())
+                .unwrap()
+                .is_correction()
+        );
+        assert!(
+            entries_different()
+                .correct_second_entry()
+                .unwrap()
+                .is_correction()
+        );
     }
 
     #[test]

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -297,7 +297,6 @@ pub struct FirstEntryInProgress {
     /// Client state for the data entry (arbitrary JSON)
     pub client_state: ClientState,
     /// Whether this entry was returned for correction
-    #[serde(default)]
     pub is_correction: bool,
 }
 

--- a/frontend/e2e-tests/tests/data-entry-GSB/resolve-errors.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/resolve-errors.e2e.ts
@@ -1,4 +1,7 @@
 import { expect } from "@playwright/test";
+import { CheckAndSavePage } from "e2e-tests/page-objects/data_entry/CheckAndSavePgObj";
+import { ExtraInvestigationPage } from "e2e-tests/page-objects/data_entry/ExtraInvestigationPgObj";
+import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
 import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
 import { ResolveErrorsPgObj } from "e2e-tests/page-objects/election/ResolveErrorsPgObj";
 import { test } from "../../fixtures";
@@ -31,6 +34,44 @@ test.describe("resolve errors", () => {
 
     await expect(electionStatusPage.inProgress).toContainText(dataEntryGSBFirstEntryHasErrors.name);
     await expect(electionStatusPage.alertFirstDataEntryResumed).toBeVisible();
+  });
+
+  test("typist can navigate all sections of a resumed first entry", async ({
+    page,
+    typistOneGSB,
+    dataEntryGSBFirstEntryHasErrors,
+  }) => {
+    await page.goto(`/elections/${dataEntryGSBFirstEntryHasErrors.election_id}/status`);
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBFirstEntryHasErrors.name }).click();
+
+    const resolveErrorsPage = new ResolveErrorsPgObj(page);
+    await resolveErrorsPage.resumeFirstEntry.click();
+    await resolveErrorsPage.save.click();
+    await expect(electionStatusPage.inProgress).toContainText(dataEntryGSBFirstEntryHasErrors.name);
+
+    // the typist gets the completed entry back, starting at the first section
+    const typistPage = typistOneGSB.page;
+    await typistPage.goto(
+      `/elections/${dataEntryGSBFirstEntryHasErrors.election_id}/data-entry/${dataEntryGSBFirstEntryHasErrors.id}/1`,
+    );
+
+    const extraInvestigationPage = new ExtraInvestigationPage(typistPage);
+    await expect(extraInvestigationPage.fieldset).toBeVisible();
+
+    // every section is reachable again, including the last one
+    await extraInvestigationPage.progressList.checkAndSave.click();
+
+    const checkAndSavePage = new CheckAndSavePage(typistPage);
+    await expect(checkAndSavePage.fieldset).toBeVisible();
+
+    // and the errors have to be accepted again before the entry can be finalised
+    await checkAndSavePage.progressList.votersAndVotes.click();
+
+    const votersAndVotesPage = new VotersAndVotesPage(typistPage);
+    await expect(votersAndVotesPage.error).toContainText("F.201");
+    await expect(votersAndVotesPage.acceptErrorsAndWarnings).not.toBeChecked();
   });
 
   test("discard first entry", async ({ page, dataEntryGSBFirstEntryHasErrors }) => {

--- a/frontend/src/features/data_entry/testing/test.utils.ts
+++ b/frontend/src/features/data_entry/testing/test.utils.ts
@@ -49,6 +49,7 @@ export function overrideServerClaimDataEntryResponse({
       address: pollingStationMockData[0]!.address,
     },
     status: "first_entry_in_progress",
+    is_correction: false,
   } satisfies ClaimDataEntryResponse);
 }
 

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -192,6 +192,24 @@ export function buildFormState(
   return { formState: newFormState, targetFormSectionId };
 }
 
+/*
+ * Build the form state for an entry that is being corrected. The typist starts at the first section and has to
+ * accept the errors and warnings again.
+ */
+export function buildCorrectionFormState(validationResults: ValidationResults, dataEntryStructure: DataEntryStructure) {
+  const firstSectionId = dataEntryStructure[0]?.id;
+  if (firstSectionId === undefined) {
+    throw new Error("Cannot determine initial section from dataEntryStructure");
+  }
+
+  // "save" is the last section
+  return buildFormState(
+    { furthest: "save", current: firstSectionId, acceptedErrorsAndWarnings: [], continue: false },
+    validationResults,
+    dataEntryStructure,
+  );
+}
+
 export function updateFormStateAfterSubmit(
   dataEntryStructure: DataEntryStructure,
   formState: FormState,

--- a/frontend/src/features/data_entry/utils/reducer.test.ts
+++ b/frontend/src/features/data_entry/utils/reducer.test.ts
@@ -42,6 +42,7 @@ test("should handle CSOFirstSession DATA_ENTRY_CLAIMED with no client_state", ()
       },
       source,
       status: "first_entry_in_progress",
+      is_correction: false,
       validation_results: {
         errors: [],
         warnings: [],
@@ -74,6 +75,7 @@ test("should handle CSONextSession DATA_ENTRY_CLAIMED with no client_state", () 
       },
       source,
       status: "first_entry_in_progress",
+      is_correction: false,
       validation_results: {
         errors: [],
         warnings: [],
@@ -91,6 +93,38 @@ test("should handle CSONextSession DATA_ENTRY_CLAIMED with no client_state", () 
   expect(state.targetFormSectionId).toEqual("voters_votes_counts");
   expect(state.results).toEqual(action.dataEntry.data);
   expect(state.error).toBeNull();
+});
+
+test("should handle DATA_ENTRY_CLAIMED for a correction", () => {
+  const action: DataEntryAction = {
+    type: "DATA_ENTRY_CLAIMED",
+    dataEntry: {
+      client_state: null,
+      data: {
+        model: "CSOFirstSession",
+        ...getInitialValues(),
+      },
+      source,
+      status: "first_entry_in_progress",
+      is_correction: true,
+      validation_results: {
+        errors: [validationResultMockData.F204],
+        warnings: [],
+      },
+    },
+  };
+
+  const state = dataEntryReducer(getInitialState(), action);
+
+  // every section is reachable and typist starts at the first section
+  expect(state.formState?.furthest).toBe("save");
+  for (const section of state.dataEntryStructure!) {
+    expect(state.formState?.sections[section.id]?.isSaved).toBe(true);
+  }
+  expect(state.targetFormSectionId).toBe("extra_investigation");
+
+  // errors and warnings are not accepted anymore
+  expect(state.formState?.sections.differences_counts?.acceptErrorsAndWarnings).toBe(false);
 });
 
 test("should handle DATA_ENTRY_CLAIM_FAILED", () => {

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -1,9 +1,16 @@
 import { assertStateIsLoaded } from "@/features/data_entry/utils/utils";
 import type { DataEntryId, ElectionWithPoliticalGroups } from "@/types/generated/openapi";
+import type { FormSectionId } from "@/types/types";
 import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 
-import type { ClientState, DataEntryAction, DataEntryState, EntryNumber } from "../types/types";
-import { buildFormState, getInitialFormState, getNextSectionID, updateFormStateAfterSubmit } from "./dataEntryUtils";
+import type { ClientState, DataEntryAction, DataEntryState, EntryNumber, FormState } from "../types/types";
+import {
+  buildCorrectionFormState,
+  buildFormState,
+  getInitialFormState,
+  getNextSectionID,
+  updateFormStateAfterSubmit,
+} from "./dataEntryUtils";
 
 export function getInitialState(
   election: ElectionWithPoliticalGroups,
@@ -33,41 +40,42 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
     case "DATA_ENTRY_CLAIMED": {
       const model = action.dataEntry.data.model;
       const dataEntryStructure = getDataEntryStructure(model, state.election);
+
+      let formState: FormState;
+      let targetFormSectionId: FormSectionId | undefined;
       if (action.dataEntry.client_state) {
-        const { formState, targetFormSectionId } = buildFormState(
+        ({ formState, targetFormSectionId } = buildFormState(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           action.dataEntry.client_state as ClientState,
           action.dataEntry.validation_results,
           dataEntryStructure,
-        );
-        return {
-          ...state,
+        ));
+      } else if (action.dataEntry.is_correction) {
+        // an entry that was returned for correction and has no client state left to restore
+        ({ formState, targetFormSectionId } = buildCorrectionFormState(
+          action.dataEntry.validation_results,
           dataEntryStructure,
-          formState,
-          targetFormSectionId,
-          previousResults: action.dataEntry.previous_results ?? null,
-          results: action.dataEntry.data,
-          source: action.dataEntry.source,
-          dataEntryStatus: action.dataEntry.status,
-          error: null,
-        };
+        ));
       } else {
-        const targetFormSectionId = dataEntryStructure[0]?.id;
-        if (targetFormSectionId === undefined) {
-          throw new Error("Cannot determine initial section from dataEntryStructure");
-        }
-        return {
-          ...state,
-          dataEntryStructure,
-          formState: getInitialFormState(dataEntryStructure),
-          targetFormSectionId,
-          previousResults: action.dataEntry.previous_results ?? null,
-          results: action.dataEntry.data,
-          source: action.dataEntry.source,
-          dataEntryStatus: action.dataEntry.status,
-          error: null,
-        };
+        formState = getInitialFormState(dataEntryStructure);
+        targetFormSectionId = dataEntryStructure[0]?.id;
       }
+
+      if (targetFormSectionId === undefined) {
+        throw new Error("Cannot determine initial section from dataEntryStructure");
+      }
+
+      return {
+        ...state,
+        dataEntryStructure,
+        formState,
+        targetFormSectionId,
+        previousResults: action.dataEntry.previous_results ?? null,
+        results: action.dataEntry.data,
+        source: action.dataEntry.source,
+        dataEntryStatus: action.dataEntry.status,
+        error: null,
+      };
     }
     case "DATA_ENTRY_CLAIM_FAILED":
       return {

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -101,6 +101,7 @@ export const claimDataEntryResponse: ClaimDataEntryResponse = {
   client_state: null,
   source: source(1),
   status: "first_entry_in_progress",
+  is_correction: false,
 };
 
 export const saveDataEntryResponse: SaveDataEntryResponse = {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -683,6 +683,8 @@ export interface ChosenCandidate {
 export interface ClaimDataEntryResponse {
   client_state: unknown;
   data: Results;
+  /** Whether the typist is correcting an entry that was completed before */
+  is_correction: boolean;
   previous_results?: CommonPollingStationResults;
   source: DataEntrySource;
   status: DataEntryStatusName;


### PR DESCRIPTION
## What & why

Enable full navigation when a data entry is returned to the typist for corrections. Resolves #1990.

## How to test

Either:
- Create a data entry with errors, then as coordinator choose to return to typist for corrects 
- Create two data entries with differences, then as coordinator choose to return either for corrections
And then verify that the typist has the entire navigation enabled when correcting the data entry.

## Reviewer notes

@oliver3 and I had some discussion about the implementation, we chose to keep the client state opaque for the backend and go for this solution (see comments in #1990).