### PR TITLE
Update visual-diff.sh after file renames

### DIFF
--- a/backend/templates/visual-diff.sh
+++ b/backend/templates/visual-diff.sh
@@ -9,35 +9,35 @@ echo "Please make sure you are on the main branch to generate the 'old' PDFs."
 read -p "Press Enter to continue..."
 
 typst compile --font-path fonts model-n-10-2.typ model-n-10-2-old.pdf
-typst compile --font-path fonts model-na-14-2-bijlage1.typ model-na-14-2-bijlage1-old.pdf
+typst compile --font-path fonts model-na-14-2-bijlage-1.typ model-na-14-2-bijlage-1-old.pdf
 typst compile --font-path fonts model-na-14-2.typ model-na-14-2-old.pdf
-typst compile --font-path fonts model-na-31-2-bijlage1.typ model-na-31-2-bijlage1-old.pdf
+typst compile --font-path fonts model-na-31-2-bijlage-1.typ model-na-31-2-bijlage-1-old.pdf
 typst compile --font-path fonts model-na-31-2-inlegvel.typ model-na-31-2-inlegvel-old.pdf
 typst compile --font-path fonts model-na-31-2.typ model-na-31-2-old.pdf
 typst compile --font-path fonts model-p-2a.typ model-p-2a-old.pdf
 typst compile --font-path fonts model-p-22-2.typ model-p-22-2-old.pdf
-typst compile --font-path fonts model-p-22-2-bijlage1.typ model-p-22-2-bijlage1-old.pdf
+typst compile --font-path fonts model-p-22-2-bijlage-1.typ model-p-22-2-bijlage-1-old.pdf
 
 # instruct the user to switch to the feature branch before generating the "new" PDFs
 echo "Please make sure you are on the feature branch to generate the 'new' PDFs."
 read -p "Press Enter to continue..."
 
 typst compile --font-path fonts model-n-10-2.typ model-n-10-2-new.pdf
-typst compile --font-path fonts model-na-14-2-bijlage1.typ model-na-14-2-bijlage1-new.pdf
+typst compile --font-path fonts model-na-14-2-bijlage-1.typ model-na-14-2-bijlage-1-new.pdf
 typst compile --font-path fonts model-na-14-2.typ model-na-14-2-new.pdf
-typst compile --font-path fonts model-na-31-2-bijlage1.typ model-na-31-2-bijlage1-new.pdf
+typst compile --font-path fonts model-na-31-2-bijlage-1.typ model-na-31-2-bijlage-1-new.pdf
 typst compile --font-path fonts model-na-31-2-inlegvel.typ model-na-31-2-inlegvel-new.pdf
 typst compile --font-path fonts model-na-31-2.typ model-na-31-2-new.pdf
 typst compile --font-path fonts model-p-2a.typ model-p-2a-new.pdf
 typst compile --font-path fonts model-p-22-2.typ model-p-22-2-new.pdf
-typst compile --font-path fonts model-p-22-2-bijlage1.typ model-p-22-2-bijlage1-new.pdf
+typst compile --font-path fonts model-p-22-2-bijlage-1.typ model-p-22-2-bijlage-1-new.pdf
 
 diff-pdf --view model-n-10-2-old.pdf model-n-10-2-new.pdf
-diff-pdf --view model-na-14-2-bijlage1-old.pdf model-na-14-2-bijlage1-new.pdf
+diff-pdf --view model-na-14-2-bijlage-1-old.pdf model-na-14-2-bijlage-1-new.pdf
 diff-pdf --view model-na-14-2-old.pdf model-na-14-2-new.pdf
-diff-pdf --view model-na-31-2-bijlage1-old.pdf model-na-31-2-bijlage1-new.pdf
+diff-pdf --view model-na-31-2-bijlage-1-old.pdf model-na-31-2-bijlage-1-new.pdf
 diff-pdf --view model-na-31-2-inlegvel-old.pdf model-na-31-2-inlegvel-new.pdf
 diff-pdf --view model-na-31-2-old.pdf model-na-31-2-new.pdf
 diff-pdf --view model-p-2a-old.pdf model-p-2a-new.pdf
 diff-pdf --view model-p-22-2-old.pdf model-p-22-2-new.pdf
-diff-pdf --view model-p-22-2-bijlage1-old.pdf model-p-22-2-bijlage1-new.pdf
+diff-pdf --view model-p-22-2-bijlage-1-old.pdf model-p-22-2-bijlage-1-new.pdf


### PR DESCRIPTION
## What & why

Update `visual-diff.sh` after file renames in https://github.com/kiesraad/abacus/pull/3709. Could be expanded further (e.g. not hardcoding filepaths), but this change at least makes it work again.

## How to test

Run `visual-diff.sh` from `backend/templates`.

## Reviewer notes

None.
