### PR TITLE
Add DSO to election create

### DIFF
--- a/frontend/e2e-tests/page-objects/election/create/CountingMethodTypePgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/CountingMethodTypePgObj.ts
@@ -3,11 +3,13 @@ import type { Locator, Page } from "@playwright/test";
 export class CountingMethodTypePgObj {
   readonly header: Locator;
   readonly cso: Locator;
+  readonly dso: Locator;
   readonly next: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 2, name: "Type stemopneming in Test" });
     this.cso = page.getByRole("radio", { name: "Centrale stemopneming (CSO)" });
+    this.dso = page.getByRole("radio", { name: "Decentrale stemopneming (DSO)" });
     this.next = page.getByRole("button", { name: "Volgende" });
   }
 }

--- a/frontend/e2e-tests/tests/election/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election/election-create.e2e.ts
@@ -51,6 +51,9 @@ test.describe("Election creation", () => {
       // Counting method page
       const countingMethodPage = new CountingMethodTypePgObj(page);
       await expect(countingMethodPage.header).toBeVisible();
+      await expect(countingMethodPage.cso).toBeVisible();
+      await countingMethodPage.cso.click();
+      await expect(countingMethodPage.cso).toBeChecked();
       await countingMethodPage.next.click();
 
       // Number of voters page
@@ -125,6 +128,9 @@ test.describe("Election creation", () => {
       // Counting method page
       const countingMethodPage = new CountingMethodTypePgObj(page);
       await expect(countingMethodPage.header).toBeVisible();
+      await expect(countingMethodPage.cso).toBeVisible();
+      await countingMethodPage.cso.click();
+      await expect(countingMethodPage.cso).toBeChecked();
       await countingMethodPage.next.click();
 
       // Number of voters page
@@ -438,9 +444,12 @@ test.describe("Election creation", () => {
       // upload polling stations
       await uploadPollingStations(page);
 
-      // Now we should be at the check and save page
+      // Counting method page
       const countingMethodPage = new CountingMethodTypePgObj(page);
       await expect(countingMethodPage.header).toBeVisible();
+      await expect(countingMethodPage.cso).toBeVisible();
+      await countingMethodPage.cso.click();
+      await expect(countingMethodPage.cso).toBeChecked();
       await countingMethodPage.next.click();
 
       // Number of voters page

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB.e2e.ts
@@ -131,6 +131,8 @@ test.describe("full flow GSB", () => {
 
     const countingMethodPage = new CountingMethodTypePgObj(page);
     await expect(countingMethodPage.header).toBeVisible();
+    await expect(countingMethodPage.cso).toBeVisible();
+    await countingMethodPage.cso.click();
     await expect(countingMethodPage.cso).toBeChecked();
     await countingMethodPage.next.click();
 

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.tsx
@@ -35,9 +35,7 @@ function renderForm(radioError: boolean, handleSubmit: (e: SubmitEvent<HTMLFormE
           </div>
           <ChoiceList>
             {radioError && (
-              <ChoiceList.Error id="include_all_candidates_error">
-                {t("apportionment.mandatory_question")}
-              </ChoiceList.Error>
+              <ChoiceList.Error id="include_all_candidates_error">{t("mandatory_question")}</ChoiceList.Error>
             )}
             <ChoiceList.Radio
               id="no_deceased"

--- a/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsPage.tsx
+++ b/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsPage.tsx
@@ -189,9 +189,7 @@ export function DrawingLotsPage() {
                       <ChoiceList>
                         <ChoiceList.Legend>{content.legend}</ChoiceList.Legend>
                         {radioError && (
-                          <ChoiceList.Error id="option_drawn_error">
-                            {t("apportionment.mandatory_question")}
-                          </ChoiceList.Error>
+                          <ChoiceList.Error id="option_drawn_error">{t("mandatory_question")}</ChoiceList.Error>
                         )}
                         {content.radioOptions.map((option) => renderChoiceListRadio(option))}
                       </ChoiceList>

--- a/frontend/src/features/election_create/components/CountingMethodType.test.tsx
+++ b/frontend/src/features/election_create/components/CountingMethodType.test.tsx
@@ -38,7 +38,7 @@ describe("CountingMethodType component", () => {
     expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).toBeChecked();
     expect(
       screen.getByRole("radio", {
-        name: /Decentrale stemopneming \(DSO\) \(Niet ondersteund in deze versie van Abacus\)/,
+        name: /Decentrale stemopneming \(DSO\)/,
       }),
     ).not.toBeChecked();
     await user.click(screen.getByRole("button", { name: "Volgende" }));

--- a/frontend/src/features/election_create/components/CountingMethodType.test.tsx
+++ b/frontend/src/features/election_create/components/CountingMethodType.test.tsx
@@ -1,9 +1,8 @@
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 
-import { renderReturningRouter, screen } from "@/testing/test-utils";
+import { renderReturningRouter, screen, waitFor } from "@/testing/test-utils";
 import type { NewElection } from "@/types/generated/openapi";
-
 import * as useElectionCreateContext from "../hooks/useElectionCreateContext";
 import { CountingMethodType } from "./CountingMethodType";
 import { ElectionCreateContextProvider } from "./ElectionCreateContextProvider";
@@ -18,6 +17,28 @@ describe("CountingMethodType component", () => {
     const router = renderReturningRouter(<CountingMethodType />);
 
     expect(router.state.location.pathname).toEqual("/elections/create");
+  });
+
+  test("Renders form and shows error when submitting without selecting a list", async () => {
+    const state = { election };
+    const dispatch = vi.fn();
+    vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
+    const user = userEvent.setup();
+
+    renderReturningRouter(
+      <ElectionCreateContextProvider>
+        <CountingMethodType />
+      </ElectionCreateContextProvider>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: `Type stemopneming in ${election.location}` }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: /Decentrale stemopneming \(DSO\)/ })).not.toBeChecked();
+    await user.click(screen.getByRole("button", { name: "Volgende" }));
+
+    expect(await screen.findByText("Deze vraag is verplicht")).toBeVisible();
   });
 
   test("Navigates to number of voters page", async () => {
@@ -35,12 +56,13 @@ describe("CountingMethodType component", () => {
     expect(
       await screen.findByRole("heading", { name: `Type stemopneming in ${election.location}` }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).toBeChecked();
-    expect(
-      screen.getByRole("radio", {
-        name: /Decentrale stemopneming \(DSO\)/,
-      }),
-    ).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).not.toBeChecked();
+    const DSORadio = screen.getByRole("radio", { name: /Decentrale stemopneming \(DSO\)/ });
+    expect(DSORadio).not.toBeChecked();
+    await waitFor(() => {
+      DSORadio.click();
+    });
+    expect(DSORadio).toBeChecked();
     await user.click(screen.getByRole("button", { name: "Volgende" }));
 
     expect(router.state.location.pathname).toEqual("/elections/create/number-of-voters");

--- a/frontend/src/features/election_create/components/CountingMethodType.tsx
+++ b/frontend/src/features/election_create/components/CountingMethodType.tsx
@@ -6,12 +6,9 @@ import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { t } from "@/i18n/translate";
-
+import { StringFormData } from "@/utils/stringFormData";
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 
-/*
- * NOTE: DSO is currently unsupported by Abacus, so it is disabled by default
- */
 export function CountingMethodType() {
   const { state, dispatch } = useElectionCreateContext();
   const navigate = useNavigate();
@@ -23,10 +20,15 @@ export function CountingMethodType() {
 
   async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
+    const formData = new StringFormData(event.currentTarget);
+    const countingMethod = formData.getString("counting_method");
+    if (!countingMethod || (countingMethod !== "CSO" && countingMethod !== "DSO")) {
+      return;
+    }
+
     dispatch({
       type: "SET_COUNTING_METHOD_TYPE",
-      // This is hardcoded to CSO until we have support for DSO
-      countingMethod: "CSO",
+      countingMethod,
     });
     await navigate("/elections/create/number-of-voters");
   }
@@ -49,26 +51,19 @@ export function CountingMethodType() {
             <ChoiceList>
               <ChoiceList.Radio
                 id="cso"
+                name={"counting_method"}
                 label={t("election.voting_method_type.cso")}
-                checked={true}
-                onChange={() => {
-                  /*
-              We need this to suppress an error because we explicitly set the `checked` property.
-              We'll actually implement this handler once we support DSO
-            */
-                }}
+                defaultValue={"CSO"}
+                defaultChecked={state.countingMethod === "CSO" || !state.countingMethod}
               >
                 {t("election.voting_method_type.cso_description")}
               </ChoiceList.Radio>
               <ChoiceList.Radio
                 id="dso"
-                label={
-                  <span>
-                    {t("election.voting_method_type.dso")} (<b>{t("election.voting_method_type.dso_not_supported")}</b>)
-                  </span>
-                }
-                checked={false}
-                disabled
+                name={"counting_method"}
+                label={t("election.voting_method_type.dso")}
+                defaultValue={"DSO"}
+                defaultChecked={state.countingMethod === "DSO"}
               >
                 {t("election.voting_method_type.dso_description")}
               </ChoiceList.Radio>

--- a/frontend/src/features/election_create/components/CountingMethodType.tsx
+++ b/frontend/src/features/election_create/components/CountingMethodType.tsx
@@ -1,4 +1,4 @@
-import type { SubmitEvent } from "react";
+import { type SubmitEvent, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/Button/Button";
@@ -6,11 +6,13 @@ import { ChoiceList } from "@/components/ui/CheckboxAndRadio/ChoiceList";
 import { Form } from "@/components/ui/Form/Form";
 import { FormLayout } from "@/components/ui/Form/FormLayout";
 import { t } from "@/i18n/translate";
+import { type VoteCountingMethod, voteCountingMethodValues } from "@/types/generated/openapi";
 import { StringFormData } from "@/utils/stringFormData";
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 
 export function CountingMethodType() {
   const { state, dispatch } = useElectionCreateContext();
+  const [error, setError] = useState<string | undefined>();
   const navigate = useNavigate();
 
   // if no election data was stored, navigate back to beginning
@@ -19,18 +21,28 @@ export function CountingMethodType() {
   }
 
   async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const formData = new StringFormData(event.currentTarget);
-    const countingMethod = formData.getString("counting_method");
-    if (!countingMethod || (countingMethod !== "CSO" && countingMethod !== "DSO")) {
-      return;
+    function isVoteCountingMethod(value: string): value is VoteCountingMethod {
+      for (countingMethod of voteCountingMethodValues) {
+        if (value === countingMethod) {
+          return true;
+        }
+      }
+      return false;
     }
 
-    dispatch({
-      type: "SET_COUNTING_METHOD_TYPE",
-      countingMethod,
-    });
-    await navigate("/elections/create/number-of-voters");
+    event.preventDefault();
+    const formData = new StringFormData(event.currentTarget);
+    let countingMethod = formData.getString("counting_method");
+
+    if (isVoteCountingMethod(countingMethod)) {
+      dispatch({
+        type: "SET_COUNTING_METHOD_TYPE",
+        countingMethod,
+      });
+      await navigate("/elections/create/number-of-voters");
+    } else {
+      setError(t("mandatory_question"));
+    }
   }
 
   return (
@@ -49,24 +61,21 @@ export function CountingMethodType() {
             </p>
 
             <ChoiceList>
-              <ChoiceList.Radio
-                id="cso"
-                name={"counting_method"}
-                label={t("election.voting_method_type.cso")}
-                defaultValue={"CSO"}
-                defaultChecked={state.countingMethod === "CSO" || !state.countingMethod}
-              >
-                {t("election.voting_method_type.cso_description")}
-              </ChoiceList.Radio>
-              <ChoiceList.Radio
-                id="dso"
-                name={"counting_method"}
-                label={t("election.voting_method_type.dso")}
-                defaultValue={"DSO"}
-                defaultChecked={state.countingMethod === "DSO"}
-              >
-                {t("election.voting_method_type.dso_description")}
-              </ChoiceList.Radio>
+              {error && <ChoiceList.Error id="choicelist-error">{error}</ChoiceList.Error>}
+              {voteCountingMethodValues.map((countingMethod) => {
+                return (
+                  <ChoiceList.Radio
+                    id={countingMethod}
+                    key={countingMethod}
+                    name={"counting_method"}
+                    label={t(`election.voting_method_type.${countingMethod}`)}
+                    defaultValue={countingMethod}
+                    defaultChecked={state.countingMethod === countingMethod}
+                  >
+                    {t(`election.voting_method_type.${countingMethod}_description`)}
+                  </ChoiceList.Radio>
+                );
+              })}
             </ChoiceList>
           </FormLayout.Section>
 

--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -452,7 +452,7 @@ describe("Election create pages", () => {
       });
     });
 
-    test("Adds new election when finishing election import", async () => {
+    test("Adds new CSO election when finishing election import", async () => {
       vi.spyOn(console, "warn").mockImplementation(() => {});
       const router = renderWithRouter();
       const user = userEvent.setup();
@@ -483,6 +483,60 @@ describe("Election create pages", () => {
         await screen.findByRole("heading", { level: 2, name: "Type stemopneming in Heemdamseburg" }),
       ).toBeVisible();
       expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).toBeChecked();
+      await user.click(screen.getByRole("button", { name: "Volgende" }));
+
+      // eligible voters
+      expect(await screen.findByRole("heading", { name: "Hoeveel kiesgerechtigden telt het GSB?" })).toBeVisible();
+      expect(screen.getByRole("textbox", { name: "Aantal kiesgerechtigden" })).toHaveValue(eligibleVoters.toString());
+      await user.click(screen.getByRole("button", { name: "Volgende" }));
+
+      // check and save
+      expect(await screen.findByRole("heading", { name: "Controleren en opslaan" })).toBeVisible();
+      await user.click(screen.getByRole("button", { name: "Opslaan" }));
+
+      await waitFor(() => {
+        expect(pushMessage).toHaveBeenCalledWith({ title: "Verkiezing GSB Gemeenteraad Test 2022 toegevoegd" });
+      });
+    });
+
+    test("Adds new DSO election when finishing election import", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const router = renderWithRouter();
+      const user = userEvent.setup();
+      const file = new File(["foo"], "foo.txt", { type: "text/plain" });
+
+      // election definition
+      await uploadElectionDefinition(router, file);
+      await inputElectionHash();
+
+      // candidates lists
+      await uploadCandidateDefinition(file);
+      await inputCandidateHash();
+
+      // committee category
+      await setCommitteeCategory();
+
+      // polling stations
+      const eligibleVoters = 1234;
+      await uploadPollingStationList(file, true, eligibleVoters);
+      expect(await screen.findByRole("heading", { level: 2, name: "Controleer stembureaus" })).toBeVisible();
+      expect(await screen.findByRole("table")).toBeVisible();
+      expect(await screen.findAllByRole("row")).toHaveLength(8);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Volgende" }));
+
+      // vote counting
+      expect(
+        await screen.findByRole("heading", { level: 2, name: "Type stemopneming in Heemdamseburg" }),
+      ).toBeVisible();
+      expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).toBeChecked();
+      const DSORadio = screen.getByRole("radio", { name: /Decentrale stemopneming \(DSO\)/ });
+      expect(DSORadio).not.toBeChecked();
+      await waitFor(() => {
+        DSORadio.click();
+      });
+      expect(DSORadio).toBeChecked();
+
       await user.click(screen.getByRole("button", { name: "Volgende" }));
 
       // eligible voters

--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -482,7 +482,14 @@ describe("Election create pages", () => {
       expect(
         await screen.findByRole("heading", { level: 2, name: "Type stemopneming in Heemdamseburg" }),
       ).toBeVisible();
-      expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).toBeChecked();
+      const CSORadio = screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ });
+      expect(CSORadio).not.toBeChecked();
+      expect(screen.getByRole("radio", { name: /Decentrale stemopneming \(DSO\)/ })).not.toBeChecked();
+      await waitFor(() => {
+        CSORadio.click();
+      });
+      expect(CSORadio).toBeChecked();
+
       await user.click(screen.getByRole("button", { name: "Volgende" }));
 
       // eligible voters
@@ -529,7 +536,7 @@ describe("Election create pages", () => {
       expect(
         await screen.findByRole("heading", { level: 2, name: "Type stemopneming in Heemdamseburg" }),
       ).toBeVisible();
-      expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).toBeChecked();
+      expect(screen.getByRole("radio", { name: /Centrale stemopneming \(CSO\)/ })).not.toBeChecked();
       const DSORadio = screen.getByRole("radio", { name: /Decentrale stemopneming \(DSO\)/ });
       expect(DSORadio).not.toBeChecked();
       await waitFor(() => {

--- a/frontend/src/i18n/locales/nl/apportionment.json
+++ b/frontend/src/i18n/locales/nl/apportionment.json
@@ -149,7 +149,6 @@
   "lists_a_seat_needs_to_be_reassigned_for": "Lijst {seat_from_lists} moet een zetel afstaan aan lijst {seat_to_list}.",
   "make_apportionment_definitive": "Je kunt de zetelverdeling nu definitief maken en het proces-verbaal downloaden.",
   "manage_deceased_candidates": "Beheer overleden kandidaten",
-  "mandatory_question": "Deze vraag is verplicht",
   "minus": "min",
   "no_candidates_are_deceased": "Alle kandidaten zijn meegenomen bij het verdelen van de zetels. Er zijn geen kandidaten buiten beschouwing gelaten vanwege overlijden.",
   "not_possible": "Zetelverdeling is niet mogelijk",

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -36,7 +36,6 @@
   },
   "configuration_not_finished": "De configuratie van Abacus is nog niet afgerond.",
   "create": "Verkiezing toevoegen",
-  "dso_not_supported": "Niet ondersteund in deze versie van Abacus",
   "election_category": {
     "title": "Type verkiezing"
   },
@@ -101,7 +100,6 @@
     "description": "Hoe worden stemmen voor de {election} in de gemeente {location} geteld? Het type stemopneming wordt bepaald door het college van burgemeester en wethouders (B&W) van de gemeente.",
     "dso": "Decentrale stemopneming (DSO)",
     "dso_description": "Op de verkiezingsdag tellen de stembureaus de stemmen per kandidaat",
-    "dso_not_supported": "Niet ondersteund in deze versie van Abacus",
     "title": "Type stemopneming in"
   },
   "you_cannot_start_data_entry_yet": "Je kan nog geen telresultaten invoeren."

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -95,11 +95,11 @@
   "use_instructions_to_import_eml": "Je hebt van het centraal stembureau instructies gekregen waarmee je de verkiezingsdefinitie kunt downloaden. Zet het bestand op deze computer en importeer het.",
   "use_instructions_to_import_polling_stations_eml": "Importeer het bestand met stembureaus. Heb je geen bestand met stembureaus? Je kan ze later nog handmatig invoeren. Sla deze stap dan over.",
   "voting_method_type": {
-    "cso": "Centrale stemopneming (CSO)",
-    "cso_description": "Op de verkiezingsdag wordt het aantal stemmen per lijst geteld. De stemmen op kandidaten worden door het gemeentelijke stembureau geteld.",
+    "CSO": "Centrale stemopneming (CSO)",
+    "CSO_description": "Op de verkiezingsdag wordt het aantal stemmen per lijst geteld. De stemmen op kandidaten worden door het gemeentelijke stembureau geteld.",
     "description": "Hoe worden stemmen voor de {election} in de gemeente {location} geteld? Het type stemopneming wordt bepaald door het college van burgemeester en wethouders (B&W) van de gemeente.",
-    "dso": "Decentrale stemopneming (DSO)",
-    "dso_description": "Op de verkiezingsdag tellen de stembureaus de stemmen per kandidaat",
+    "DSO": "Decentrale stemopneming (DSO)",
+    "DSO_description": "Op de verkiezingsdag tellen de stembureaus de stemmen per kandidaat",
     "title": "Type stemopneming in"
   },
   "you_cannot_start_data_entry_yet": "Je kan nog geen telresultaten invoeren."

--- a/frontend/src/i18n/locales/nl/generic.json
+++ b/frontend/src/i18n/locales/nl/generic.json
@@ -45,6 +45,7 @@
   "list_name": "Lijstnaam",
   "loading": "Laden...",
   "logs": "Logs",
+  "mandatory_question": "Deze vraag is verplicht",
   "manual_input": "Handmatig invullen",
   "import_from_file": "Importeren uit een bestand",
   "menu": "Menu",


### PR DESCRIPTION
Closes #3694 

## What & why

- Make DSO in election create not disabled
- Process selected counting method
- Add test
- Remove (now) unused i18n (that was somehow even duplicated)
- Set no default for counting method and added validation

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Import a test election
- Do not select a counting method and check the error message
- Select DSO
- Verify that the election is saved with counting method DSO

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->