### PR TITLE
Allow importing polling stations with invalid number of voters (backport of #3704)

### DIFF
--- a/backend/src/eml/error.rs
+++ b/backend/src/eml/error.rs
@@ -8,7 +8,6 @@ pub enum EMLImportError {
     InvalidDateFormat,
     InvalidVotingMethod,
     InvalidPollingStation,
-    InvalidNumberOfVoters,
     MismatchElection,
     MismatchElectionDate,
     MismatchElectionDomain,

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -30,7 +30,8 @@ use eml_nl::{
     io::{EMLParsingMode, EMLRead as _},
     utils::{
         AffiliationId, AffiliationType, AuthorityId, CandidateId, ElectionDomainId, ElectionId,
-        Gender, ReportingUnitIdentifierId, StringValueData, VotingChannelType, VotingMethod,
+        Gender, ReportingUnitIdentifierId, StringValue, StringValueData, VotingChannelType,
+        VotingMethod,
     },
 };
 pub use error::EMLImportError;
@@ -45,6 +46,15 @@ use crate::domain::{
     results::{Results, political_group_candidate_votes::PoliticalGroupCandidateVotes},
     summary::ElectionSummary,
 };
+
+fn max_votes(max_votes: &StringValue<NonZeroU64>) -> u32 {
+    match max_votes.copied_value() {
+        // If max_votes is too large we fall back to zero
+        Ok(v) => v.get().try_into().unwrap_or(0u32),
+        // If max_votes is not present or an invalid value we fall back to zero
+        Err(_) => 0u32,
+    }
+}
 
 impl NewElection {
     pub fn from_eml_str(election_definition_data: &str) -> Result<Self, EMLImportError> {
@@ -83,12 +93,7 @@ impl NewElection {
 
         // typically number of voters is not available in the EML, but it could
         // be so we try and extract it anyway
-        let max_votes = election.contest.max_votes.copied_value();
-        let number_of_voters = max_votes
-            .map(|v| v.get())
-            .unwrap_or(0)
-            .try_into()
-            .unwrap_or(0);
+        let number_of_voters = max_votes(&election.contest.max_votes);
 
         // the number of seats must be between 9 and 45 for municipal elections
         #[expect(
@@ -926,12 +931,8 @@ pub fn number_of_voters_from_polling_stations_eml(
         .contests
         .first()
         .ok_or(EMLImportError::PollingStationsWithoutContest)?;
-    contest
-        .max_votes
-        .copied_value()?
-        .get()
-        .try_into()
-        .map_err(|_| EMLImportError::InvalidNumberOfVoters)
+
+    Ok(max_votes(&contest.max_votes))
 }
 
 pub fn polling_stations_eml_matches_election(
@@ -1126,6 +1127,34 @@ mod tests {
         assert_eq!(
             result_gsb.total_votes.unwrap().eligible_voter_count,
             StringValue::from_value(1001u64)
+        );
+    }
+
+    #[test]
+    fn test_max_votes_extraction() {
+        assert_eq!(max_votes(&StringValue::Raw("0".into())), 0);
+        assert_eq!(max_votes(&StringValue::Raw("-1".into())), 0);
+        assert_eq!(max_votes(&StringValue::Raw("not-a-number".into())), 0);
+        assert_eq!(max_votes(&StringValue::Raw("100".into())), 100);
+        assert_eq!(
+            max_votes(&StringValue::Parsed(NonZeroU64::new(10).unwrap())),
+            10
+        );
+        assert_eq!(
+            max_votes(&StringValue::Parsed(NonZeroU64::new(u64::MAX).unwrap())),
+            0
+        );
+        assert_eq!(
+            max_votes(&StringValue::Parsed(
+                NonZeroU64::new((u32::MAX as u64) + 1).unwrap()
+            )),
+            0
+        );
+        assert_eq!(
+            max_votes(&StringValue::Parsed(
+                NonZeroU64::new(u32::MAX as u64).unwrap()
+            )),
+            u32::MAX
         );
     }
 }

--- a/backend/src/eml/tests/eml110b_zero_number_of_voters.eml.xml
+++ b/backend/src/eml/tests/eml110b_zero_number_of_voters.eml.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EML xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:kr="http://www.kiesraad.nl/extensions" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Id="110b" SchemaVersion="5">
+  <TransactionId>1</TransactionId>
+  <ManagingAuthority>
+    <AuthorityIdentifier Id="0000">Test</AuthorityIdentifier>
+    <AuthorityAddress/>
+  </ManagingAuthority>
+  <kr:CreationDateTime>2024-05-27T17:05:57</kr:CreationDateTime>
+  <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"/>
+  <ElectionEvent>
+    <EventIdentifier/>
+    <Election>
+      <ElectionIdentifier Id="EP2024">
+        <ElectionName>Europees Parlement 2024</ElectionName>
+        <ElectionCategory>EP</ElectionCategory>
+        <kr:ElectionSubcategory>EP</kr:ElectionSubcategory>
+        <kr:ElectionDate>2024-06-06</kr:ElectionDate>
+      </ElectionIdentifier>
+      <Contest>
+        <ContestIdentifier Id="geen"/>
+        <ReportingUnit>
+          <ReportingUnitIdentifier Id="0000">Test</ReportingUnitIdentifier>
+        </ReportingUnit>
+        <VotingMethod>SPV</VotingMethod>
+        <MaxVotes>0</MaxVotes>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Stadhuis</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1011 PN</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="1">1273</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Melkweg</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1017 PH</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="2">0</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Clubhuis Parkschouwburg PST/Swift</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1018 ST</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="3">870</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Universiteitsbibliotheek Amsterdam</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1012 WP</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="4">867</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>MBO College Centrum</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1016 SB</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="5">1151</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>OBS De Witte Olifant</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1011 LX</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="6">1022</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Voormalige Stadstimmertuin</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1018 ET</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="7">1278</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>OBS De Witte Olifant</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1011 CN</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="8">1385</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Openbare Basisschool (OBS) De Burght</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1015 CD</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="9">871</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>The Hoxton Hotel</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1016 BJ</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="10">491</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+        <PollingPlace Channel="polling">
+          <PhysicalLocation>
+            <Address>
+              <Locality>
+                <xal:LocalityName>Kerk De Duif</xal:LocalityName>
+                <xal:PostalCode>
+                  <xal:PostalCodeNumber>1017 LD</xal:PostalCodeNumber>
+                </xal:PostalCode>
+              </Locality>
+            </Address>
+            <PollingStation Id="11">859</PollingStation>
+          </PhysicalLocation>
+        </PollingPlace>
+      </Contest>
+    </Election>
+  </ElectionEvent>
+</EML>

--- a/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
@@ -14,7 +14,7 @@ import { CheckElectionDefinitionPgObj } from "e2e-tests/page-objects/election/cr
 import { CheckPollingStationDefinitionPgObj } from "e2e-tests/page-objects/election/create/CheckPollingStationDefinitionPgObj";
 import { UploadCandidateDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadCandidateDefinitionPgObj";
 import { UploadElectionDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadElectionDefinitionPgObj";
-import { UploadPollingStationDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadPollingStationDefinitionPgObj";
+import { UploadPollingStationsFilePgObj } from "e2e-tests/page-objects/election/create/UploadPollingStationsFilePgObj";
 import { AddInvestigationPgObj } from "e2e-tests/page-objects/investigations/AddInvestigationPgObj";
 import { InvestigationOverviewPgObj } from "e2e-tests/page-objects/investigations/InvestigationOverviewPgObj";
 import { InvestigationPrintCorrigendumPgObj } from "e2e-tests/page-objects/investigations/InvestigationPrintCorrigendumPgObj";
@@ -126,9 +126,9 @@ export async function uploadCandidatesAndInputHash(page: Page, eml: Eml230b) {
 }
 
 export async function uploadPollingStations(page: Page, eml = eml110b) {
-  const uploadElectionDefinitionPage = new UploadPollingStationDefinitionPgObj(page);
-  await expect(uploadElectionDefinitionPage.header).toBeVisible();
-  await uploadElectionDefinitionPage.uploadFile(eml.path);
+  const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
+  await expect(uploadPollingStationsPage.header).toBeVisible();
+  await uploadPollingStationsPage.uploadFile(eml.path);
 
   const checkDefinitionPage = new CheckPollingStationDefinitionPgObj(page);
   await expect(checkDefinitionPage.header).toBeVisible();

--- a/frontend/e2e-tests/page-objects/election/create/UploadPollingStationsFilePgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/create/UploadPollingStationsFilePgObj.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 
-export class UploadPollingStationDefinitionPgObj {
+export class UploadPollingStationsFilePgObj {
   readonly header: Locator;
   readonly invalidFileAlert: Locator;
   readonly upload: Locator;

--- a/frontend/e2e-tests/test-data/eml-files.ts
+++ b/frontend/e2e-tests/test-data/eml-files.ts
@@ -67,6 +67,11 @@ export const eml110b_single = {
   path: "../backend/src/eml/tests/eml110b_1_station.eml.xml",
 };
 
+export const eml110b_zero_voters = {
+  filename: "eml110b_zero_number_of_voters.eml.xml",
+  path: "../backend/src/eml/tests/eml110b_zero_number_of_voters.eml.xml",
+};
+
 export type Eml230b = {
   filename: string;
   path: string;

--- a/frontend/e2e-tests/tests/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election-create.e2e.ts
@@ -13,14 +13,14 @@ import { CountingMethodTypePgObj } from "e2e-tests/page-objects/election/create/
 import { NumberOfVotersPgObj } from "e2e-tests/page-objects/election/create/NumberOfVotersPgObj";
 import { UploadCandidateDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadCandidateDefinitionPgObj";
 import { UploadElectionDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadElectionDefinitionPgObj";
-import { UploadPollingStationDefinitionPgObj } from "e2e-tests/page-objects/election/create/UploadPollingStationDefinitionPgObj";
+import { UploadPollingStationsFilePgObj } from "e2e-tests/page-objects/election/create/UploadPollingStationsFilePgObj";
 import { ElectionHome } from "e2e-tests/page-objects/election/ElectionHomePgObj";
 import { ElectionsOverviewPgObj } from "e2e-tests/page-objects/election/ElectionsOverviewPgObj";
 import { AdminNavBar } from "e2e-tests/page-objects/nav_bar/AdminNavBarPgObj";
 import { PollingStationImportPgObj } from "e2e-tests/page-objects/polling_station/PollingStationImportPgObj";
 import { PollingStationListEmptyPgObj } from "e2e-tests/page-objects/polling_station/PollingStationListEmptyPgObj";
 import { PollingStationListPgObj } from "e2e-tests/page-objects/polling_station/PollingStationListPgObj";
-import { eml110a, eml110b, eml230b } from "e2e-tests/test-data/eml-files";
+import { eml110a, eml110b, eml110b_zero_voters, eml230b } from "e2e-tests/test-data/eml-files";
 import { test } from "../fixtures";
 
 test.use({
@@ -112,7 +112,7 @@ test.describe("Election creation", () => {
       await uploadCandidatesAndInputHash(page, eml230b);
 
       // skip polling stations
-      const uploadPollingStationsPage = new UploadPollingStationDefinitionPgObj(page);
+      const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
       await expect(uploadPollingStationsPage.header).toBeVisible();
       await uploadPollingStationsPage.skipButton.click();
 
@@ -374,8 +374,8 @@ test.describe("Election creation", () => {
       await uploadCandidatesAndInputHash(page, eml230b);
 
       // Now we should be at the polling station upload page
-      const uploadPollingStationDefinitionPage = new UploadPollingStationDefinitionPgObj(page);
-      await expect(uploadPollingStationDefinitionPage.header).toBeVisible();
+      const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
+      await expect(uploadPollingStationsPage.header).toBeVisible();
 
       // Back button
       await page.goBack();
@@ -404,8 +404,8 @@ test.describe("Election creation", () => {
       await uploadCandidatesAndInputHash(page, eml230b);
 
       // Now we should be at the polling station upload page
-      const uploadPollingStationDefinitionPage = new UploadPollingStationDefinitionPgObj(page);
-      await expect(uploadPollingStationDefinitionPage.header).toBeVisible();
+      const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
+      await expect(uploadPollingStationsPage.header).toBeVisible();
 
       // Now upload a new election
       const uploadElectionDefinitionPage = new UploadElectionDefinitionPgObj(page);
@@ -467,6 +467,41 @@ test.describe("Election creation", () => {
   });
 
   test.describe("polling stations", () => {
+    test("it accepts a polling station file with maxvotes 0", async ({ page }) => {
+      await page.goto("/elections");
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await overviewPage.create.click();
+
+      await uploadElectionAndInputHash(page);
+
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
+
+      await uploadCandidatesAndInputHash(page, eml230b);
+
+      await uploadPollingStations(page, eml110b_zero_voters);
+
+      const countingMethodPage = new CountingMethodTypePgObj(page);
+      await expect(countingMethodPage.header).toBeVisible();
+      await countingMethodPage.cso.check();
+      await countingMethodPage.next.click();
+
+      const numberOfVotersPage = new NumberOfVotersPgObj(page);
+      await expect(numberOfVotersPage.header).toBeVisible();
+      await expect(numberOfVotersPage.input).toHaveValue("");
+      await numberOfVotersPage.input.fill("45678");
+      await numberOfVotersPage.next.click();
+
+      const checkAndSavePage = new CheckAndSavePgObj(page);
+      await expect(checkAndSavePage.header).toBeVisible();
+      await expect(checkAndSavePage.numberOfVoters).toContainText("45.678");
+
+      await checkAndSavePage.saveElection();
+      await expect(overviewPage.adminHeader).toBeVisible();
+      await expect(overviewPage.alertGSBElectionCreated).toBeVisible();
+    });
+
     test("it fails on valid, but incorrect polling station file", async ({ page }) => {
       await page.goto("/elections");
       const overviewPage = new ElectionsOverviewPgObj(page);
@@ -484,12 +519,12 @@ test.describe("Election creation", () => {
       await uploadCandidatesAndInputHash(page, eml230b);
 
       // upload wrong file
-      const uploadElectionDefinitionPage = new UploadPollingStationDefinitionPgObj(page);
-      await expect(uploadElectionDefinitionPage.header).toBeVisible();
-      await uploadElectionDefinitionPage.uploadFile(eml110a.path);
-      await expect(uploadElectionDefinitionPage.fieldset).toContainText(eml110a.filename);
-      await expect(uploadElectionDefinitionPage.invalidFileAlert).toBeVisible();
-      await expect(uploadElectionDefinitionPage.invalidFileAlert).toContainText(
+      const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
+      await expect(uploadPollingStationsPage.header).toBeVisible();
+      await uploadPollingStationsPage.uploadFile(eml110a.path);
+      await expect(uploadPollingStationsPage.fieldset).toContainText(eml110a.filename);
+      await expect(uploadPollingStationsPage.invalidFileAlert).toBeVisible();
+      await expect(uploadPollingStationsPage.invalidFileAlert).toContainText(
         "Het bestand eml110a_test.eml.xml bevat geen geldige lijst met stembureaus. Kies een ander bestand.",
       );
     });


### PR DESCRIPTION
Backport of #3704 to the 1.1 release branch. The changes could not be cleanly cherry-picked because of conflicts related to DSO in the e2e tests, so please review carefully.