### PR TITLE
Implement data entry correction discard

### DIFF
--- a/backend/fuzz/fuzz_targets/data_entry_status.rs
+++ b/backend/fuzz/fuzz_targets/data_entry_status.rs
@@ -386,7 +386,7 @@ fuzz_target!(|transitions: Vec<Transition>| {
                 state.finalise_first_entry(&election(), users.first(correct_user))
             }
             Transition::DiscardFirstEntryInProgress(correct_user) => {
-                state.discard_first_entry_in_progress(users.first(correct_user))
+                state.discard_first_entry_in_progress(users.first(correct_user), &election())
             }
             Transition::DiscardFirstEntryWithErrors => state.discard_first_entry_with_errors(),
             Transition::ClaimSecondEntry(correct_user) => {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -759,7 +759,7 @@
         ]
       },
       "delete": {
-        "summary": "Discard an in-progress (not finalised) data entry (typist_csb, typist_gsb)",
+        "summary": "Discard an in-progress data entry or a correction. Discarding a\ncorrection finalises the other entry as the first entry. (typist_csb, typist_gsb)",
         "operationId": "data_entry_discard",
         "parameters": [
           {

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -463,7 +463,8 @@ async fn data_entry_save(
     Ok(SaveDataEntryResponse { validation_results })
 }
 
-/// Discard an in-progress (not finalised) data entry
+/// Discard an in-progress data entry or a correction. Discarding a
+/// correction finalises the other entry as the first entry.
 #[utoipa::path(
     delete,
     path = "/api/data_entries/{data_entry_id}/{entry_number}",
@@ -492,7 +493,9 @@ async fn data_entry_discard(
 
     let user_id = user.id();
     let new_state = match entry_number {
-        EntryNumber::FirstEntry => state.discard_first_entry_in_progress(user_id)?,
+        EntryNumber::FirstEntry => {
+            state.discard_first_entry_in_progress(user_id, &context.election)?
+        }
         EntryNumber::SecondEntry => {
             state.discard_second_entry_in_progress(user_id, &context.election)?
         }
@@ -2106,6 +2109,121 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_data_entry_discard_first_entry_correction(pool: SqlitePool) {
+        let polling_station_id = PollingStationId::from(211);
+        let data_entry_id = DataEntryId::from(201);
+        finalise_different_entries(pool.clone()).await;
+
+        let response = resolve_differences(
+            pool.clone(),
+            data_entry_id,
+            ResolveDifferencesAction::KeepSecondAndCorrectFirst,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // discard the correction as the typist correcting the first entry
+        let response = discard(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+
+        audit_log::assert_last_event(
+            &mut conn,
+            AuditEventType::DataEntryDiscarded,
+            AuditEventLevel::Info,
+            serde_json::to_value(DataEntryAuditData::from(data_entry.clone())).unwrap(),
+        )
+        .await;
+
+        // the kept second entry has become the finalised first entry
+        let DataEntryStatus::FirstEntryFinalised(state) = data_entry.state.0 else {
+            panic!("Expected entry to be in FirstEntryFinalised state");
+        };
+        assert_eq!(state.first_entry_user_id, UserId::from(2));
+        let Results::CSOFirstSession(first_entry) = state.finalised_first_entry else {
+            panic!("Expected entry to be CSOFirstSession model");
+        };
+        assert_eq!(first_entry.voters_counts.poll_card_count, 100);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_data_entry_discard_second_entry_correction(pool: SqlitePool) {
+        let polling_station_id = PollingStationId::from(211);
+        let data_entry_id = DataEntryId::from(201);
+        finalise_different_entries(pool.clone()).await;
+
+        let response = resolve_differences(
+            pool.clone(),
+            data_entry_id,
+            ResolveDifferencesAction::KeepFirstAndCorrectSecond,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // discard the correction as the typist correcting the second entry
+        let response = discard(pool.clone(), data_entry_id, EntryNumber::SecondEntry).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+
+        audit_log::assert_last_event(
+            &mut conn,
+            AuditEventType::DataEntryDiscarded,
+            AuditEventLevel::Info,
+            serde_json::to_value(DataEntryAuditData::from(data_entry.clone())).unwrap(),
+        )
+        .await;
+
+        // The finalised first entry is kept unchanged
+        let DataEntryStatus::FirstEntryFinalised(state) = data_entry.state.0 else {
+            panic!("Expected entry to be in FirstEntryFinalised state");
+        };
+        assert_eq!(state.first_entry_user_id, UserId::from(1));
+        let Results::CSOFirstSession(first_entry) = state.finalised_first_entry else {
+            panic!("Expected entry to be CSOFirstSession model");
+        };
+        assert_eq!(first_entry.voters_counts.poll_card_count, 99);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_data_entry_discard_first_entry_correction_other_user_fails(pool: SqlitePool) {
+        let polling_station_id = PollingStationId::from(211);
+        let data_entry_id = DataEntryId::from(201);
+        finalise_different_entries(pool.clone()).await;
+
+        let response = resolve_differences(
+            pool.clone(),
+            data_entry_id,
+            ResolveDifferencesAction::KeepSecondAndCorrectFirst,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // discarding the correction as a different typist fails
+        let user = User::test_user(Role::TypistGSB, UserId::from(2));
+        let response = data_entry_discard(
+            user.clone(),
+            State(pool.clone()),
+            Path((data_entry_id, EntryNumber::FirstEntry)),
+            AuditService::new(Some(user), None),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let result: ErrorResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result.reference, ErrorReference::InvalidStateTransition);
+
+        // check that the data entry is still in FirstEntryCorrection state
+        let mut conn = pool.acquire().await.unwrap();
+        let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+        assert_matches!(data_entry.state.0, DataEntryStatus::FirstEntryCorrection(_));
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_data_entry_reset_first_entry_in_progress(pool: SqlitePool) {
         // create data entry
         let polling_station_id = PollingStationId::from(211);
@@ -2242,6 +2360,79 @@ mod tests {
 
         // Check that the data entry is not deleted
         assert!(ps_has_data_entry(&mut conn, polling_station_id).await);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_data_entry_reset_first_entry_correction(pool: SqlitePool) {
+        let polling_station_id = PollingStationId::from(211);
+        let data_entry_id = DataEntryId::from(201);
+        finalise_different_entries(pool.clone()).await;
+
+        let response = resolve_differences(
+            pool.clone(),
+            data_entry_id,
+            ResolveDifferencesAction::KeepSecondAndCorrectFirst,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let correction = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+        assert_matches!(correction.state.0, DataEntryStatus::FirstEntryCorrection(_));
+
+        // reset data entry with status FirstEntryCorrection
+        let response = reset(pool.clone(), data_entry_id).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        // check that the data entry is reset to Empty
+        let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+        assert_eq!(data_entry.state.0, DataEntryStatus::Empty);
+
+        audit_log::assert_last_event(
+            &mut conn,
+            AuditEventType::DataEntryReset,
+            AuditEventLevel::Info,
+            serde_json::to_value(DataEntryAuditData::from(correction.clone())).unwrap(),
+        )
+        .await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_data_entry_reset_second_entry_correction(pool: SqlitePool) {
+        let polling_station_id = PollingStationId::from(211);
+        let data_entry_id = DataEntryId::from(201);
+        finalise_different_entries(pool.clone()).await;
+
+        let response = resolve_differences(
+            pool.clone(),
+            data_entry_id,
+            ResolveDifferencesAction::KeepFirstAndCorrectSecond,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let correction = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+        assert_matches!(
+            correction.state.0,
+            DataEntryStatus::SecondEntryCorrection(_)
+        );
+
+        // reset data entry with status SecondEntryCorrection
+        let response = reset(pool.clone(), data_entry_id).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        // check that the data entry is reset to Empty
+        let data_entry = get_data_entry_for_ps(&mut conn, polling_station_id).await;
+        assert_eq!(data_entry.state.0, DataEntryStatus::Empty);
+
+        audit_log::assert_last_event(
+            &mut conn,
+            AuditEventType::DataEntryReset,
+            AuditEventLevel::Info,
+            serde_json::to_value(DataEntryAuditData::from(correction.clone())).unwrap(),
+        )
+        .await;
     }
 
     mod data_entry_resolve_differences {

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -748,10 +748,12 @@ impl DataEntryStatus {
         }
     }
 
-    /// Discard the first entry while it is in progress
+    /// Discard the first entry while it is in progress or being corrected.
+    /// Discarding a correction keeps the second entry as the finalised first entry.
     pub fn discard_first_entry_in_progress(
         self,
         user_id: UserId,
+        election: &ElectionWithPoliticalGroups,
     ) -> Result<Self, DataEntryTransitionError> {
         match self {
             DataEntryStatus::FirstEntryInProgress(state) => {
@@ -760,6 +762,27 @@ impl DataEntryStatus {
                 }
 
                 Ok(DataEntryStatus::Empty)
+            }
+            DataEntryStatus::FirstEntryCorrection(state) => {
+                if state.first_entry_user_id != user_id {
+                    return Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser);
+                }
+
+                let validation_results = state.finalised_second_entry.start_validate(election)?;
+                if validation_results.has_errors() {
+                    // The kept entry was validated to be without errors when the correction
+                    // started, so this shouldn't happen.
+                    return Err(DataEntryTransitionError::ValidationError(
+                        validation_results,
+                    ));
+                }
+
+                Ok(Self::FirstEntryFinalised(FirstEntryFinalised {
+                    first_entry_user_id: state.second_entry_user_id,
+                    finalised_first_entry: state.finalised_second_entry,
+                    first_entry_finished_at: state.second_entry_finished_at,
+                    finalised_with_warnings: validation_results.has_warnings(),
+                }))
             }
             DataEntryStatus::FirstEntryFinalised(_) | DataEntryStatus::SecondEntryInProgress(_) => {
                 Err(DataEntryTransitionError::FirstEntryAlreadyFinalised)
@@ -771,7 +794,8 @@ impl DataEntryStatus {
         }
     }
 
-    /// Discard the second entry while it is in progress
+    /// Discard the second entry while it is in progress or being corrected.
+    /// Discarding a correction keeps the first entry as the finalised first entry.
     pub fn discard_second_entry_in_progress(
         self,
         user_id: UserId,
@@ -790,11 +814,39 @@ impl DataEntryStatus {
                 }
 
                 let validation_results = finalised_first_entry.start_validate(election)?;
+                if validation_results.has_errors() {
+                    // The first entry was validated to be without errors when it was
+                    // finalised, so this shouldn't happen.
+                    return Err(DataEntryTransitionError::ValidationError(
+                        validation_results,
+                    ));
+                }
 
                 Ok(DataEntryStatus::FirstEntryFinalised(FirstEntryFinalised {
                     first_entry_user_id,
                     finalised_first_entry,
                     first_entry_finished_at,
+                    finalised_with_warnings: validation_results.has_warnings(),
+                }))
+            }
+            DataEntryStatus::SecondEntryCorrection(state) => {
+                if state.second_entry_user_id != user_id {
+                    return Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser);
+                }
+
+                let validation_results = state.finalised_first_entry.start_validate(election)?;
+                if validation_results.has_errors() {
+                    // The kept entry was validated to be without errors when the correction
+                    // started, so this shouldn't happen.
+                    return Err(DataEntryTransitionError::ValidationError(
+                        validation_results,
+                    ));
+                }
+
+                Ok(Self::FirstEntryFinalised(FirstEntryFinalised {
+                    first_entry_user_id: state.first_entry_user_id,
+                    finalised_first_entry: state.finalised_first_entry,
+                    first_entry_finished_at: state.first_entry_finished_at,
                     finalised_with_warnings: validation_results.has_warnings(),
                 }))
             }
@@ -1249,6 +1301,30 @@ mod tests {
         })
     }
 
+    fn first_entry_correction() -> DataEntryStatus {
+        DataEntryStatus::FirstEntryCorrection(FirstEntryCorrection {
+            first_entry_user_id: UserId::from(0),
+            second_entry_user_id: UserId::from(1),
+            first_entry: example_results(),
+            finalised_second_entry: example_results().with_difference(),
+            second_entry_finished_at: Utc::now(),
+            progress: 0,
+            client_state: ClientState::new_from_str(Some("{}")).unwrap(),
+        })
+    }
+
+    fn second_entry_correction() -> DataEntryStatus {
+        DataEntryStatus::SecondEntryCorrection(SecondEntryCorrection {
+            first_entry_user_id: UserId::from(0),
+            finalised_first_entry: example_results(),
+            second_entry_user_id: UserId::from(1),
+            second_entry: example_results().with_difference(),
+            first_entry_finished_at: Utc::now(),
+            progress: 0,
+            client_state: ClientState::new_from_str(Some("{}")).unwrap(),
+        })
+    }
+
     /// Empty --> FirstEntryInProgress: claim
     #[test]
     fn empty_to_first_entry_in_progress() {
@@ -1384,7 +1460,7 @@ mod tests {
         // Happy path
         assert!(matches!(
             first_entry_in_progress()
-                .discard_first_entry_in_progress(UserId::from(0))
+                .discard_first_entry_in_progress(UserId::from(0), &election())
                 .unwrap(),
             DataEntryStatus::Empty
         ));
@@ -1394,21 +1470,22 @@ mod tests {
     #[test]
     fn first_entry_finalised_discard_first_entry_error() {
         assert_eq!(
-            first_entry_finalised().discard_first_entry_in_progress(UserId::from(0)),
+            first_entry_finalised().discard_first_entry_in_progress(UserId::from(0), &election()),
             Err(DataEntryTransitionError::FirstEntryAlreadyFinalised)
         );
     }
     #[test]
     fn second_entry_in_progress_discard_first_entry_error() {
         assert_eq!(
-            second_entry_in_progress().discard_first_entry_in_progress(UserId::from(0)),
+            second_entry_in_progress()
+                .discard_first_entry_in_progress(UserId::from(0), &election()),
             Err(DataEntryTransitionError::FirstEntryAlreadyFinalised)
         );
     }
     #[test]
     fn definitive_discard_first_entry_error() {
         assert_eq!(
-            definitive().discard_first_entry_in_progress(UserId::from(0)),
+            definitive().discard_first_entry_in_progress(UserId::from(0), &election()),
             Err(DataEntryTransitionError::SecondEntryAlreadyFinalised)
         );
     }
@@ -1417,7 +1494,7 @@ mod tests {
     #[test]
     fn first_entry_in_progress_discard_as_other_user_error() {
         assert_eq!(
-            first_entry_in_progress().discard_first_entry_in_progress(UserId::from(1)),
+            first_entry_in_progress().discard_first_entry_in_progress(UserId::from(1), &election()),
             Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser)
         );
     }
@@ -1690,6 +1767,19 @@ mod tests {
         ));
     }
 
+    /// Discarding an in-progress second entry errors when the finalised first entry
+    /// unexpectedly has errors (should never happen)
+    #[test]
+    fn second_entry_in_progress_discard_first_entry_has_errors() {
+        let mut status = second_entry_in_progress();
+        status.set_first_entry(example_results().with_error());
+
+        assert!(matches!(
+            status.discard_second_entry_in_progress(UserId::from(0), &election()),
+            Err(DataEntryTransitionError::ValidationError(_))
+        ));
+    }
+
     /// SecondEntryInProgress --> FirstEntryFinalised: error when discarding as a different user
     #[test]
     fn second_entry_in_progress_discard_as_other_user_error() {
@@ -1917,6 +2007,131 @@ mod tests {
         );
     }
 
+    /// FirstEntryCorrection --> FirstEntryFinalised: discard
+    /// The kept second entry becomes the first entry
+    #[test]
+    fn first_entry_correction_to_first_entry_finalised_discard() {
+        let initial = first_entry_correction();
+        let DataEntryStatus::FirstEntryCorrection(correction) = initial.clone() else {
+            panic!("expected FirstEntryCorrection");
+        };
+
+        let next = initial
+            .discard_first_entry_in_progress(UserId::from(0), &election())
+            .unwrap();
+
+        if let DataEntryStatus::FirstEntryFinalised(kept_entry) = next {
+            assert_eq!(
+                kept_entry.first_entry_user_id,
+                correction.second_entry_user_id
+            );
+            assert_eq!(
+                kept_entry.finalised_first_entry,
+                correction.finalised_second_entry
+            );
+            assert_eq!(
+                kept_entry.first_entry_finished_at,
+                correction.second_entry_finished_at
+            );
+        } else {
+            panic!("{next:?}")
+        };
+    }
+
+    /// FirstEntryCorrection --> FirstEntryFinalised: error when discarding as a different user
+    #[test]
+    fn first_entry_correction_discard_as_other_user_error() {
+        assert_eq!(
+            first_entry_correction().discard_first_entry_in_progress(UserId::from(1), &election()),
+            Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser)
+        );
+    }
+
+    /// Discarding a first entry correction as second entry is invalid
+    #[test]
+    fn first_entry_correction_discard_second_entry_error() {
+        assert_eq!(
+            first_entry_correction().discard_second_entry_in_progress(UserId::from(1), &election()),
+            Err(DataEntryTransitionError::Invalid)
+        );
+    }
+
+    /// Discarding a first entry correction errors when the kept second entry
+    /// unexpectedly has errors (should never happen)
+    #[test]
+    fn first_entry_correction_discard_kept_entry_has_errors() {
+        let mut status = first_entry_correction();
+        status.set_second_entry(example_results().with_error());
+
+        assert!(matches!(
+            status.discard_first_entry_in_progress(UserId::from(0), &election()),
+            Err(DataEntryTransitionError::ValidationError(_))
+        ));
+    }
+
+    /// SecondEntryCorrection --> FirstEntryFinalised: discard
+    /// The finalised first entry is kept unchanged
+    #[test]
+    fn second_entry_correction_to_first_entry_finalised_discard() {
+        let initial = second_entry_correction();
+        let DataEntryStatus::SecondEntryCorrection(correction) = initial.clone() else {
+            panic!("expected SecondEntryCorrection");
+        };
+
+        let next = initial
+            .discard_second_entry_in_progress(UserId::from(1), &election())
+            .unwrap();
+
+        if let DataEntryStatus::FirstEntryFinalised(kept_entry) = next {
+            assert_eq!(
+                kept_entry.first_entry_user_id,
+                correction.first_entry_user_id
+            );
+            assert_eq!(
+                kept_entry.finalised_first_entry,
+                correction.finalised_first_entry
+            );
+            assert_eq!(
+                kept_entry.first_entry_finished_at,
+                correction.first_entry_finished_at
+            );
+        } else {
+            panic!("{next:?}")
+        };
+    }
+
+    /// SecondEntryCorrection --> FirstEntryFinalised: error when discarding as a different user
+    #[test]
+    fn second_entry_correction_discard_as_other_user_error() {
+        assert_eq!(
+            second_entry_correction()
+                .discard_second_entry_in_progress(UserId::from(0), &election()),
+            Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser)
+        );
+    }
+
+    /// Discarding a second entry correction as first entry is invalid
+    #[test]
+    fn second_entry_correction_discard_first_entry_error() {
+        assert_eq!(
+            second_entry_correction().discard_first_entry_in_progress(UserId::from(0), &election()),
+            Err(DataEntryTransitionError::Invalid)
+        );
+    }
+
+    /// Discarding a second entry correction errors when the kept first entry
+    /// unexpectedly has errors (should never happen)
+    #[test]
+    fn second_entry_correction_discard_kept_entry_has_errors() {
+        let mut status = second_entry_correction();
+        status.set_first_entry(example_results().with_error());
+
+        assert!(matches!(
+            status.discard_second_entry_in_progress(UserId::from(1), &election()),
+            Err(DataEntryTransitionError::ValidationError(_))
+        ));
+    }
+
     /// update_first_entry should fail for other states
     #[test]
     fn first_entry_finalised_update_first_entry() {
@@ -2051,8 +2266,8 @@ mod tests {
                 data_entry::{
                     DataEntryStatus,
                     tests::{
-                        election, entries_different, example_results, first_entry_in_progress,
-                        second_entry_in_progress,
+                        election, entries_different, example_results, first_entry_correction,
+                        first_entry_in_progress, second_entry_correction, second_entry_in_progress,
                     },
                 },
                 results::Results,
@@ -2068,7 +2283,10 @@ mod tests {
                         state.finalised_first_entry = results
                     }
                     DataEntryStatus::EntriesDifferent(state) => state.first_entry = results,
-                    _ => panic!("first_entry() not implemented for this status"),
+                    DataEntryStatus::SecondEntryCorrection(state) => {
+                        state.finalised_first_entry = results
+                    }
+                    _ => panic!("set_first_entry() not implemented for this status"),
                 }
             }
 
@@ -2076,7 +2294,10 @@ mod tests {
                 match self {
                     DataEntryStatus::SecondEntryInProgress(state) => state.second_entry = results,
                     DataEntryStatus::EntriesDifferent(state) => state.second_entry = results,
-                    _ => panic!("second_entry() not implemented for this status"),
+                    DataEntryStatus::FirstEntryCorrection(state) => {
+                        state.finalised_second_entry = results
+                    }
+                    _ => panic!("set_second_entry() not implemented for this status"),
                 }
             }
         }
@@ -2166,6 +2387,56 @@ mod tests {
                     .unwrap()
                     .finalised_with_warnings(),
                 Some(&false)
+            )
+        }
+
+        #[test]
+        fn discard_first_entry_correction_without_warnings() {
+            assert_eq!(
+                first_entry_correction()
+                    .discard_first_entry_in_progress(UserId::from(0), &election())
+                    .unwrap()
+                    .finalised_with_warnings(),
+                Some(&false)
+            )
+        }
+
+        #[test]
+        fn discard_first_entry_correction_with_warnings() {
+            let mut status = first_entry_correction();
+            status.set_second_entry(example_results().with_warning());
+
+            assert_eq!(
+                status
+                    .discard_first_entry_in_progress(UserId::from(0), &election())
+                    .unwrap()
+                    .finalised_with_warnings(),
+                Some(&true)
+            )
+        }
+
+        #[test]
+        fn discard_second_entry_correction_without_warnings() {
+            assert_eq!(
+                second_entry_correction()
+                    .discard_second_entry_in_progress(UserId::from(1), &election())
+                    .unwrap()
+                    .finalised_with_warnings(),
+                Some(&false)
+            )
+        }
+
+        #[test]
+        fn discard_second_entry_correction_with_warnings() {
+            let mut status = second_entry_correction();
+            status.set_first_entry(example_results().with_warning());
+
+            assert_eq!(
+                status
+                    .discard_second_entry_in_progress(UserId::from(1), &election())
+                    .unwrap()
+                    .finalised_with_warnings(),
+                Some(&true)
             )
         }
 

--- a/frontend/e2e-tests/tests/data-entry-GSB/resolve-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/resolve-differences.e2e.ts
@@ -1,4 +1,7 @@
 import { expect } from "@playwright/test";
+import { AbortInputModal } from "e2e-tests/page-objects/data_entry/AbortInputModalPgObj";
+import { DataEntryBasePage } from "e2e-tests/page-objects/data_entry/DataEntryBasePgObj";
+import { DataEntryHomePage } from "e2e-tests/page-objects/data_entry/DataEntryHomePgObj";
 import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
 import { ResolveDifferencesPgObj } from "e2e-tests/page-objects/election/ResolveDifferencesPgObj";
 import { ResolveErrorsPgObj } from "e2e-tests/page-objects/election/ResolveErrorsPgObj";
@@ -119,6 +122,82 @@ test.describe("resolve differences", () => {
     await expect(electionStatusPage.alertDifferencesResolved).toBeVisible();
     await expect(electionStatusPage.alertDifferencesResolved).toContainText(
       "Omdat beide invoeren zijn verwijderd, moet stembureau 33 twee keer opnieuw ingevoerd worden.",
+    );
+  });
+
+  test("typist discards a second entry correction", async ({ page, typistTwoGSB, dataEntryGSBEntriesDifferent }) => {
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBEntriesDifferent.name }).click();
+
+    const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
+    await resolveDifferencesPage.keepFirstEntry.click();
+    await resolveDifferencesPage.correctWrongEntry.click();
+    await resolveDifferencesPage.save.click();
+
+    await expect(electionStatusPage.inProgress).toContainText(
+      [dataEntryGSBEntriesDifferent.name, "2e invoer", "Aliyah van den Berg"].join(""),
+    );
+
+    // the typist correcting the second entry abandons the correction
+    const typistPage = typistTwoGSB.page;
+    await typistPage.goto(
+      `/elections/${dataEntryGSBEntriesDifferent.election_id}/data-entry/${dataEntryGSBEntriesDifferent.id}/2`,
+    );
+
+    const dataEntryPage = new DataEntryBasePage(typistPage);
+    await dataEntryPage.abortInput.click();
+
+    const abortInputModal = new AbortInputModal(typistPage);
+    await expect(abortInputModal.heading).toBeVisible();
+    await abortInputModal.discardInput.click();
+
+    const dataEntryHomePage = new DataEntryHomePage(typistPage);
+    await expect(dataEntryHomePage.fieldset).toBeVisible();
+
+    // the finalised first entry is kept, so a new second entry can be started
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
+    await expect(electionStatusPage.firstEntryFinished).toContainText(
+      `${dataEntryGSBEntriesDifferent.name}Sam Kuijpers`,
+    );
+  });
+
+  test("typist discards a first entry correction", async ({ page, typistOneGSB, dataEntryGSBEntriesDifferent }) => {
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.errorsAndWarnings.getByRole("row", { name: dataEntryGSBEntriesDifferent.name }).click();
+
+    const resolveDifferencesPage = new ResolveDifferencesPgObj(page);
+    await resolveDifferencesPage.keepSecondEntry.click();
+    await resolveDifferencesPage.correctWrongEntry.click();
+    await resolveDifferencesPage.save.click();
+
+    await expect(electionStatusPage.inProgress).toContainText(
+      [dataEntryGSBEntriesDifferent.name, "1e invoer", "Sam Kuijpers"].join(""),
+    );
+
+    // the typist correcting the first entry abandons the correction
+    const typistPage = typistOneGSB.page;
+    await typistPage.goto(
+      `/elections/${dataEntryGSBEntriesDifferent.election_id}/data-entry/${dataEntryGSBEntriesDifferent.id}/1`,
+    );
+
+    const dataEntryPage = new DataEntryBasePage(typistPage);
+    await dataEntryPage.abortInput.click();
+
+    const abortInputModal = new AbortInputModal(typistPage);
+    await expect(abortInputModal.heading).toBeVisible();
+    await abortInputModal.discardInput.click();
+
+    const dataEntryHomePage = new DataEntryHomePage(typistPage);
+    await expect(dataEntryHomePage.fieldset).toBeVisible();
+
+    // the kept second entry has become the finalised first entry
+    await page.goto(`/elections/${dataEntryGSBEntriesDifferent.election_id}/status`);
+    await expect(electionStatusPage.firstEntryFinished).toContainText(
+      `${dataEntryGSBEntriesDifferent.name}Aliyah van den Berg`,
     );
   });
 });

--- a/frontend/src/features/data_entry_detail/components/delete/ReadOnlyDataEntryDelete.test.tsx
+++ b/frontend/src/features/data_entry_detail/components/delete/ReadOnlyDataEntryDelete.test.tsx
@@ -64,8 +64,13 @@ describe("ReadOnlyDataEntryDelete", () => {
     expect(onDeleted).toHaveBeenCalledOnce();
   });
 
-  test("Renders different text when there are 2 data entries", async () => {
-    const { onDeleted } = renderComponent("definitive");
+  test.each<DataEntryStatusName>([
+    "second_entry_in_progress",
+    "first_entry_correction",
+    "second_entry_correction",
+    "definitive",
+  ])("Renders different text when there are 2 data entries (%s)", async (status) => {
+    const { onDeleted } = renderComponent(status);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Invoer verwijderen" }));


### PR DESCRIPTION
## What & why

Implement data entry correction discard. When discarding a first data entry correction the second data entry becomes the new first entry. When discarding a second data entry correction, the first entry stays the first entry. Both transitions go to the `FirstEntryFinalised` state. Also see the [data entry state diagram](https://github.com/kiesraad/abacus/blob/d10737654569fa9facd993701b841edbd40b1e78/documentatie/state-machines/data-entry-state.md).

Resolves #3658, because the reset transition already works. 

## How to test

Create a data entry with differences, resolve by choosing correction, test discarding as typist and check new state.
