### PR TITLE
Update CSO models to the 2027 versions

### DIFF
--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -257,6 +257,32 @@
   )
 }
 
+/// Like empty_letterbox, but replaces the digit entry area (and the original
+/// value area when `with_original: true`) with a single merged cell containing
+/// "Niet invullen".
+#let no_entry_letterbox(letter, cells: 5, with_original: false, content) = {
+  let stroke = 0.5pt + black
+  let no_entry_cell = grid.cell(align: center + horizon, stroke: stroke, [Niet invullen])
+
+  // Note: `wide_cells` is not needed for `no_entry_letterbox` atm.
+  let entry_width = cells * 2em
+  let columns = if with_original {
+    (entry_width, entry_width, 3.5em, 1fr)
+  } else {
+    (entry_width, 3.5em, 1fr)
+  }
+
+  grid(
+    inset: 9pt,
+    columns: columns,
+    align: (center, right),
+    ..cell_if(with_original, no_entry_cell),
+    no_entry_cell,
+    grid.cell(stroke: stroke, align: center + horizon, fill: luma(213), text(weight: "bold", letter)),
+    grid.cell(align: horizon + left, content),
+  )
+}
+
 /// Display a box with a prefixed label and a value
 #let letterbox(letter, original_value: none, value: none, light: true, bold_top_border: false, wide_cells: true, content) = {
   empty_letterbox(

--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -204,6 +204,11 @@
   prefilled_text(fmt-number(value, thousands-sep: thousands-sep, zero: zero))
 }
 
+/// Lock the height of all letterbox rows. Needed bc > 1 line suffixes (`content`)
+/// would vertically stretch the box. Note: in case of > 2 line suffixes, content
+/// will spill outside the designated area.
+#let letterbox_row_height = 2.70em
+
 #let empty_letterbox(letter, cells: 5, light: true, original_value: none, value: none, bold_top_border: false, wide_cells: false, content) = {
   let bg_grey = luma(213)
   let bg = if light { bg_grey } else { black }
@@ -233,6 +238,7 @@
 
   grid(
     inset: 9pt,
+    rows: letterbox_row_height,
     columns: grid_columns,
     align: (center, right),
     grid.vline(stroke: (thickness: 0.5pt, dash: "solid")),
@@ -252,7 +258,7 @@
       )
     }),
     grid.vline(stroke: (thickness: 0.5pt, dash: "solid")),
-    grid.cell(stroke: (rest: 0.5pt + black) + top_border_stroke, align: center, fill: bg, text(fill: fill, weight: "bold", letter)),
+    grid.cell(stroke: (rest: 0.5pt + black) + top_border_stroke, align: center + horizon, fill: bg, text(fill: fill, weight: "bold", letter)),
     grid.cell(align: horizon + left, content),
   )
 }
@@ -274,6 +280,7 @@
 
   grid(
     inset: 9pt,
+    rows: letterbox_row_height,
     columns: columns,
     align: (center, right),
     ..cell_if(with_original, no_entry_cell),
@@ -302,6 +309,7 @@
 #let number_box(value: none, content) = {
   grid(
     inset: 9pt,
+    rows: letterbox_row_height,
     columns: (8em, 1fr),
     align: (center, right),
     grid.vline(stroke: (thickness: 0.5pt, dash: "solid")),

--- a/backend/templates/model-n-10-2.typ
+++ b/backend/templates/model-n-10-2.typ
@@ -163,11 +163,12 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
   #sum(
     empty_letterbox("A")[Stempassen],
-    empty_letterbox("B")[Volmachtbewijzen (schriftelijk of via ingevulde stempas)],
+    empty_letterbox("B")[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas)],
+    no_entry_letterbox("C")[Kiezerspassen (niet van toepassing bij gemeente- en eilandraadsverkiezingen)],
     empty_letterbox(
       "D",
       light: false,
-    )[Totaal toegelaten kiezers (A+B)],
+    )[*Totaal toegelaten kiezers (A+B)*],
   )
 ][
   Tel het aantal geldige stempassen, volmachtbewijzen en kiezerspassen
@@ -176,12 +177,12 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
     empty_letterbox("A")[Stempassen],
     empty_letterbox(
       "B",
-    )[Volmachtbewijzen (schriftelijk of via ingevulde stempas of kiezerspas)],
+    )[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas of kiezerspas)],
     empty_letterbox("C")[Kiezerspassen],
     empty_letterbox(
       "D",
       light: false,
-    )[Totaal toegelaten kiezers (A+B+C)],
+    )[*Totaal toegelaten kiezers (A+B+C)*],
   )
 ]
 
@@ -217,9 +218,9 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
 === Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
 
-#checkbox[D en H zijn gelijk #sym.arrow.r *Ga door naar #ref(<signing>)*]
+#checkbox[D en H zijn *gelijk* #sym.arrow.r *Ga door naar #ref(<signing>)*]
 
-#checkbox[H is groter is dan D (meer uitgebrachte stemmen dan toegelaten kiezers)]
+#checkbox[H is *groter* dan D (meer uitgebrachte stemmen dan toegelaten kiezers)]
 
 #box(inset: (left: 3em, bottom: 1em), empty_letterbox(
   "I",
@@ -227,7 +228,7 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
   light: false,
 )[Aantal méér getelde stemmen (bereken: H _min_ D)])
 
-#checkbox[H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)]
+#checkbox[H is *kleiner* dan D (minder uitgebrachte stemmen dan toegelaten kiezers)]
 
 #box(inset: (left: 3em, bottom: 1em), empty_letterbox(
   "J",
@@ -244,11 +245,13 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
 = Ondertekening <signing>
 
+Het proces-verbaal moet worden ondertekend door alle aanwezige leden. Bij een stembureau zijn dit er minimaal 3.
+
 #signing_form_label[Datum]
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en twee leden van het stembureau
+== Voorzitter en twee leden van het stembureau
 
 #signing_form_label[Voorzitter van het stembureau:]
 
@@ -260,7 +263,7 @@ Bijvoorbeeld als er meerdere verkiezingen tegelijk werden georganiseerd, en een 
 
 == Ondertekening door andere aanwezige leden van het stembureau
 
-#signing_form_label[Extra ondertekening: (niet verplicht)]
+#signing_form_label[Extra ondertekening:]
 
 #stack(spacing: 0.5em, ..range(0, 4).map(_ => textbox[Naam:][Handtekening:]))
 

--- a/backend/templates/model-na-14-2-bijlage-1.typ
+++ b/backend/templates/model-na-14-2-bijlage-1.typ
@@ -52,7 +52,8 @@ dit dan op. Schrijf zo concreet mogelijk op wat de opdracht van het centraal ste
 is. Bijvoorbeeld: hertel de stembiljetten van lijst 12.
 
 ==== Aanleiding van het onderzoek
-#empty_lines(10)
+
+#text_area_with_content(input.investigation.reason)
 
 #block(below: 3em)
 

--- a/backend/templates/model-na-14-2-bijlage-1.typ
+++ b/backend/templates/model-na-14-2-bijlage-1.typ
@@ -22,6 +22,17 @@
   ]
 )
 
+= Bijlage 1
+
+== Verslagen van tellingen van stembureaus die zijn herteld door het #location_type
+
+#line(length: 100%)
+
+_Let op! Alleen voor #is_municipality[gemeenten][openbare lichamen] waar een centrale stemopneming heeft
+plaatsgevonden. De bijlagen worden separaat gepubliceerd bij het betreffende stembureau._
+
+#pagebreak(weak: true)
+
 = Stembureau #input.polling_station.number \ #input.polling_station.name
 
 #line(length: 100%)
@@ -34,13 +45,16 @@ Het #location_type heeft de telresultaten van dit stembureau onderzocht en is to
 
 = Aanleiding en opdracht onderzoek
 
-Geef aan *waarom* de resultaten van dit stembureau zijn onderzocht. Denk bijvoorbeeld aan een onverklaard telverschil, of een bezwaar. Schrijf ook op wat er in *opdracht* van het centraal stembureau is onderzocht. Bijvoorbeeld: hertel de stembiljetten van lijst 12.
+Geef aan *waarom* de resultaten van dit stembureau zijn onderzocht. Denk bijvoorbeeld
+aan een onverklaard telverschil, een andere (vermoeden van een) fout of een bezwaar.
+Als het onderzoek heeft plaatsgevonden in opdracht van het centraal stembureau, schrijf
+dit dan op. Schrijf zo concreet mogelijk op wat de opdracht van het centraal stembureau
+is. Bijvoorbeeld: hertel de stembiljetten van lijst 12.
 
-==== Aanleiding en opdracht van het centraal stembureau
+==== Aanleiding van het onderzoek
+#empty_lines(10)
 
-#text_area_with_content(input.investigation.reason)
-
-#block(below: 1.5em)
+#block(below: 3em)
 
 Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
 
@@ -50,9 +64,9 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
 #block(below: 1.5em)
 
 #block(
-  breakable: false, 
+  breakable: false,
   {
-    [Is er een *gecorrigeerde uitslag*?]
+    [Heeft het onderzoek geleid tot een *gecorrigeerde uitslag*?]
     checkbox[Nee #sym.arrow.r *Neem de uitkomst van het onderzoek over in het proces-verbaal van het #location_type (nieuwe zitting). Deze bijlage hoeft verder niet ingevuld te worden.*]
     checkbox[Ja #sym.arrow.r *Ga verder met B1 - #ref(<corrected_results>)*]
   }
@@ -65,19 +79,19 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
 #emph_block[
   Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere
   telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de
-  kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in de eerste
+  kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere
   zitting door het #location_type zijn vastgesteld.
 ]
 
 == Toegelaten kiezers
 
 #if not is_local_election(true, false) and "voter_card_count" in input.previous_results.voters_counts [
-  Het totaal van alle getelde geldige stempassen, kiezerspassen en volmachtbewijzen
-  
+  Het totaal van alle getelde geldige stempassen, volmachtbewijzen en kiezerspassen
+
   #sum(
     with_correction_title: true,
     empty_letterbox("A", cells: 4, original_value: input.previous_results.voters_counts.poll_card_count, bold_top_border: true)[Stempassen],
-    empty_letterbox("B", cells: 4, original_value: input.previous_results.voters_counts.proxy_certificate_count)[Volmachtbewijzen],
+    empty_letterbox("B", cells: 4, original_value: input.previous_results.voters_counts.proxy_certificate_count)[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas of kiezerspas)],
     empty_letterbox("C", cells: 4, original_value: input.previous_results.voters_counts.voter_card_count)[Kiezerspassen],
     empty_letterbox("D", cells: 4, original_value: input.previous_results.voters_counts.total_admitted_voters_count, light: false)[
       *Totaal toegelaten kiezers (A+B+C)*
@@ -85,11 +99,12 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
   )
 ] else [
   Het totaal van alle getelde geldige stempassen en volmachtbewijzen
-  
+
   #sum(
     with_correction_title: true,
     empty_letterbox("A", cells: 4, original_value: input.previous_results.voters_counts.poll_card_count, bold_top_border: true)[Stempassen],
-    empty_letterbox("B", cells: 4, original_value: input.previous_results.voters_counts.proxy_certificate_count)[Volmachtbewijzen],
+    empty_letterbox("B", cells: 4, original_value: input.previous_results.voters_counts.proxy_certificate_count)[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas)],
+    no_entry_letterbox("C", cells: 4, with_original: true)[Kiezerspassen (niet van toepassing bij gemeente- en eilandraadsverkiezingen)],
     empty_letterbox("D", cells: 4, original_value: input.previous_results.voters_counts.total_admitted_voters_count, light: false)[
       *Totaal toegelaten kiezers (A+B)*
     ]
@@ -101,7 +116,7 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
 == Uitgebrachte stemmen <cast_votes>
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
-ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in de eerste zitting door het #location_type zijn vastgesteld.
+ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 #if input.votes_tables.len() > 0 [
   #sum(
@@ -137,13 +152,14 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 == Verschillen tussen aantal kiezers en uitgebrachte stemmen
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
-ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in de eerste zitting door het #location_type zijn vastgesteld.
+ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld. Is het getal bij I én J gewijzigd? Vul dan
+bij beiden het gecorrigeerde getal in. Vink alléén het selectievakje aan dat van toepassing is.
 
 === Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
 
-#checkbox[D en H zijn gelijk #sym.arrow.r Ga door naar B1 - #ref(<per_list_and_candidate>)]
+#checkbox[D en H zijn *gelijk* #sym.arrow.r Ga door naar B1 - #ref(<per_list_and_candidate>)]
 
-#checkbox[H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)]
+#checkbox[H is *groter* dan D (meer uitgebrachte stemmen dan toegelaten kiezers)]
 #box(width: 500pt, inset: (left: 3em, bottom: 1em))[
     #grid(
       correction_title_grid(correction_width: 6em, input_width: 6em),
@@ -151,7 +167,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
     )
 ]
 
-#checkbox[H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)]
+#checkbox[H is *kleiner* dan D (minder uitgebrachte stemmen dan toegelaten kiezers)]
 #box(width: 500pt, inset: (left: 3em, bottom: 1em))[
   #grid(
     correction_title_grid(correction_width: 6em, input_width: 6em),
@@ -159,7 +175,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
   )
 ]
 
-=== Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H volledig verklaren?
+=== Zijn er tijdens de stemming dingen opgeschreven die het bovenstaande verschil tussen D en H volledig verklaren?
 
 (Gebruik het proces-verbaal van het stembureau #sym.arrow.r *Tijdens de stemming, vraag 1.2.2*)
 
@@ -170,7 +186,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 
 == Stemmen per lijst en per kandidaat <per_list_and_candidate>
 
-Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in de eerste zitting door het #location_type zijn vastgesteld.
+Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-14-2-bijlage-1.typ
+++ b/backend/templates/model-na-14-2-bijlage-1.typ
@@ -80,7 +80,7 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
 #emph_block[
   Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere
   telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de
-  kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere
+  kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere
   zitting door het #location_type zijn vastgesteld.
 ]
 
@@ -117,7 +117,7 @@ Schrijf op wat de *uitkomst* van het onderzoek door het #location_type was.
 == Uitgebrachte stemmen <cast_votes>
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
-ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
+ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 #if input.votes_tables.len() > 0 [
   #sum(
@@ -153,7 +153,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 == Verschillen tussen aantal kiezers en uitgebrachte stemmen
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
-ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld. Is het getal bij I én J gewijzigd? Vul dan
+ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld. Is het getal bij I én J gewijzigd? Vul dan
 bij beiden het gecorrigeerde getal in. Vink alléén het selectievakje aan dat van toepassing is.
 
 === Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
@@ -187,7 +187,7 @@ bij beiden het gecorrigeerde getal in. Vink alléén het selectievakje aan dat v
 
 == Stemmen per lijst en per kandidaat <per_list_and_candidate>
 
-Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
+Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 #pagebreak(weak: true)
 

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -59,7 +59,7 @@ de aantallen in het proces-verbaal.
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn
 veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen
-die in de eerste zitting door het #location_type zijn
+die in een eerdere zitting door het #location_type zijn
 vastgesteld.
 
 == Aantal kiesgerechtigden
@@ -69,24 +69,24 @@ vastgesteld.
 == Toegelaten kiezers
 
 #if not is_local_election(true, false) and "voter_card_count" in input.summary.voters_counts [
-  Het totaal van alle getelde geldige stempassen, kiezerspassen en volmachtbewijzen.
-  
+  Het totaal van alle getelde geldige stempassen, volmachtbewijzen en kiezerspassen
+
   #sum(
     with_correction_title: true,
     letterbox("A", original_value: input.previous_summary.voters_counts.poll_card_count, value: input.summary.voters_counts.poll_card_count, bold_top_border: true, wide_cells: true)[Stempassen],
-    letterbox("B", original_value: input.previous_summary.voters_counts.proxy_certificate_count, value: input.summary.voters_counts.proxy_certificate_count, wide_cells: true)[Volmachtbewijzen],
+    letterbox("B", original_value: input.previous_summary.voters_counts.proxy_certificate_count, value: input.summary.voters_counts.proxy_certificate_count, wide_cells: true)[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas of kiezerspas)],
     letterbox("C", original_value: input.previous_summary.voters_counts.voter_card_count, value: input.summary.voters_counts.voter_card_count, wide_cells: true)[Kiezerspassen],
     letterbox("D", original_value: input.previous_summary.voters_counts.total_admitted_voters_count, value: input.summary.voters_counts.total_admitted_voters_count, wide_cells: true, light: false)[
       *Totaal toegelaten kiezers (A+B+C)*
     ]
   )
 ] else [
-  Het totaal van alle getelde geldige stempassen en volmachtbewijzen.
-  
+  Het totaal van alle getelde geldige stempassen en volmachtbewijzen
+
   #sum(
     with_correction_title: true,
     letterbox("A", original_value: input.previous_summary.voters_counts.poll_card_count, value: input.summary.voters_counts.poll_card_count, bold_top_border: true, wide_cells: true)[Stempassen],
-    letterbox("B", original_value: input.previous_summary.voters_counts.proxy_certificate_count, value: input.summary.voters_counts.proxy_certificate_count, wide_cells: true)[Volmachtbewijzen],
+    letterbox("B", original_value: input.previous_summary.voters_counts.proxy_certificate_count, value: input.summary.voters_counts.proxy_certificate_count, wide_cells: true)[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas)],
     letterbox("D", original_value: input.previous_summary.voters_counts.total_admitted_voters_count, value: input.summary.voters_counts.total_admitted_voters_count, wide_cells: true, light: false)[
       *Totaal toegelaten kiezers (A+B)*
     ]
@@ -97,7 +97,7 @@ vastgesteld.
 
 == Uitgebrachte stemmen <cast_votes>
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
-ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in de eerste zitting door het #location_type zijn vastgesteld.
+ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 #if input.votes_tables.len() > 0 [
   #sum(
@@ -129,6 +129,8 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 #pagebreak(weak: true)
 
 == Verschillen tussen aantal kiezers en uitgebrachte stemmen
+
+Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 === Is bij *alle afzonderlijke stembureaus* in #is_municipality[deze gemeente][dit openbaar lichaam] het aantal uitgebrachte stemmen en het aantal toegelaten kiezers gelijk?
 
@@ -171,7 +173,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
     sum_total: columns => [Totaal lijst (kolom #columns)],
     total_instruction: [Neem dit totaal over in rubriek #ref(<cast_votes>) van deze bijlage bij de juiste lijst.],
     explainer_text: [
-      Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in de eerste zitting door het #location_type zijn vastgesteld.
+      Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
     ],
   )
 }
@@ -180,11 +182,13 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 
 = Ondertekening
 
+Het proces-verbaal moet worden ondertekend door alle aanwezige leden. Bij een #location_type zijn dit er minimaal #is_local_election[3][5].
+
 #signing_form_label[Datum]
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_local_election[twee][vier] leden van het #location_type
+== Voorzitter en #is_local_election[twee][vier] leden van het #location_type
 
 #signing_form_label[Voorzitter van het #location_type:]
 
@@ -196,7 +200,7 @@ ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staa
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
-#signing_form_label[Extra ondertekening: (niet verplicht)]
+#signing_form_label[Extra ondertekening:]
 
 #stack(spacing: 0.5em, ..range(0, is_local_election(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -58,7 +58,7 @@ de aantallen in het proces-verbaal.
 = Gecorrigeerde telresultaten van #is_municipality[de gemeente][het openbaar lichaam]
 
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn
-veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen
+veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen
 die in een eerdere zitting door het #location_type zijn
 vastgesteld.
 
@@ -97,7 +97,7 @@ vastgesteld.
 
 == Uitgebrachte stemmen <cast_votes>
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
-ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
+ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
 #if input.votes_tables.len() > 0 [
   #sum(
@@ -140,7 +140,7 @@ Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere tell
 
 #checkbox(checked: differences)[Nee, er zijn stembureaus met een verschil]
 
-=== #if input.summary.differences_counts.more_ballots_count.count > 0 [Voor de stembureaus met de nummers #comma_list(input.summary.differences_counts.more_ballots_count.data_entry_sources.map(p => p.number))] else [In geen van de stembureaus] zijn er *méér* uitgebrachte stemmen dan toegelaten kiezers geteld. Noteer onder ‘gecorrigeerd' het nieuwe verschil.
+=== #if input.summary.differences_counts.more_ballots_count.count > 0 [Voor de stembureaus met de nummers #comma_list(input.summary.differences_counts.more_ballots_count.data_entry_sources.map(p => p.number))] else [In geen van de stembureaus] zijn er *méér* uitgebrachte stemmen dan toegelaten kiezers geteld. Noteer onder ‘gecorrigeerd’ het nieuwe verschil.
 
 #grid(
   rows: auto,
@@ -148,7 +148,7 @@ Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere tell
   letterbox("I", original_value: input.previous_summary.differences_counts.more_ballots_count.count, value: input.summary.differences_counts.more_ballots_count.count, bold_top_border: true, wide_cells: true)[Totaal aantal méér getelde stemmen]
 )
 
-=== #if input.summary.differences_counts.fewer_ballots_count.count > 0 [Voor de stembureaus met de nummers #comma_list(input.summary.differences_counts.fewer_ballots_count.data_entry_sources.map(p => p.number))] else [In geen van de stembureaus] zijn er *minder* uitgebrachte stemmen dan toegelaten kiezers geteld. Noteer onder ‘gecorrigeerd' het nieuwe verschil.
+=== #if input.summary.differences_counts.fewer_ballots_count.count > 0 [Voor de stembureaus met de nummers #comma_list(input.summary.differences_counts.fewer_ballots_count.data_entry_sources.map(p => p.number))] else [In geen van de stembureaus] zijn er *minder* uitgebrachte stemmen dan toegelaten kiezers geteld. Noteer onder ‘gecorrigeerd’ het nieuwe verschil.
 
 #grid(
   rows: auto,
@@ -173,7 +173,7 @@ Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere tell
     sum_total: columns => [Totaal lijst (kolom #columns)],
     total_instruction: [Neem dit totaal over in rubriek #ref(<cast_votes>) van deze bijlage bij de juiste lijst.],
     explainer_text: [
-      Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd'. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
+      Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
     ],
   )
 }

--- a/backend/templates/model-na-31-2-bijlage-1.typ
+++ b/backend/templates/model-na-31-2-bijlage-1.typ
@@ -24,6 +24,16 @@
 
 #set heading(numbering: none)
 
+= Bijlage 1
+
+== Verslagen van tellingen van stembureaus
+
+#line(length: 100%)
+
+_De bijlagen worden separaat gepubliceerd bij het betreffende stembureau._
+
+#pagebreak(weak: true)
+
 = Stembureau #input.polling_station.number \ #input.polling_station.name
 
 #line(length: 100%)
@@ -34,17 +44,29 @@ Het stembureau heeft op de dag van de verkiezingen de stemmen per lijst geteld. 
 
 #show: doc => attachment_numbering(doc, "B1")
 
-= Alleen bij extra onderzoek: opmerkingen #location_type
+= Extra onderzoek: opmerkingen #location_type
 
-=== Heeft het #location_type extra onderzoek gedaan vanwege een andere reden dan een onverklaard verschil?
+#emph_block[
+  Het #location_type kan tijdens de zitting nadat zij de telling van het stembureau heeft afgerond, extra onderzoek uitvoeren.
+  Bijvoorbeeld als er sprake is van een opvallend hoog aantal ongeldige of blanco uitgebrachte
+  stemmen. Geef in dit onderdeel aan of, en zo ja, welk extra onderzoek #location_type heeft uitgevoerd.
+]
+
+#block(below: 1em)
+
+Heeft het #location_type *extra* onderzoek gedaan?
 
 #checkbox[Ja]
 #checkbox[Nee]
 
-=== Zijn de stembiljetten naar aanleiding van het extra onderzoek (gedeeltelijk) herteld?
+#block(below: 1em)
+
+Zijn de stembiljetten naar aanleiding van het *extra* onderzoek (gedeeltelijk) herteld?
 
 #checkbox[Ja]
 #checkbox[Nee]
+
+#block(below: 1em)
 
 Licht hieronder toe wat de reden van het extra onderzoek was
 
@@ -56,22 +78,31 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 == Aantallen kiezers en stemmen
 
-=== Was er in de telresultaten van het *stembureau* (rubriek 2.3 van het proces-verbaal van het stembureau) een onverklaard verschil tussen het totaal aantal getelde stembiljetten en het aantal toegelaten kiezers?
+#emph_block[
+  Is in de telresultaten van het stembureau (rubriek 2.3 van het proces-verbaal van
+  het stembureau) het verschil tussen het totaal aantal getelde stemmen en het aantal
+  toegelaten kiezers volledig verklaard? Controleer daarbij ook of rubriek 2.3 van het
+  proces-verbaal van het stembureau correct is ingevuld en de verklaringen het verschil
+  daadwerkelijk verklaren.
+]
 
-#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (#is_local_election[stempassen en volmachten][stempassen, kiezerspassen en volmachten])*, en noteer de uitkomsten bij rubriek 3.1]
-#checkbox[Nee]
+#checkbox[Ja]
+#checkbox[*Nee #sym.arrow.r Hertel het aantal toegelaten kiezers (#is_local_election[stempassen en volmachten][stempassen, kiezerspassen en volmachten])*, en noteer de uitkomsten bij rubriek 3.1]
 
 == Tel de stembiljetten
 
 #emph_block[
-  Tel nu de stembiljetten per kandidaat en noteer de uitkomsten bij rubrieken 3.2 en 3.5 van deze bijlage.
+  Tel nu de stembiljetten per kandidaat en noteer de uitkomsten bij rubrieken *3.2* en *3.5* van deze bijlage.
 ]
 
 == Tellingen op lijstniveau
 
-=== Is er een verschil tussen het totaal aantal getelde stemmen (vak H van rubriek 2.2) zoals eerder vastgesteld door het *stembureau* en zoals door u geteld op het *#location_type*?
+#emph_block[
+  Is er een verschil tussen het totaal aantal getelde stemmen zoals eerder vastgesteld
+  door het #underline[*stembureau*] (vak H van rubriek 2.2) en zoals door u geteld op het #underline[*#location_type*] (vak H van rubriek 3.2)?
+]
 
-#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (tenzij dat bij de vorige vraag al gedaan is)*, en noteer de uitkomsten bij rubriek 3.1]
+#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (tenzij dat bij de vraag 2.1 al gedaan is)*, en vul de resultaten in rubriek 3.1]
 #checkbox[Nee]
 
 #pagebreak(weak: true)
@@ -109,20 +140,23 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 == Toegelaten kiezers <admitted_voters>
 
-=== Heeft het #location_type het aantal toegelaten kiezers opnieuw geteld? Schrijf dan die aantallen op. Neem anders de aantallen over die het stembureau heeft opgeschreven in het proces-verbaal.
+#emph_block[
+  Heeft het #location_type het aantal toegelaten kiezers opnieuw geteld? Schrijf dan die aantallen op. Neem anders de aantallen over die het stembureau heeft opgeschreven in het proces-verbaal.
+]
 
 #is_local_election[
   #sum(
-    empty_letterbox("A")[Stempassen], 
-    empty_letterbox("B")[Volmachtbewijzen], 
-    empty_letterbox("D", light: false)[Totaal toegelaten kiezers (A+B)],
+    empty_letterbox("A")[Stempassen],
+    empty_letterbox("B")[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas)],
+    no_entry_letterbox("C")[Kiezerspassen (niet van toepassing bij gemeente- en eilandraadsverkiezingen)],
+    empty_letterbox("D", light: false)[*Totaal toegelaten kiezers (A+B)*],
   )
 ][
   #sum(
     empty_letterbox("A")[Stempassen],
-    empty_letterbox("B")[Volmachtbewijzen],
+    empty_letterbox("B")[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas of kiezerspas)],
     empty_letterbox("C")[Kiezerspassen],
-    empty_letterbox("D", light: false)[Totaal toegelaten kiezers (A+B+C)],
+    empty_letterbox("D", light: false)[*Totaal toegelaten kiezers (A+B+C)*],
   )
 ]
 
@@ -156,34 +190,36 @@ Licht hieronder toe wat de reden van het extra onderzoek was
 
 === Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
 
-#checkbox[D en H zijn gelijk #sym.arrow.r Ga door naar #ref(<polling_station_declaration>)]
+#checkbox[D en H zijn *gelijk* #sym.arrow.r *Ga door naar #ref(<polling_station_declaration>)*]
 
-#checkbox[H is groter is dan D (meer uitgebrachte stemmen dan toegelaten kiezers)]
+#checkbox[H is *groter* dan D (meer uitgebrachte stemmen dan toegelaten kiezers)]
 
 #box(inset: (left: 3em, bottom: 1em), empty_letterbox(
   "I",
   cells: 3,
   light: false,
-)[Aantal méér getelde stemmen (bereken: H min D)])
+)[Aantal méér getelde stemmen (bereken: H _min_ D)])
 
-#checkbox[H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)]
+#checkbox[H is *kleiner* dan D (minder uitgebrachte stemmen dan toegelaten kiezers)]
 
 #box(inset: (left: 3em, bottom: 1em), empty_letterbox(
   "J",
   cells: 3,
   light: false,
-)[Aantal minder getelde stemmen (bereken: D min H)])
+)[Aantal minder getelde stemmen (bereken: D _min_ H)])
 
-=== Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H *volledig* verklaren?
+=== Zijn er tijdens de stemming dingen opgeschreven die het bovenstaande verschil tussen D en H *volledig* verklaren?
 
-_(Gebruik het proces-verbaal van het stembureau #sym.arrow.r Tijdens de stemming, vraag 1.2.2)_
+(Gebruik het proces-verbaal van het stembureau #sym.arrow.r *Tijdens de stemming, vraag 1.2.2*)
 
 #checkbox[Ja]
 #checkbox[Nee, er is een onverklaard verschil #sym.arrow.r Hertel het aantal toegelaten kiezers (tenzij dat bij rubriek 2 al gedaan is) en noteer dit bij #ref(<admitted_voters>)]
 
 == Verklaringen vanuit het stembureau <polling_station_declaration>
 
-=== Neem de verklaringen over die in het *proces-verbaal van het stembureau bij vraag 1.2.2* staan. Ook als er nu geen telverschil meer is of als het telverschil kleiner is.
+#emph_block[
+  Neem de verklaringen over die in het *proces-verbaal van het stembureau bij vraag 1.2.2* staan. Ook als er nu geen telverschil meer is of als het telverschil kleiner is.
+]
 
 #empty_lines(12)
 

--- a/backend/templates/model-na-31-2-bijlage-1.typ
+++ b/backend/templates/model-na-31-2-bijlage-1.typ
@@ -102,7 +102,7 @@ Licht hieronder toe wat de reden van het extra onderzoek was
   door het #underline[*stembureau*] (vak H van rubriek 2.2) en zoals door u geteld op het #underline[*#location_type*] (vak H van rubriek 3.2)?
 ]
 
-#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (tenzij dat bij de vraag 2.1 al gedaan is)*, en vul de resultaten in rubriek 3.1]
+#checkbox[Ja #sym.arrow.r *Hertel het aantal toegelaten kiezers (tenzij dat bij vraag 2.1 al gedaan is)*, en vul de resultaten in rubriek 3.1 in]
 #checkbox[Nee]
 
 #pagebreak(weak: true)

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -163,13 +163,13 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
     letterbox(
       "B",
       value: input.summary.voters_counts.proxy_certificate_count,
-    )[Volmachtbewijzen (schriftelijk of via ingevulde stempas)],
+    )[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas of kiezerspas)],
     letterbox("C", value: input.summary.voters_counts.voter_card_count)[Kiezerspassen],
     letterbox(
       "D",
       light: false,
       value: input.summary.voters_counts.total_admitted_voters_count,
-    )[Totaal toegelaten kiezers (A+B+C)],
+    )[*Totaal toegelaten kiezers (A+B+C)*],
   )
 ] else [
   Tel het aantal geldige stempassen en volmachtbewijzen
@@ -179,12 +179,12 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
     letterbox(
       "B",
       value: input.summary.voters_counts.proxy_certificate_count,
-    )[Volmachtbewijzen (schriftelijk of via ingevulde stempas)],
+    )[Volmachtbewijzen (schriftelijk of via ingevulde achterkant stempas)],
     letterbox(
       "D",
       light: false,
       value: input.summary.voters_counts.total_admitted_voters_count,
-    )[Totaal toegelaten kiezers (A+B)],
+    )[*Totaal toegelaten kiezers (A+B)*],
   )
 ]
 
@@ -228,7 +228,7 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
 
 #let differences = input.summary.differences_counts.more_ballots_count.count > 0 or input.summary.differences_counts.fewer_ballots_count.count > 0
 
-#checkbox(checked: not differences)[Ja, #sym.arrow.r Ga door naar #ref(<monitoring_protocol>)]
+#checkbox(checked: not differences)[Ja]
 
 #checkbox(checked: differences)[Nee, er zijn stembureaus met een verschil]
 
@@ -279,11 +279,13 @@ Voer de controle uit volgens de stappen in het controleprotocol.
 
 = Ondertekening
 
+Het proces-verbaal moet worden ondertekend door alle aanwezige leden. Bij een #location_type zijn dit er minimaal #is_local_election[3][5].
+
 #signing_form_label[Datum]
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_local_election[twee][vier] leden van het #location_type
+== Voorzitter en #is_local_election[twee][vier] leden van het #location_type
 
 #signing_form_label[Voorzitter van het #location_type:]
 
@@ -295,7 +297,7 @@ Voer de controle uit volgens de stappen in het controleprotocol.
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
-#signing_form_label[Extra ondertekening: (niet verplicht)]
+#signing_form_label[Extra ondertekening:]
 
 #stack(spacing: 0.5em, ..range(0, is_local_election(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 

--- a/backend/templates/model-p-22-2.typ
+++ b/backend/templates/model-p-22-2.typ
@@ -290,7 +290,7 @@ Na toewijzing van de volle zetels blijft een aantal te verdelen zetels over. Dit
 #let initial_highest_average_steps = if input.seat_assignment.keys().contains("initial_highest_average_steps") { input.seat_assignment.initial_highest_average_steps } else { () };
 #if input.seat_assignment.initial_total_residual_seats > 0 [
   #if input.election.number_of_seats < LARGE_COUNCIL_THRESHOLD [
-    - Het #location_type berekent hoeveel stemmen elke lijst overhoudt na toekenning van de volle zetels. Dat is het 'overschot' aan stemmen voor die lijst.
+    - Het #location_type berekent hoeveel stemmen elke lijst overhoudt na toekenning van de volle zetels. Dat is het ‘overschot’ aan stemmen voor die lijst.
     - Het #location_type verdeelt de restzetels, in volgorde van de grootste overschotten. Elke lijst kan maar één restzetel krijgen. Alleen lijsten die ten minste 75% van de kiesdeler hebben behaald kunnen een restzetel krijgen.
     - Als er daarna nog restzetels over zijn, verdeelt het #location_type die volgens het systeem van de grootste gemiddelden. Ook bij deze verdeling mag iedere lijst maar één restzetel krijgen.
     - Als lijsten precies evenveel stemmen behalen en er niet voldoende restzetels zijn voor die lijsten, dan wordt geloot welke lijst de restzetel krijgt.
@@ -358,7 +358,7 @@ Na toewijzing van de volle zetels blijft een aantal te verdelen zetels over. Dit
       [+ #format_political_group_name(absolute_majority.number, absolute_majority.name, with_prefix: "with_list_prefix") heeft meer dan de helft van de stemmen behaald en heeft daardoor een volstrekte meerderheid. Omdat de lijst op basis van de zetelverdeling niet meer dan de helft van de zetels heeft gekregen, heeft de lijst via de restzetelverdeling een extra (rest)zetel gekregen.]
     }
     for exhausted_list in exhausted_lists {
-      [+ #format_political_group_name(exhausted_list.number, exhausted_list.name, with_prefix: "with_list_prefix") heeft niet voldoende kandidaten beschikbaar om de haar toegewezen zetels te bezetten. De 'overtollige' zetels gaan over op andere lijsten door toepassing van het systeem van de grootste #if input.election.number_of_seats < LARGE_COUNCIL_THRESHOLD { [overschotten en/of gemiddelden] } else { [gemiddelden] }.]
+      [+ #format_political_group_name(exhausted_list.number, exhausted_list.name, with_prefix: "with_list_prefix") heeft niet voldoende kandidaten beschikbaar om de haar toegewezen zetels te bezetten. De ‘overtollige’ zetels gaan over op andere lijsten door toepassing van het systeem van de grootste #if input.election.number_of_seats < LARGE_COUNCIL_THRESHOLD { [overschotten en/of gemiddelden] } else { [gemiddelden] }.]
     }
   }
 
@@ -546,7 +546,7 @@ De aan de lijsten toegewezen volle zetels en restzetels zijn bij elkaar opgeteld
 
 #empty_lines(5)
 
-=== Is voor de invoer gebruik gemaakt van de bestanden die zijn uitgewisseld via het platform 'Teluitslagen'?
+=== Is voor de invoer gebruik gemaakt van de bestanden die zijn uitgewisseld via het platform ‘Teluitslagen’?
 
 #checkbox()[Ja]
 #checkbox()[Nee, de resultaten van de papieren processen-verbaal twee keer handmatig ingevoerd in de uitslagensoftware]

--- a/backend/templates/model-p-2a.typ
+++ b/backend/templates/model-p-2a.typ
@@ -135,11 +135,13 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
 
 = Ondertekening
 
+Het proces-verbaal moet worden ondertekend door alle aanwezige leden. Bij een #location_type zijn dit er minimaal #is_local_election[3][5].
+
 #signing_form_label[Datum]
 
 #textbox_only_bottom_stroke[Datum en tijd:][Plaats:]
 
-== Verplicht: voorzitter en #is_local_election[twee][vier] leden van het #location_type
+== Voorzitter en #is_local_election[twee][vier] leden van het #location_type
 
 #signing_form_label[Voorzitter van het #location_type:]
 
@@ -151,7 +153,7 @@ Bijvoorbeeld een schorsing of als er meerdere verkiezingen tegelijk werden georg
 
 == Ondertekening door andere aanwezige leden van het #location_type
 
-#signing_form_label[Extra ondertekening: (niet verplicht)]
+#signing_form_label[Extra ondertekening:]
 
 #stack(spacing: 0.5em, ..range(0, is_local_election(3, 1)).map(_ => textbox[Naam:][Handtekening:]))
 


### PR DESCRIPTION
## What & why

Implement version 2027 changes to CSO models for Epic https://github.com/kiesraad/abacus/issues/3497.

Issues:
- Resolves https://github.com/kiesraad/abacus/issues/3530
- Resolves https://github.com/kiesraad/abacus/issues/3533
- Resolves https://github.com/kiesraad/abacus/issues/3534
- Resolves https://github.com/kiesraad/abacus/issues/3536
- Resolves https://github.com/kiesraad/abacus/issues/3537
- Resolves https://github.com/kiesraad/abacus/issues/3539

For all issues:
- Change `(van - tot)` -> `van - tot` was implemented in https://github.com/kiesraad/abacus/pull/3735
- Header for intentionally left blank pages was implemented in https://github.com/kiesraad/abacus/pull/3722 
- Changes to footers is handled in https://github.com/kiesraad/abacus/pull/3731

Per issue:

#### N10-2 pv stembureau CSO (#3530)

Implemented:
- 2.1	toevoeging 'achterkant' bij volmachtbewijzen ingevulde stempas/kiezerspas
- 2.3.1	Dikdrukken van gelijk, groter en kleiner
- 3	toelichting ondertekening toegevoegd
- 3.1	verwijdering van 'verplicht'
- 3.2	verwijdering van 'niet verplicht'
- 2.1	Toelichting toegevoegd dat veld C in GR-versie niet van toepassing is

<img width="660" height="234" alt="image" src="https://github.com/user-attachments/assets/d28208d1-7516-4c44-bcd5-34e8ec1eb11d" />
    
Not implemented:
- 2.1	de komma tussen stempassen en volmachtbewijzen vervangen voor 'en'.

As this already seemed to be implemented for local:

<img width="660" height="234" alt="image" src="https://github.com/user-attachments/assets/ca51c85f-a02b-420b-900d-fa163f4f389d" />

and unwanted for not local: 

<img width="660" height="234" alt="image" src="https://github.com/user-attachments/assets/28afc6a1-4cc7-447f-86f5-5302757e5576" />

Not mentioned in the issue but implemented for consistency:

- Bold for 'Totaal toegelaten kiezers'

<img width="1094" height="162" alt="image" src="https://github.com/user-attachments/assets/0d8f2c6a-db0b-4b45-b638-0c00db78de15" />

##### Output

Old:
- [model-n-10-2.pdf](https://github.com/user-attachments/files/30584996/model-n-10-2.pdf)

New: 
- [model-n-10-2-GR.pdf](https://github.com/user-attachments/files/30585003/model-n-10-2-GR.pdf)
- [model-n-10-2-PS.pdf](https://github.com/user-attachments/files/30585009/model-n-10-2-PS.pdf)
- [model-n-10-2-WS.pdf](https://github.com/user-attachments/files/30585011/model-n-10-2-WS.pdf)

---

#### Na 14-2 Corrigendum bij het pv van een GSB (CSO) - hoofddocument (#3533)

Implemented:
- 1, 1.3, 1.5(2x)	toelichting aangepast-> 'eerste zitting' gewijzigd in 'een eerdere zitting'
- 1.2	achter volmachtbewijzen: toevoeging van schriftelijke volmacht of op ingevulde achterkant stempas/kiezerspas
- 1.4	toelichting toegevoegd over de term oorspronkelijk
- 2 (2x)	toelichting ondertekening toegevoegd
- 2.1 (2x)	verwijdering van 'verplicht'
- 2.2 (2x)	verwijdering van 'niet verplicht'

Not implemented:
- 1.1	oorspronkelijk' verwijderd boven kolom kiesgerechtigden

Because: no 'oorspronkelijk': 
<img width="278" height="97" alt="image" src="https://github.com/user-attachments/assets/1fa4880d-f6d6-4663-a31a-fda62c707d26" />

##### Output

Old:
- [model-na-14-2-GR.pdf](https://github.com/user-attachments/files/30585105/model-na-14-2-GR.pdf)
- [model-na-14-2-PS.pdf](https://github.com/user-attachments/files/30585106/model-na-14-2-PS.pdf)
- [model-na-14-2-WS.pdf](https://github.com/user-attachments/files/30585107/model-na-14-2-WS.pdf)

New:
- [model-na-14-2-GR.pdf](https://github.com/user-attachments/files/30585121/model-na-14-2-GR.pdf)
- [model-na-14-2-PS.pdf](https://github.com/user-attachments/files/30585123/model-na-14-2-PS.pdf)
- [model-na-14-2-WS.pdf](https://github.com/user-attachments/files/30585124/model-na-14-2-WS.pdf)

---

#### Na 14-2 Corrigendum bij het pv van een GSB (CSO) - Bijlage 1 (#3534)

Implemented
- Bijlage 1 voorblad	Zin toegevoegd over publiceren van de bijlagen
- B1-1	Titels, toelichting, vraag gecorrigeerde uitslag in overeenstemming gebracht met tekst in Na 14-1 versie 2
- B1-2.1	Toelichting toegevoegd dat veld C in GR-versie niet van toepassing is
- B1-2.1	achter volmachtbewijzen: toevoeging van schriftelijke volmacht of op ingevulde achterkant stempas/kiezerspas
- B1-2, B1-2.2, B1-2.3, B1-2.4 (2x)	toelichting aangepast-> 'eerste zitting' gewijzigd in 'een eerdere zitting'
- B1-2.3	Toelichting toegevoegd dat vakjes altijd aangevinkt moeten worden
- B1-2.3.1	Dikdrukken van gelijk, groter en kleiner
- B1-2.3.2	toevoeging van 'bovenstaand' bij verschil

❗Remark: implemented the letterbox like this:
<img width="640" height="263" alt="image" src="https://github.com/user-attachments/assets/0b53ffd6-1929-4f62-8669-27a3c2dc0579" />

as a free interpretation from the suggested layout in the PDF in the issue:

<img width="639" height="270" alt="image" src="https://github.com/user-attachments/assets/7ae7817a-d8cb-4d15-8584-da412657667b" />

##### Output

Old: 
- [model-na-14-2-bijlage-1-GR.pdf](https://github.com/user-attachments/files/30585324/model-na-14-2-bijlage-1-GR.pdf)
- [model-na-14-2-bijlage-1-PS.pdf](https://github.com/user-attachments/files/30585325/model-na-14-2-bijlage-1-PS.pdf)
- [model-na-14-2-bijlage-1-WS.pdf](https://github.com/user-attachments/files/30585326/model-na-14-2-bijlage-1-WS.pdf)

New:
- [model-na-14-2-bijlage-1-GR.pdf](https://github.com/user-attachments/files/30585338/model-na-14-2-bijlage-1-GR.pdf)
- [model-na-14-2-bijlage-1-PS.pdf](https://github.com/user-attachments/files/30585339/model-na-14-2-bijlage-1-PS.pdf)
- [model-na-14-2-bijlage-1-WS.pdf](https://github.com/user-attachments/files/30585340/model-na-14-2-bijlage-1-WS.pdf)

---

#### Na 31-2 pv GSB CSO - hoofddocument (#3536)

Implemented:
- 2.2	toevoeging 'achterkant' bij volmachtbewijzen ingevulde stempas/kiezerspas
- 2.4.1	'ga door naar 2.5' verwijderd
- 3	toelichting ondertekening toegevoegd
- 3.1	verwijdering van 'verplicht'
- 3.2	verwijdering van 'niet verplicht'

❗Remark:
In the PDF in the issue there is no distinction between `Ondertekening <versie gemeente- en eilandraadsverkiezingen>` and `Ondertekening <versie overige verkiezingen>` in number of required members (both mention `3`). This is inconsistent with the other models AND with the sum of chairman + members. Consistent would be to mention `5` for `Ondertekening <versie overige verkiezingen>`. This is what is implemented. Also mentioned to discuss with the organisation [here](https://github.com/kiesraad/abacus/issues/3497#issuecomment-5140847701)

##### Output

Old:
- [model-na-31-2-GR.pdf](https://github.com/user-attachments/files/30585787/model-na-31-2-GR.pdf)
- [model-na-31-2-inlegvel.pdf](https://github.com/user-attachments/files/30585788/model-na-31-2-inlegvel.pdf)
- [model-na-31-2-PS.pdf](https://github.com/user-attachments/files/30585789/model-na-31-2-PS.pdf)
- [model-na-31-2-WS.pdf](https://github.com/user-attachments/files/30585790/model-na-31-2-WS.pdf)

New:
- [model-na-31-2-GR.pdf](https://github.com/user-attachments/files/30585817/model-na-31-2-GR.pdf)
- [model-na-31-2-inlegvel.pdf](https://github.com/user-attachments/files/30585818/model-na-31-2-inlegvel.pdf)
- [model-na-31-2-PS.pdf](https://github.com/user-attachments/files/30585820/model-na-31-2-PS.pdf)
- [model-na-31-2-WS.pdf](https://github.com/user-attachments/files/30585822/model-na-31-2-WS.pdf)

---

#### Na 31-2 pv GSB CSO - Bijlage 1 (#3537)

Implemented:
- B1-1	Toelichting bij extra onderzoek toegevoegd, titel aangepast
- B1-2.1	Vraagstelling in overeenstemming gebracht met vraagstelling pv stembureau en verduidelijkende tekst toegevoegd
- B1-3.1	Toelichting toegevoegd dat veld C in GR-versie niet van toepassing is
- B1-3.1	Achter volmachtbewijzen: toevoeging van schriftelijke volmacht of op ingevulde achterkant stempas/kiezerspas
- B1- 3.3.1	Dikdrukken van gelijk, groter en kleiner
- B1-3.3.2	toevoeging van 'bovenstaand' bij verschil
- B1-3.4.1	subnummer weggehaald

❗Remark:  
This has been implemented: "B1-2.3	'vorige vraag' aangepast in 'vraag 2.1', verwijzingen naar vak H toegvoegd", but copy maybe needs an update: 
- "de vraag" (?)
- "en vul de resultaten in rubriek 3.1" (?)

<img width="1514" height="234" alt="image" src="https://github.com/user-attachments/assets/362a0f0b-5b2e-4e5d-9844-0efd3b6a30fb" />

❗ This seems to be the only location to use the underlined text decoration. 
<img width="534" height="191" alt="image" src="https://github.com/user-attachments/assets/a5099e0c-2cb1-4d23-b078-375ecc450607" />

❗Remark: the answer in question 2.1 are reversed - The _frontend_ change for this, needs a bit more in-depth research, so I created a new issue (https://github.com/kiesraad/abacus/issues/3740). Does not have any impact on this PR. 

##### Output

Old:
- [model-na-31-2-bijlage-1-GR.pdf](https://github.com/user-attachments/files/30586647/model-na-31-2-bijlage-1-GR.pdf)
- [model-na-31-2-bijlage-1-PS.pdf](https://github.com/user-attachments/files/30586648/model-na-31-2-bijlage-1-PS.pdf)
- [model-na-31-2-bijlage-1-WS.pdf](https://github.com/user-attachments/files/30586649/model-na-31-2-bijlage-1-WS.pdf)

New:
- [model-na-31-2-bijlage-1-GR.pdf](https://github.com/user-attachments/files/30586655/model-na-31-2-bijlage-1-GR.pdf)
- [model-na-31-2-bijlage-1-PS.pdf](https://github.com/user-attachments/files/30586656/model-na-31-2-bijlage-1-PS.pdf)
- [model-na-31-2-bijlage-1-WS.pdf](https://github.com/user-attachments/files/30586657/model-na-31-2-bijlage-1-WS.pdf)


---

#### P 2a pv nieuwe zitting GSB (#3539)

Implemented:
- 2	toelichting ondertekening toegevoegd
- 2.1	verwijdering van 'verplicht'
- 2.2	verwijdering van 'niet verplicht'

Old:
- [model-p-2a.pdf](https://github.com/user-attachments/files/30586822/model-p-2a.pdf)

New:
- [model-p-2a.pdf](https://github.com/user-attachments/files/30586840/model-p-2a.pdf)


