### PR TITLE
Build Windows installer in weekly e2e workflow

### DIFF
--- a/.github/workflows/weekly-e2e-tests.yml
+++ b/.github/workflows/weekly-e2e-tests.yml
@@ -87,6 +87,40 @@ jobs:
         with:
           name: abacus-${{ matrix.target.os }}-weekly
           path: ${{ matrix.target.binary }}
+      - name: Build with airgap detection and TLS (for the installer)
+        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
+        if: matrix.target.os == 'windows-latest'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: abacus-windows-latest-weekly-release
+          path: ${{ matrix.target.binary }}
+        if: matrix.target.os == 'windows-latest'
+
+  build-installer:
+    name: Build Windows installer
+    needs:
+      - build
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: packaging/windows
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - name: Download Abacus
+        uses: actions/download-artifact@v8
+        with:
+          name: abacus-windows-latest-weekly-release
+          path: packaging/windows
+      - name: Download Visual C++ Redistributable
+        run: Invoke-WebRequest -Uri https://aka.ms/vc14/vc_redist.x64.exe -OutFile VC_redist.x64.exe
+      # Inno Setup is preinstalled on the runner image
+      - name: Compile installer
+        run: '& "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" abacus.iss'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: abacus-windows-installer-weekly
+          path: packaging/windows/Output/abacussetup.exe
 
   playwright-e2e:
     name: Playwright e2e tests (${{ matrix.os }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,5 +1,9 @@
 # Windows installer
 
+The weekly end-to-end tests workflow compiles this installer on every run and publishes it as
+the `abacus-windows-installer-weekly` artifact. That build is not signed, so it is only
+suitable for testing. Follow the steps below to build a signed installer.
+
 Follow the next steps to compile the installer:
 
 1. Download and install [Inno Setup 6.7](https://jrsoftware.org/). Use this version to get the same result.


### PR DESCRIPTION
## What & why

Build Windows installer in weekly e2e workflow so that we always have a recent Windows installer build available, like when @marjoleintamis wanted a new build for documentation work earlier today. I chose to extend the weekly e2e workflow because it already builds for Windows and runs the testsuite so we can be  sure that the build works like expected.

## How to test

[CI passes](https://github.com/kiesraad/abacus/actions/runs/30849099225)
