### PR TITLE
Faster test compilation

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -88,14 +88,10 @@ jobs:
       BINSTALL_DISABLE_TELEMETRY: "true"
     steps:
       - uses: actions/checkout@v7.0.1
-      # Test backend
-      - name: Install musl
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      # Test backend. Uses the default host target (x86_64-unknown-linux-gnu) for faster linking
+      # using rust-lld, and avoiding copying libc and libstd into every test binary.
       - name: Setup Rust
-        shell: bash
-        run: >
-          rustup toolchain install &&
-          rustup target add x86_64-unknown-linux-musl
+        run: rustup toolchain install
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
@@ -111,11 +107,11 @@ jobs:
       - name: Check Clippy with default features
         run: cargo --verbose --locked clippy --workspace --all-targets -- -D warnings
       - name: Check Clippy with all features
-        run: cargo --verbose --locked clippy --target=x86_64-unknown-linux-musl --workspace --all-targets --all-features -- -D warnings
+        run: cargo --verbose --locked clippy --workspace --all-targets --all-features -- -D warnings
       - name: Install Nextest
         run: cargo binstall cargo-nextest
       - name: Run tests
-        run: cargo --verbose --locked nextest run --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst,tls
+        run: cargo --verbose --locked nextest run --workspace --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation
         run: cargo doc --workspace --no-deps --all-features --document-private-items
         env:

--- a/.github/workflows/weekly-e2e-tests.yml
+++ b/.github/workflows/weekly-e2e-tests.yml
@@ -73,6 +73,14 @@ jobs:
       - name: Install musl
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
+      - name: Create empty Storybook build dir for memory-serve
+        run: mkdir -p dist-storybook
+        working-directory: ./frontend
+        if: matrix.target.os == 'ubuntu-latest'
+      # The Backend job in build-lint-test.yml checks Clippy only for the host target, so check with musl here
+      - name: Check Clippy with all features
+        run: cargo --locked clippy --workspace --all-targets --all-features --target=${{ matrix.target.name }} -- -D warnings
+        if: matrix.target.os == 'ubuntu-latest'
       - name: Build without airgap detection
         run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v7

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -142,6 +142,12 @@ workspace = true
 [profile.release]
 overflow-checks = true
 
+# line-tables-only keeps file and line numbers in backtraces but omits type and variable information.
+# This saves ~30% compile time and ~60% disk space for the linked (test) binaries.
+# See "Debugging with gdb/lldb" in README.md to go back to full DWARF debug symbols.
+[profile.dev]
+debug = "line-tables-only"
+
 # Optimising Argon2 make hashing operations ~12x faster and cuts backend test suite CPU time by ~60%
 [profile.dev.package.argon2]
 opt-level = 3

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,14 +61,12 @@ sqlx database setup
 cargo run --features memory-serve
 ```
 
-By default (for compilation efficiency) Abacus will use Typst from a Rust dylib.
-Rust dylibs are not stable, so should not be used in production. If you want to
-switch to the statically linked Typst (as is done with production builds of
-Abacus) you can simply enable the `embed-typst` feature. This can be combined 
-with the memory-serve feature as well, e.g.:
+PDF generation uses a statically linked Typst, enabled by the `embed-typst` feature. That feature is part of the default
+feature set. If you build with `--no-default-features` you have to enable it explicitly, otherwise `generate_pdf` is
+unimplemented and PDF generation is unavailable. It can be combined with the memory-serve feature, e.g.:
 
 ```shell
-cargo build --features memory-serve,embed-typst
+cargo build --no-default-features --features memory-serve,embed-typst
 ```
 
 ### Linting

--- a/backend/README.md
+++ b/backend/README.md
@@ -77,6 +77,19 @@ Use `cargo clippy --all-targets --all-features -- -D warnings` to lint the proje
 
 Use `cargo test` to run the tests. The tests are also run in a GitHub Actions workflow.
 
+### Debugging with gdb/lldb
+
+Debug builds are compiled with [`debug = "line-tables-only"`](debug), which keeps panic backtraces with file and line
+numbers but omits type and variable information. To inspect variables in a debugger:
+
+- **Single command:** `CARGO_PROFILE_DEV_DEBUG=2 cargo build` (or `cargo nextest run`, `cargo run`).
+- **Entire workspace:** create `backend/.cargo/config.toml` (Git ignores the `.cargo` directory):
+
+      [profile.dev]
+      debug = 2
+
+[debug]: https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+
 ### Air gap detection
 
 In production, Abacus must be built with air gap detection enabled. To enforce air gap detection during build, enable the feature `airgap-detection`:


### PR DESCRIPTION
## What & why

- Fix outdated comment about dylib
- Use [`line-tables-only`](https://doc.rust-lang.org/cargo/reference/profiles.html#debug) debug setting, this saves ~30% compile time and ~60% disk space. The tradeoff is that debugging with type and variable information needs a special build, as documented in `backend/README.md`.
- Let the backend CI job use the default host target (`x86_64-unknown-linux-gnu`) for faster linking using rust-lld, and avoiding copying libc and libstd into every test binary.

Speedup for this PR:
| Metric | Before | After | Δ | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Full backend job (cold cache) | 12m45s | 8m35s | −4m10s (−33 %) | 1.49× |
| Full backend job (warm cache) | 6m22s | 3m28s | **−2m54s (−46 %)** | **1.84×** |
| Test binary build (cold) | 5m16s | 3m22s | −1m54s (−36 %) | 1.56× |
| Test binary build (warm) | 3m18s | 55s | **−2m23s (−72 %)** | **3.59×** |
| Test execution | 1m14s–1m21s | 1m01s–1m06s | ~−13s (−18 %) | 1.20× |
| Cargo cache size | 1526 MB | 1048 MB | −478 MB (−31 %) | 1.46× |

## How to test

CI should pass, running locally should still work.

## Reviewer notes

Review per commit.