### PR TITLE
Rename coverage job ids

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ env:
   TZ: "Europe/Amsterdam"
 
 jobs:
-  backend:
+  backend-coverage:
     name: Backend coverage
     runs-on: ubuntu-latest
     defaults:
@@ -85,7 +85,7 @@ jobs:
       - name: Report disk space
         run: df -h
 
-  frontend:
+  frontend-coverage:
     name: Frontend coverage
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Get build date
         run: |
           BUILD_DATE=$(date -u +'%Y-%m-%d')
-          echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_ENV
+          echo "BUILD_DATE=$BUILD_DATE" >> "$GITHUB_ENV"
       - name: Create release directory
         run: mkdir -p release
       - name: Download abacus
@@ -186,7 +186,7 @@ jobs:
           rmdir abacus-release-windows-latest
         working-directory: release
       - name: Create a SHA256SUMS file
-        run: sha256sum -b * > SHA256SUMS
+        run: sha256sum -b -- * > SHA256SUMS
         working-directory: release
       - name: Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2


### PR DESCRIPTION
## What & why

- Rename coverage job ids to avoid cache key collisions with the backend job in the 'Build, lint & test' workflow (does not happen now, but it would if both jobs used the same Rust toolchain).
- Fix [actionlint](https://github.com/rhysd/actionlint) findings.

## How to test

CI should pass.