### PR TITLE
Update text for resolve differences options

### DIFF
--- a/frontend/e2e-tests/page-objects/election/ResolveDifferencesPgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/ResolveDifferencesPgObj.ts
@@ -24,8 +24,8 @@ export class ResolveDifferencesPgObj {
     this.keepSecondEntry = page.getByRole("radio", { name: /Tweede invoer/ });
     this.discardBothEntries = page.getByRole("radio", { name: /Geen van beide/ });
     this.wrongEntryQuestion = page.getByRole("heading", { name: /Wat wil je doen/ });
-    this.correctWrongEntry = page.getByRole("radio", { name: /Laten herstellen/ });
-    this.discardWrongEntry = page.getByRole("radio", { name: /Opnieuw laten invoeren/ });
+    this.correctWrongEntry = page.getByRole("radio", { name: /Verschillen laten herstellen/ });
+    this.discardWrongEntry = page.getByRole("radio", { name: /Hele proces-verbaal opnieuw/ });
     this.correctionBlocked = page.getByText(/Uit de tweede invoer blijkt/);
     this.save = page.getByRole("button", { name: "Opslaan" });
     this.continueToResolveErrors = page.getByRole("button", { name: "Verder naar fouten oplossen" });

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.stories.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesForm.stories.tsx
@@ -75,8 +75,10 @@ export const Default: Story = {
 
     const firstEntry = canvas.getByRole("radio", { name: "Eerste invoer (Gebruiker01)" });
     const discardBoth = canvas.getByRole("radio", { name: "Geen van beide: alles opnieuw invoeren" });
-    const correctWrongEntry = canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" });
-    const discardWrongEntry = canvas.getByRole("radio", { name: "Opnieuw laten invoeren" });
+    const correctWrongEntry = canvas.getByRole("radio", {
+      name: "Verschillen laten herstellen door de oorspronkelijke invoerder",
+    });
+    const discardWrongEntry = canvas.getByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" });
 
     // Nothing is selected initially and the second question is disabled
     await expect(firstEntry).not.toBeChecked();
@@ -118,8 +120,10 @@ export const FirstEntrySelected: Story = {
     await expect(canvas.getByRole("radio", { name: "Eerste invoer (Gebruiker01)" })).toBeChecked();
 
     // The second question is enabled once an entry is chosen
-    await expect(canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" })).toBeEnabled();
-    await expect(canvas.getByRole("radio", { name: "Opnieuw laten invoeren" })).toBeEnabled();
+    await expect(
+      canvas.getByRole("radio", { name: "Verschillen laten herstellen door de oorspronkelijke invoerder" }),
+    ).toBeEnabled();
+    await expect(canvas.getByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" })).toBeEnabled();
   },
 };
 
@@ -138,8 +142,10 @@ export const SecondEntryHasErrors: Story = {
       ),
     ).toBeVisible();
 
-    const correctWrongEntry = canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" });
-    const discardWrongEntry = canvas.getByRole("radio", { name: "Opnieuw laten invoeren" });
+    const correctWrongEntry = canvas.getByRole("radio", {
+      name: "Verschillen laten herstellen door de oorspronkelijke invoerder",
+    });
+    const discardWrongEntry = canvas.getByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" });
     await expect(correctWrongEntry).toBeDisabled();
     await expect(correctWrongEntry).not.toBeChecked();
     await expect(discardWrongEntry).toBeDisabled();
@@ -165,8 +171,10 @@ export const FirstEntryHasErrors: Story = {
       ),
     ).toBeVisible();
 
-    const correctWrongEntry = canvas.getByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" });
-    const discardWrongEntry = canvas.getByRole("radio", { name: "Opnieuw laten invoeren" });
+    const correctWrongEntry = canvas.getByRole("radio", {
+      name: "Verschillen laten herstellen door de oorspronkelijke invoerder",
+    });
+    const discardWrongEntry = canvas.getByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" });
     await expect(correctWrongEntry).toBeDisabled();
     await expect(correctWrongEntry).not.toBeChecked();
     await expect(discardWrongEntry).toBeDisabled();

--- a/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
+++ b/frontend/src/features/resolve_differences/components/ResolveDifferencesPage.test.tsx
@@ -98,9 +98,9 @@ describe("ResolveDifferencesPage", () => {
     // Second question is visible but disabled until an entry is kept
     expect(await screen.findByRole("heading", { level: 3, name: /Wat wil je doen/ })).toBeVisible();
     expect(
-      await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }),
+      await screen.findByRole("radio", { name: "Verschillen laten herstellen door de oorspronkelijke invoerder" }),
     ).toBeDisabled();
-    expect(await screen.findByRole("radio", { name: "Opnieuw laten invoeren" })).toBeDisabled();
+    expect(await screen.findByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" })).toBeDisabled();
   });
 
   test("should show the selection in the table", async () => {
@@ -126,9 +126,9 @@ describe("ResolveDifferencesPage", () => {
     await renderPage();
 
     const correctWrongEntry = await screen.findByRole("radio", {
-      name: "Laten herstellen door oorspronkelijke invoerder",
+      name: "Verschillen laten herstellen door de oorspronkelijke invoerder",
     });
-    const discardWrongEntry = await screen.findByRole("radio", { name: "Opnieuw laten invoeren" });
+    const discardWrongEntry = await screen.findByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" });
 
     expect(correctWrongEntry).toBeDisabled();
     expect(discardWrongEntry).toBeDisabled();
@@ -174,25 +174,25 @@ describe("ResolveDifferencesPage", () => {
   test.each([
     {
       q1: "Eerste invoer (Gebruiker01)",
-      q2: "Opnieuw laten invoeren",
+      q2: "Hele proces-verbaal opnieuw laten invoeren",
       status: "first_entry_finalised",
       action: "keep_first_and_discard_second",
     },
     {
       q1: "Eerste invoer (Gebruiker01)",
-      q2: "Laten herstellen door oorspronkelijke invoerder",
+      q2: "Verschillen laten herstellen door de oorspronkelijke invoerder",
       status: "first_entry_finalised",
       action: "keep_first_and_correct_second",
     },
     {
       q1: "Tweede invoer (Gebruiker02)",
-      q2: "Opnieuw laten invoeren",
+      q2: "Hele proces-verbaal opnieuw laten invoeren",
       status: "first_entry_finalised",
       action: "keep_second_and_discard_first",
     },
     {
       q1: "Tweede invoer (Gebruiker02)",
-      q2: "Laten herstellen door oorspronkelijke invoerder",
+      q2: "Verschillen laten herstellen door de oorspronkelijke invoerder",
       status: "first_entry_finalised",
       action: "keep_second_and_correct_first",
     },
@@ -222,7 +222,7 @@ describe("ResolveDifferencesPage", () => {
 
     overrideResponseStatus("first_entry_finalised");
     await user.click(await screen.findByRole("radio", { name: "Tweede invoer (Gebruiker02)" }));
-    await user.click(await screen.findByRole("radio", { name: "Opnieuw laten invoeren" }));
+    await user.click(await screen.findByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" }));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(getElectionStatus).toHaveBeenCalledTimes(2);
@@ -235,7 +235,7 @@ describe("ResolveDifferencesPage", () => {
     await renderPage();
     overrideResponseStatus("first_entry_finalised");
     await user.click(await screen.findByRole("radio", { name: "Eerste invoer (Gebruiker01)" }));
-    await user.click(await screen.findByRole("radio", { name: "Opnieuw laten invoeren" }));
+    await user.click(await screen.findByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" }));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(pushMessage).toHaveBeenCalledWith({
@@ -253,7 +253,7 @@ describe("ResolveDifferencesPage", () => {
     await renderPage();
     overrideResponseStatus("first_entry_finalised");
     await user.click(await screen.findByRole("radio", { name: "Tweede invoer (Gebruiker02)" }));
-    await user.click(await screen.findByRole("radio", { name: "Opnieuw laten invoeren" }));
+    await user.click(await screen.findByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" }));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(pushMessage).toHaveBeenCalledWith({
@@ -271,7 +271,9 @@ describe("ResolveDifferencesPage", () => {
     await renderPage();
     overrideResponseStatus("second_entry_correction");
     await user.click(await screen.findByRole("radio", { name: "Eerste invoer (Gebruiker01)" }));
-    await user.click(await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }));
+    await user.click(
+      await screen.findByRole("radio", { name: "Verschillen laten herstellen door de oorspronkelijke invoerder" }),
+    );
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(pushMessage).toHaveBeenCalledWith({
@@ -286,7 +288,9 @@ describe("ResolveDifferencesPage", () => {
     await renderPage();
     overrideResponseStatus("first_entry_correction");
     await user.click(await screen.findByRole("radio", { name: "Tweede invoer (Gebruiker02)" }));
-    await user.click(await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }));
+    await user.click(
+      await screen.findByRole("radio", { name: "Verschillen laten herstellen door de oorspronkelijke invoerder" }),
+    );
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(pushMessage).toHaveBeenCalledWith({
@@ -318,7 +322,7 @@ describe("ResolveDifferencesPage", () => {
 
     overrideResponseStatus("first_entry_has_errors");
     await user.click(await screen.findByRole("radio", { name: "Tweede invoer (Gebruiker02)" }));
-    await user.click(await screen.findByRole("radio", { name: "Opnieuw laten invoeren" }));
+    await user.click(await screen.findByRole("radio", { name: "Hele proces-verbaal opnieuw laten invoeren" }));
     await user.click(await screen.findByRole("button", { name: "Opslaan" }));
 
     expect(pushMessage).toHaveBeenCalledWith({
@@ -349,7 +353,7 @@ describe("ResolveDifferencesPage", () => {
       ),
     ).toBeVisible();
     expect(
-      await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }),
+      await screen.findByRole("radio", { name: "Verschillen laten herstellen door de oorspronkelijke invoerder" }),
     ).toBeDisabled();
 
     await user.click(await screen.findByRole("button", { name: "Verder naar fouten oplossen" }));
@@ -377,7 +381,7 @@ describe("ResolveDifferencesPage", () => {
       ),
     ).toBeVisible();
     expect(
-      await screen.findByRole("radio", { name: "Laten herstellen door oorspronkelijke invoerder" }),
+      await screen.findByRole("radio", { name: "Verschillen laten herstellen door de oorspronkelijke invoerder" }),
     ).toBeDisabled();
 
     await user.click(await screen.findByRole("button", { name: "Verder naar fouten oplossen" }));

--- a/frontend/src/i18n/locales/nl/resolve_differences.json
+++ b/frontend/src/i18n/locales/nl/resolve_differences.json
@@ -23,8 +23,8 @@
   "section": "Rubriek",
   "title": "Verschil tussen eerste en tweede invoer",
   "wrong_entry_options": {
-    "correct": "Laten herstellen door oorspronkelijke invoerder",
-    "discard": "Opnieuw laten invoeren"
+    "correct": "Verschillen laten herstellen door de oorspronkelijke invoerder",
+    "discard": "Hele proces-verbaal opnieuw laten invoeren"
   },
   "wrong_entry_question": "Wat wil je doen met de invoer die <u>niet</u> klopt?"
 }


### PR DESCRIPTION
## What & why

The options for what to do with the incorrect data entry were not distinct enough, so the two texts were changed to make it more clear

See [Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=21130-78594&t=ioaxb7pIYxJTpTlL-1)

## How to test

- All automated tests should still succeed
- Text changes can be seen on the resolve differences page

<img width="1019" height="566" alt="image" src="https://github.com/user-attachments/assets/dc0dd199-748c-42e0-b607-cb2676f6a317" />


## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->