### PR TITLE
Resolving differences for first entry with errors

### DIFF
--- a/backend/fuzz/fuzz_targets/data_entry_status.rs
+++ b/backend/fuzz/fuzz_targets/data_entry_status.rs
@@ -230,7 +230,11 @@ fn is_as_expected(
         }
         // KeepFirstEntry
         (DataEntryStatus::EntriesDifferent(_), Transition::KeepFirstEntry) => {
-            matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
+            if first_entry_correct {
+                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
+            } else {
+                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryHasErrors(_)))
+            }
         }
         // KeepSecondEntry
         (DataEntryStatus::EntriesDifferent(_), Transition::KeepSecondEntry) => {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6426,6 +6426,7 @@
         "required": [
           "first_entry_user_id",
           "first_entry",
+          "first_entry_has_errors",
           "second_entry_user_id",
           "second_entry",
           "second_entry_has_errors",
@@ -6434,6 +6435,9 @@
         "properties": {
           "first_entry": {
             "$ref": "#/components/schemas/Results"
+          },
+          "first_entry_has_errors": {
+            "type": "boolean"
           },
           "first_entry_user_id": {
             "$ref": "#/components/schemas/UserId"

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -795,6 +795,7 @@ async fn data_entry_resolve_errors(
 pub struct DataEntryGetDifferencesResponse {
     pub first_entry_user_id: UserId,
     pub first_entry: Results,
+    pub first_entry_has_errors: bool,
     pub second_entry_user_id: UserId,
     pub second_entry: Results,
     pub second_entry_has_errors: bool,
@@ -834,12 +835,15 @@ async fn data_entry_get_differences(
             second_entry,
             ..
         }) => {
+            let first_entry_has_errors =
+                first_entry.start_validate(&context.election)?.has_errors();
             let second_entry_has_errors =
                 second_entry.start_validate(&context.election)?.has_errors();
 
             Ok(Json(DataEntryGetDifferencesResponse {
                 first_entry_user_id,
                 first_entry,
+                first_entry_has_errors,
                 second_entry_user_id,
                 second_entry,
                 second_entry_has_errors,
@@ -886,7 +890,9 @@ async fn data_entry_resolve_differences(
         ResolveDifferencesAction::KeepFirstAndDiscardSecond => {
             state.keep_first_entry(&context.election)?
         }
-        ResolveDifferencesAction::KeepFirstAndCorrectSecond => state.correct_second_entry()?,
+        ResolveDifferencesAction::KeepFirstAndCorrectSecond => {
+            state.correct_second_entry(&context.election)?
+        }
         ResolveDifferencesAction::KeepSecondAndDiscardFirst => {
             state.keep_second_entry(&context.election)?
         }
@@ -1256,6 +1262,43 @@ mod tests {
         second_entry.data.voters_counts_mut().poll_card_count = 100;
 
         finalise_different_entries_with(pool, second_entry).await;
+    }
+
+    /// Like `finalise_different_entries`, but the first entry has an error.
+    async fn finalise_different_entries_first_entry_has_errors(pool: SqlitePool) {
+        let data_entry_id = DataEntryId::from(201);
+        finalise_different_entries(pool.clone()).await;
+
+        // Keep the second entry and let the original typist correct the first entry
+        let response = resolve_differences(
+            pool.clone(),
+            data_entry_id,
+            ResolveDifferencesAction::KeepSecondAndCorrectFirst,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // The corrected first entry has an error and still differs from the second entry
+        let mut first_entry = example_data_entry();
+        first_entry.data.voters_counts_mut().poll_card_count = 100;
+
+        let response = claim(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = save(
+            pool.clone(),
+            first_entry,
+            data_entry_id,
+            EntryNumber::FirstEntry,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = finalise(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let DataEntryStatusResponse { status } = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(status, DataEntryStatusName::EntriesDifferent);
     }
 
     async fn finalise_with_errors(pool: SqlitePool) {
@@ -2393,6 +2436,68 @@ mod tests {
 
             let differences = get_differences(pool.clone(), data_entry_id).await;
             assert!(differences.second_entry_has_errors);
+            assert!(!differences.first_entry_has_errors);
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_get_differences_first_entry_has_errors(pool: SqlitePool) {
+            let data_entry_id = DataEntryId::from(201);
+            finalise_different_entries_first_entry_has_errors(pool.clone()).await;
+
+            let differences = get_differences(pool.clone(), data_entry_id).await;
+            assert!(differences.first_entry_has_errors);
+            assert!(!differences.second_entry_has_errors);
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_keep_first_has_errors_rejects_correction(pool: SqlitePool) {
+            let polling_station_id = PollingStationId::from(211);
+            let data_entry_id = DataEntryId::from(201);
+            finalise_different_entries_first_entry_has_errors(pool.clone()).await;
+
+            let response = resolve_differences(
+                pool.clone(),
+                data_entry_id,
+                ResolveDifferencesAction::KeepFirstAndCorrectSecond,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            let result: ErrorResponse = serde_json::from_slice(&body).unwrap();
+            assert_eq!(result.reference, ErrorReference::InvalidStateTransition);
+
+            // The state must be unchanged
+            let mut conn = pool.acquire().await.unwrap();
+            let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+            assert!(matches!(
+                data_entry.state.0,
+                DataEntryStatus::EntriesDifferent(_)
+            ));
+        }
+
+        #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+        async fn test_keep_first_has_errors_discard_second(pool: SqlitePool) {
+            let polling_station_id = PollingStationId::from(211);
+            let data_entry_id = DataEntryId::from(201);
+            finalise_different_entries_first_entry_has_errors(pool.clone()).await;
+
+            let response = resolve_differences(
+                pool.clone(),
+                data_entry_id,
+                ResolveDifferencesAction::KeepFirstAndDiscardSecond,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let mut conn = pool.acquire().await.unwrap();
+            let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+            let DataEntryStatus::FirstEntryHasErrors(state) = data_entry.state.0 else {
+                panic!("Expected entry to be in FirstEntryHasErrors state");
+            };
+            assert_eq!(
+                state.finalised_first_entry.voters_counts().poll_card_count,
+                100
+            );
         }
 
         #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -36,7 +36,7 @@ pub enum DataEntryTransitionError {
     CannotTransitionUsingDifferentUser,
     /// The second data entry needs to be claimed by a user other than the one who claimed the first entry
     SecondEntryNeedsDifferentUser,
-    /// Correction is not allowed because the second entry has errors
+    /// Correction is not allowed because the entry to be kept has errors
     CorrectionNotAllowed,
     ValidatorError(DataError),
     ValidationError(ValidationResults),
@@ -846,12 +846,20 @@ impl DataEntryStatus {
             DataEntryStatus::EntriesDifferent(state) => {
                 let validation_results = state.first_entry.start_validate(election)?;
 
-                Ok(Self::FirstEntryFinalised(FirstEntryFinalised {
-                    first_entry_user_id: state.first_entry_user_id,
-                    finalised_first_entry: state.first_entry.clone(),
-                    first_entry_finished_at: state.first_entry_finished_at,
-                    finalised_with_warnings: validation_results.has_warnings(),
-                }))
+                if validation_results.has_errors() {
+                    Ok(Self::FirstEntryHasErrors(FirstEntryHasErrors {
+                        first_entry_user_id: state.first_entry_user_id,
+                        finalised_first_entry: state.first_entry.clone(),
+                        first_entry_finished_at: state.first_entry_finished_at,
+                    }))
+                } else {
+                    Ok(Self::FirstEntryFinalised(FirstEntryFinalised {
+                        first_entry_user_id: state.first_entry_user_id,
+                        finalised_first_entry: state.first_entry.clone(),
+                        first_entry_finished_at: state.first_entry_finished_at,
+                        finalised_with_warnings: validation_results.has_warnings(),
+                    }))
+                }
             }
             _ => Err(DataEntryTransitionError::Invalid),
         }
@@ -914,9 +922,17 @@ impl DataEntryStatus {
     }
 
     /// Correct second entry while resolving differences
-    pub fn correct_second_entry(self) -> Result<Self, DataEntryTransitionError> {
+    /// This is only allowed when the first entry has no errors.
+    pub fn correct_second_entry(
+        self,
+        election: &ElectionWithPoliticalGroups,
+    ) -> Result<Self, DataEntryTransitionError> {
         match &self {
             DataEntryStatus::EntriesDifferent(state) => {
+                if state.first_entry.start_validate(election)?.has_errors() {
+                    return Err(DataEntryTransitionError::CorrectionNotAllowed);
+                }
+
                 Ok(Self::SecondEntryCorrection(SecondEntryCorrection {
                     first_entry_user_id: state.first_entry_user_id,
                     finalised_first_entry: state.first_entry.clone(),
@@ -1078,7 +1094,7 @@ impl Display for DataEntryTransitionError {
             }
             DataEntryTransitionError::Invalid => write!(f, "Invalid state transition"),
             DataEntryTransitionError::CorrectionNotAllowed => {
-                write!(f, "Correction not allowed: second entry has errors")
+                write!(f, "Correction not allowed: the entry to be kept has errors")
             }
             DataEntryTransitionError::ValidatorError(data_error) => {
                 write!(f, "Validator error: {data_error}")
@@ -1761,6 +1777,49 @@ mod tests {
     }
 
     #[test]
+    fn entries_different_to_first_entry_has_errors_keep_first_entry() {
+        // Create first entry with validation errors that will trigger FirstEntryHasErrors
+        let first_entry = example_results().with_error();
+        let second_entry = example_results().with_difference();
+
+        let initial = DataEntryStatus::EntriesDifferent(EntriesDifferent {
+            first_entry: first_entry.clone(),
+            first_entry_user_id: UserId::from(0),
+            second_entry,
+            second_entry_user_id: UserId::from(0),
+            first_entry_finished_at: Utc::now(),
+            second_entry_finished_at: Utc::now(),
+        });
+        let next = initial.keep_first_entry(&election()).unwrap();
+
+        if let DataEntryStatus::FirstEntryHasErrors(kept_entry) = next {
+            assert_eq!(kept_entry.finalised_first_entry, first_entry);
+        } else {
+            panic!("{next:?}")
+        };
+    }
+
+    #[test]
+    fn entries_different_keep_first_and_correct_second_with_errors_is_rejected() {
+        let first_entry = example_results().with_error();
+        let second_entry = example_results();
+
+        let initial = DataEntryStatus::EntriesDifferent(EntriesDifferent {
+            first_entry,
+            first_entry_user_id: UserId::from(0),
+            second_entry,
+            second_entry_user_id: UserId::from(0),
+            first_entry_finished_at: Utc::now(),
+            second_entry_finished_at: Utc::now(),
+        });
+
+        assert_eq!(
+            initial.correct_second_entry(&election()),
+            Err(DataEntryTransitionError::CorrectionNotAllowed)
+        );
+    }
+
+    #[test]
     fn definitive_keep_first_entry_error() {
         assert_eq!(
             definitive().keep_first_entry(&election()),
@@ -1924,7 +1983,7 @@ mod tests {
         );
         assert!(
             entries_different()
-                .correct_second_entry()
+                .correct_second_entry(&election())
                 .unwrap()
                 .is_correction()
         );

--- a/documentatie/state-machines/data-entry-state.md
+++ b/documentatie/state-machines/data-entry-state.md
@@ -14,13 +14,17 @@ Note the difference between `discard` and `reset`:
 When resolving differences between the first and second data entry (`EntriesDifferent` state), one of the options for the coordinator is to
 discard one entry. In this case, the remaining entry will from then on be the first entry, and the data entry is open for a new second entry.
 
-Instead of discarding an entry, the coordinator can also have it corrected by
-the typist who entered it. That is only possible when the entry that is kept has
-no errors. The first entry never has errors at this point, so keeping the first
-entry and correcting the second is always allowed. Keeping the second entry
-while it has errors is not allowed: the coordinator has to resolve errors first,
-so the only option is to discard the first entry, which transitions the state to
-`FirstEntryHasErrors`.
+Instead of discarding an entry, the coordinator can also have it corrected by the typist who entered it. That is only
+possible when the entry that is kept has no errors. Keeping an entry that has errors while correcting the other one is
+not allowed: the coordinator has to resolve the errors first, so the only option is to discard the other entry, which
+transitions the state to `FirstEntryHasErrors`.
+
+Both the first and second entries can have errors in the `EntriesDifferent` state:
+- the first entry through `Empty` -> `FirstEntryInProgress` -> `FirstEntryFinalised` -> `SecondEntryInProgress` ->
+  `EntriesDifferent` -> `FirstEntryCorrection` -> introduce errors in first entry -> `EntriesDifferent` with errors in
+  first entry
+- the second entry through `Empty` -> `FirstEntryInProgress` -> `FirstEntryFinalised` -> `SecondEntryInProgress` ->
+  introduce errors in second entry -> `EntriesDifferent` with errors in second entry.
 
 ```mermaid
 stateDiagram-v2
@@ -51,7 +55,7 @@ stateDiagram-v2
   resolve_differences --> Empty: discard both entries
   resolve_differences --> first_has_errors: discard one entry
   resolve_differences --> FirstEntryCorrection: correct first entry<br>(only without errors in second entry)
-  resolve_differences --> SecondEntryCorrection: correct second entry
+  resolve_differences --> SecondEntryCorrection: correct second entry<br>(only without errors in first entry)
 
   FirstEntryCorrection --> is_different: finalise
   FirstEntryCorrection --> FirstEntryFinalised: discard
@@ -60,5 +64,3 @@ stateDiagram-v2
 
   Definitive --> [*]
 ```
-
-

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.stories.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.stories.tsx
@@ -150,6 +150,33 @@ export const SecondEntryHasErrors: Story = {
   },
 };
 
+export const FirstEntryHasErrors: Story = {
+  ...Default,
+  args: {
+    formState: { ...defaultFormState, correctEntry: "first", correctionBlocked: true },
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText(
+        "Uit de eerste invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. " +
+          "Daarom kan je de tweede invoer nu niet laten herstellen door de oorspronkelijke invoerder. " +
+          "Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. " +
+          "De tweede invoer wordt verwijderd.",
+      ),
+    ).toBeVisible();
+
+    const correctWrongEntry = canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" });
+    const discardWrongEntry = canvas.getByRole("radio", { name: "Opnieuw laten invoeren" });
+    await expect(correctWrongEntry).toBeDisabled();
+    await expect(correctWrongEntry).not.toBeChecked();
+    await expect(discardWrongEntry).toBeDisabled();
+    await expect(discardWrongEntry).toBeChecked();
+
+    // The submit button announces that resolving the errors is the next step
+    await expect(canvas.getByRole("button", { name: "Verder naar fouten oplossen" })).toBeVisible();
+  },
+};
+
 export const WithValidationErrors: Story = {
   ...Default,
   args: {

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.tsx
@@ -5,7 +5,36 @@ import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { t, tx } from "@/i18n/translate";
 
-import { effectiveWrongEntryAction, type ResolveDifferencesFormState } from "../utils/differences";
+import { type CorrectEntry, effectiveWrongEntryAction, type ResolveDifferencesFormState } from "../utils/differences";
+
+// Explains why the kept entry blocks correcting the other one.
+function correctionBlockedMessage(correctEntry: CorrectEntry | undefined): string | undefined {
+  if (correctEntry === "first") {
+    return t("resolve_differences.correction_blocked.first_entry_has_errors");
+  }
+  if (correctEntry === "second") {
+    return t("resolve_differences.correction_blocked.second_entry_has_errors");
+  }
+  return undefined;
+}
+
+// Renders nothing when correcting the other entry is not blocked
+function CorrectionBlockedAlert({
+  correctEntry,
+  correctionBlocked,
+}: Pick<ResolveDifferencesFormState, "correctEntry" | "correctionBlocked">) {
+  const message = correctionBlocked ? correctionBlockedMessage(correctEntry) : undefined;
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <Alert type="notify" small>
+      {message}
+    </Alert>
+  );
+}
 
 export interface ResolveDifferencesFormProps {
   firstEntryName: string;
@@ -75,11 +104,7 @@ export function ResolveDifferencesForm({
           </ChoiceList>
         </FormLayout.Section>
         <FormLayout.Section title={tx("resolve_differences.wrong_entry_question")}>
-          {correctionBlocked && (
-            <Alert type="notify" small>
-              {t("resolve_differences.correction_blocked")}
-            </Alert>
-          )}
+          <CorrectionBlockedAlert correctEntry={correctEntry} correctionBlocked={correctionBlocked} />
           <ChoiceList disabled={wrongEntryDisabled}>
             {wrongEntryError && (
               <ChoiceList.Error id="resolve-differences-wrong-entry-error">{wrongEntryError}</ChoiceList.Error>

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -355,4 +355,32 @@ describe("ResolveDifferencesPage", () => {
     await user.click(await screen.findByRole("button", { name: "Verder naar fouten oplossen" }));
     expect(resolve).toHaveBeenCalledWith("keep_second_and_discard_first");
   });
+
+  test("should block correcting the second entry when the kept first entry has errors", async () => {
+    const user = userEvent.setup();
+    const resolve = spyOnHandler(DataEntryResolveDifferencesHandler);
+    overrideOnce("get", "/api/data_entries/3/resolve_differences", 200, {
+      ...dataEntryStatusDifferences,
+      first_entry_has_errors: true,
+    });
+
+    await renderPage();
+    overrideResponseStatus("first_entry_has_errors");
+    await user.click(await screen.findByRole("radio", { name: "Eerste invoer (Gebruiker01)" }));
+
+    expect(
+      await screen.findByText(
+        "Uit de eerste invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. " +
+          "Daarom kan je de tweede invoer nu niet laten herstellen door de oorspronkelijke invoerder. " +
+          "Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. " +
+          "De tweede invoer wordt verwijderd.",
+      ),
+    ).toBeVisible();
+    expect(
+      await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }),
+    ).toBeDisabled();
+
+    await user.click(await screen.findByRole("button", { name: "Verder naar fouten oplossen" }));
+    expect(resolve).toHaveBeenCalledWith("keep_first_and_discard_second");
+  });
 });

--- a/frontend/src/features/resolve_differences/hooks/useDataEntryDifferences.ts
+++ b/frontend/src/features/resolve_differences/hooks/useDataEntryDifferences.ts
@@ -22,6 +22,7 @@ import {
   effectiveWrongEntryAction,
   getQuestionErrors,
   getResolveDifferencesAction,
+  isCorrectionBlocked,
   type ResolveDifferencesFormState,
   type WrongEntryAction,
 } from "../utils/differences";
@@ -88,8 +89,7 @@ export function useDataEntryDifferences(
     dataEntryStructure = getDataEntryStructure(differences.first_entry.model, election);
   }
 
-  // Block correction of first entry when second entry has errors
-  const correctionBlocked = correctEntry === "second" && (differences?.second_entry_has_errors ?? false);
+  const correctionBlocked = isCorrectionBlocked(correctEntry, differences);
   const effectiveAction = effectiveWrongEntryAction(correctEntry, wrongEntryAction, correctionBlocked);
 
   const questionErrors = getQuestionErrors(correctEntry, effectiveAction, submitted);

--- a/frontend/src/features/resolve_differences/utils/differences.test.ts
+++ b/frontend/src/features/resolve_differences/utils/differences.test.ts
@@ -4,9 +4,11 @@ import { resultsMockData } from "@/features/resolve_differences/testing/polling-
 import {
   type CorrectEntry,
   getResolveDifferencesAction,
+  isCorrectionBlocked,
   sectionHasDifferences,
   type WrongEntryAction,
 } from "@/features/resolve_differences/utils/differences";
+import { dataEntryStatusDifferences } from "@/testing/api-mocks/DataEntryMockData";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
 import type { ResolveDifferencesAction } from "@/types/generated/openapi";
 import { getDataEntryStructure } from "@/utils/dataEntryStructure";
@@ -46,5 +48,45 @@ describe("getResolveDifferencesAction", () => {
     { correctEntry: "second", wrongEntryAction: undefined, expected: undefined },
   ])("maps ($correctEntry, $wrongEntryAction) to $expected", ({ correctEntry, wrongEntryAction, expected }) => {
     expect(getResolveDifferencesAction(correctEntry, wrongEntryAction)).toBe(expected);
+  });
+});
+
+describe("isCorrectionBlocked", () => {
+  test.each<{
+    correctEntry: CorrectEntry | undefined;
+    firstHasErrors: boolean;
+    secondHasErrors: boolean;
+    expected: boolean;
+  }>([
+    // errors in the entry that is kept block correcting the other one
+    { correctEntry: "first", firstHasErrors: true, secondHasErrors: false, expected: true },
+    { correctEntry: "first", firstHasErrors: false, secondHasErrors: true, expected: false },
+    { correctEntry: "second", firstHasErrors: false, secondHasErrors: true, expected: true },
+    { correctEntry: "second", firstHasErrors: true, secondHasErrors: false, expected: false },
+    { correctEntry: "first", firstHasErrors: true, secondHasErrors: true, expected: true },
+    { correctEntry: "second", firstHasErrors: true, secondHasErrors: true, expected: true },
+    { correctEntry: "first", firstHasErrors: false, secondHasErrors: false, expected: false },
+    { correctEntry: "second", firstHasErrors: false, secondHasErrors: false, expected: false },
+    // there is nothing to correct when both entries are discarded, or when no choice was made yet
+    { correctEntry: "neither", firstHasErrors: true, secondHasErrors: true, expected: false },
+    { correctEntry: undefined, firstHasErrors: true, secondHasErrors: true, expected: false },
+  ])("maps (keeping $correctEntry with errors in first: $firstHasErrors, second: $secondHasErrors) to $expected", ({
+    correctEntry,
+    firstHasErrors,
+    secondHasErrors,
+    expected,
+  }) => {
+    const differences = {
+      ...dataEntryStatusDifferences,
+      first_entry_has_errors: firstHasErrors,
+      second_entry_has_errors: secondHasErrors,
+    };
+
+    expect(isCorrectionBlocked(correctEntry, differences)).toBe(expected);
+  });
+
+  test("is not blocked while the differences are still loading", () => {
+    expect(isCorrectionBlocked("first", null)).toBe(false);
+    expect(isCorrectionBlocked("second", null)).toBe(false);
   });
 });

--- a/frontend/src/features/resolve_differences/utils/differences.ts
+++ b/frontend/src/features/resolve_differences/utils/differences.ts
@@ -1,5 +1,5 @@
 import { t } from "@/i18n/translate";
-import type { ResolveDifferencesAction } from "@/types/generated/openapi";
+import type { DataEntryGetDifferencesResponse, ResolveDifferencesAction } from "@/types/generated/openapi";
 import type { DataEntryResults, DataEntrySection } from "@/types/types";
 import { mapResultsToSectionValues } from "@/utils/dataEntryMapping";
 
@@ -18,6 +18,20 @@ export interface ResolveDifferencesFormState {
   correctionBlocked: boolean;
   correctEntryError: string | undefined;
   wrongEntryError: string | undefined;
+}
+
+/** Correcting the other entry is blocked when the entry that is kept has errors. */
+export function isCorrectionBlocked(
+  correctEntry: CorrectEntry | undefined,
+  differences: DataEntryGetDifferencesResponse | null,
+): boolean {
+  if (correctEntry === "first") {
+    return differences?.first_entry_has_errors ?? false;
+  }
+  if (correctEntry === "second") {
+    return differences?.second_entry_has_errors ?? false;
+  }
+  return false;
 }
 
 export function effectiveWrongEntryAction(

--- a/frontend/src/i18n/locales/nl/resolve_differences.json
+++ b/frontend/src/i18n/locales/nl/resolve_differences.json
@@ -1,6 +1,9 @@
 {
   "continue_to_resolve_errors": "Verder naar fouten oplossen",
-  "correction_blocked": "Uit de tweede invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. Daarom kan je de eerste invoer nu niet laten herstellen door de oorspronkelijke invoerder. Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. De eerste invoer wordt verwijderd.",
+  "correction_blocked": {
+    "first_entry_has_errors": "Uit de eerste invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. Daarom kan je de tweede invoer nu niet laten herstellen door de oorspronkelijke invoerder. Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. De tweede invoer wordt verwijderd.",
+    "second_entry_has_errors": "Uit de tweede invoer blijkt dat er waarschijnlijk fouten in het papieren proces-verbaal zijn gemaakt. Daarom kan je de eerste invoer nu niet laten herstellen door de oorspronkelijke invoerder. Eerst moet het papieren proces-verbaal worden gecontroleerd. Dat doen we in de volgende stap. De eerste invoer wordt verwijderd."
+  },
   "form_content": "De resultaten van dit stembureau zijn pas definitief als er twee gelijke invoeren zijn. Kies de invoer die overeenkomt met het papieren proces-verbaal.",
   "form_question": "Welke invoer klopt?",
   "headers": {

--- a/frontend/src/testing/api-mocks/DataEntryMockData.ts
+++ b/frontend/src/testing/api-mocks/DataEntryMockData.ts
@@ -231,6 +231,7 @@ export const dataEntryStatusDifferences: DataEntryGetDifferencesResponse = {
       },
     ],
   },
+  first_entry_has_errors: false,
   second_entry_has_errors: false,
   source: source(3),
 };

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -795,6 +795,7 @@ export interface DataEntry {
 
 export interface DataEntryGetDifferencesResponse {
   first_entry: Results;
+  first_entry_has_errors: boolean;
   first_entry_user_id: UserId;
   second_entry: Results;
   second_entry_has_errors: boolean;


### PR DESCRIPTION
## What & why

Also special case for resolving differences for first entry with errors: only discarding the second entry should be allowed. Similar to #3706. Resolves #3720.

Screenshot:
<img width="500" src="https://github.com/user-attachments/assets/10c79b7e-e5df-4de0-a16c-fc9f4798b28b" />

## How to test

Create a data entry with differences and errors in the first entry: first first+second data entries with differences, resolve by correcting the first entry, then introducing errors in the first entry. This should lead the data entry through these state transitions: `Empty` -> `FirstEntryInProgress` -> `FirstEntryFinalised` -> `SecondEntryInProgress` -> `EntriesDifferent` -> `FirstEntryCorrection` -> introduce errors in first entry -> `EntriesDifferent` with errors in first entry.
