### PR TITLE
DataEntryStructure new DSO variants

### DIFF
--- a/backend/src/domain/results/mod.rs
+++ b/backend/src/domain/results/mod.rs
@@ -407,7 +407,8 @@ impl Validate for Results {
     ) -> Result<ValidationResults, DataError> {
         match self {
             Results::DSOFirstSession(_) | Results::DSONextSession(_) => {
-                todo!("implement in #3687")
+                // TODO: https://github.com/kiesraad/abacus/issues/3687
+                Ok(ValidationResults::default())
             }
             Results::CSOFirstSession(results) => {
                 let mut validation_results = results

--- a/frontend/src/components/data_entry/DataEntrySubsections.tsx
+++ b/frontend/src/components/data_entry/DataEntrySubsections.tsx
@@ -43,7 +43,7 @@ export function DataEntrySubsections({
                 subsection={subsection}
                 currentValues={currentValues}
                 setValues={setValues}
-                defaultProps={defaultProps}
+                errorsAndWarnings={defaultProps.errorsAndWarnings}
                 readOnly={readOnly}
               />
             );

--- a/frontend/src/components/data_entry/subsections/RadioSubsection.stories.tsx
+++ b/frontend/src/components/data_entry/subsections/RadioSubsection.stories.tsx
@@ -32,9 +32,6 @@ const meta = {
   args: {
     subsection: radioSubsection,
     currentValues: {},
-    defaultProps: {
-      errorsAndWarningsAccepted: false,
-    },
     readOnly: false,
   },
 } satisfies Meta<typeof RadioSubsectionComponent>;

--- a/frontend/src/components/data_entry/subsections/RadioSubsection.tsx
+++ b/frontend/src/components/data_entry/subsections/RadioSubsection.tsx
@@ -7,10 +7,7 @@ export interface RadioSubsectionProps {
   subsection: RadioSubsection;
   currentValues: SectionValues;
   setValues: (path: string, value: string) => void;
-  defaultProps: {
-    errorsAndWarnings?: Map<string, "error" | "warning">;
-    errorsAndWarningsAccepted: boolean;
-  };
+  errorsAndWarnings?: Map<string, "error" | "warning">;
   readOnly?: boolean;
 }
 
@@ -18,14 +15,14 @@ export function RadioSubsectionComponent({
   subsection,
   currentValues,
   setValues,
-  defaultProps,
+  errorsAndWarnings,
   readOnly = false,
 }: RadioSubsectionProps) {
   return (
     <div className={cls.container}>
       <ChoiceList>
         {subsection.title && <ChoiceList.Legend>{subsection.title}</ChoiceList.Legend>}
-        {defaultProps.errorsAndWarnings?.get(`data.${subsection.path}`) && (
+        {errorsAndWarnings?.get(`data.${subsection.path}`) && (
           <ChoiceList.Error id={`${subsection.path}-error`}>{subsection.error}</ChoiceList.Error>
         )}
         {subsection.options.map((option) => (

--- a/frontend/src/components/ui/NumberInput/NumberInput.module.css
+++ b/frontend/src/components/ui/NumberInput/NumberInput.module.css
@@ -26,7 +26,7 @@
     }
   }
 
-  [disabled] {
+  input:disabled {
     border: solid var(--bg-gray-darkest);
     background: var(--bg-gray-darker);
   }

--- a/frontend/src/components/ui/NumberInput/NumberInput.module.css
+++ b/frontend/src/components/ui/NumberInput/NumberInput.module.css
@@ -25,4 +25,9 @@
       flex-grow: 1;
     }
   }
+
+  [disabled] {
+    border: solid var(--bg-gray-darkest);
+    background: var(--bg-gray-darker);
+  }
 }

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -152,16 +152,6 @@ describe("isFormSectionEmpty", () => {
       short_title: "Boolean Test",
       subsections: [
         {
-          type: "radio",
-          short_title: "Radio Test",
-          error: "Radio error",
-          path: "test.radio_field",
-          options: [
-            { value: "true", label: "Yes", short_label: "Yes" },
-            { value: "false", label: "No", short_label: "No" },
-          ],
-        },
-        {
           type: "checkboxes",
           short_title: "Checkbox Test",
           error_path: "test.checkbox_error",
@@ -177,7 +167,6 @@ describe("isFormSectionEmpty", () => {
     const valuesWithFalse = {
       ...getInitialValues(),
       test: {
-        radio_field: false,
         checkbox_field: false,
       },
     };
@@ -188,12 +177,50 @@ describe("isFormSectionEmpty", () => {
     const valuesWithTrue = {
       ...getInitialValues(),
       test: {
-        radio_field: true,
-        checkbox_field: false,
+        checkbox_field: true,
       },
     };
 
     expect(isFormSectionEmpty([booleanSection], section, valuesWithTrue)).toBeFalsy();
+  });
+
+  test("radio fields with empty value are considered null", () => {
+    const radioSection: DataEntrySection = {
+      id: "radio_test",
+      title: "Radio Test Section",
+      short_title: "Radio Test",
+      subsections: [
+        {
+          type: "radio",
+          short_title: "Radio Test",
+          error: "Radio error",
+          path: "test.radio_field",
+          options: [{ label: "Radio", short_label: "Radio", value: "OptionA" }],
+        },
+      ],
+    };
+
+    const section = getDefaultFormSection("radio_test", 0);
+
+    // Test with empty values - should be considered null
+    const data = {
+      ...getInitialValues(),
+      test: {
+        radio_field: "",
+      },
+    };
+
+    expect(isFormSectionEmpty([radioSection], section, data)).toBeTruthy();
+
+    // Test with a non-empty value - should be considered non-empty
+    const valuesWithTrue = {
+      ...getInitialValues(),
+      test: {
+        radio_field: "OptionA",
+      },
+    };
+
+    expect(isFormSectionEmpty([radioSection], section, valuesWithTrue)).toBeFalsy();
   });
 });
 

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -65,6 +65,11 @@ export function isFormSectionEmpty(
           return false;
         }
         break;
+      case "enum":
+        if (value !== null && value !== "") {
+          return false;
+        }
+        break;
     }
   }
 

--- a/frontend/src/i18n/locales/nl/about_report.json
+++ b/frontend/src/i18n/locales/nl/about_report.json
@@ -1,0 +1,17 @@
+{
+  "form_title": "Over het proces-verbaal",
+  "short_title": "Over het proces-verbaal",
+  "validation_error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+  "corrigendum_present": {
+    "title": "Is er een <strong>corrigendum</strong> bij het papieren proces-verbaal aanwezig?",
+    "short_title": "Corrigendum aanwezig?",
+    "one_document": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+    "two_documents": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)"
+  },
+  "checks_and_corrections_present": {
+    "title": "Is voorin het proces-verbaal de extra pagina <strong>controles en correcties</strong> ingevoegd?",
+    "short_title": "Extra pagina controles en correcties aanwezig?",
+    "page_present": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+    "page_missing": "Nee, de pagina ontbreekt"
+  }
+}

--- a/frontend/src/i18n/locales/nl/about_report.json
+++ b/frontend/src/i18n/locales/nl/about_report.json
@@ -6,7 +6,9 @@
     "title": "Is er een <strong>corrigendum</strong> bij het papieren proces-verbaal aanwezig?",
     "short_title": "Corrigendum aanwezig?",
     "one_document": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
-    "two_documents": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)"
+    "one_document_short": "Nee, alleen een proces-verbaal",
+    "two_documents": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+    "two_documents_short": "Ja, een proces-verbaal en een corrigendum"
   },
   "checks_and_corrections_present": {
     "title": "Is voorin het proces-verbaal de extra pagina <strong>controles en correcties</strong> ingevoegd?",

--- a/frontend/src/i18n/locales/nl/checks_and_corrections.json
+++ b/frontend/src/i18n/locales/nl/checks_and_corrections.json
@@ -1,0 +1,26 @@
+{
+  "form_title": "Controles en correcties",
+  "form_description": "Neem de vinkjes over zoals ze op het papieren formulier zijn gezet.",
+  "short_title": "Controles en correcties",
+  "validation_error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+  "own_initiative": "Op eigen initiatief van het gemeentelijk stembureau",
+  "reason_investigation_own_initiative": {
+    "title": "Waarom heeft het gemeentelijk stembureau de telresultaten onderzocht?",
+    "short_title": "Waarom heeft het GSB de telresultaten onderzocht?",
+    "unaccounted_difference": "Vanwege een onverklaard verschil",
+    "other_error": "Vanwege (het vermoeden van) een andere fout"
+  },
+  "corrected_results_own_initiative": {
+    "title": "Zijn er gecorrigeerde telresultaten?",
+    "short_title": "Zijn er gecorrigeerde telresultaten?",
+    "no": "Nee, de oorspronkelijke telresultaten waren correct",
+    "yes": "Ja, er zijn gecorrigeerde telresultaten"
+  },
+  "corrected_results_csb_request": {
+    "title": "Zijn er gecorrigeerde telresultaten?",
+    "short_title": "Zijn er gecorrigeerde telresultaten?",
+    "no": "Nee, de oorspronkelijke telresultaten waren correct",
+    "yes": "Ja, er zijn gecorrigeerde telresultaten"
+  },
+  "csb_request": "Op verzoek van het centraal stembureau"
+}

--- a/frontend/src/i18n/locales/nl/nl.ts
+++ b/frontend/src/i18n/locales/nl/nl.ts
@@ -1,9 +1,11 @@
+import about_report from "./about_report.json";
 import account from "./account.json";
 import apportionment from "./apportionment.json";
 import backups from "./backups.json";
 import candidate from "./candidate.json";
 import candidates_votes from "./candidates_votes.json";
 import check_and_save from "./check_and_save.json";
+import checks_and_corrections from "./checks_and_corrections.json";
 import committee_category from "./committee_category.json";
 import committee_session_status from "./committee_session_status.json";
 import counting_differences_polling_station from "./counting_differences_polling_station.json";
@@ -37,11 +39,13 @@ import voters_votes_counts from "./voters_votes_counts.json";
 
 const nl = {
   ...generic,
+  about_report,
   account,
   apportionment,
   candidate,
   candidates_votes,
   check_and_save,
+  checks_and_corrections,
   committee_category,
   committee_session_status,
   counting_differences_polling_station,

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -20,9 +20,9 @@ export interface MessageSubsection {
 }
 
 export interface RadioSubsectionOption {
-  value: "true" | "false";
+  value: string;
   /** Label for data entry form view */
-  label: string;
+  label: string | ReactElement;
   /** Short label for differences view */
   short_label: string;
   autoFocusInput?: boolean;
@@ -31,8 +31,8 @@ export interface RadioSubsectionOption {
 export interface RadioSubsection {
   type: "radio";
   /** Title to display above the radio buttons */
-  title?: string;
-  /** Description to display above the checkboxes */
+  title?: string | ReactElement;
+  /** Description to display above the radio buttons */
   description?: string;
   /** Short title for differences view */
   short_title: string;

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Municipal.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Municipal.snap
@@ -1,1 +1,467 @@
-[]
+[
+  {
+    "id": "voters_votes_counts",
+    "sectionNumber": "2.1 en 2.2",
+    "short_title": "Aantal kiezers en stemmen",
+    "subsections": [
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": true,
+            "code": "Z",
+            "path": "number_of_voters",
+            "title": "Kiesgerechtigden",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
+        "type": "message",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": false,
+            "code": "A",
+            "path": "voters_counts.poll_card_count",
+            "title": "Stempassen",
+          },
+          {
+            "code": "B",
+            "path": "voters_counts.proxy_certificate_count",
+            "title": "Volmachtbewijzen",
+          },
+          {
+            "addSeparator": true,
+            "code": "C",
+            "isDisabled": true,
+            "path": "voters_counts.voter_card_count",
+            "title": "Kiezerspassen",
+          },
+          {
+            "addSeparator": true,
+            "code": "D",
+            "isTotal": true,
+            "path": "voters_counts.total_admitted_voters_count",
+            "title": "Totaal toegelaten kiezers",
+          },
+          {
+            "addSeparator": false,
+            "code": "E.1",
+            "path": "votes_counts.political_group_total_votes.0.total",
+            "title": "Totaal Lijst 1 – Vurige Vleugels Partij",
+          },
+          {
+            "addSeparator": true,
+            "code": "E.2",
+            "path": "votes_counts.political_group_total_votes.1.total",
+            "title": "Totaal Lijst 2 – Wijzen van Water en Wind",
+          },
+          {
+            "code": "E",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_candidates_count",
+            "title": "Totaal stemmen op kandidaten",
+          },
+          {
+            "code": "F",
+            "path": "votes_counts.blank_votes_count",
+            "title": "Blanco stemmen",
+          },
+          {
+            "addSeparator": true,
+            "code": "G",
+            "path": "votes_counts.invalid_votes_count",
+            "title": "Ongeldige stemmen",
+          },
+          {
+            "code": "H",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_cast_count",
+            "title": "Totaal uitgebrachte stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+    ],
+    "title": "Toegelaten kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "differences_counts",
+    "sectionNumber": "2.3",
+    "short_title": "Verschillen D & H",
+    "subsections": [
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.compare_votes_cast_admitted_voters",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "D en H zijn gelijk",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+            "short_label": "D en H zijn gelijk",
+          },
+          {
+            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+            "short_label": "H is groter dan D",
+          },
+          {
+            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+            "short_label": "H is kleiner dan D",
+          },
+        ],
+        "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.1
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "code": "I",
+            "path": "differences_counts.more_ballots_count",
+            "title": "Aantal méér getelde stemmen",
+          },
+          {
+            "code": "J",
+            "path": "differences_counts.fewer_ballots_count",
+            "title": "Aantal minder getelde stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.difference_completely_accounted_for",
+        "options": [
+          {
+            "label": "Ja",
+            "path": "differences_counts.difference_completely_accounted_for.yes",
+            "short_label": "Ja",
+          },
+          {
+            "label": "Nee, er is een onverklaard verschil",
+            "path": "differences_counts.difference_completely_accounted_for.no",
+            "short_label": "Nee, er is een onverklaard verschil",
+          },
+        ],
+        "short_title": "Verschil tussen D en H volledig verklaard?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.2
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                volledig
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             verklaren?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "political_group_votes_1",
+    "short_title": "Lijst 1 – Vurige Vleugels Partij",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.0.candidate_votes.0.votes",
+            "title": "Zilverlicht, E. (Eldor)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.0.candidate_votes.1.votes",
+            "title": "Donderbrul, G. (Grom)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "3",
+            "path": "political_group_votes.0.candidate_votes.2.votes",
+            "title": "Fluisterwind, S. (Seraphina)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "4",
+            "path": "political_group_votes.0.candidate_votes.3.votes",
+            "title": "Nachtschaduw, V. (Vesper)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "5",
+            "path": "political_group_votes.0.candidate_votes.4.votes",
+            "title": "Stormvleugel, R. (Ravian)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "6",
+            "path": "political_group_votes.0.candidate_votes.5.votes",
+            "title": "Sterrenzwerver, M. (Mirella)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "7",
+            "path": "political_group_votes.0.candidate_votes.6.votes",
+            "title": "Maanfluisteraar, X. (Xander)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "8",
+            "path": "political_group_votes.0.candidate_votes.7.votes",
+            "title": "Windzanger, P. (Paxton)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "9",
+            "path": "political_group_votes.0.candidate_votes.8.votes",
+            "title": "Vuurvlinder, F. (Faelia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "10",
+            "path": "political_group_votes.0.candidate_votes.9.votes",
+            "title": "Rotsbreker, H. (Helga)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "11",
+            "path": "political_group_votes.0.candidate_votes.10.votes",
+            "title": "Zonnewende, L. (Luna)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "12",
+            "path": "political_group_votes.0.candidate_votes.11.votes",
+            "title": "Groenhart, T. (Timo)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "13",
+            "path": "political_group_votes.0.candidate_votes.12.votes",
+            "title": "Veldbloem, N. (Naima)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "14",
+            "path": "political_group_votes.0.candidate_votes.13.votes",
+            "title": "IJzeren, V. (Vincent)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "15",
+            "path": "political_group_votes.0.candidate_votes.14.votes",
+            "title": "Blauwhof, P. (Priya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "16",
+            "path": "political_group_votes.0.candidate_votes.15.votes",
+            "title": "Windmaker, J. (Jamal)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "17",
+            "path": "political_group_votes.0.candidate_votes.16.votes",
+            "title": "Sterrenveld, E. (Esmée)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "18",
+            "path": "political_group_votes.0.candidate_votes.17.votes",
+            "title": "Roodman, M. (Mohammed)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "19",
+            "path": "political_group_votes.0.candidate_votes.18.votes",
+            "title": "Zilverberg, C. (Chen)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "20",
+            "path": "political_group_votes.0.candidate_votes.19.votes",
+            "title": "Duinwalker, S. (Soraya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "21",
+            "path": "political_group_votes.0.candidate_votes.20.votes",
+            "title": "Lichtveld, A. (Alex)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "22",
+            "path": "political_group_votes.0.candidate_votes.21.votes",
+            "title": "Kruidentuin, H. (Habiba)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "23",
+            "path": "political_group_votes.0.candidate_votes.22.votes",
+            "title": "Vlietstra, B. (Bram)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "24",
+            "path": "political_group_votes.0.candidate_votes.23.votes",
+            "title": "Meermin, K. (Kai)",
+          },
+          {
+            "addSeparator": true,
+            "autoFocusInput": false,
+            "code": "25",
+            "path": "political_group_votes.0.candidate_votes.24.votes",
+            "title": "Goudappel, D. (Diana)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "26",
+            "path": "political_group_votes.0.candidate_votes.25.votes",
+            "title": "Bosrank, F. (Finn)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "27",
+            "path": "political_group_votes.0.candidate_votes.26.votes",
+            "title": "Sterrenveld, J. (Julia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "28",
+            "path": "political_group_votes.0.candidate_votes.27.votes",
+            "title": "Regenboog, G. (Giovanni)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "29",
+            "path": "political_group_votes.0.candidate_votes.28.votes",
+            "title": "Hemelrijk, M. (Milan)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.0.total",
+            "title": "Totaal lijst 1",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 1 – Vurige Vleugels Partij",
+  },
+  {
+    "id": "political_group_votes_2",
+    "short_title": "Lijst 2 – Wijzen van Water en Wind",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.1.candidate_votes.0.votes",
+            "title": "Foo, A. (Alice)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.1.candidate_votes.1.votes",
+            "title": "Doe, C. (Charlie)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.1.total",
+            "title": "Totaal lijst 2",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 2 – Wijzen van Water en Wind",
+  },
+]

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Municipal.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Municipal.snap
@@ -1,5 +1,183 @@
 [
   {
+    "id": "about_report",
+    "short_title": "Over het proces-verbaal",
+    "subsections": [
+      {
+        "error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "options": [
+          {
+            "label": <React.Fragment>
+              <React.Fragment>
+                Ja, ik heb 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    twee documenten
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 (een proces-verbaal en een corrigendum)
+              </React.Fragment>
+            </React.Fragment>,
+            "short_label": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+            "value": "TwoDocuments",
+          },
+          {
+            "label": <React.Fragment>
+              <React.Fragment>
+                Nee, ik heb 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    één document
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 (alleen een proces-verbaal)
+              </React.Fragment>
+            </React.Fragment>,
+            "short_label": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+            "value": "OneDocument",
+          },
+        ],
+        "path": "about_report.corrigendum_present",
+        "short_title": "Corrigendum aanwezig?",
+        "title": <React.Fragment>
+          <React.Fragment>
+            Is er een 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                corrigendum
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             bij het papieren proces-verbaal aanwezig?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "radio",
+      },
+      {
+        "error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "options": [
+          {
+            "label": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+            "short_label": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+            "value": "PagePresent",
+          },
+          {
+            "label": "Nee, de pagina ontbreekt",
+            "short_label": "Nee, de pagina ontbreekt",
+            "value": "PageMissing",
+          },
+        ],
+        "path": "about_report.checks_and_corrections_present",
+        "short_title": "Extra pagina controles en correcties aanwezig?",
+        "title": <React.Fragment>
+          <React.Fragment>
+            Is voorin het proces-verbaal de extra pagina 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                controles en correcties
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             ingevoegd?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "radio",
+      },
+    ],
+    "title": "Over het proces-verbaal",
+  },
+  {
+    "id": "checks_and_corrections",
+    "short_title": "Controles en correcties",
+    "subsections": [
+      {
+        "message": "Neem de vinkjes over zoals ze op het papieren formulier zijn gezet.",
+        "type": "message",
+      },
+      {
+        "title": "Op eigen initiatief van het gemeentelijk stembureau",
+        "type": "heading",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.reason_investigation_own_initiative",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "Vanwege een onverklaard verschil",
+            "path": "checks_and_corrections.reason_investigation_own_initiative.unaccounted_difference",
+            "short_label": "Vanwege een onverklaard verschil",
+          },
+          {
+            "label": "Vanwege (het vermoeden van) een andere fout",
+            "path": "checks_and_corrections.reason_investigation_own_initiative.other_error",
+            "short_label": "Vanwege (het vermoeden van) een andere fout",
+          },
+        ],
+        "short_title": "Waarom heeft het GSB de telresultaten onderzocht?",
+        "title": "Waarom heeft het gemeentelijk stembureau de telresultaten onderzocht?",
+        "type": "checkboxes",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.corrected_results_own_initiative",
+        "options": [
+          {
+            "label": "Nee, de oorspronkelijke telresultaten waren correct",
+            "path": "checks_and_corrections.corrected_results_own_initiative.no",
+            "short_label": "Nee, de oorspronkelijke telresultaten waren correct",
+          },
+          {
+            "label": "Ja, er zijn gecorrigeerde telresultaten",
+            "path": "checks_and_corrections.corrected_results_own_initiative.yes",
+            "short_label": "Ja, er zijn gecorrigeerde telresultaten",
+          },
+        ],
+        "short_title": "Zijn er gecorrigeerde telresultaten?",
+        "title": "Zijn er gecorrigeerde telresultaten?",
+        "type": "checkboxes",
+      },
+      {
+        "title": "Op verzoek van het centraal stembureau",
+        "type": "heading",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.corrected_results_csb_request",
+        "options": [
+          {
+            "label": "Nee, de oorspronkelijke telresultaten waren correct",
+            "path": "checks_and_corrections.corrected_results_csb_request.no",
+            "short_label": "Nee, de oorspronkelijke telresultaten waren correct",
+          },
+          {
+            "label": "Ja, er zijn gecorrigeerde telresultaten",
+            "path": "checks_and_corrections.corrected_results_csb_request.yes",
+            "short_label": "Ja, er zijn gecorrigeerde telresultaten",
+          },
+        ],
+        "short_title": "Zijn er gecorrigeerde telresultaten?",
+        "title": "Zijn er gecorrigeerde telresultaten?",
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Controles en correcties",
+  },
+  {
     "id": "voters_votes_counts",
     "sectionNumber": "2.1 en 2.2",
     "short_title": "Aantal kiezers en stemmen",
@@ -13,26 +191,6 @@
         "rows": [
           {
             "autoFocusInput": true,
-            "code": "Z",
-            "path": "number_of_voters",
-            "title": "Kiesgerechtigden",
-          },
-        ],
-        "type": "inputGrid",
-      },
-      {
-        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
-        "type": "message",
-      },
-      {
-        "headers": [
-          "Veld",
-          "Geteld aantal",
-          "Omschrijving",
-        ],
-        "rows": [
-          {
-            "autoFocusInput": false,
             "code": "A",
             "path": "voters_counts.poll_card_count",
             "title": "Stempassen",
@@ -108,17 +266,56 @@
         "options": [
           {
             "autoFocusInput": true,
-            "label": "D en H zijn gelijk",
+            "label": <React.Fragment>
+              <React.Fragment>
+                D en H zijn 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    gelijk
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
             "short_label": "D en H zijn gelijk",
           },
           {
-            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    groter
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (meer uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
             "short_label": "H is groter dan D",
           },
           {
-            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    kleiner
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (minder uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
             "short_label": "H is kleiner dan D",
           },

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Municipal.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Municipal.snap
@@ -22,7 +22,7 @@
                  (een proces-verbaal en een corrigendum)
               </React.Fragment>
             </React.Fragment>,
-            "short_label": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+            "short_label": "Ja, een proces-verbaal en een corrigendum",
             "value": "TwoDocuments",
           },
           {
@@ -41,7 +41,7 @@
                  (alleen een proces-verbaal)
               </React.Fragment>
             </React.Fragment>,
-            "short_label": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+            "short_label": "Nee, alleen een proces-verbaal",
             "value": "OneDocument",
           },
         ],

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Provincial.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Provincial.snap
@@ -1,5 +1,183 @@
 [
   {
+    "id": "about_report",
+    "short_title": "Over het proces-verbaal",
+    "subsections": [
+      {
+        "error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "options": [
+          {
+            "label": <React.Fragment>
+              <React.Fragment>
+                Ja, ik heb 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    twee documenten
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 (een proces-verbaal en een corrigendum)
+              </React.Fragment>
+            </React.Fragment>,
+            "short_label": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+            "value": "TwoDocuments",
+          },
+          {
+            "label": <React.Fragment>
+              <React.Fragment>
+                Nee, ik heb 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    één document
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 (alleen een proces-verbaal)
+              </React.Fragment>
+            </React.Fragment>,
+            "short_label": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+            "value": "OneDocument",
+          },
+        ],
+        "path": "about_report.corrigendum_present",
+        "short_title": "Corrigendum aanwezig?",
+        "title": <React.Fragment>
+          <React.Fragment>
+            Is er een 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                corrigendum
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             bij het papieren proces-verbaal aanwezig?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "radio",
+      },
+      {
+        "error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "options": [
+          {
+            "label": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+            "short_label": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+            "value": "PagePresent",
+          },
+          {
+            "label": "Nee, de pagina ontbreekt",
+            "short_label": "Nee, de pagina ontbreekt",
+            "value": "PageMissing",
+          },
+        ],
+        "path": "about_report.checks_and_corrections_present",
+        "short_title": "Extra pagina controles en correcties aanwezig?",
+        "title": <React.Fragment>
+          <React.Fragment>
+            Is voorin het proces-verbaal de extra pagina 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                controles en correcties
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             ingevoegd?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "radio",
+      },
+    ],
+    "title": "Over het proces-verbaal",
+  },
+  {
+    "id": "checks_and_corrections",
+    "short_title": "Controles en correcties",
+    "subsections": [
+      {
+        "message": "Neem de vinkjes over zoals ze op het papieren formulier zijn gezet.",
+        "type": "message",
+      },
+      {
+        "title": "Op eigen initiatief van het gemeentelijk stembureau",
+        "type": "heading",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.reason_investigation_own_initiative",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "Vanwege een onverklaard verschil",
+            "path": "checks_and_corrections.reason_investigation_own_initiative.unaccounted_difference",
+            "short_label": "Vanwege een onverklaard verschil",
+          },
+          {
+            "label": "Vanwege (het vermoeden van) een andere fout",
+            "path": "checks_and_corrections.reason_investigation_own_initiative.other_error",
+            "short_label": "Vanwege (het vermoeden van) een andere fout",
+          },
+        ],
+        "short_title": "Waarom heeft het GSB de telresultaten onderzocht?",
+        "title": "Waarom heeft het gemeentelijk stembureau de telresultaten onderzocht?",
+        "type": "checkboxes",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.corrected_results_own_initiative",
+        "options": [
+          {
+            "label": "Nee, de oorspronkelijke telresultaten waren correct",
+            "path": "checks_and_corrections.corrected_results_own_initiative.no",
+            "short_label": "Nee, de oorspronkelijke telresultaten waren correct",
+          },
+          {
+            "label": "Ja, er zijn gecorrigeerde telresultaten",
+            "path": "checks_and_corrections.corrected_results_own_initiative.yes",
+            "short_label": "Ja, er zijn gecorrigeerde telresultaten",
+          },
+        ],
+        "short_title": "Zijn er gecorrigeerde telresultaten?",
+        "title": "Zijn er gecorrigeerde telresultaten?",
+        "type": "checkboxes",
+      },
+      {
+        "title": "Op verzoek van het centraal stembureau",
+        "type": "heading",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.corrected_results_csb_request",
+        "options": [
+          {
+            "label": "Nee, de oorspronkelijke telresultaten waren correct",
+            "path": "checks_and_corrections.corrected_results_csb_request.no",
+            "short_label": "Nee, de oorspronkelijke telresultaten waren correct",
+          },
+          {
+            "label": "Ja, er zijn gecorrigeerde telresultaten",
+            "path": "checks_and_corrections.corrected_results_csb_request.yes",
+            "short_label": "Ja, er zijn gecorrigeerde telresultaten",
+          },
+        ],
+        "short_title": "Zijn er gecorrigeerde telresultaten?",
+        "title": "Zijn er gecorrigeerde telresultaten?",
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Controles en correcties",
+  },
+  {
     "id": "voters_votes_counts",
     "sectionNumber": "2.1 en 2.2",
     "short_title": "Aantal kiezers en stemmen",
@@ -13,26 +191,6 @@
         "rows": [
           {
             "autoFocusInput": true,
-            "code": "Z",
-            "path": "number_of_voters",
-            "title": "Kiesgerechtigden",
-          },
-        ],
-        "type": "inputGrid",
-      },
-      {
-        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
-        "type": "message",
-      },
-      {
-        "headers": [
-          "Veld",
-          "Geteld aantal",
-          "Omschrijving",
-        ],
-        "rows": [
-          {
-            "autoFocusInput": false,
             "code": "A",
             "path": "voters_counts.poll_card_count",
             "title": "Stempassen",
@@ -108,17 +266,56 @@
         "options": [
           {
             "autoFocusInput": true,
-            "label": "D en H zijn gelijk",
+            "label": <React.Fragment>
+              <React.Fragment>
+                D en H zijn 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    gelijk
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
             "short_label": "D en H zijn gelijk",
           },
           {
-            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    groter
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (meer uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
             "short_label": "H is groter dan D",
           },
           {
-            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    kleiner
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (minder uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
             "short_label": "H is kleiner dan D",
           },

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Provincial.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Provincial.snap
@@ -1,1 +1,467 @@
-[]
+[
+  {
+    "id": "voters_votes_counts",
+    "sectionNumber": "2.1 en 2.2",
+    "short_title": "Aantal kiezers en stemmen",
+    "subsections": [
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": true,
+            "code": "Z",
+            "path": "number_of_voters",
+            "title": "Kiesgerechtigden",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
+        "type": "message",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": false,
+            "code": "A",
+            "path": "voters_counts.poll_card_count",
+            "title": "Stempassen",
+          },
+          {
+            "code": "B",
+            "path": "voters_counts.proxy_certificate_count",
+            "title": "Volmachtbewijzen",
+          },
+          {
+            "addSeparator": true,
+            "code": "C",
+            "isDisabled": false,
+            "path": "voters_counts.voter_card_count",
+            "title": "Kiezerspassen",
+          },
+          {
+            "addSeparator": true,
+            "code": "D",
+            "isTotal": true,
+            "path": "voters_counts.total_admitted_voters_count",
+            "title": "Totaal toegelaten kiezers",
+          },
+          {
+            "addSeparator": false,
+            "code": "E.1",
+            "path": "votes_counts.political_group_total_votes.0.total",
+            "title": "Totaal Lijst 1 – Vurige Vleugels Partij",
+          },
+          {
+            "addSeparator": true,
+            "code": "E.2",
+            "path": "votes_counts.political_group_total_votes.1.total",
+            "title": "Totaal Lijst 2 – Wijzen van Water en Wind",
+          },
+          {
+            "code": "E",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_candidates_count",
+            "title": "Totaal stemmen op kandidaten",
+          },
+          {
+            "code": "F",
+            "path": "votes_counts.blank_votes_count",
+            "title": "Blanco stemmen",
+          },
+          {
+            "addSeparator": true,
+            "code": "G",
+            "path": "votes_counts.invalid_votes_count",
+            "title": "Ongeldige stemmen",
+          },
+          {
+            "code": "H",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_cast_count",
+            "title": "Totaal uitgebrachte stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+    ],
+    "title": "Toegelaten kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "differences_counts",
+    "sectionNumber": "2.3",
+    "short_title": "Verschillen D & H",
+    "subsections": [
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.compare_votes_cast_admitted_voters",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "D en H zijn gelijk",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+            "short_label": "D en H zijn gelijk",
+          },
+          {
+            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+            "short_label": "H is groter dan D",
+          },
+          {
+            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+            "short_label": "H is kleiner dan D",
+          },
+        ],
+        "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.1
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "code": "I",
+            "path": "differences_counts.more_ballots_count",
+            "title": "Aantal méér getelde stemmen",
+          },
+          {
+            "code": "J",
+            "path": "differences_counts.fewer_ballots_count",
+            "title": "Aantal minder getelde stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.difference_completely_accounted_for",
+        "options": [
+          {
+            "label": "Ja",
+            "path": "differences_counts.difference_completely_accounted_for.yes",
+            "short_label": "Ja",
+          },
+          {
+            "label": "Nee, er is een onverklaard verschil",
+            "path": "differences_counts.difference_completely_accounted_for.no",
+            "short_label": "Nee, er is een onverklaard verschil",
+          },
+        ],
+        "short_title": "Verschil tussen D en H volledig verklaard?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.2
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                volledig
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             verklaren?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "political_group_votes_1",
+    "short_title": "Lijst 1 – Vurige Vleugels Partij",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.0.candidate_votes.0.votes",
+            "title": "Zilverlicht, E. (Eldor)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.0.candidate_votes.1.votes",
+            "title": "Donderbrul, G. (Grom)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "3",
+            "path": "political_group_votes.0.candidate_votes.2.votes",
+            "title": "Fluisterwind, S. (Seraphina)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "4",
+            "path": "political_group_votes.0.candidate_votes.3.votes",
+            "title": "Nachtschaduw, V. (Vesper)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "5",
+            "path": "political_group_votes.0.candidate_votes.4.votes",
+            "title": "Stormvleugel, R. (Ravian)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "6",
+            "path": "political_group_votes.0.candidate_votes.5.votes",
+            "title": "Sterrenzwerver, M. (Mirella)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "7",
+            "path": "political_group_votes.0.candidate_votes.6.votes",
+            "title": "Maanfluisteraar, X. (Xander)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "8",
+            "path": "political_group_votes.0.candidate_votes.7.votes",
+            "title": "Windzanger, P. (Paxton)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "9",
+            "path": "political_group_votes.0.candidate_votes.8.votes",
+            "title": "Vuurvlinder, F. (Faelia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "10",
+            "path": "political_group_votes.0.candidate_votes.9.votes",
+            "title": "Rotsbreker, H. (Helga)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "11",
+            "path": "political_group_votes.0.candidate_votes.10.votes",
+            "title": "Zonnewende, L. (Luna)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "12",
+            "path": "political_group_votes.0.candidate_votes.11.votes",
+            "title": "Groenhart, T. (Timo)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "13",
+            "path": "political_group_votes.0.candidate_votes.12.votes",
+            "title": "Veldbloem, N. (Naima)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "14",
+            "path": "political_group_votes.0.candidate_votes.13.votes",
+            "title": "IJzeren, V. (Vincent)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "15",
+            "path": "political_group_votes.0.candidate_votes.14.votes",
+            "title": "Blauwhof, P. (Priya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "16",
+            "path": "political_group_votes.0.candidate_votes.15.votes",
+            "title": "Windmaker, J. (Jamal)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "17",
+            "path": "political_group_votes.0.candidate_votes.16.votes",
+            "title": "Sterrenveld, E. (Esmée)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "18",
+            "path": "political_group_votes.0.candidate_votes.17.votes",
+            "title": "Roodman, M. (Mohammed)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "19",
+            "path": "political_group_votes.0.candidate_votes.18.votes",
+            "title": "Zilverberg, C. (Chen)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "20",
+            "path": "political_group_votes.0.candidate_votes.19.votes",
+            "title": "Duinwalker, S. (Soraya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "21",
+            "path": "political_group_votes.0.candidate_votes.20.votes",
+            "title": "Lichtveld, A. (Alex)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "22",
+            "path": "political_group_votes.0.candidate_votes.21.votes",
+            "title": "Kruidentuin, H. (Habiba)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "23",
+            "path": "political_group_votes.0.candidate_votes.22.votes",
+            "title": "Vlietstra, B. (Bram)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "24",
+            "path": "political_group_votes.0.candidate_votes.23.votes",
+            "title": "Meermin, K. (Kai)",
+          },
+          {
+            "addSeparator": true,
+            "autoFocusInput": false,
+            "code": "25",
+            "path": "political_group_votes.0.candidate_votes.24.votes",
+            "title": "Goudappel, D. (Diana)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "26",
+            "path": "political_group_votes.0.candidate_votes.25.votes",
+            "title": "Bosrank, F. (Finn)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "27",
+            "path": "political_group_votes.0.candidate_votes.26.votes",
+            "title": "Sterrenveld, J. (Julia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "28",
+            "path": "political_group_votes.0.candidate_votes.27.votes",
+            "title": "Regenboog, G. (Giovanni)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "29",
+            "path": "political_group_votes.0.candidate_votes.28.votes",
+            "title": "Hemelrijk, M. (Milan)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.0.total",
+            "title": "Totaal lijst 1",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 1 – Vurige Vleugels Partij",
+  },
+  {
+    "id": "political_group_votes_2",
+    "short_title": "Lijst 2 – Wijzen van Water en Wind",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.1.candidate_votes.0.votes",
+            "title": "Foo, A. (Alice)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.1.candidate_votes.1.votes",
+            "title": "Doe, C. (Charlie)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.1.total",
+            "title": "Totaal lijst 2",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 2 – Wijzen van Water en Wind",
+  },
+]

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Provincial.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.Provincial.snap
@@ -22,7 +22,7 @@
                  (een proces-verbaal en een corrigendum)
               </React.Fragment>
             </React.Fragment>,
-            "short_label": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+            "short_label": "Ja, een proces-verbaal en een corrigendum",
             "value": "TwoDocuments",
           },
           {
@@ -41,7 +41,7 @@
                  (alleen een proces-verbaal)
               </React.Fragment>
             </React.Fragment>,
-            "short_label": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+            "short_label": "Nee, alleen een proces-verbaal",
             "value": "OneDocument",
           },
         ],

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.WaterAuthority.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.WaterAuthority.snap
@@ -1,5 +1,183 @@
 [
   {
+    "id": "about_report",
+    "short_title": "Over het proces-verbaal",
+    "subsections": [
+      {
+        "error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "options": [
+          {
+            "label": <React.Fragment>
+              <React.Fragment>
+                Ja, ik heb 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    twee documenten
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 (een proces-verbaal en een corrigendum)
+              </React.Fragment>
+            </React.Fragment>,
+            "short_label": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+            "value": "TwoDocuments",
+          },
+          {
+            "label": <React.Fragment>
+              <React.Fragment>
+                Nee, ik heb 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    één document
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 (alleen een proces-verbaal)
+              </React.Fragment>
+            </React.Fragment>,
+            "short_label": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+            "value": "OneDocument",
+          },
+        ],
+        "path": "about_report.corrigendum_present",
+        "short_title": "Corrigendum aanwezig?",
+        "title": <React.Fragment>
+          <React.Fragment>
+            Is er een 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                corrigendum
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             bij het papieren proces-verbaal aanwezig?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "radio",
+      },
+      {
+        "error": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "options": [
+          {
+            "label": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+            "short_label": "Ja, de pagina ‘controles en correcties’ is aanwezig",
+            "value": "PagePresent",
+          },
+          {
+            "label": "Nee, de pagina ontbreekt",
+            "short_label": "Nee, de pagina ontbreekt",
+            "value": "PageMissing",
+          },
+        ],
+        "path": "about_report.checks_and_corrections_present",
+        "short_title": "Extra pagina controles en correcties aanwezig?",
+        "title": <React.Fragment>
+          <React.Fragment>
+            Is voorin het proces-verbaal de extra pagina 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                controles en correcties
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             ingevoegd?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "radio",
+      },
+    ],
+    "title": "Over het proces-verbaal",
+  },
+  {
+    "id": "checks_and_corrections",
+    "short_title": "Controles en correcties",
+    "subsections": [
+      {
+        "message": "Neem de vinkjes over zoals ze op het papieren formulier zijn gezet.",
+        "type": "message",
+      },
+      {
+        "title": "Op eigen initiatief van het gemeentelijk stembureau",
+        "type": "heading",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.reason_investigation_own_initiative",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "Vanwege een onverklaard verschil",
+            "path": "checks_and_corrections.reason_investigation_own_initiative.unaccounted_difference",
+            "short_label": "Vanwege een onverklaard verschil",
+          },
+          {
+            "label": "Vanwege (het vermoeden van) een andere fout",
+            "path": "checks_and_corrections.reason_investigation_own_initiative.other_error",
+            "short_label": "Vanwege (het vermoeden van) een andere fout",
+          },
+        ],
+        "short_title": "Waarom heeft het GSB de telresultaten onderzocht?",
+        "title": "Waarom heeft het gemeentelijk stembureau de telresultaten onderzocht?",
+        "type": "checkboxes",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.corrected_results_own_initiative",
+        "options": [
+          {
+            "label": "Nee, de oorspronkelijke telresultaten waren correct",
+            "path": "checks_and_corrections.corrected_results_own_initiative.no",
+            "short_label": "Nee, de oorspronkelijke telresultaten waren correct",
+          },
+          {
+            "label": "Ja, er zijn gecorrigeerde telresultaten",
+            "path": "checks_and_corrections.corrected_results_own_initiative.yes",
+            "short_label": "Ja, er zijn gecorrigeerde telresultaten",
+          },
+        ],
+        "short_title": "Zijn er gecorrigeerde telresultaten?",
+        "title": "Zijn er gecorrigeerde telresultaten?",
+        "type": "checkboxes",
+      },
+      {
+        "title": "Op verzoek van het centraal stembureau",
+        "type": "heading",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "checks_and_corrections.corrected_results_csb_request",
+        "options": [
+          {
+            "label": "Nee, de oorspronkelijke telresultaten waren correct",
+            "path": "checks_and_corrections.corrected_results_csb_request.no",
+            "short_label": "Nee, de oorspronkelijke telresultaten waren correct",
+          },
+          {
+            "label": "Ja, er zijn gecorrigeerde telresultaten",
+            "path": "checks_and_corrections.corrected_results_csb_request.yes",
+            "short_label": "Ja, er zijn gecorrigeerde telresultaten",
+          },
+        ],
+        "short_title": "Zijn er gecorrigeerde telresultaten?",
+        "title": "Zijn er gecorrigeerde telresultaten?",
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Controles en correcties",
+  },
+  {
     "id": "voters_votes_counts",
     "sectionNumber": "2.1 en 2.2",
     "short_title": "Aantal kiezers en stemmen",
@@ -13,26 +191,6 @@
         "rows": [
           {
             "autoFocusInput": true,
-            "code": "Z",
-            "path": "number_of_voters",
-            "title": "Kiesgerechtigden",
-          },
-        ],
-        "type": "inputGrid",
-      },
-      {
-        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
-        "type": "message",
-      },
-      {
-        "headers": [
-          "Veld",
-          "Geteld aantal",
-          "Omschrijving",
-        ],
-        "rows": [
-          {
-            "autoFocusInput": false,
             "code": "A",
             "path": "voters_counts.poll_card_count",
             "title": "Stempassen",
@@ -108,17 +266,56 @@
         "options": [
           {
             "autoFocusInput": true,
-            "label": "D en H zijn gelijk",
+            "label": <React.Fragment>
+              <React.Fragment>
+                D en H zijn 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    gelijk
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
             "short_label": "D en H zijn gelijk",
           },
           {
-            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    groter
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (meer uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
             "short_label": "H is groter dan D",
           },
           {
-            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    kleiner
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (minder uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
             "short_label": "H is kleiner dan D",
           },

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.WaterAuthority.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.WaterAuthority.snap
@@ -1,1 +1,467 @@
-[]
+[
+  {
+    "id": "voters_votes_counts",
+    "sectionNumber": "2.1 en 2.2",
+    "short_title": "Aantal kiezers en stemmen",
+    "subsections": [
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": true,
+            "code": "Z",
+            "path": "number_of_voters",
+            "title": "Kiesgerechtigden",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
+        "type": "message",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": false,
+            "code": "A",
+            "path": "voters_counts.poll_card_count",
+            "title": "Stempassen",
+          },
+          {
+            "code": "B",
+            "path": "voters_counts.proxy_certificate_count",
+            "title": "Volmachtbewijzen",
+          },
+          {
+            "addSeparator": true,
+            "code": "C",
+            "isDisabled": false,
+            "path": "voters_counts.voter_card_count",
+            "title": "Kiezerspassen",
+          },
+          {
+            "addSeparator": true,
+            "code": "D",
+            "isTotal": true,
+            "path": "voters_counts.total_admitted_voters_count",
+            "title": "Totaal toegelaten kiezers",
+          },
+          {
+            "addSeparator": false,
+            "code": "E.1",
+            "path": "votes_counts.political_group_total_votes.0.total",
+            "title": "Totaal Lijst 1 – Vurige Vleugels Partij",
+          },
+          {
+            "addSeparator": true,
+            "code": "E.2",
+            "path": "votes_counts.political_group_total_votes.1.total",
+            "title": "Totaal Lijst 2 – Wijzen van Water en Wind",
+          },
+          {
+            "code": "E",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_candidates_count",
+            "title": "Totaal stemmen op kandidaten",
+          },
+          {
+            "code": "F",
+            "path": "votes_counts.blank_votes_count",
+            "title": "Blanco stemmen",
+          },
+          {
+            "addSeparator": true,
+            "code": "G",
+            "path": "votes_counts.invalid_votes_count",
+            "title": "Ongeldige stemmen",
+          },
+          {
+            "code": "H",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_cast_count",
+            "title": "Totaal uitgebrachte stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+    ],
+    "title": "Toegelaten kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "differences_counts",
+    "sectionNumber": "2.3",
+    "short_title": "Verschillen D & H",
+    "subsections": [
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.compare_votes_cast_admitted_voters",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "D en H zijn gelijk",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+            "short_label": "D en H zijn gelijk",
+          },
+          {
+            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+            "short_label": "H is groter dan D",
+          },
+          {
+            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+            "short_label": "H is kleiner dan D",
+          },
+        ],
+        "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.1
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "code": "I",
+            "path": "differences_counts.more_ballots_count",
+            "title": "Aantal méér getelde stemmen",
+          },
+          {
+            "code": "J",
+            "path": "differences_counts.fewer_ballots_count",
+            "title": "Aantal minder getelde stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.difference_completely_accounted_for",
+        "options": [
+          {
+            "label": "Ja",
+            "path": "differences_counts.difference_completely_accounted_for.yes",
+            "short_label": "Ja",
+          },
+          {
+            "label": "Nee, er is een onverklaard verschil",
+            "path": "differences_counts.difference_completely_accounted_for.no",
+            "short_label": "Nee, er is een onverklaard verschil",
+          },
+        ],
+        "short_title": "Verschil tussen D en H volledig verklaard?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.2
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                volledig
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             verklaren?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "political_group_votes_1",
+    "short_title": "Lijst 1 – Vurige Vleugels Partij",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.0.candidate_votes.0.votes",
+            "title": "Zilverlicht, E. (Eldor)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.0.candidate_votes.1.votes",
+            "title": "Donderbrul, G. (Grom)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "3",
+            "path": "political_group_votes.0.candidate_votes.2.votes",
+            "title": "Fluisterwind, S. (Seraphina)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "4",
+            "path": "political_group_votes.0.candidate_votes.3.votes",
+            "title": "Nachtschaduw, V. (Vesper)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "5",
+            "path": "political_group_votes.0.candidate_votes.4.votes",
+            "title": "Stormvleugel, R. (Ravian)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "6",
+            "path": "political_group_votes.0.candidate_votes.5.votes",
+            "title": "Sterrenzwerver, M. (Mirella)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "7",
+            "path": "political_group_votes.0.candidate_votes.6.votes",
+            "title": "Maanfluisteraar, X. (Xander)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "8",
+            "path": "political_group_votes.0.candidate_votes.7.votes",
+            "title": "Windzanger, P. (Paxton)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "9",
+            "path": "political_group_votes.0.candidate_votes.8.votes",
+            "title": "Vuurvlinder, F. (Faelia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "10",
+            "path": "political_group_votes.0.candidate_votes.9.votes",
+            "title": "Rotsbreker, H. (Helga)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "11",
+            "path": "political_group_votes.0.candidate_votes.10.votes",
+            "title": "Zonnewende, L. (Luna)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "12",
+            "path": "political_group_votes.0.candidate_votes.11.votes",
+            "title": "Groenhart, T. (Timo)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "13",
+            "path": "political_group_votes.0.candidate_votes.12.votes",
+            "title": "Veldbloem, N. (Naima)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "14",
+            "path": "political_group_votes.0.candidate_votes.13.votes",
+            "title": "IJzeren, V. (Vincent)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "15",
+            "path": "political_group_votes.0.candidate_votes.14.votes",
+            "title": "Blauwhof, P. (Priya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "16",
+            "path": "political_group_votes.0.candidate_votes.15.votes",
+            "title": "Windmaker, J. (Jamal)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "17",
+            "path": "political_group_votes.0.candidate_votes.16.votes",
+            "title": "Sterrenveld, E. (Esmée)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "18",
+            "path": "political_group_votes.0.candidate_votes.17.votes",
+            "title": "Roodman, M. (Mohammed)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "19",
+            "path": "political_group_votes.0.candidate_votes.18.votes",
+            "title": "Zilverberg, C. (Chen)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "20",
+            "path": "political_group_votes.0.candidate_votes.19.votes",
+            "title": "Duinwalker, S. (Soraya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "21",
+            "path": "political_group_votes.0.candidate_votes.20.votes",
+            "title": "Lichtveld, A. (Alex)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "22",
+            "path": "political_group_votes.0.candidate_votes.21.votes",
+            "title": "Kruidentuin, H. (Habiba)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "23",
+            "path": "political_group_votes.0.candidate_votes.22.votes",
+            "title": "Vlietstra, B. (Bram)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "24",
+            "path": "political_group_votes.0.candidate_votes.23.votes",
+            "title": "Meermin, K. (Kai)",
+          },
+          {
+            "addSeparator": true,
+            "autoFocusInput": false,
+            "code": "25",
+            "path": "political_group_votes.0.candidate_votes.24.votes",
+            "title": "Goudappel, D. (Diana)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "26",
+            "path": "political_group_votes.0.candidate_votes.25.votes",
+            "title": "Bosrank, F. (Finn)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "27",
+            "path": "political_group_votes.0.candidate_votes.26.votes",
+            "title": "Sterrenveld, J. (Julia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "28",
+            "path": "political_group_votes.0.candidate_votes.27.votes",
+            "title": "Regenboog, G. (Giovanni)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "29",
+            "path": "political_group_votes.0.candidate_votes.28.votes",
+            "title": "Hemelrijk, M. (Milan)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.0.total",
+            "title": "Totaal lijst 1",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 1 – Vurige Vleugels Partij",
+  },
+  {
+    "id": "political_group_votes_2",
+    "short_title": "Lijst 2 – Wijzen van Water en Wind",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.1.candidate_votes.0.votes",
+            "title": "Foo, A. (Alice)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.1.candidate_votes.1.votes",
+            "title": "Doe, C. (Charlie)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.1.total",
+            "title": "Totaal lijst 2",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 2 – Wijzen van Water en Wind",
+  },
+]

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.WaterAuthority.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSOFirstSession.WaterAuthority.snap
@@ -22,7 +22,7 @@
                  (een proces-verbaal en een corrigendum)
               </React.Fragment>
             </React.Fragment>,
-            "short_label": "Ja, ik heb <strong>twee documenten</strong> (een proces-verbaal en een corrigendum)",
+            "short_label": "Ja, een proces-verbaal en een corrigendum",
             "value": "TwoDocuments",
           },
           {
@@ -41,7 +41,7 @@
                  (alleen een proces-verbaal)
               </React.Fragment>
             </React.Fragment>,
-            "short_label": "Nee, ik heb <strong>één document</strong> (alleen een proces-verbaal)",
+            "short_label": "Nee, alleen een proces-verbaal",
             "value": "OneDocument",
           },
         ],

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Municipal.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Municipal.snap
@@ -1,1 +1,467 @@
-[]
+[
+  {
+    "id": "voters_votes_counts",
+    "sectionNumber": "2.1 en 2.2",
+    "short_title": "Aantal kiezers en stemmen",
+    "subsections": [
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": true,
+            "code": "Z",
+            "path": "number_of_voters",
+            "title": "Kiesgerechtigden",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
+        "type": "message",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": false,
+            "code": "A",
+            "path": "voters_counts.poll_card_count",
+            "title": "Stempassen",
+          },
+          {
+            "code": "B",
+            "path": "voters_counts.proxy_certificate_count",
+            "title": "Volmachtbewijzen",
+          },
+          {
+            "addSeparator": true,
+            "code": "C",
+            "isDisabled": true,
+            "path": "voters_counts.voter_card_count",
+            "title": "Kiezerspassen",
+          },
+          {
+            "addSeparator": true,
+            "code": "D",
+            "isTotal": true,
+            "path": "voters_counts.total_admitted_voters_count",
+            "title": "Totaal toegelaten kiezers",
+          },
+          {
+            "addSeparator": false,
+            "code": "E.1",
+            "path": "votes_counts.political_group_total_votes.0.total",
+            "title": "Totaal Lijst 1 – Vurige Vleugels Partij",
+          },
+          {
+            "addSeparator": true,
+            "code": "E.2",
+            "path": "votes_counts.political_group_total_votes.1.total",
+            "title": "Totaal Lijst 2 – Wijzen van Water en Wind",
+          },
+          {
+            "code": "E",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_candidates_count",
+            "title": "Totaal stemmen op kandidaten",
+          },
+          {
+            "code": "F",
+            "path": "votes_counts.blank_votes_count",
+            "title": "Blanco stemmen",
+          },
+          {
+            "addSeparator": true,
+            "code": "G",
+            "path": "votes_counts.invalid_votes_count",
+            "title": "Ongeldige stemmen",
+          },
+          {
+            "code": "H",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_cast_count",
+            "title": "Totaal uitgebrachte stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+    ],
+    "title": "Toegelaten kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "differences_counts",
+    "sectionNumber": "2.3",
+    "short_title": "Verschillen D & H",
+    "subsections": [
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.compare_votes_cast_admitted_voters",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "D en H zijn gelijk",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+            "short_label": "D en H zijn gelijk",
+          },
+          {
+            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+            "short_label": "H is groter dan D",
+          },
+          {
+            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+            "short_label": "H is kleiner dan D",
+          },
+        ],
+        "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.1
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "code": "I",
+            "path": "differences_counts.more_ballots_count",
+            "title": "Aantal méér getelde stemmen",
+          },
+          {
+            "code": "J",
+            "path": "differences_counts.fewer_ballots_count",
+            "title": "Aantal minder getelde stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.difference_completely_accounted_for",
+        "options": [
+          {
+            "label": "Ja",
+            "path": "differences_counts.difference_completely_accounted_for.yes",
+            "short_label": "Ja",
+          },
+          {
+            "label": "Nee, er is een onverklaard verschil",
+            "path": "differences_counts.difference_completely_accounted_for.no",
+            "short_label": "Nee, er is een onverklaard verschil",
+          },
+        ],
+        "short_title": "Verschil tussen D en H volledig verklaard?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.2
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                volledig
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             verklaren?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "political_group_votes_1",
+    "short_title": "Lijst 1 – Vurige Vleugels Partij",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.0.candidate_votes.0.votes",
+            "title": "Zilverlicht, E. (Eldor)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.0.candidate_votes.1.votes",
+            "title": "Donderbrul, G. (Grom)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "3",
+            "path": "political_group_votes.0.candidate_votes.2.votes",
+            "title": "Fluisterwind, S. (Seraphina)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "4",
+            "path": "political_group_votes.0.candidate_votes.3.votes",
+            "title": "Nachtschaduw, V. (Vesper)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "5",
+            "path": "political_group_votes.0.candidate_votes.4.votes",
+            "title": "Stormvleugel, R. (Ravian)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "6",
+            "path": "political_group_votes.0.candidate_votes.5.votes",
+            "title": "Sterrenzwerver, M. (Mirella)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "7",
+            "path": "political_group_votes.0.candidate_votes.6.votes",
+            "title": "Maanfluisteraar, X. (Xander)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "8",
+            "path": "political_group_votes.0.candidate_votes.7.votes",
+            "title": "Windzanger, P. (Paxton)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "9",
+            "path": "political_group_votes.0.candidate_votes.8.votes",
+            "title": "Vuurvlinder, F. (Faelia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "10",
+            "path": "political_group_votes.0.candidate_votes.9.votes",
+            "title": "Rotsbreker, H. (Helga)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "11",
+            "path": "political_group_votes.0.candidate_votes.10.votes",
+            "title": "Zonnewende, L. (Luna)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "12",
+            "path": "political_group_votes.0.candidate_votes.11.votes",
+            "title": "Groenhart, T. (Timo)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "13",
+            "path": "political_group_votes.0.candidate_votes.12.votes",
+            "title": "Veldbloem, N. (Naima)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "14",
+            "path": "political_group_votes.0.candidate_votes.13.votes",
+            "title": "IJzeren, V. (Vincent)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "15",
+            "path": "political_group_votes.0.candidate_votes.14.votes",
+            "title": "Blauwhof, P. (Priya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "16",
+            "path": "political_group_votes.0.candidate_votes.15.votes",
+            "title": "Windmaker, J. (Jamal)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "17",
+            "path": "political_group_votes.0.candidate_votes.16.votes",
+            "title": "Sterrenveld, E. (Esmée)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "18",
+            "path": "political_group_votes.0.candidate_votes.17.votes",
+            "title": "Roodman, M. (Mohammed)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "19",
+            "path": "political_group_votes.0.candidate_votes.18.votes",
+            "title": "Zilverberg, C. (Chen)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "20",
+            "path": "political_group_votes.0.candidate_votes.19.votes",
+            "title": "Duinwalker, S. (Soraya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "21",
+            "path": "political_group_votes.0.candidate_votes.20.votes",
+            "title": "Lichtveld, A. (Alex)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "22",
+            "path": "political_group_votes.0.candidate_votes.21.votes",
+            "title": "Kruidentuin, H. (Habiba)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "23",
+            "path": "political_group_votes.0.candidate_votes.22.votes",
+            "title": "Vlietstra, B. (Bram)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "24",
+            "path": "political_group_votes.0.candidate_votes.23.votes",
+            "title": "Meermin, K. (Kai)",
+          },
+          {
+            "addSeparator": true,
+            "autoFocusInput": false,
+            "code": "25",
+            "path": "political_group_votes.0.candidate_votes.24.votes",
+            "title": "Goudappel, D. (Diana)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "26",
+            "path": "political_group_votes.0.candidate_votes.25.votes",
+            "title": "Bosrank, F. (Finn)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "27",
+            "path": "political_group_votes.0.candidate_votes.26.votes",
+            "title": "Sterrenveld, J. (Julia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "28",
+            "path": "political_group_votes.0.candidate_votes.27.votes",
+            "title": "Regenboog, G. (Giovanni)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "29",
+            "path": "political_group_votes.0.candidate_votes.28.votes",
+            "title": "Hemelrijk, M. (Milan)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.0.total",
+            "title": "Totaal lijst 1",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 1 – Vurige Vleugels Partij",
+  },
+  {
+    "id": "political_group_votes_2",
+    "short_title": "Lijst 2 – Wijzen van Water en Wind",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.1.candidate_votes.0.votes",
+            "title": "Foo, A. (Alice)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.1.candidate_votes.1.votes",
+            "title": "Doe, C. (Charlie)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.1.total",
+            "title": "Totaal lijst 2",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 2 – Wijzen van Water en Wind",
+  },
+]

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Municipal.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Municipal.snap
@@ -13,26 +13,6 @@
         "rows": [
           {
             "autoFocusInput": true,
-            "code": "Z",
-            "path": "number_of_voters",
-            "title": "Kiesgerechtigden",
-          },
-        ],
-        "type": "inputGrid",
-      },
-      {
-        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
-        "type": "message",
-      },
-      {
-        "headers": [
-          "Veld",
-          "Geteld aantal",
-          "Omschrijving",
-        ],
-        "rows": [
-          {
-            "autoFocusInput": false,
             "code": "A",
             "path": "voters_counts.poll_card_count",
             "title": "Stempassen",
@@ -108,17 +88,56 @@
         "options": [
           {
             "autoFocusInput": true,
-            "label": "D en H zijn gelijk",
+            "label": <React.Fragment>
+              <React.Fragment>
+                D en H zijn 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    gelijk
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
             "short_label": "D en H zijn gelijk",
           },
           {
-            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    groter
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (meer uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
             "short_label": "H is groter dan D",
           },
           {
-            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    kleiner
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (minder uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
             "short_label": "H is kleiner dan D",
           },

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Provincial.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Provincial.snap
@@ -1,1 +1,467 @@
-[]
+[
+  {
+    "id": "voters_votes_counts",
+    "sectionNumber": "2.1 en 2.2",
+    "short_title": "Aantal kiezers en stemmen",
+    "subsections": [
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": true,
+            "code": "Z",
+            "path": "number_of_voters",
+            "title": "Kiesgerechtigden",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
+        "type": "message",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": false,
+            "code": "A",
+            "path": "voters_counts.poll_card_count",
+            "title": "Stempassen",
+          },
+          {
+            "code": "B",
+            "path": "voters_counts.proxy_certificate_count",
+            "title": "Volmachtbewijzen",
+          },
+          {
+            "addSeparator": true,
+            "code": "C",
+            "isDisabled": false,
+            "path": "voters_counts.voter_card_count",
+            "title": "Kiezerspassen",
+          },
+          {
+            "addSeparator": true,
+            "code": "D",
+            "isTotal": true,
+            "path": "voters_counts.total_admitted_voters_count",
+            "title": "Totaal toegelaten kiezers",
+          },
+          {
+            "addSeparator": false,
+            "code": "E.1",
+            "path": "votes_counts.political_group_total_votes.0.total",
+            "title": "Totaal Lijst 1 – Vurige Vleugels Partij",
+          },
+          {
+            "addSeparator": true,
+            "code": "E.2",
+            "path": "votes_counts.political_group_total_votes.1.total",
+            "title": "Totaal Lijst 2 – Wijzen van Water en Wind",
+          },
+          {
+            "code": "E",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_candidates_count",
+            "title": "Totaal stemmen op kandidaten",
+          },
+          {
+            "code": "F",
+            "path": "votes_counts.blank_votes_count",
+            "title": "Blanco stemmen",
+          },
+          {
+            "addSeparator": true,
+            "code": "G",
+            "path": "votes_counts.invalid_votes_count",
+            "title": "Ongeldige stemmen",
+          },
+          {
+            "code": "H",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_cast_count",
+            "title": "Totaal uitgebrachte stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+    ],
+    "title": "Toegelaten kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "differences_counts",
+    "sectionNumber": "2.3",
+    "short_title": "Verschillen D & H",
+    "subsections": [
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.compare_votes_cast_admitted_voters",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "D en H zijn gelijk",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+            "short_label": "D en H zijn gelijk",
+          },
+          {
+            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+            "short_label": "H is groter dan D",
+          },
+          {
+            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+            "short_label": "H is kleiner dan D",
+          },
+        ],
+        "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.1
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "code": "I",
+            "path": "differences_counts.more_ballots_count",
+            "title": "Aantal méér getelde stemmen",
+          },
+          {
+            "code": "J",
+            "path": "differences_counts.fewer_ballots_count",
+            "title": "Aantal minder getelde stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.difference_completely_accounted_for",
+        "options": [
+          {
+            "label": "Ja",
+            "path": "differences_counts.difference_completely_accounted_for.yes",
+            "short_label": "Ja",
+          },
+          {
+            "label": "Nee, er is een onverklaard verschil",
+            "path": "differences_counts.difference_completely_accounted_for.no",
+            "short_label": "Nee, er is een onverklaard verschil",
+          },
+        ],
+        "short_title": "Verschil tussen D en H volledig verklaard?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.2
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                volledig
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             verklaren?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "political_group_votes_1",
+    "short_title": "Lijst 1 – Vurige Vleugels Partij",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.0.candidate_votes.0.votes",
+            "title": "Zilverlicht, E. (Eldor)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.0.candidate_votes.1.votes",
+            "title": "Donderbrul, G. (Grom)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "3",
+            "path": "political_group_votes.0.candidate_votes.2.votes",
+            "title": "Fluisterwind, S. (Seraphina)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "4",
+            "path": "political_group_votes.0.candidate_votes.3.votes",
+            "title": "Nachtschaduw, V. (Vesper)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "5",
+            "path": "political_group_votes.0.candidate_votes.4.votes",
+            "title": "Stormvleugel, R. (Ravian)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "6",
+            "path": "political_group_votes.0.candidate_votes.5.votes",
+            "title": "Sterrenzwerver, M. (Mirella)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "7",
+            "path": "political_group_votes.0.candidate_votes.6.votes",
+            "title": "Maanfluisteraar, X. (Xander)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "8",
+            "path": "political_group_votes.0.candidate_votes.7.votes",
+            "title": "Windzanger, P. (Paxton)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "9",
+            "path": "political_group_votes.0.candidate_votes.8.votes",
+            "title": "Vuurvlinder, F. (Faelia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "10",
+            "path": "political_group_votes.0.candidate_votes.9.votes",
+            "title": "Rotsbreker, H. (Helga)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "11",
+            "path": "political_group_votes.0.candidate_votes.10.votes",
+            "title": "Zonnewende, L. (Luna)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "12",
+            "path": "political_group_votes.0.candidate_votes.11.votes",
+            "title": "Groenhart, T. (Timo)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "13",
+            "path": "political_group_votes.0.candidate_votes.12.votes",
+            "title": "Veldbloem, N. (Naima)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "14",
+            "path": "political_group_votes.0.candidate_votes.13.votes",
+            "title": "IJzeren, V. (Vincent)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "15",
+            "path": "political_group_votes.0.candidate_votes.14.votes",
+            "title": "Blauwhof, P. (Priya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "16",
+            "path": "political_group_votes.0.candidate_votes.15.votes",
+            "title": "Windmaker, J. (Jamal)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "17",
+            "path": "political_group_votes.0.candidate_votes.16.votes",
+            "title": "Sterrenveld, E. (Esmée)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "18",
+            "path": "political_group_votes.0.candidate_votes.17.votes",
+            "title": "Roodman, M. (Mohammed)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "19",
+            "path": "political_group_votes.0.candidate_votes.18.votes",
+            "title": "Zilverberg, C. (Chen)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "20",
+            "path": "political_group_votes.0.candidate_votes.19.votes",
+            "title": "Duinwalker, S. (Soraya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "21",
+            "path": "political_group_votes.0.candidate_votes.20.votes",
+            "title": "Lichtveld, A. (Alex)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "22",
+            "path": "political_group_votes.0.candidate_votes.21.votes",
+            "title": "Kruidentuin, H. (Habiba)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "23",
+            "path": "political_group_votes.0.candidate_votes.22.votes",
+            "title": "Vlietstra, B. (Bram)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "24",
+            "path": "political_group_votes.0.candidate_votes.23.votes",
+            "title": "Meermin, K. (Kai)",
+          },
+          {
+            "addSeparator": true,
+            "autoFocusInput": false,
+            "code": "25",
+            "path": "political_group_votes.0.candidate_votes.24.votes",
+            "title": "Goudappel, D. (Diana)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "26",
+            "path": "political_group_votes.0.candidate_votes.25.votes",
+            "title": "Bosrank, F. (Finn)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "27",
+            "path": "political_group_votes.0.candidate_votes.26.votes",
+            "title": "Sterrenveld, J. (Julia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "28",
+            "path": "political_group_votes.0.candidate_votes.27.votes",
+            "title": "Regenboog, G. (Giovanni)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "29",
+            "path": "political_group_votes.0.candidate_votes.28.votes",
+            "title": "Hemelrijk, M. (Milan)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.0.total",
+            "title": "Totaal lijst 1",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 1 – Vurige Vleugels Partij",
+  },
+  {
+    "id": "political_group_votes_2",
+    "short_title": "Lijst 2 – Wijzen van Water en Wind",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.1.candidate_votes.0.votes",
+            "title": "Foo, A. (Alice)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.1.candidate_votes.1.votes",
+            "title": "Doe, C. (Charlie)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.1.total",
+            "title": "Totaal lijst 2",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 2 – Wijzen van Water en Wind",
+  },
+]

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Provincial.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.Provincial.snap
@@ -13,26 +13,6 @@
         "rows": [
           {
             "autoFocusInput": true,
-            "code": "Z",
-            "path": "number_of_voters",
-            "title": "Kiesgerechtigden",
-          },
-        ],
-        "type": "inputGrid",
-      },
-      {
-        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
-        "type": "message",
-      },
-      {
-        "headers": [
-          "Veld",
-          "Geteld aantal",
-          "Omschrijving",
-        ],
-        "rows": [
-          {
-            "autoFocusInput": false,
             "code": "A",
             "path": "voters_counts.poll_card_count",
             "title": "Stempassen",
@@ -108,17 +88,56 @@
         "options": [
           {
             "autoFocusInput": true,
-            "label": "D en H zijn gelijk",
+            "label": <React.Fragment>
+              <React.Fragment>
+                D en H zijn 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    gelijk
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
             "short_label": "D en H zijn gelijk",
           },
           {
-            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    groter
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (meer uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
             "short_label": "H is groter dan D",
           },
           {
-            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    kleiner
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (minder uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
             "short_label": "H is kleiner dan D",
           },

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.WaterAuthority.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.WaterAuthority.snap
@@ -1,1 +1,467 @@
-[]
+[
+  {
+    "id": "voters_votes_counts",
+    "sectionNumber": "2.1 en 2.2",
+    "short_title": "Aantal kiezers en stemmen",
+    "subsections": [
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": true,
+            "code": "Z",
+            "path": "number_of_voters",
+            "title": "Kiesgerechtigden",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
+        "type": "message",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "autoFocusInput": false,
+            "code": "A",
+            "path": "voters_counts.poll_card_count",
+            "title": "Stempassen",
+          },
+          {
+            "code": "B",
+            "path": "voters_counts.proxy_certificate_count",
+            "title": "Volmachtbewijzen",
+          },
+          {
+            "addSeparator": true,
+            "code": "C",
+            "isDisabled": false,
+            "path": "voters_counts.voter_card_count",
+            "title": "Kiezerspassen",
+          },
+          {
+            "addSeparator": true,
+            "code": "D",
+            "isTotal": true,
+            "path": "voters_counts.total_admitted_voters_count",
+            "title": "Totaal toegelaten kiezers",
+          },
+          {
+            "addSeparator": false,
+            "code": "E.1",
+            "path": "votes_counts.political_group_total_votes.0.total",
+            "title": "Totaal Lijst 1 – Vurige Vleugels Partij",
+          },
+          {
+            "addSeparator": true,
+            "code": "E.2",
+            "path": "votes_counts.political_group_total_votes.1.total",
+            "title": "Totaal Lijst 2 – Wijzen van Water en Wind",
+          },
+          {
+            "code": "E",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_candidates_count",
+            "title": "Totaal stemmen op kandidaten",
+          },
+          {
+            "code": "F",
+            "path": "votes_counts.blank_votes_count",
+            "title": "Blanco stemmen",
+          },
+          {
+            "addSeparator": true,
+            "code": "G",
+            "path": "votes_counts.invalid_votes_count",
+            "title": "Ongeldige stemmen",
+          },
+          {
+            "code": "H",
+            "isTotal": true,
+            "path": "votes_counts.total_votes_cast_count",
+            "title": "Totaal uitgebrachte stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+    ],
+    "title": "Toegelaten kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "differences_counts",
+    "sectionNumber": "2.3",
+    "short_title": "Verschillen D & H",
+    "subsections": [
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.compare_votes_cast_admitted_voters",
+        "options": [
+          {
+            "autoFocusInput": true,
+            "label": "D en H zijn gelijk",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
+            "short_label": "D en H zijn gelijk",
+          },
+          {
+            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
+            "short_label": "H is groter dan D",
+          },
+          {
+            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
+            "short_label": "H is kleiner dan D",
+          },
+        ],
+        "short_title": "Extra onderzoek vanwege andere reden dan onverklaard verschil?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.1
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Vergelijk D (totaal toegelaten kiezers) en H (totaal uitgebrachte stemmen)
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+      {
+        "headers": [
+          "Veld",
+          "Geteld aantal",
+          "Omschrijving",
+        ],
+        "rows": [
+          {
+            "code": "I",
+            "path": "differences_counts.more_ballots_count",
+            "title": "Aantal méér getelde stemmen",
+          },
+          {
+            "code": "J",
+            "path": "differences_counts.fewer_ballots_count",
+            "title": "Aantal minder getelde stemmen",
+          },
+        ],
+        "type": "inputGrid",
+      },
+      {
+        "error_message": "Controleer of je antwoord gelijk is aan het papieren proces-verbaal",
+        "error_path": "differences_counts.difference_completely_accounted_for",
+        "options": [
+          {
+            "label": "Ja",
+            "path": "differences_counts.difference_completely_accounted_for.yes",
+            "short_label": "Ja",
+          },
+          {
+            "label": "Nee, er is een onverklaard verschil",
+            "path": "differences_counts.difference_completely_accounted_for.no",
+            "short_label": "Nee, er is een onverklaard verschil",
+          },
+        ],
+        "short_title": "Verschil tussen D en H volledig verklaard?",
+        "title": <React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                2.3.2
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             Zijn er tijdens de stemming dingen opgeschreven die het verschil tussen D en H 
+          </React.Fragment>
+          <strong>
+            <React.Fragment>
+              <React.Fragment>
+                volledig
+              </React.Fragment>
+            </React.Fragment>
+          </strong>
+          <React.Fragment>
+             verklaren?
+          </React.Fragment>
+        </React.Fragment>,
+        "type": "checkboxes",
+      },
+    ],
+    "title": "Verschillen tussen aantal kiezers en uitgebrachte stemmen",
+  },
+  {
+    "id": "political_group_votes_1",
+    "short_title": "Lijst 1 – Vurige Vleugels Partij",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.0.candidate_votes.0.votes",
+            "title": "Zilverlicht, E. (Eldor)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.0.candidate_votes.1.votes",
+            "title": "Donderbrul, G. (Grom)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "3",
+            "path": "political_group_votes.0.candidate_votes.2.votes",
+            "title": "Fluisterwind, S. (Seraphina)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "4",
+            "path": "political_group_votes.0.candidate_votes.3.votes",
+            "title": "Nachtschaduw, V. (Vesper)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "5",
+            "path": "political_group_votes.0.candidate_votes.4.votes",
+            "title": "Stormvleugel, R. (Ravian)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "6",
+            "path": "political_group_votes.0.candidate_votes.5.votes",
+            "title": "Sterrenzwerver, M. (Mirella)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "7",
+            "path": "political_group_votes.0.candidate_votes.6.votes",
+            "title": "Maanfluisteraar, X. (Xander)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "8",
+            "path": "political_group_votes.0.candidate_votes.7.votes",
+            "title": "Windzanger, P. (Paxton)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "9",
+            "path": "political_group_votes.0.candidate_votes.8.votes",
+            "title": "Vuurvlinder, F. (Faelia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "10",
+            "path": "political_group_votes.0.candidate_votes.9.votes",
+            "title": "Rotsbreker, H. (Helga)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "11",
+            "path": "political_group_votes.0.candidate_votes.10.votes",
+            "title": "Zonnewende, L. (Luna)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "12",
+            "path": "political_group_votes.0.candidate_votes.11.votes",
+            "title": "Groenhart, T. (Timo)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "13",
+            "path": "political_group_votes.0.candidate_votes.12.votes",
+            "title": "Veldbloem, N. (Naima)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "14",
+            "path": "political_group_votes.0.candidate_votes.13.votes",
+            "title": "IJzeren, V. (Vincent)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "15",
+            "path": "political_group_votes.0.candidate_votes.14.votes",
+            "title": "Blauwhof, P. (Priya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "16",
+            "path": "political_group_votes.0.candidate_votes.15.votes",
+            "title": "Windmaker, J. (Jamal)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "17",
+            "path": "political_group_votes.0.candidate_votes.16.votes",
+            "title": "Sterrenveld, E. (Esmée)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "18",
+            "path": "political_group_votes.0.candidate_votes.17.votes",
+            "title": "Roodman, M. (Mohammed)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "19",
+            "path": "political_group_votes.0.candidate_votes.18.votes",
+            "title": "Zilverberg, C. (Chen)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "20",
+            "path": "political_group_votes.0.candidate_votes.19.votes",
+            "title": "Duinwalker, S. (Soraya)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "21",
+            "path": "political_group_votes.0.candidate_votes.20.votes",
+            "title": "Lichtveld, A. (Alex)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "22",
+            "path": "political_group_votes.0.candidate_votes.21.votes",
+            "title": "Kruidentuin, H. (Habiba)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "23",
+            "path": "political_group_votes.0.candidate_votes.22.votes",
+            "title": "Vlietstra, B. (Bram)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "24",
+            "path": "political_group_votes.0.candidate_votes.23.votes",
+            "title": "Meermin, K. (Kai)",
+          },
+          {
+            "addSeparator": true,
+            "autoFocusInput": false,
+            "code": "25",
+            "path": "political_group_votes.0.candidate_votes.24.votes",
+            "title": "Goudappel, D. (Diana)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "26",
+            "path": "political_group_votes.0.candidate_votes.25.votes",
+            "title": "Bosrank, F. (Finn)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "27",
+            "path": "political_group_votes.0.candidate_votes.26.votes",
+            "title": "Sterrenveld, J. (Julia)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "28",
+            "path": "political_group_votes.0.candidate_votes.27.votes",
+            "title": "Regenboog, G. (Giovanni)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "29",
+            "path": "political_group_votes.0.candidate_votes.28.votes",
+            "title": "Hemelrijk, M. (Milan)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.0.total",
+            "title": "Totaal lijst 1",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 1 – Vurige Vleugels Partij",
+  },
+  {
+    "id": "political_group_votes_2",
+    "short_title": "Lijst 2 – Wijzen van Water en Wind",
+    "subsections": [
+      {
+        "headers": [
+          "Nummer",
+          "Aantal stemmen",
+          "Kandidaat",
+        ],
+        "rows": [
+          {
+            "addSeparator": false,
+            "autoFocusInput": true,
+            "code": "1",
+            "path": "political_group_votes.1.candidate_votes.0.votes",
+            "title": "Foo, A. (Alice)",
+          },
+          {
+            "addSeparator": false,
+            "autoFocusInput": false,
+            "code": "2",
+            "path": "political_group_votes.1.candidate_votes.1.votes",
+            "title": "Doe, C. (Charlie)",
+          },
+          {
+            "isListTotal": true,
+            "path": "political_group_votes.1.total",
+            "title": "Totaal lijst 2",
+          },
+        ],
+        "type": "inputGrid",
+        "zebra": true,
+      },
+    ],
+    "title": "Lijst 2 – Wijzen van Water en Wind",
+  },
+]

--- a/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.WaterAuthority.snap
+++ b/frontend/src/utils/__snapshots__/dataEntryStructure.DSONextSession.WaterAuthority.snap
@@ -13,26 +13,6 @@
         "rows": [
           {
             "autoFocusInput": true,
-            "code": "Z",
-            "path": "number_of_voters",
-            "title": "Kiesgerechtigden",
-          },
-        ],
-        "type": "inputGrid",
-      },
-      {
-        "message": "Voer je een corrigendum in, en staat het aantal kiesgerechtigden niet op het formulier? Pak dan het oorspronkelijke proces-verbaal erbij, en vul de waarde in die daar staat ingevuld.",
-        "type": "message",
-      },
-      {
-        "headers": [
-          "Veld",
-          "Geteld aantal",
-          "Omschrijving",
-        ],
-        "rows": [
-          {
-            "autoFocusInput": false,
             "code": "A",
             "path": "voters_counts.poll_card_count",
             "title": "Stempassen",
@@ -108,17 +88,56 @@
         "options": [
           {
             "autoFocusInput": true,
-            "label": "D en H zijn gelijk",
+            "label": <React.Fragment>
+              <React.Fragment>
+                D en H zijn 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    gelijk
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.admitted_voters_equal_votes_cast",
             "short_label": "D en H zijn gelijk",
           },
           {
-            "label": "H is groter dan D (meer uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    groter
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (meer uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_greater_than_admitted_voters",
             "short_label": "H is groter dan D",
           },
           {
-            "label": "H is kleiner dan D (minder uitgebrachte stemmen dan toegelaten kiezers)",
+            "label": <React.Fragment>
+              <React.Fragment>
+                H is 
+              </React.Fragment>
+              <strong>
+                <React.Fragment>
+                  <React.Fragment>
+                    kleiner
+                  </React.Fragment>
+                </React.Fragment>
+              </strong>
+              <React.Fragment>
+                 dan D (minder uitgebrachte stemmen dan toegelaten kiezers)
+              </React.Fragment>
+            </React.Fragment>,
             "path": "differences_counts.compare_votes_cast_admitted_voters.votes_cast_smaller_than_admitted_voters",
             "short_label": "H is kleiner dan D",
           },

--- a/frontend/src/utils/dataEntryMapping.test.ts
+++ b/frontend/src/utils/dataEntryMapping.test.ts
@@ -74,9 +74,8 @@ const createRadioSection = (): DataEntrySection => {
 
 describe("mapSectionValues", () => {
   test.each([
-    { input: "true", expected: true, description: "true" },
-    { input: "false", expected: false, description: "false" },
-    { input: "", expected: undefined, description: "empty" },
+    { input: "OptionA", expected: "OptionA", description: "true" },
+    { input: "", expected: null, description: "empty" },
   ])("should handle radio $description", ({ input, expected }) => {
     const radioSection = createRadioSection();
     const current = { test: null };
@@ -89,11 +88,11 @@ describe("mapSectionValues", () => {
 
   test("should use section info to distinguish radio vs inputGrid fields", () => {
     const current = {
-      test: null,
+      test: "OptionA",
       test2: null,
     };
     const formValues = {
-      test: "true", // Radio field - should become boolean
+      test: "", // Radio field - should become null
       test2: "456", // InputGrid field - should be deformatted to number
     };
 
@@ -113,7 +112,7 @@ describe("mapSectionValues", () => {
 
     const result = mapSectionValues(current, formValues, testSection);
 
-    expect(result.test).toBe(true); // Radio test field becomes boolean
+    expect(result.test).toBe(null); // Radio test field becomes null
     expect(result.test2).toBe(456); // InputGrid field gets deformatted to number
   });
 

--- a/frontend/src/utils/dataEntryMapping.ts
+++ b/frontend/src/utils/dataEntryMapping.ts
@@ -1,20 +1,20 @@
 import type { DataEntryResults, DataEntrySection, SectionValues } from "@/types/types";
 import { parseIntUserInput } from "@/utils/strings";
 
-type PathValue = boolean | number | string | undefined;
+type PathValue = boolean | number | string | null | undefined;
 
 /**
  * Extracts all data field paths and their types from a DataEntrySection as a Map
  * @param section The data entry section to extract field information from
  * @returns Map where key is the field path and value is the field type
  */
-export function extractFieldInfoFromSection(section: DataEntrySection): Map<string, "boolean" | "number"> {
-  const fieldInfoMap = new Map<string, "boolean" | "number">();
+export function extractFieldInfoFromSection(section: DataEntrySection): Map<string, "boolean" | "number" | "enum"> {
+  const fieldInfoMap = new Map<string, "boolean" | "number" | "enum">();
 
   for (const subsection of section.subsections) {
     switch (subsection.type) {
       case "radio":
-        fieldInfoMap.set(subsection.path, "boolean");
+        fieldInfoMap.set(subsection.path, "enum");
         break;
       case "inputGrid":
         for (const row of subsection.rows) {
@@ -101,7 +101,7 @@ export function setValueAtPath(
   data: DataEntryResults,
   path: string,
   value: string,
-  valueType: "boolean" | "number" | undefined,
+  valueType: "boolean" | "number" | "enum" | undefined,
 ): void {
   const segments = path.split(".");
   const lastProperty = segments.pop();
@@ -144,8 +144,8 @@ function traversePath(data: DataEntryResults, segments: string[]): unknown {
 
 function processValue(
   value: string,
-  valueType: "boolean" | "number" | undefined,
-): boolean | number | string | undefined {
+  valueType: "boolean" | "number" | "enum" | undefined,
+): boolean | number | string | null | undefined {
   if (valueType === "boolean") {
     if (value === "") {
       return undefined;
@@ -155,6 +155,10 @@ function processValue(
 
   if (valueType === "number") {
     return parseIntUserInput(value) ?? 0;
+  }
+
+  if (valueType === "enum" && value === "") {
+    return null;
   }
 
   return value;
@@ -170,7 +174,7 @@ export function stringRepresentsInteger(str: string): boolean {
 }
 
 function valueToString(value: PathValue): string {
-  if (value === undefined || value === 0) {
+  if (value === undefined || value === null || value === 0) {
     return "";
   }
   return String(value);
@@ -181,7 +185,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isPathValue(value: unknown): value is PathValue {
-  return typeof value === "boolean" || typeof value === "number" || typeof value === "string" || value === undefined;
+  return (
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string" ||
+    value === null ||
+    value === undefined
+  );
 }
 
 /**

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -237,12 +237,12 @@ const aboutReportSection: DataEntrySection = {
       options: [
         {
           label: tx("about_report.corrigendum_present.two_documents"),
-          short_label: t("about_report.corrigendum_present.two_documents"),
+          short_label: t("about_report.corrigendum_present.two_documents_short"),
           value: "TwoDocuments" satisfies CorrigendumPresent,
         },
         {
           label: tx("about_report.corrigendum_present.one_document"),
-          short_label: t("about_report.corrigendum_present.one_document"),
+          short_label: t("about_report.corrigendum_present.one_document_short"),
           value: "OneDocument" satisfies CorrigendumPresent,
         },
       ],

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -1,5 +1,10 @@
 import { t, tx } from "@/i18n/translate";
-import type { ElectionWithPoliticalGroups, PoliticalGroup } from "@/types/generated/openapi";
+import type {
+  ChecksAndCorrectionsPresent,
+  CorrigendumPresent,
+  ElectionWithPoliticalGroups,
+  PoliticalGroup,
+} from "@/types/generated/openapi";
 import type {
   CheckboxesSubsection,
   DataEntryModel,
@@ -15,11 +20,19 @@ import { isLocalElection } from "./election";
 type ModelForGSB = Extract<DataEntryModel, "DSOFirstSession" | "CSOFirstSession" | "DSONextSession" | "CSONextSession">;
 type ModelForCSB = Extract<DataEntryModel, "GSB">;
 
-const isEntryGSB = (model: DataEntryModel): model is ModelForGSB => {
-  return model === "CSOFirstSession" || model === "CSONextSession";
+const isEntryForGSB = (model: DataEntryModel): model is ModelForGSB => {
+  switch (model) {
+    case "DSOFirstSession":
+    case "CSOFirstSession":
+    case "DSONextSession":
+    case "CSONextSession":
+      return true;
+    case "GSB":
+      return false;
+  }
 };
 
-const isEntryCSB = (model: DataEntryModel): model is ModelForCSB => {
+const isEntryForCSB = (model: DataEntryModel): model is ModelForCSB => {
   return model === "GSB";
 };
 
@@ -39,7 +52,7 @@ const createVotersAndVotesRows = (
       code: "A",
       path: "voters_counts.poll_card_count",
       title: t("voters_votes_counts.voters_counts.poll_card_count"),
-      autoFocusInput: isEntryGSB(model),
+      autoFocusInput: isEntryForGSB(model),
     },
     {
       code: "B",
@@ -93,7 +106,7 @@ export const createVotersAndVotesSection = (
 ): DataEntrySection => {
   const subsections: DataEntrySection["subsections"] = [];
 
-  if (!isEntryGSB(model)) {
+  if (!isEntryForGSB(model)) {
     subsections.push({
       type: "inputGrid",
       headers: [t("field"), t("counted_number"), t("description")],
@@ -181,7 +194,7 @@ export const createDifferencesSection = (model: DataEntryModel): DataEntrySectio
     ],
   };
 
-  if (isEntryCSB(model)) {
+  if (isEntryForCSB(model)) {
     return {
       id: "differences_counts",
       title: t("differences_counts.form_title"),
@@ -210,7 +223,131 @@ export const createDifferencesSection = (model: DataEntryModel): DataEntrySectio
   };
 };
 
-export const extraInvestigationSection: DataEntrySection = {
+const aboutReportSection: DataEntrySection = {
+  id: "about_report",
+  title: t("about_report.form_title"),
+  short_title: t("about_report.short_title"),
+  subsections: [
+    {
+      type: "radio",
+      path: "about_report.corrigendum_present",
+      title: tx("about_report.corrigendum_present.title"),
+      short_title: t("about_report.corrigendum_present.short_title"),
+      error: t("about_report.validation_error"),
+      options: [
+        {
+          label: tx("about_report.corrigendum_present.two_documents"),
+          short_label: t("about_report.corrigendum_present.two_documents"),
+          value: "TwoDocuments" satisfies CorrigendumPresent,
+        },
+        {
+          label: tx("about_report.corrigendum_present.one_document"),
+          short_label: t("about_report.corrigendum_present.one_document"),
+          value: "OneDocument" satisfies CorrigendumPresent,
+        },
+      ],
+    },
+    {
+      type: "radio",
+      path: "about_report.checks_and_corrections_present",
+      title: tx("about_report.checks_and_corrections_present.title"),
+      short_title: t("about_report.checks_and_corrections_present.short_title"),
+      error: t("about_report.validation_error"),
+      options: [
+        {
+          label: t("about_report.checks_and_corrections_present.page_present"),
+          short_label: t("about_report.checks_and_corrections_present.page_present"),
+          value: "PagePresent" satisfies ChecksAndCorrectionsPresent,
+        },
+        {
+          label: t("about_report.checks_and_corrections_present.page_missing"),
+          short_label: t("about_report.checks_and_corrections_present.page_missing"),
+          value: "PageMissing" satisfies ChecksAndCorrectionsPresent,
+        },
+      ],
+    },
+  ],
+};
+
+const checksAndCorrections: DataEntrySection = {
+  id: "checks_and_corrections",
+  title: t("checks_and_corrections.form_title"),
+  short_title: t("checks_and_corrections.short_title"),
+  subsections: [
+    {
+      type: "message",
+      message: t("checks_and_corrections.form_description"),
+    },
+    {
+      type: "heading",
+      title: t("checks_and_corrections.own_initiative"),
+    },
+    {
+      type: "checkboxes",
+      title: t("checks_and_corrections.reason_investigation_own_initiative.title"),
+      short_title: t("checks_and_corrections.reason_investigation_own_initiative.short_title"),
+      error_path: "checks_and_corrections.reason_investigation_own_initiative",
+      error_message: t("checks_and_corrections.validation_error"),
+      options: [
+        {
+          path: "checks_and_corrections.reason_investigation_own_initiative.unaccounted_difference",
+          label: t("checks_and_corrections.reason_investigation_own_initiative.unaccounted_difference"),
+          short_label: t("checks_and_corrections.reason_investigation_own_initiative.unaccounted_difference"),
+          autoFocusInput: true,
+        },
+        {
+          path: "checks_and_corrections.reason_investigation_own_initiative.other_error",
+          label: t("checks_and_corrections.reason_investigation_own_initiative.other_error"),
+          short_label: t("checks_and_corrections.reason_investigation_own_initiative.other_error"),
+        },
+      ],
+    },
+    {
+      type: "checkboxes",
+      title: t("checks_and_corrections.corrected_results_own_initiative.title"),
+      short_title: t("checks_and_corrections.corrected_results_own_initiative.short_title"),
+      error_path: "checks_and_corrections.corrected_results_own_initiative",
+      error_message: t("checks_and_corrections.validation_error"),
+      options: [
+        {
+          path: "checks_and_corrections.corrected_results_own_initiative.no",
+          label: t("checks_and_corrections.corrected_results_own_initiative.no"),
+          short_label: t("checks_and_corrections.corrected_results_own_initiative.no"),
+        },
+        {
+          path: "checks_and_corrections.corrected_results_own_initiative.yes",
+          label: t("checks_and_corrections.corrected_results_own_initiative.yes"),
+          short_label: t("checks_and_corrections.corrected_results_own_initiative.yes"),
+        },
+      ],
+    },
+    {
+      type: "heading",
+      title: t("checks_and_corrections.csb_request"),
+    },
+    {
+      type: "checkboxes",
+      title: t("checks_and_corrections.corrected_results_csb_request.title"),
+      short_title: t("checks_and_corrections.corrected_results_csb_request.short_title"),
+      error_path: "checks_and_corrections.corrected_results_csb_request",
+      error_message: t("checks_and_corrections.validation_error"),
+      options: [
+        {
+          path: "checks_and_corrections.corrected_results_csb_request.no",
+          label: t("checks_and_corrections.corrected_results_csb_request.no"),
+          short_label: t("checks_and_corrections.corrected_results_csb_request.no"),
+        },
+        {
+          path: "checks_and_corrections.corrected_results_csb_request.yes",
+          label: t("checks_and_corrections.corrected_results_csb_request.yes"),
+          short_label: t("checks_and_corrections.corrected_results_csb_request.yes"),
+        },
+      ],
+    },
+  ],
+};
+
+const extraInvestigationSection: DataEntrySection = {
   id: "extra_investigation",
   title: t("extra_investigation.form_title"),
   short_title: t("extra_investigation.short_title"),
@@ -262,7 +399,7 @@ export const extraInvestigationSection: DataEntrySection = {
   ],
 };
 
-export const countingDifferencesPollingStation: DataEntrySection = {
+const countingDifferencesPollingStation: DataEntrySection = {
   id: "counting_differences_polling_station",
   title: t("counting_differences_polling_station.form_title"),
   short_title: t("counting_differences_polling_station.short_title"),
@@ -369,6 +506,8 @@ function buildDataEntryStructure(model: DataEntryModel, election: ElectionWithPo
   switch (model) {
     case "DSOFirstSession":
       return [
+        aboutReportSection,
+        checksAndCorrections,
         createVotersAndVotesSection(model, election),
         createDifferencesSection(model),
         ...createPoliticalGroupSections(election),

--- a/frontend/src/utils/dataEntryStructure.ts
+++ b/frontend/src/utils/dataEntryStructure.ts
@@ -369,7 +369,9 @@ function buildDataEntryStructure(model: DataEntryModel, election: ElectionWithPo
   switch (model) {
     case "DSOFirstSession":
       return [
-        /* TODO: https://github.com/kiesraad/abacus/issues/3685 */
+        createVotersAndVotesSection(model, election),
+        createDifferencesSection(model),
+        ...createPoliticalGroupSections(election),
       ];
     case "CSOFirstSession":
       return [
@@ -380,15 +382,7 @@ function buildDataEntryStructure(model: DataEntryModel, election: ElectionWithPo
         ...createPoliticalGroupSections(election),
       ];
     case "DSONextSession":
-      return [
-        /* TODO: https://github.com/kiesraad/abacus/issues/3685 */
-      ];
     case "CSONextSession":
-      return [
-        createVotersAndVotesSection(model, election),
-        createDifferencesSection(model),
-        ...createPoliticalGroupSections(election),
-      ];
     case "GSB":
       return [
         createVotersAndVotesSection(model, election),


### PR DESCRIPTION
## What & why

Resolves #3685 
Resolves #3683

- Added DSO variants to `dataEntryStructure.ts`
- Updated `RadioSubSection` to be in line with `CheckboxesSubsection`
- Adjusted `dataEntryMapping`/`dataEntryUtils` to support radio values
  - A radio can be `null` or one of the given options

## How to test

- Compare with screens in [Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=9239-29975&m=dev)
- Check if i18n is correct, especially short titles. 
- Check the dataEntryStructure snapshots
  - In the [first commit](https://github.com/kiesraad/abacus/pull/3745/commits/8cf9364728bbb31e4af40146acec97d954e298d6) I've added the sections that are identical with CSO.
  - In the [second commit](https://github.com/kiesraad/abacus/pull/3745/commits/55a14dff95d27539ac4c511b79374b5d0bb26777) I've added the new sections.

Without https://github.com/kiesraad/abacus/issues/3695 and https://github.com/kiesraad/abacus/issues/3728 this PR is tricky to test. 

To test it locally: in `data_entry_claim` replace `let initial = Results::new(...` with:

```rs
let initial = DSOFirstSession(DSOFirstSessionResults {
    about_report: Default::default(),
    checks_and_corrections: Default::default(),
    voters_counts: Results::default_voters_counts(&context.election),
    votes_counts: VotesCounts {
        political_group_total_votes: Results::default_political_group_total_votes(
            &context.election.political_groups,
        ),
        ..Default::default()
    },
    differences_counts: Default::default(),
    political_group_votes: Results::default_political_group_votes(
        &context.election.political_groups,
    ),
});
```

And claim a data entry in election 1.

Screenshots:
<img width="871" height="428" alt="image" src="https://github.com/user-attachments/assets/74b27cff-f9fd-4e55-b87e-ed3b40f4cee5" />

<img width="869" height="753" alt="image" src="https://github.com/user-attachments/assets/a8805875-bfc2-43b4-b653-759fc2305076" />


## Reviewer notes

- Does not contain logic to skip "Controles en correcties" yet. Made a separate issue for that: https://github.com/kiesraad/abacus/issues/3746
- Validations will be done in https://github.com/kiesraad/abacus/issues/3687