### PR TITLE
Show correction warning and clear fields

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6193,6 +6193,13 @@
           "client_state": {
             "type": "object"
           },
+          "correction_warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fields for which a warning should be shown that a difference should be corrected"
+          },
           "data": {
             "$ref": "#/components/schemas/Results"
           },
@@ -9503,6 +9510,7 @@
           "F402",
           "F403",
           "W001",
+          "W002",
           "W201",
           "W202",
           "W203",

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -154,6 +154,10 @@ pub struct ClaimDataEntryResponse {
     pub status: DataEntryStatusName,
     /// Whether the typist is correcting an entry that was completed before
     pub is_correction: bool,
+    /// Fields for which a warning should be shown that a difference should be corrected
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub correction_warnings: Option<Vec<String>>,
 }
 
 pub fn router() -> OpenApiRouter<AppState> {
@@ -282,6 +286,32 @@ impl ResolveDifferencesAction {
     }
 }
 
+async fn get_previous_results(
+    tx: &mut SqliteConnection,
+    source: &DataEntrySource,
+) -> Result<Option<CommonPollingStationResults>, APIError> {
+    let prev_data_entry_id = match source {
+        DataEntrySource::PollingStation(ps) => ps.prev_data_entry_id(),
+        _ => None,
+    };
+
+    // If there is a previous data entry with status definitive
+    let previous_results: Option<CommonPollingStationResults> = match prev_data_entry_id {
+        Some(prev_id) => match data_entry_repo::get_status(tx, prev_id).await? {
+            // Match polling station results only and get the common results
+            DataEntryStatus::Definitive(d) => match d.results {
+                Results::CSOFirstSession(r) => Some(r.as_common()),
+                Results::CSONextSession(r) => Some(r.as_common()),
+                _ => None,
+            },
+            _ => None,
+        },
+        None => None,
+    };
+
+    Ok(previous_results)
+}
+
 /// Claim a data entry, returning any existing progress
 #[utoipa::path(
     post,
@@ -309,24 +339,7 @@ async fn data_entry_claim(
 
     let (context, state) = validate_and_get_data(&mut tx, data_entry_id, &user).await?;
 
-    let prev_data_entry_id = match &context.source {
-        DataEntrySource::PollingStation(ps) => ps.prev_data_entry_id(),
-        _ => None,
-    };
-
-    // If there is a previous data entry with status definitive
-    let previous_results: Option<CommonPollingStationResults> = match prev_data_entry_id {
-        Some(prev_id) => match data_entry_repo::get_status(&mut tx, prev_id).await? {
-            // Match polling station results only and get the common results
-            DataEntryStatus::Definitive(d) => match d.results {
-                Results::CSOFirstSession(r) => Some(r.as_common()),
-                Results::CSONextSession(r) => Some(r.as_common()),
-                _ => None,
-            },
-            _ => None,
-        },
-        None => None,
-    };
+    let previous_results = get_previous_results(&mut tx, &context.source).await?;
 
     let initial = Results::new(
         &context.election,
@@ -366,6 +379,13 @@ async fn data_entry_claim(
 
     tx.commit().await?;
 
+    let correction_warnings = match new_state {
+        DataEntryStatus::FirstEntryCorrection(_) | DataEntryStatus::SecondEntryCorrection(_) => {
+            new_state.compare_entries()
+        }
+        _ => None,
+    };
+
     Ok(Json(ClaimDataEntryResponse {
         data: data.clone(),
         client_state,
@@ -374,6 +394,7 @@ async fn data_entry_claim(
         source: context.source,
         status: new_state.status_name(),
         is_correction: new_state.is_correction(),
+        correction_warnings,
     }))
 }
 

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -243,18 +243,13 @@ impl Validate for DataEntryStatus {
                 ..
             })
             | DataEntryStatus::Definitive(Definitive { results: entry, .. }) => {
-                entry.validate(election, &"data".into())
+                entry.validate(election, path)
             }
             DataEntryStatus::SecondEntryInProgress(state) => {
-                let mut validation_results =
-                    state.second_entry.validate(election, &"data".into())?;
-                let mut different_fields: Vec<String> = vec![];
-                state.second_entry.compare(
-                    &state.finalised_first_entry,
-                    &mut different_fields,
-                    path,
-                );
-                if !different_fields.is_empty() {
+                let mut validation_results = state.second_entry.validate(election, path)?;
+                if let Some(different_fields) = self.compare_entries()
+                    && !different_fields.is_empty()
+                {
                     validation_results.warnings.push(ValidationResult {
                         fields: different_fields.clone(),
                         code: ValidationResultCode::W001,
@@ -1066,6 +1061,40 @@ impl DataEntryStatus {
             _ => None,
         }
     }
+
+    pub fn compare_entries(&self) -> Option<Vec<String>> {
+        match self {
+            DataEntryStatus::Empty
+            | DataEntryStatus::FirstEntryInProgress(_)
+            | DataEntryStatus::FirstEntryHasErrors(_)
+            | DataEntryStatus::FirstEntryFinalised(_) => None,
+            DataEntryStatus::SecondEntryInProgress(SecondEntryInProgress {
+                finalised_first_entry: first_entry,
+                second_entry,
+                ..
+            })
+            | DataEntryStatus::EntriesDifferent(EntriesDifferent {
+                first_entry,
+                second_entry,
+                ..
+            })
+            | DataEntryStatus::FirstEntryCorrection(FirstEntryCorrection {
+                first_entry,
+                finalised_second_entry: second_entry,
+                ..
+            })
+            | DataEntryStatus::SecondEntryCorrection(SecondEntryCorrection {
+                finalised_first_entry: first_entry,
+                second_entry,
+                ..
+            }) => {
+                let mut different_fields: Vec<String> = vec![];
+                second_entry.compare(first_entry, &mut different_fields, &"data".into());
+                Some(different_fields)
+            }
+            DataEntryStatus::Definitive(_) => None,
+        }
+    }
 }
 
 impl Display for DataEntryTransitionError {
@@ -1246,6 +1275,30 @@ mod tests {
             second_entry_user_id: UserId::from(0),
             first_entry_finished_at: Utc::now(),
             second_entry_finished_at: Utc::now(),
+        })
+    }
+
+    fn first_entry_correction() -> DataEntryStatus {
+        DataEntryStatus::FirstEntryCorrection(FirstEntryCorrection {
+            first_entry_user_id: UserId::from(1),
+            second_entry_user_id: UserId::from(2),
+            first_entry: example_results(),
+            finalised_second_entry: example_results().with_difference(),
+            second_entry_finished_at: Utc::now(),
+            progress: 0,
+            client_state: Default::default(),
+        })
+    }
+
+    fn second_entry_correction() -> DataEntryStatus {
+        DataEntryStatus::SecondEntryCorrection(SecondEntryCorrection {
+            first_entry_user_id: UserId::from(1),
+            second_entry_user_id: UserId::from(2),
+            finalised_first_entry: example_results(),
+            second_entry: example_results().with_difference(),
+            first_entry_finished_at: Utc::now(),
+            progress: 0,
+            client_state: Default::default(),
         })
     }
 
@@ -2214,6 +2267,65 @@ mod tests {
                     .finalised_with_warnings(),
                 Some(&true)
             )
+        }
+    }
+
+    mod compare_entries {
+        use super::*;
+
+        #[test]
+        fn no_two_entries() {
+            for status in [
+                DataEntryStatus::Empty,
+                first_entry_in_progress(),
+                first_entry_has_errors(),
+                first_entry_finalised(),
+                definitive(),
+            ] {
+                assert!(
+                    status.compare_entries().is_none(),
+                    "should be none for state {status:?}"
+                );
+            }
+        }
+
+        const EXPECTED_DIFFERENCES: [&str; 2] = [
+            "data.voters_counts.poll_card_count",
+            "data.voters_counts.proxy_certificate_count",
+        ];
+
+        #[test]
+        fn second_entry_in_progress_differences() {
+            let mut state = second_entry_in_progress();
+            state.set_second_entry(example_results().with_difference());
+
+            assert_eq!(
+                state.compare_entries(),
+                Some(EXPECTED_DIFFERENCES.iter().map(|s| s.to_string()).collect())
+            );
+        }
+
+        #[test]
+        fn entries_different_differences() {
+            assert_eq!(
+                entries_different().compare_entries(),
+                Some(EXPECTED_DIFFERENCES.iter().map(|s| s.to_string()).collect())
+            );
+        }
+
+        #[test]
+        fn first_entry_correction_differences() {
+            assert_eq!(
+                first_entry_correction().compare_entries(),
+                Some(EXPECTED_DIFFERENCES.iter().map(|s| s.to_string()).collect())
+            );
+        }
+        #[test]
+        fn second_entry_correction_differences() {
+            assert_eq!(
+                second_entry_correction().compare_entries(),
+                Some(EXPECTED_DIFFERENCES.iter().map(|s| s.to_string()).collect())
+            );
         }
     }
 }

--- a/backend/src/domain/validate.rs
+++ b/backend/src/domain/validate.rs
@@ -114,6 +114,8 @@ pub enum ValidationResultCode {
 
     /// GSB CSO, GSB DSO, CSB: (Bij tweede invoer) Niet alle ingevoerde waardes van de tweede invoer zijn gelijk aan die van de eerste invoer
     W001,
+    /// GSB CSO, GSB DSO, CSB: (Bij verschil met andere invoer) Een coördinator heeft beide invoeren vergeleken, en aangegeven dat in deze invoer fouten zijn gemaakt
+    W002,
     /// GSB CSO, GSB DSO: 'Aantal kiezers en stemmen': Aantal blanco stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
     W201,
     /// GSB CSO, GSB DSO: 'Aantal kiezers en stemmen': Aantal ongeldige stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen

--- a/backend/src/domain/validate.rs
+++ b/backend/src/domain/validate.rs
@@ -115,6 +115,7 @@ pub enum ValidationResultCode {
     /// GSB CSO, GSB DSO, CSB: (Bij tweede invoer) Niet alle ingevoerde waardes van de tweede invoer zijn gelijk aan die van de eerste invoer
     W001,
     /// GSB CSO, GSB DSO, CSB: (Bij verschil met andere invoer) Een coördinator heeft beide invoeren vergeleken, en aangegeven dat in deze invoer fouten zijn gemaakt
+    /// This warning is triggered in the frontend, not in the backend.
     W002,
     /// GSB CSO, GSB DSO: 'Aantal kiezers en stemmen': Aantal blanco stemmen is groter dan of gelijk aan 3% van het totaal aantal uitgebrachte stemmen
     W201,

--- a/frontend/src/features/backups/components/BackupsPage.test.tsx
+++ b/frontend/src/features/backups/components/BackupsPage.test.tsx
@@ -81,9 +81,11 @@ describe("BackupsPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Nu back-up maken" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "De back-up met deze naam bestaat al, probeer het later opnieuw",
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toHaveTextContent(
+        "De back-up met deze naam bestaat al, probeer het later opnieuw",
+      );
+    });
     expect(screen.queryByText(/Laatste back-up gemaakt om/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/data_entry/components/DataEntryProgress.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.tsx
@@ -27,6 +27,10 @@ export function DataEntryProgress() {
     (formSection?: FormSection): Exclude<MenuStatus, "active"> => {
       if (!formSection) return "idle";
 
+      if (formSection.correctionWarning) {
+        return "warning";
+      }
+
       if (!formSection.errors.isEmpty()) {
         return "error";
       }

--- a/frontend/src/features/data_entry/components/DataEntrySection.tsx
+++ b/frontend/src/features/data_entry/components/DataEntrySection.tsx
@@ -55,10 +55,13 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
 
   // Memoize errors to prevent unnecessary focus triggers in Feedback
   const memoizedErrors = useMemo(
-    () => formSection.errors.getAll().filter((result) => result.code !== "F401"),
-    [formSection.errors],
+    () => (formSection.correctionWarning ? [] : formSection.errors.getAll().filter((result) => result.code !== "F401")),
+    [formSection.correctionWarning, formSection.errors],
   );
-  const memoizedWarnings = useMemo(() => formSection.warnings.getAll(), [formSection.warnings]);
+  const memoizedWarnings = useMemo(
+    () => (formSection.correctionWarning ? [] : formSection.warnings.getAll()),
+    [formSection.correctionWarning, formSection.warnings],
+  );
 
   // Scroll unaccepted warnings/errors checkbox into view when error for it is triggered
   useEffect(() => {
@@ -112,7 +115,16 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
             shouldFocus={formSection.errors.isEmpty()}
           />
         )}
-
+        {formSection.correctionWarning && (
+          <Feedback
+            id="feedback-warning"
+            type="warning"
+            election={election}
+            validationResults={[formSection.correctionWarning]}
+            userRole={user.role}
+            shouldFocus={true}
+          />
+        )}
         <DataEntrySubsections
           key={section.id}
           section={section}
@@ -122,7 +134,6 @@ export function DataEntrySection({ committeeCategory }: DataEntryProps) {
           defaultProps={defaultProps}
           missingTotalError={trailingError !== undefined}
         />
-
         {trailingError && (
           <div id="missing-total-error" className={cls.missingTotalError}>
             <Alert type="error" small>

--- a/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
+++ b/frontend/src/features/data_entry/hooks/useDataEntryFormSection.ts
@@ -49,17 +49,24 @@ export function useDataEntryFormSection() {
   if (!formSection) {
     throw new Error(`Form section ${sectionId} not found in form state`);
   }
-  const { errors, warnings, isSaved, isSubmitted, acceptErrorsAndWarnings, hasChanges } = formSection;
-  const defaultProps = {
-    errorsAndWarnings: isSaved ? mapValidationResultSetsToFields(errors, warnings) : undefined,
-    errorsAndWarningsAccepted: acceptErrorsAndWarnings,
-  };
+  const { correctionWarning, errors, warnings, isSaved, isSubmitted, acceptErrorsAndWarnings, hasChanges } =
+    formSection;
+  const defaultProps = correctionWarning
+    ? {
+        errorsAndWarnings: new Map(correctionWarning.fields.map((f) => [f, "warning" as const])),
+        errorsAndWarningsAccepted: false,
+      }
+    : {
+        errorsAndWarnings: isSaved ? mapValidationResultSetsToFields(errors, warnings) : undefined,
+        errorsAndWarningsAccepted: acceptErrorsAndWarnings,
+      };
 
   // Find error code that is shown on the bottom of the form
   const trailingError = errors.find("F401");
 
   // Whether to show the accept errors and warnings checkbox
-  const showAcceptErrorsAndWarnings = (!formSection.warnings.isEmpty() || !formSection.errors.isEmpty()) && !hasChanges;
+  const showAcceptErrorsAndWarnings =
+    !formSection.correctionWarning && (!formSection.warnings.isEmpty() || !formSection.errors.isEmpty()) && !hasChanges;
 
   // register changes when fields change
   const setValues = (path: string, value: string) => {

--- a/frontend/src/features/data_entry/types/types.ts
+++ b/frontend/src/features/data_entry/types/types.ts
@@ -8,9 +8,10 @@ import type {
   DataEntryStatusName,
   DataEntryStatusResponse,
   ElectionWithPoliticalGroups,
+  ValidationResult,
   ValidationResults,
 } from "@/types/generated/openapi";
-import type { DataEntryResults, DataEntryStructure, FormSectionId, SectionValues } from "@/types/types";
+import type { DataEntryResults, DataEntryStructure, FormSectionId, ResultsPath, SectionValues } from "@/types/types";
 import type { ValidationResultSet } from "@/utils/ValidationResults";
 
 export type EntryNumber = 1 | 2;
@@ -133,6 +134,7 @@ export interface ClientState {
   current: FormSectionId;
   acceptedErrorsAndWarnings: FormSectionId[];
   continue: boolean;
+  correctionWarnings?: ResultsPath[];
 }
 
 export interface FormState {
@@ -151,4 +153,5 @@ export type FormSection = {
   acceptErrorsAndWarningsError: boolean;
   errors: ValidationResultSet;
   warnings: ValidationResultSet;
+  correctionWarning?: ValidationResult;
 };

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
 import type { ValidationResult, ValidationResultCode } from "@/types/generated/openapi";
-import type { DataEntrySection } from "@/types/types";
+import type { DataEntryResults, DataEntrySection } from "@/types/types";
 import { ValidationResultSet } from "@/utils/ValidationResults";
 
 import {
@@ -13,11 +13,13 @@ import {
 } from "../testing/mock-data";
 import type { FormState } from "../types/types";
 import {
+  addCorrectionWarnings,
   addValidationResultsToFormState,
   calculateDataEntryProgress,
   formSectionComplete,
   getNextSectionID,
   isFormSectionEmpty,
+  resetFieldValues,
   resetFormSectionState,
 } from "./dataEntryUtils";
 
@@ -287,5 +289,84 @@ describe("addValidationResultToFormState", () => {
     addValidationResultsToFormState(validationResults, formState, dataEntryStructure, "errors");
 
     expect(formState.sections.differences_counts!.errors.size()).toBe(0);
+  });
+});
+
+describe("correction warnings", () => {
+  test("addCorrectionWarnings", () => {
+    const defaultState = getDefaultDataEntryState();
+    const formState = defaultState.formState;
+    const structure = defaultState.dataEntryStructure;
+
+    const correctionWarnings = [
+      "data.voters_counts.poll_card_count",
+      "data.voters_counts.proxy_certificate_count",
+      "data.political_group_votes.0.candidate_votes.0.votes",
+    ];
+
+    addCorrectionWarnings(structure, correctionWarnings, formState);
+
+    expect(formState.sections.voters_votes_counts!.correctionWarning).toStrictEqual({
+      code: "W002",
+      fields: ["data.voters_counts.poll_card_count", "data.voters_counts.proxy_certificate_count"],
+    });
+    expect(formState.sections.differences_counts!.correctionWarning).toBeUndefined();
+    expect(formState.sections.political_group_votes_1!.correctionWarning).toStrictEqual({
+      code: "W002",
+      fields: ["data.political_group_votes.0.candidate_votes.0.votes"],
+    });
+  });
+
+  test("resetFieldValues", () => {
+    const defaultState = getDefaultDataEntryState();
+    const structure = defaultState.dataEntryStructure;
+    const data: DataEntryResults = {
+      voters_counts: {
+        poll_card_count: 99,
+        proxy_certificate_count: 1,
+        voter_card_count: 5,
+        total_admitted_voters_count: 5,
+      },
+      differences_counts: {
+        difference_completely_accounted_for: {
+          yes: true,
+          no: false,
+        },
+      },
+      political_group_votes: [
+        {
+          candidate_votes: [{ votes: 100 }, { votes: 33 }, { votes: 2 }],
+        },
+      ],
+    };
+
+    const correctionWarnings = [
+      "data.voters_counts.poll_card_count",
+      "data.voters_counts.proxy_certificate_count",
+      "data.differences_counts.difference_completely_accounted_for",
+      "data.political_group_votes.0.candidate_votes.0.votes",
+    ];
+
+    resetFieldValues(structure, correctionWarnings, data);
+
+    expect(data).toStrictEqual({
+      voters_counts: {
+        poll_card_count: 0,
+        proxy_certificate_count: 0,
+        voter_card_count: 5,
+        total_admitted_voters_count: 5,
+      },
+      differences_counts: {
+        difference_completely_accounted_for: {
+          yes: false,
+          no: false,
+        },
+      },
+      political_group_votes: [
+        {
+          candidate_votes: [{ votes: 0 }, { votes: 33 }, { votes: 2 }],
+        },
+      ],
+    });
   });
 });

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -1,7 +1,7 @@
 import type { ValidationResult, ValidationResults } from "@/types/generated/openapi";
-import type { DataEntryResults, DataEntryStructure, FormSectionId } from "@/types/types";
-import { extractFieldInfoFromSection, getValueAtPath } from "@/utils/dataEntryMapping";
-import { doesValidationResultApplyToSection, ValidationResultSet } from "@/utils/ValidationResults";
+import type { DataEntryResults, DataEntryStructure, FormSectionId, ResultsPath } from "@/types/types";
+import { extractFieldInfoFromSection, getValueAtPath, resetValueAtPath } from "@/utils/dataEntryMapping";
+import { doesValidationResultApplyToSection, isFieldInSection, ValidationResultSet } from "@/utils/ValidationResults";
 import type { ClientState, FormSection, FormState } from "../types/types";
 
 export function formSectionComplete(section: FormSection): boolean {
@@ -115,6 +115,13 @@ export function getClientState(
   acceptErrorsAndWarnings: boolean,
   continueToNextSection: boolean,
 ) {
+  // Collect all the correctionWarning fields from the sections
+  const correctionWarnings = Object.values(formState.sections).reduce(
+    (warnings: ResultsPath[], section: FormSection) =>
+      section.correctionWarning ? warnings.concat(section.correctionWarning.fields) : warnings,
+    [],
+  );
+
   const clientState: ClientState = {
     furthest: formState.furthest,
     current: currentSectionId,
@@ -123,6 +130,7 @@ export function getClientState(
       .filter((s: FormSection) => s.id !== currentSectionId)
       .map((s: FormSection) => s.id),
     continue: continueToNextSection,
+    correctionWarnings: correctionWarnings.length > 0 ? correctionWarnings : undefined,
   };
   // the form state is not updated for the current submission,
   // so add the current section to the accepted warnings if needed
@@ -179,6 +187,11 @@ export function buildFormState(
     (sectionID: FormSectionId) => sectionID === serverCurrentSection,
   );
 
+  // set correctionWarning on the sections
+  if (clientState.correctionWarnings) {
+    addCorrectionWarnings(dataEntryStructure, clientState.correctionWarnings, newFormState);
+  }
+
   updateFormStateAfterSubmit(
     dataEntryStructure,
     newFormState,
@@ -233,6 +246,8 @@ export function updateFormStateAfterSubmit(
     currentFormSection.isSubmitted = saved;
     // There are no changes after a successful submit
     currentFormSection.hasChanges = false;
+    // Remove correction warning
+    currentFormSection.correctionWarning = undefined;
   }
 
   //distribute errors and warnings to sections
@@ -264,6 +279,28 @@ export function addValidationResultsToFormState(
           formSection[errorsOrWarnings].add(validationResult);
         }
       }
+    }
+  }
+}
+
+export function addCorrectionWarnings(dataEntryStructure: DataEntryStructure, fields: string[], formState: FormState) {
+  for (const section of dataEntryStructure) {
+    const sectionFields = fields.filter((field) => isFieldInSection(field, section));
+    const formSection = formState.sections[section.id];
+    if (formSection === undefined || sectionFields.length === 0) {
+      continue;
+    }
+
+    formSection.correctionWarning = { code: "W002", fields: sectionFields };
+  }
+}
+
+export function resetFieldValues(dataEntryStructure: DataEntryStructure, fields: string[], results: DataEntryResults) {
+  for (const section of dataEntryStructure) {
+    const sectionFields = fields.filter((field) => isFieldInSection(field, section));
+
+    for (const field of sectionFields) {
+      resetValueAtPath(section, results, field);
     }
   }
 }

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -45,7 +45,7 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
 
       let formState: FormState;
       let targetFormSectionId: FormSectionId | undefined;
-      const results = action.dataEntry.data;
+      const results = structuredClone(action.dataEntry.data);
 
       if (action.dataEntry.client_state) {
         ({ formState, targetFormSectionId } = buildFormState(

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -5,10 +5,12 @@ import { getDataEntryStructure } from "@/utils/dataEntryStructure";
 
 import type { ClientState, DataEntryAction, DataEntryState, EntryNumber, FormState } from "../types/types";
 import {
+  addCorrectionWarnings,
   buildCorrectionFormState,
   buildFormState,
   getInitialFormState,
   getNextSectionID,
+  resetFieldValues,
   updateFormStateAfterSubmit,
 } from "./dataEntryUtils";
 
@@ -43,6 +45,8 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
 
       let formState: FormState;
       let targetFormSectionId: FormSectionId | undefined;
+      const results = action.dataEntry.data;
+
       if (action.dataEntry.client_state) {
         ({ formState, targetFormSectionId } = buildFormState(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -56,11 +60,15 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
           action.dataEntry.validation_results,
           dataEntryStructure,
         ));
+
+        if (action.dataEntry.correction_warnings) {
+          addCorrectionWarnings(dataEntryStructure, action.dataEntry.correction_warnings, formState);
+          resetFieldValues(dataEntryStructure, action.dataEntry.correction_warnings, results);
+        }
       } else {
         formState = getInitialFormState(dataEntryStructure);
         targetFormSectionId = dataEntryStructure[0]?.id;
       }
-
       if (targetFormSectionId === undefined) {
         throw new Error("Cannot determine initial section from dataEntryStructure");
       }
@@ -71,7 +79,7 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
         formState,
         targetFormSectionId,
         previousResults: action.dataEntry.previous_results ?? null,
-        results: action.dataEntry.data,
+        results,
         source: action.dataEntry.source,
         dataEntryStatus: action.dataEntry.status,
         error: null,

--- a/frontend/src/i18n/locales/nl/feedback_CSB.json
+++ b/frontend/src/i18n/locales/nl/feedback_CSB.json
@@ -68,6 +68,17 @@
       "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'."
     }
   },
+  "W002": {
+    "typist": {
+      "title": "Verschil met andere invoer. Nieuwe invoer nodig",
+      "content": "Een coördinator heeft beide invoeren vergeleken, en aangegeven dat in deze invoer fouten zijn gemaakt. Neem de gemarkeerde velden opnieuw over van het papieren proces verbaal.",
+      "actions": "<ul><li>Heb je alles ingevuld en komt je invoer overeen met het papier? Ga dan verder.</li></ul>"
+    },
+    "coordinator": {
+      "title": "W.002 is er alleen voor invoerders",
+      "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'."
+    }
+  },
   "W204": {
     "coordinator": {
       "title": "Het totaal aantal uitgebrachte stemmen (H) is nul",

--- a/frontend/src/i18n/locales/nl/feedback_GSB.json
+++ b/frontend/src/i18n/locales/nl/feedback_GSB.json
@@ -146,6 +146,17 @@
       "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'."
     }
   },
+  "W002": {
+    "typist": {
+      "title": "Verschil met andere invoer. Nieuwe invoer nodig",
+      "content": "Een coördinator heeft beide invoeren vergeleken, en aangegeven dat in deze invoer fouten zijn gemaakt. Neem de gemarkeerde velden opnieuw over van het papieren proces verbaal.",
+      "actions": "<ul><li>Heb je alles ingevuld en komt je invoer overeen met het papier? Ga dan verder.</li></ul>"
+    },
+    "coordinator": {
+      "title": "W.002 is er alleen voor invoerders",
+      "content": "Voor de coördinator hebben we het scherm 'verschillen oplossen'."
+    }
+  },
   "W201": {
     "coordinator": {
       "title": "Het aantal blanco stemmen (F) is erg hoog",

--- a/frontend/src/testing/api-mocks/ValidationResultMockData.ts
+++ b/frontend/src/testing/api-mocks/ValidationResultMockData.ts
@@ -103,6 +103,13 @@ export const validationResultMockData: ErrorWarningsMap<ValidationResultCode> = 
     code: "F403",
   },
   W001: { fields: ["data.voters_counts.poll_card_count"], code: "W001" },
+  W002: {
+    fields: [
+      "data.political_group_votes.0.candidate_votes.0.votes",
+      "data.political_group_votes.0.candidate_votes.1.votes",
+    ],
+    code: "W002",
+  },
   W201: { fields: ["data.votes_counts.blank_votes_count"], code: "W201" },
   W202: { fields: ["data.votes_counts.invalid_votes_count"], code: "W202" },
   W203: {

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -699,6 +699,8 @@ export interface ChosenCandidate {
  */
 export interface ClaimDataEntryResponse {
   client_state: unknown;
+  /** Fields for which a warning should be shown that a difference should be corrected */
+  correction_warnings?: string[];
   data: Results;
   /** Whether the typist is correcting an entry that was completed before */
   is_correction: boolean;
@@ -1755,6 +1757,7 @@ export const validationResultCodeValues = [
   "F402",
   "F403",
   "W001",
+  "W002",
   "W201",
   "W202",
   "W203",

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -90,6 +90,10 @@ export type DataEntrySubsection =
   | InputGridSubsection
   | CheckboxesSubsection;
 
+export function isCheckboxesSubsection(subsection: DataEntrySubsection): subsection is CheckboxesSubsection {
+  return subsection.type === "checkboxes";
+}
+
 export interface DataEntrySection {
   id: FormSectionId;
   title: string;

--- a/frontend/src/utils/ValidationResults.ts
+++ b/frontend/src/utils/ValidationResults.ts
@@ -51,67 +51,73 @@ export function doesValidationResultApplyToSection(
   validationResult: ValidationResult,
   section: DataEntrySection,
 ): boolean {
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO function should be refactored
-  return validationResult.fields.some((fieldName) => {
-    // Remove "data." prefix if present
-    const normalizedFieldName = fieldName.startsWith("data.") ? fieldName.substring(5) : fieldName;
+  return validationResult.fields.some((field) => isFieldInSection(field, section));
+}
 
-    // Check exact matches in the section
-    for (const subsection of section.subsections) {
-      switch (subsection.type) {
-        case "radio":
-          if (subsection.path === normalizedFieldName) {
+/** Remove "data." prefix if present */
+export function normalizeFieldName(fieldName: string): string {
+  return fieldName.startsWith("data.") ? fieldName.substring(5) : fieldName;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO function should be refactored
+export function isFieldInSection(fieldName: string, section: DataEntrySection): boolean {
+  const normalizedFieldName = normalizeFieldName(fieldName);
+
+  // Check exact matches in the section
+  for (const subsection of section.subsections) {
+    switch (subsection.type) {
+      case "radio":
+        if (subsection.path === normalizedFieldName) {
+          return true;
+        }
+        break;
+
+      case "inputGrid":
+        for (const row of subsection.rows) {
+          if (row.path === normalizedFieldName) {
             return true;
           }
-          break;
+        }
+        break;
 
-        case "inputGrid":
-          for (const row of subsection.rows) {
-            if (row.path === normalizedFieldName) {
-              return true;
-            }
-          }
-          break;
-
-        case "checkboxes":
-          for (const option of subsection.options) {
-            if (option.path === normalizedFieldName) {
-              return true;
-            }
-          }
-          break;
-      }
-    }
-
-    // Check parent object paths
-    for (const subsection of section.subsections) {
-      switch (subsection.type) {
-        case "radio":
-          if (subsection.path.startsWith(`${normalizedFieldName}.`)) {
+      case "checkboxes":
+        for (const option of subsection.options) {
+          if (option.path === normalizedFieldName) {
             return true;
           }
-          break;
-
-        case "inputGrid":
-          for (const row of subsection.rows) {
-            if (row.path.startsWith(`${normalizedFieldName}.`) || row.path.startsWith(`${normalizedFieldName}[`)) {
-              return true;
-            }
-          }
-          break;
-
-        case "checkboxes":
-          for (const option of subsection.options) {
-            if (option.path.startsWith(`${normalizedFieldName}.`)) {
-              return true;
-            }
-          }
-          break;
-      }
+        }
+        break;
     }
+  }
 
-    return false;
-  });
+  // Check parent object paths
+  for (const subsection of section.subsections) {
+    switch (subsection.type) {
+      case "radio":
+        if (subsection.path.startsWith(`${normalizedFieldName}.`)) {
+          return true;
+        }
+        break;
+
+      case "inputGrid":
+        for (const row of subsection.rows) {
+          if (row.path.startsWith(`${normalizedFieldName}.`) || row.path.startsWith(`${normalizedFieldName}[`)) {
+            return true;
+          }
+        }
+        break;
+
+      case "checkboxes":
+        for (const option of subsection.options) {
+          if (option.path.startsWith(`${normalizedFieldName}.`)) {
+            return true;
+          }
+        }
+        break;
+    }
+  }
+
+  return false;
 }
 
 /*

--- a/frontend/src/utils/dataEntryMapping.test.ts
+++ b/frontend/src/utils/dataEntryMapping.test.ts
@@ -8,6 +8,7 @@ import {
   getValueAtPath,
   mapResultsToSectionValues,
   mapSectionValues,
+  resetValueAtPath,
   setValueAtPath,
   stringRepresentsInteger,
 } from "./dataEntryMapping";
@@ -15,27 +16,27 @@ import { createDifferencesSection, createVotersAndVotesSection } from "./dataEnt
 
 // Helper function to create a checkbox section for testing
 const createCheckboxesSection = (): DataEntrySection => {
-  // Use TypeScript `as` for testing
   return {
-    id: "test",
-    title: "test",
-    short_title: "test",
+    id: "checkboxes_section",
+    title: "Checkboxes Section",
+    short_title: "Checkboxes",
     subsections: [
       {
         type: "checkboxes",
-        short_title: "test",
-        error_path: "test",
+        title: "Field",
+        short_title: "Field",
+        error_path: "checkbox_struct.field",
         error_message: "error",
         options: [
           {
-            path: "test.yes",
-            label: "yes",
-            short_label: "yes",
+            path: "checkbox_struct.field.option_a",
+            label: "Option A",
+            short_label: "A",
           },
           {
-            path: "test.no",
-            label: "no",
-            short_label: "no",
+            path: "checkbox_struct.field.option_b",
+            label: "Option B",
+            short_label: "B",
           },
         ],
       },
@@ -46,26 +47,45 @@ const createCheckboxesSection = (): DataEntrySection => {
 // Helper function to create a radio section for testing
 const createRadioSection = (): DataEntrySection => {
   return {
-    id: "test",
-    title: "test",
-    short_title: "test",
+    id: "radio_section",
+    title: "Radio Section",
+    short_title: "Radio",
     subsections: [
       {
         type: "radio",
-        short_title: "test",
+        title: "Field",
+        short_title: "Field",
         error: "error",
-        path: "test",
+        path: "radio_struct.field",
         options: [
           {
-            value: "true",
-            label: "yes",
+            value: "OptionA",
+            label: "A",
             short_label: "yes",
           },
           {
-            value: "false",
-            label: "no",
+            value: "OptionB",
+            label: "B",
             short_label: "no",
           },
+        ],
+      },
+    ],
+  };
+};
+
+const createInputGridSection = (): DataEntrySection => {
+  return {
+    id: "input_grid_section",
+    title: "Input Grid Section",
+    short_title: "Input Grid",
+    subsections: [
+      {
+        type: "inputGrid",
+        headers: ["field", "counted_number", "description"],
+        rows: [
+          { code: "A", path: "numbers_struct.row_a", title: "Row A" },
+          { code: "B", path: "numbers_struct.row_b", title: "Row B" },
         ],
       },
     ],
@@ -78,42 +98,35 @@ describe("mapSectionValues", () => {
     { input: "", expected: null, description: "empty" },
   ])("should handle radio $description", ({ input, expected }) => {
     const radioSection = createRadioSection();
-    const current = { test: null };
-    const formValues = { test: input };
+    const current = { radio_struct: { field: null } };
+    const formValues = { "radio_struct.field": input };
 
     const result = mapSectionValues(current, formValues, radioSection);
 
-    expect(result.test).toBe(expected);
+    expect(result.radio_struct.field).toBe(expected);
   });
 
-  test("should use section info to distinguish radio vs inputGrid fields", () => {
+  test("should use field info to distinguish radio vs inputGrid fields", () => {
     const current = {
-      test: "OptionA",
-      test2: null,
+      radio_struct: { field: null },
+      numbers_struct: { row_a: null },
     };
     const formValues = {
-      test: "", // Radio field - should become null
-      test2: "456", // InputGrid field - should be deformatted to number
+      "radio_struct.field": "", // Radio field - should become null
+      "numbers_struct.row_a": "456", // InputGrid field - should be deformatted to number
     };
 
     const testSection: DataEntrySection = {
       id: "voters_votes_counts",
       title: "Test Section",
       short_title: "Test",
-      subsections: [
-        ...createRadioSection().subsections,
-        {
-          type: "inputGrid",
-          headers: ["field", "counted_number", "description"],
-          rows: [{ code: "A", path: "test2", title: "Test Title" }],
-        },
-      ],
+      subsections: [...createRadioSection().subsections, ...createInputGridSection().subsections],
     };
 
     const result = mapSectionValues(current, formValues, testSection);
 
-    expect(result.test).toBe(null); // Radio test field becomes null
-    expect(result.test2).toBe(456); // InputGrid field gets deformatted to number
+    expect(result.radio_struct.field).toBe(null); // Radio test field becomes null
+    expect(result.numbers_struct.row_a).toBe(456); // InputGrid field gets deformatted to number
   });
 
   test("should handle numbers correctly when section info is provided", () => {
@@ -391,15 +404,15 @@ describe("mapSectionValues", () => {
   });
 
   test("should handle checkboxes subsection", () => {
-    const current = { test: { yes: null, no: null } };
+    const current = { checkbox_struct: { field: { option_a: false, option_b: false } } };
     const formValues = {
-      "test.yes": "true",
-      "test.no": "false",
+      "checkbox_struct.field.option_a": "true",
+      "checkbox_struct.field.option_b": "false",
     };
 
     const result = mapSectionValues(current, formValues, createCheckboxesSection());
-    expect(result.test.yes).toBe(true);
-    expect(result.test.no).toBe(false);
+    expect(result.checkbox_struct.field.option_a).toBe(true);
+    expect(result.checkbox_struct.field.option_b).toBe(false);
   });
 });
 
@@ -651,9 +664,12 @@ describe("mapResultsToSectionValues", () => {
 
   test("should handle mixed subsections components", () => {
     const results = {
-      test: true,
-      voters_counts: {
-        poll_card_count: 100,
+      radio_struct: {
+        field: "OptionA",
+      },
+      numbers_struct: {
+        row_a: 100,
+        row_b: 0,
       },
     };
 
@@ -665,43 +681,40 @@ describe("mapResultsToSectionValues", () => {
         { type: "message", message: "description" },
         ...createRadioSection().subsections,
         { type: "heading", title: "description" },
-        {
-          type: "inputGrid",
-          headers: ["field", "counted_number", "description"],
-          rows: [{ path: "voters_counts.poll_card_count", title: "Test Title" }],
-        },
+        ...createInputGridSection().subsections,
       ],
     };
 
     const formValues = mapResultsToSectionValues(mixedSection, results);
 
-    expect(Object.keys(formValues).length).toBe(2);
-    expect(formValues.test).toBe("true");
-    expect(formValues["voters_counts.poll_card_count"]).toBe("100");
+    expect(Object.keys(formValues).length).toBe(3);
+    expect(formValues["radio_struct.field"]).toBe("OptionA");
+    expect(formValues["numbers_struct.row_a"]).toBe("100");
+    expect(formValues["numbers_struct.row_b"]).toBe("");
   });
 
   test("should extract checkboxes boolean values to string form", () => {
     const checkboxesSection = createCheckboxesSection();
     // Test with both true values
-    const results = { test: { yes: true, no: true } };
+    const results = { checkbox_struct: { field: { option_a: true, option_b: true } } };
 
     let formValues = mapResultsToSectionValues(checkboxesSection, results);
-    expect(formValues["test.yes"]).toBe("true");
-    expect(formValues["test.no"]).toBe("true");
+    expect(formValues["checkbox_struct.field.option_a"]).toBe("true");
+    expect(formValues["checkbox_struct.field.option_b"]).toBe("true");
 
     // Test with both false values
-    results.test = { yes: false, no: false };
+    results.checkbox_struct.field = { option_a: false, option_b: false };
 
     formValues = mapResultsToSectionValues(checkboxesSection, results);
-    expect(formValues["test.yes"]).toBe("false");
-    expect(formValues["test.no"]).toBe("false");
+    expect(formValues["checkbox_struct.field.option_a"]).toBe("false");
+    expect(formValues["checkbox_struct.field.option_b"]).toBe("false");
 
     // Test with mixed values
-    results.test = { yes: true, no: false };
+    results.checkbox_struct.field = { option_a: true, option_b: false };
 
     formValues = mapResultsToSectionValues(checkboxesSection, results);
-    expect(formValues["test.yes"]).toBe("true");
-    expect(formValues["test.no"]).toBe("false");
+    expect(formValues["checkbox_struct.field.option_a"]).toBe("true");
+    expect(formValues["checkbox_struct.field.option_b"]).toBe("false");
   });
 });
 
@@ -850,5 +863,35 @@ describe("setValueAtPath", () => {
 
       expect(e).toBeInstanceOf(Error);
     }
+  });
+});
+
+test("resetValueAtPath", () => {
+  const mixedSection: DataEntrySection = {
+    id: "mixed_section",
+    title: "Mixed Section",
+    short_title: "Mixed",
+    subsections: [
+      ...createInputGridSection().subsections,
+      { type: "message", message: "Please select things" },
+      ...createCheckboxesSection().subsections,
+      ...createRadioSection().subsections,
+    ],
+  };
+
+  const data = {
+    numbers_struct: { row_a: 10, row_b: 20 },
+    checkbox_struct: { field: { option_a: true, option_b: false } },
+    radio_struct: { field: "OptionA" },
+  };
+
+  resetValueAtPath(mixedSection, data, "data.numbers_struct.row_b");
+  resetValueAtPath(mixedSection, data, "data.checkbox_struct.field");
+  resetValueAtPath(mixedSection, data, "data.radio_struct.field");
+
+  expect(data).toStrictEqual({
+    numbers_struct: { row_a: 10, row_b: 0 },
+    checkbox_struct: { field: { option_a: false, option_b: false } },
+    radio_struct: { field: null },
   });
 });

--- a/frontend/src/utils/dataEntryMapping.ts
+++ b/frontend/src/utils/dataEntryMapping.ts
@@ -1,5 +1,12 @@
-import type { DataEntryResults, DataEntrySection, SectionValues } from "@/types/types";
+import {
+  type DataEntryResults,
+  type DataEntrySection,
+  isCheckboxesSubsection,
+  type ResultsPath,
+  type SectionValues,
+} from "@/types/types";
 import { parseIntUserInput } from "@/utils/strings";
+import { normalizeFieldName } from "@/utils/ValidationResults";
 
 type PathValue = boolean | number | string | null | undefined;
 
@@ -119,6 +126,29 @@ export function setValueAtPath(
 }
 
 /**
+ * Reset the value at the specified path to its empty value.
+ */
+export function resetValueAtPath(section: DataEntrySection, data: DataEntryResults, path: ResultsPath) {
+  const normalizedPath = normalizeFieldName(path);
+
+  // Check if the path refers to a checkboxes subsection by its error_path,
+  // because then we have to reset the individual options instead.
+  const checkboxes = section.subsections
+    .filter(isCheckboxesSubsection)
+    .find(({ error_path }) => error_path === normalizedPath);
+
+  if (checkboxes) {
+    for (const option of checkboxes.options) {
+      setValueAtPath(data, option.path, "", "boolean");
+    }
+  } else {
+    const fieldInfoMap = extractFieldInfoFromSection(section);
+    const valueType = fieldInfoMap.get(normalizedPath);
+    setValueAtPath(data, normalizedPath, "", valueType);
+  }
+}
+
+/**
  * Traverses the data object based on the provided path segments
  * @param data The data object to traverse
  * @param segments The path segments to follow
@@ -147,9 +177,6 @@ function processValue(
   valueType: "boolean" | "number" | "enum" | undefined,
 ): boolean | number | string | null | undefined {
   if (valueType === "boolean") {
-    if (value === "") {
-      return undefined;
-    }
     return value === "true";
   }
 


### PR DESCRIPTION
## What & why

Resolves https://github.com/kiesraad/abacus/issues/3657

When a typist starts correcting differences in their data entry, a warning should be shown per section with differences, and the fields that were different should be emptied. See [Figma design](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=21910-10295&t=zsI6gOwSEsHto50q-1).

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

With two different typists, create differences between the two data entries. As a coordinater, resolve the differences by giving one entry back to the typist. See that that typist can redo their entry and that the warnings are shown and fields are emptied.


<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes
I initially started in separate commits, but subsequent improvements were hard to interactive rebase, so I ended up with one commit unfortunately.

- In the claim endpoint, add `correction_warnings` for either of the correction states, which is a list of fields that are different
  - New method `compare_entries()` for `DataEntryStatus` that compares the two entries for the states that have them
- On first claim (no client_state), add `correctionWarning` and reset field values for the correct sections
  - Functions `addCorrectionWarnings()` and `resetFieldValues()` added
  - Function `resetValueAtPath()` added in `dataEntryMapping.ts`
  - Update test data in `dataEntryMapping.test.ts` to have more useful paths
- Store and retrieve the `correctionWarnings` in the `ClientState` when saving and claiming again
- Add W002 validation and translations
- Show only the section `correctionWarning` if present, else show the normal errors and warnings and errorsAndWarningsAccepted

And also:
- Fix flaky test `BackupsPage.test.tsx` (was happening only locally?)

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->