### PR TITLE
Execute SQLx tests in-memory during CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -110,6 +110,8 @@ jobs:
         run: cargo --verbose --locked clippy --workspace --all-targets --all-features -- -D warnings
       - name: Install Nextest
         run: cargo binstall cargo-nextest
+      - name: Symlink sqlx test directory to /dev/shm
+        run: mkdir -p /dev/shm/sqlx && ln -s /dev/shm/sqlx target/sqlx
       - name: Run tests
         run: cargo --verbose --locked nextest run --workspace --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -72,6 +72,8 @@ jobs:
         run: cargo binstall cargo-llvm-cov
       - name: Install Nextest
         run: cargo binstall cargo-nextest
+      - name: Symlink sqlx test directory to /dev/shm
+        run: mkdir -p /dev/shm/sqlx && ln -s /dev/shm/sqlx target/sqlx
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --workspace --branch --profile ci --features embed-typst,airgap-detection --cobertura --output-path ./target/llvm-cov-target/codecov.json
       - name: Upload coverage to Codecov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,31 +29,6 @@ jobs:
       # Branch coverage requires Rust nightly: https://github.com/taiki-e/cargo-llvm-cov/issues/8
       RUSTUP_TOOLCHAIN: nightly-2026-07-10
     steps:
-      # Free up runner disk space, so that our job has enough space to run
-      # https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
-      - name: Free up runner disk space
-        working-directory: /
-        run: >
-          df -h
-          &&
-          echo "Freeing up disk space..."
-          &&
-          sudo rm -rf
-          /opt/az
-          /opt/google
-          /opt/hostedtoolcache
-          /opt/microsoft
-          /usr/lib/google-cloud-sdk
-          /usr/lib/jvm
-          /usr/local/.ghcup
-          /usr/local/julia*
-          /usr/local/lib/android
-          /usr/local/share/chromium
-          /usr/local/share/powershell
-          /usr/share/dotnet
-          /usr/share/swift
-          &&
-          df -h
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:


### PR DESCRIPTION
## What & why

- Execute SQLx tests in-memory during CI by symlinking the sqlx test directory to `/dev/shm`. Test runtimes are quite variable so not sure how big the improvement is.
- Remove disk space freeing step from Codecov job, because GitHub Actions runners have enough free disk space without this step.

## How to test

CI still passes.
