### PR TITLE
Small fixes for CSV files GSB/CSB

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e44b143a6a48317033079275252e49eb0da3214728b16e3e61144d43eadd39"
+checksum = "22238651fa78fcefcc99b649b4fb7ca205c9a07a3594cdea2715d6a1ed1b3252"
 dependencies = [
  "chrono",
  "quick-xml 0.41.0",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,7 +77,7 @@ axum.workspace = true
 axum-extra.workspace = true
 chrono.workspace = true
 clap = { version = "4.6", default-features = false, features = ["derive", "std", "help", "env", "string"] }
-eml-nl = { version = "0.6.1" }
+eml-nl = { version = "0.6.2" }
 hyper = { version = "1", features = ["full"] }
 icu_collator = "2.2.0"
 icu_locale_core = "2.2.0"

--- a/backend/src/domain/election.rs
+++ b/backend/src/domain/election.rs
@@ -103,7 +103,7 @@ impl NameResolver for ElectionWithPoliticalGroups {
         self.political_groups
             .iter()
             .find(|pg| pg.number == aff_id)
-            .map(|pg| pg.registered_name.clone())
+            .map(|pg| pg.name.clone())
     }
 
     fn resolve_candidate_name(

--- a/backend/tests/report_integration_test.rs
+++ b/backend/tests/report_integration_test.rs
@@ -83,7 +83,7 @@ pub async fn read_zip_entry(
         reader.entry().filename().as_str().unwrap(),
         expected_filename
     );
-    assert!(reader.entry().uncompressed_size() > 1024);
+    assert!(reader.entry().uncompressed_size() > 512);
     let mut buf = Vec::new();
     reader.read_to_end_checked(&mut buf).await.unwrap();
     buf
@@ -109,7 +109,6 @@ async fn test_gsb_election_first_session_zip_download_works(pool: SqlitePool) {
     let pdf_hash1 = sha2::Sha256::digest(read_zip_entry(&archive, 0, "Model_Na31-2.pdf").await);
     let xml_zip = read_zip_entry(&archive, 1, "Telling_GR2024_Heemdamseburg.zip").await;
     let csv = read_zip_entry(&archive, 2, "osv4-3_telling_gr2024_heemdamseburg.csv").await;
-    assert!(csv.len() > 1024);
     let xml_archive = ZipFileReader::new(xml_zip).await.unwrap();
     assert_eq!(xml_archive.file().entries().len(), 1);
     let eml_hash1 = sha2::Sha256::digest(
@@ -163,7 +162,6 @@ async fn test_gsb_election_next_session_zip_download_works(pool: SqlitePool) {
     let pdf_hash1 = sha2::Sha256::digest(read_zip_entry(&archive, 0, "Model_Na14-2.pdf").await);
     let xml_zip = read_zip_entry(&archive, 1, "Telling_GR2026_GroteStad.zip").await;
     let csv = read_zip_entry(&archive, 2, "osv4-3_telling_gr2026_grotestad.csv").await;
-    assert!(csv.len() > 1024);
     let xml_archive = ZipFileReader::new(xml_zip).await.unwrap();
     assert_eq!(xml_archive.file().entries().len(), 1);
     let eml_hash1 = sha2::Sha256::digest(
@@ -419,7 +417,6 @@ async fn test_csb_election_zip_download_total_counts_works(pool: SqlitePool) {
     let archive = ZipFileReader::new(bytes).await.unwrap();
     assert_eq!(archive.file().entries().len(), 2);
     let csv_count = read_zip_entry(&archive, 0, "osv4-3_telling_gr2024_juinen.csv").await;
-    assert!(csv_count.len() > 1024);
     let xml_zip = read_zip_entry(&archive, 1, "Totaaltelling_GR2024_Juinen.zip").await;
     let xml_archive = ZipFileReader::new(xml_zip).await.unwrap();
     assert_eq!(xml_archive.file().entries().len(), 1);


### PR DESCRIPTION
## What & why

Resolves #3711

- Stat rows in the CSV are now only rendered if the value has been set
  - Implemented in https://github.com/kiesraad/rust-eml-nl/pull/53 and part of `rust-eml-nl 0.6.2`
- Updated crate in `cargo.toml`
- Updated `NameResolver`  so unnamed lists will now be formatted in the CSV

## How to test

- Generate an election
- Complete the data entry and download the ZIP
- View the CSV, validate that:
  - The rows that are mentioned in the issue are removed
  - The row `geldige kiezerspas` only shows for WS/PS
  - An unnamed list now shows the name

## Reviewer notes

Test filesize check has been adjusted to a minimum of 512 bytes instead of 1024 bytes, since the CSV of test `test_gsb_election_first_session_zip_download_works` which uses the `election_2` fixture is so small (925 bytes). Removed duplicated filesize checks. 