### PR TITLE
Optimise Argon2 hashing

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -141,3 +141,7 @@ workspace = true
 
 [profile.release]
 overflow-checks = true
+
+# Optimising Argon2 make hashing operations ~12x faster and cuts backend test suite CPU time by ~60%
+[profile.dev.package.argon2]
+opt-level = 3

--- a/backend/src/repository/user_repo.rs
+++ b/backend/src/repository/user_repo.rs
@@ -13,6 +13,10 @@ use crate::{
 
 const MIN_UPDATE_LAST_ACTIVITY_AT_SECS: i64 = 60; // 1 minute
 
+/// Pre-computed Argon2id hash of "TotallyValidP4ssW0rd". This hash is never verified, only used in a fixture.
+#[cfg(test)]
+const TEST_USER_PASSWORD_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$ySkT+RWXZ+VGKh0wxfz9kA$aCyyi3a6ok9WaKiX5Jvacrxi9ifPxTOQ8wba40rVAbg";
+
 id!(UserId);
 
 /// User object, corresponds to a row in the users table
@@ -102,10 +106,7 @@ impl User {
             fullname: Some("Full Name".to_string()),
             role,
             needs_password_change: false,
-            password_hash: hash_password(
-                &ValidatedPassword::new("test_user_1", "TotallyValidP4ssW0rd", None).unwrap(),
-            )
-            .unwrap(),
+            password_hash: HashedPassword::from(TEST_USER_PASSWORD_HASH.to_string()),
             last_activity_at: None,
             is_logged_in: false,
             updated_at: Utc::now(),
@@ -658,11 +659,9 @@ mod tests {
             fullname: Some("Full Name".to_string()),
             role: Role::TypistGSB,
             needs_password_change: false,
-            password_hash: password::hash_password(
-                &password::ValidatedPassword::new("test_user_1", "TotallyValidP4ssW0rd", None)
-                    .unwrap(),
-            )
-            .unwrap(),
+            password_hash: password::HashedPassword::from(
+                super::TEST_USER_PASSWORD_HASH.to_string(),
+            ),
             last_activity_at: None,
             is_logged_in: false,
             updated_at: chrono::Utc::now(),


### PR DESCRIPTION
## What & why

Optimise Argon2 hashing:
- Compile the Argon2 crate with optimisations enabled ([`opt-level = 3`](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level)), speeding up hash-and-verify operations by ~12x.
- Use a pre-computed Argon2 hash for test user: the hash is never verified, only used in a fixture. This cuts a lot of useless hashing operations from the test suite, because the `test_user` function is used in many places.

Combined these changes cut CPU time for the test suite by 65% for me:

| Metric | Before | After | Δ | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Wall clock | 40.48 s | 33.05 s | −7.43 s (−18 %) | 1.22× |
| CPU | 261.18 s | 92.08 s | **−169.10 s (−65 %)** | **2.84×** |

For machines with fewer CPU cores, such as GitHub Actions runners that only have 4 cores, the wall time improvements are way bigger:

| Step | Before | After | Δ | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `cargo nextest run` | 262.7 s | 89.5 s | **−173.1 s (−66 %)** | **2.93×** |

I also noticed that using the dev homepage feels a lot faster because user logins are ~12x faster too.

## How to test

Check out locally, run the backend test suite (`cargo nextest run`) and be amazed by the speedup!