### PR TITLE
Prevent GitHub Actions cache thrashing

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -87,21 +87,6 @@ jobs:
       SQLX_OFFLINE: "true"
       BINSTALL_DISABLE_TELEMETRY: "true"
     steps:
-      # Free up runner disk space, so that our job has enough space to run
-      # https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
-      - name: Free up runner disk space
-        working-directory: /
-        run: >
-          df -h
-          &&
-          echo "Freeing up disk space..."
-          &&
-          sudo rm -rf
-          /usr/local/.ghcup
-          /usr/share/dotnet
-          /usr/share/swift
-          &&
-          df -h
       - uses: actions/checkout@v7.0.1
       # Test backend
       - name: Install musl
@@ -276,6 +261,8 @@ jobs:
             backend/fuzz -> target
             backend/apportionment/fuzz -> target
           shared-key: "fuzzer"
+          # Save cache only for main and release branches to prevent cache thrashing
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
       - name: Install cargo fuzz
         working-directory: ./backend/fuzz
         run: cargo install cargo-fuzz

--- a/.github/workflows/pdf-diff.yml
+++ b/.github/workflows/pdf-diff.yml
@@ -3,12 +3,21 @@ name: Track PDF model changes
 on:
   workflow_dispatch:
   pull_request:
+  # Run on pushes to main and release branches to populate cache
+  push:
+    branches:
+      - main
+      - release-*
 
 permissions:
   contents: read
 
 env:
   TZ: "Europe/Amsterdam"
+
+concurrency:
+  group: pdf-diff-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   diff:
@@ -32,19 +41,27 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: "backend -> target"
+          # Save cache only for main and release branches to prevent cache thrashing
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
       - name: Generate PDFs
         run: cargo run --bin gen-pdf --features embed-typst -- --directory base
+      # PDF diffing steps are skipped for push events: base and head are the same commit
       - name: Switch to current branch
+        if: github.event_name != 'push'
         uses: actions/checkout@v7.0.1
         with:
           clean: false
       - name: Setup Rust for current branch
+        if: github.event_name != 'push'
         run: rustup toolchain install
       - name: Generate PDFs on the current branch
+        if: github.event_name != 'push'
         run: cargo run --bin gen-pdf --features embed-typst -- --directory head
       - name: Install diff-pdf
+        if: github.event_name != 'push'
         run: sudo apt-get update && sudo apt-get install -y diff-pdf-wx
       - name: Generate PDF diff summary
+        if: github.event_name != 'push'
         id: diff_summary
         uses: actions/github-script@v9
         env:


### PR DESCRIPTION
## What & why

Prevent GitHub Actions cache thrashing, i.e. useful caches being evicted by caches that are never reused:
- The PDF diff job cache was never shared between branches, causing a lot of single-use caches. This PR changes it to create a cache for main and release branches. This cache can then be read by the PR jobs.
- Also set [cancel-in-progress](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) for the PDF diff workflow, just like for the Build, lint & test workflow.
- Configure the Backend fuzzer job to only save caches for main and release branches, as the nightly toolchain bumps can also cache thrashing for that job.
- "Free up runner disk space" disk space is no longer needed, the runners already have 88G free at the start.

Screenshot showing cache full of PDF diff runs:
<img src="https://github.com/user-attachments/assets/2eff280f-4ab9-4382-ad5b-e8777b1b3816" />

## How to test

CI should pass.