### PR TITLE
Run fuzzers in nightly CI workflow and other small CI fixes

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run tests
         run: cargo nextest run --verbose --locked --workspace --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation
-        run: cargo doc --workspace --no-deps --all-features --document-private-items
+        run: cargo doc --locked --workspace --no-deps --all-features --document-private-items
         env:
           RUSTDOCFLAGS: "-D warnings"
       - name: Create documentation artifact

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Nextest
         run: cargo binstall cargo-nextest
       - name: Symlink sqlx test directory to /dev/shm
-        run: mkdir -p /dev/shm/sqlx && ln -s /dev/shm/sqlx target/sqlx
+        run: mkdir -p target /dev/shm/sqlx && rm -rf target/sqlx && ln -s /dev/shm/sqlx target/sqlx
       - name: Run tests
         run: cargo nextest run --verbose --locked --workspace --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           workspaces: "backend -> target"
       - name: Build
-        run: cargo --verbose --locked build --target=x86_64-unknown-linux-musl --no-default-features --features openapi,dev-database,memory-serve,embed-typst,storybook --bin abacus
+        run: cargo build --verbose --locked --target=x86_64-unknown-linux-musl --no-default-features --features openapi,dev-database,memory-serve,embed-typst,storybook --bin abacus
       - uses: actions/upload-artifact@v7
         with:
           name: abacus
@@ -103,17 +103,17 @@ jobs:
         run: mkdir -p dist dist-storybook
         working-directory: ./frontend
       - name: Check rustfmt
-        run: cargo --verbose --locked fmt --all -- --check
+        run: cargo fmt --verbose --all -- --check
       - name: Check Clippy with default features
-        run: cargo --verbose --locked clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --verbose --locked --workspace --all-targets -- -D warnings
       - name: Check Clippy with all features
-        run: cargo --verbose --locked clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --verbose --locked --workspace --all-targets --all-features -- -D warnings
       - name: Install Nextest
         run: cargo binstall cargo-nextest
       - name: Symlink sqlx test directory to /dev/shm
         run: mkdir -p /dev/shm/sqlx && ln -s /dev/shm/sqlx target/sqlx
       - name: Run tests
-        run: cargo --verbose --locked nextest run --workspace --no-default-features --features openapi,dev-database,embed-typst,tls
+        run: cargo nextest run --verbose --locked --workspace --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation
         run: cargo doc --workspace --no-deps --all-features --document-private-items
         env:
@@ -259,10 +259,10 @@ jobs:
           # Save cache only for main and release branches to prevent cache thrashing
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
       - name: Check Clippy for ./backend/fuzz
-        run: cargo --verbose --locked clippy --all-targets -- -D warnings
+        run: cargo clippy --verbose --locked --all-targets -- -D warnings
         working-directory: ./backend/fuzz
       - name: Check Clippy for ./backend/apportionment/fuzz
-        run: cargo --verbose --locked clippy --all-targets -- -D warnings
+        run: cargo clippy --verbose --locked --all-targets -- -D warnings
         working-directory: ./backend/apportionment/fuzz
 
   rustdoc:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -235,8 +235,8 @@ jobs:
           -T ./abacus \
           https://abacus-test.nl/etes/api/v1/executable/${{ github.event.pull_request.head.sha || github.sha }}/${{ github.sha }}
 
-  fuzz:
-    name: Backend fuzzer
+  fuzz-check:
+    name: Fuzz targets
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -249,33 +249,21 @@ jobs:
       - name: Setup Rust Nightly
         working-directory: ./backend/fuzz
         run: rustup toolchain install
-      - name: Setup Rust Nightly (apportionment)
-        working-directory: ./backend/apportionment/fuzz
-        run: rustup toolchain install
       - name: Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: |
             backend/fuzz -> target
             backend/apportionment/fuzz -> target
-          shared-key: "fuzzer"
+          shared-key: "fuzz-check"
           # Save cache only for main and release branches to prevent cache thrashing
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
-      - name: Install cargo fuzz
-        working-directory: ./backend/fuzz
-        run: cargo install cargo-fuzz
       - name: Check Clippy for ./backend/fuzz
-        run: cargo --verbose --locked clippy -- -D warnings
+        run: cargo --verbose --locked clippy --all-targets -- -D warnings
         working-directory: ./backend/fuzz
       - name: Check Clippy for ./backend/apportionment/fuzz
-        run: cargo --verbose --locked clippy -- -D warnings
+        run: cargo --verbose --locked clippy --all-targets -- -D warnings
         working-directory: ./backend/apportionment/fuzz
-      - name: Run data entry fuzzer
-        working-directory: ./backend/fuzz
-        run: cargo fuzz run data_entry_status -- -max_total_time=60
-      - name: Run simple apportionment fuzzer
-        working-directory: ./backend/apportionment/fuzz
-        run: cargo fuzz run simple_apportionment -- -max_total_time=60
 
   rustdoc:
     name: Deploy rustdoc to GitHub Pages

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Nextest
         run: cargo binstall cargo-nextest
       - name: Symlink sqlx test directory to /dev/shm
-        run: mkdir -p target /dev/shm/sqlx && ln -s /dev/shm/sqlx target/sqlx
+        run: mkdir -p target /dev/shm/sqlx && rm -rf target/sqlx && ln -s /dev/shm/sqlx target/sqlx
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --workspace --branch --profile ci --features embed-typst,airgap-detection --cobertura --output-path ./target/llvm-cov-target/codecov.json
       - name: Upload coverage to Codecov

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -55,7 +55,7 @@ jobs:
           key: ${{ matrix.target }}
       # The corpus is restored from the previous run
       - name: Restore fuzz corpus
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ matrix.dir }}/corpus/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
@@ -67,7 +67,7 @@ jobs:
       - name: Minimise corpus
         run: cargo fuzz cmin ${{ matrix.target }}
       - name: Save fuzz corpus
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6.1.0
         with:
           path: ${{ matrix.dir }}/corpus/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,81 @@
+name: Fuzz
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+env:
+  TZ: "Europe/Amsterdam"
+  CARGO_TERM_COLOR: always
+  SQLX_OFFLINE: "true"
+  FUZZ_MAX_TOTAL_TIME: 600
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: data_entry_status
+            dir: backend/fuzz
+          - target: simple_apportionment
+            dir: backend/apportionment/fuzz
+          - target: apportionment
+            dir: backend/apportionment/fuzz
+          - target: anonymity
+            dir: backend/apportionment/fuzz
+          - target: fractions
+            dir: backend/apportionment/fuzz
+          - target: house_monotonicity
+            dir: backend/apportionment/fuzz
+          - target: population_monotonicity
+            dir: backend/apportionment/fuzz
+          # differential_osv2020 is omitted: it needs the external OSV2020 wrapper binary.
+    defaults:
+      run:
+        working-directory: ./${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - name: Setup Rust Nightly
+        run: rustup toolchain install
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          workspaces: "${{ matrix.dir }} -> target"
+          key: ${{ matrix.target }}
+      # The corpus is restored from the previous run
+      - name: Restore fuzz corpus
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ matrix.dir }}/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-${{ matrix.target }}-
+      - name: Install cargo fuzz
+        run: cargo install cargo-fuzz
+      - name: Run fuzzer
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=${{ env.FUZZ_MAX_TOTAL_TIME }}
+      - name: Minimise corpus
+        run: cargo fuzz cmin ${{ matrix.target }}
+      - name: Save fuzz corpus
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ matrix.dir }}/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+      - name: Upload crash artifacts
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: ${{ matrix.dir }}/artifacts/${{ matrix.target }}
+          retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,17 +80,17 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Run tests
-        run: cargo --locked test --release --workspace --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
+        run: cargo test --locked --release --workspace --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
       # no airgap detection build
       - name: Build without airgap detection
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v7
         with:
           name: abacus-${{ matrix.target.os }}-no-airgap-detection
           path: ${{ matrix.target.binary }}
       # airgap detection build
       - name: Build
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/weekly-e2e-tests.yml
+++ b/.github/workflows/weekly-e2e-tests.yml
@@ -79,16 +79,16 @@ jobs:
         if: matrix.target.os == 'ubuntu-latest'
       # The Backend job in build-lint-test.yml checks Clippy only for the host target, so check with musl here
       - name: Check Clippy with all features
-        run: cargo --locked clippy --workspace --all-targets --all-features --target=${{ matrix.target.name }} -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets --all-features --target=${{ matrix.target.name }} -- -D warnings
         if: matrix.target.os == 'ubuntu-latest'
       - name: Build without airgap detection
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v7
         with:
           name: abacus-${{ matrix.target.os }}-weekly
           path: ${{ matrix.target.binary }}
       - name: Build with airgap detection and TLS (for the installer)
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
         if: matrix.target.os == 'windows-latest'
       - uses: actions/upload-artifact@v7
         with:

--- a/backend/apportionment/fuzz/README.md
+++ b/backend/apportionment/fuzz/README.md
@@ -17,6 +17,10 @@ Basic commands:
 
 More documentation can be found in the [Rust Fuzz Book](https://rust-fuzz.github.io/book/cargo-fuzz.html).
 
+Every fuzz target except `differential_osv2020` is fuzzed nightly in CI, with one job per fuzz target. The differential
+target is skipped because it needs the external OSV2020 wrapper binary. Pull requests only lint the fuzz targets using
+Clippy. See [fuzzing in CI](../../fuzz/README.md#fuzzing-in-ci) for details.
+
 To check the fuzz test coverage, see the [instructions in our `fuzz` package](../../fuzz/README.md#checking-the-fuzz-test-coverage).
 The `coverage_differential_osv2020.sh` script can be used as a starting point depending on your system configuration.
 

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e44b143a6a48317033079275252e49eb0da3214728b16e3e61144d43eadd39"
+checksum = "22238651fa78fcefcc99b649b4fb7ca205c9a07a3594cdea2715d6a1ed1b3252"
 dependencies = [
  "chrono",
  "quick-xml",

--- a/backend/fuzz/README.md
+++ b/backend/fuzz/README.md
@@ -34,6 +34,16 @@ Here, `NEW` indicates that a new code path has been triggered, and `REDUCE` indi
 Fuzzers never give hard guarantees on the correctness of software, but they are quite good at finding bugs.
 If the fuzzer has found a problem, it will exit and print the error. The error message will contain which unexpected transition took place. If after a few minutes the fuzzer stops finding new paths and has not found any problems we can be fairly certain the data entry system matches the state machine described in the fuzz test. Terminate the process manually when you feel like this is the case.
 
+### Fuzzing in CI
+
+The fuzzers do not run on pull requests. The `build-lint-test.yml` workflow only checks that the fuzz targets compile
+and lint (using Clippy). The fuzzers themselves run nightly using the `fuzz.yml` workflow. Every fuzz target gets its
+own matrix job and ten minutes of fuzzing. Each job caches its own corpus between runs, so each run continues from the
+coverage reached before rather than starting from scratch (unless the job cache is removed).
+
+When a target fails, its crashing input is uploaded as the `fuzz-artifacts-<target>` artifact. To reproduce the crash,
+download it into `artifacts/<target>/` and reproduce with `cargo fuzz run <target> <path to input>`.
+
 ### Checking the fuzz test coverage
 
 To gain some insight in what the fuzzer has actually tested, we can check the coverage of the fuzzer using the `fuzz coverage` command.


### PR DESCRIPTION
## What & why

- Run fuzzers in nightly CI workflow and only lint in PR workflow. Fuzzing for 60s in the PR workflow is not very effective, especially because we did not cache the corpus between runs, so every PR would restart fuzzing from scratch. The new nightly CI workflow caches the fuzz corpus between runs.
- Fix some other small CI issues:
  - Update `backend/fuzz/Cargo.lock` because it was out of date
  - Use Cargo `--locked` option in correct position: the option was not passed to Clippy, silently updating the `Cargo.lock` file if it was out of date. rustfmt does not accept a `--locked` flag at all. This is why CI did not throw an error for the out of date file `backend/fuzz/Cargo.lock`. See https://github.com/rust-lang/cargo/issues/11390.
  - Remove `target/sqlx` if it exists, for example if it was restored from the cache.
  - Add `--locked` to `cargo doc` step

## How to test

CI passes. The nightly fuzz workflow run can be [seen working in my fork](https://github.com/praseodym/abacus/actions/runs/31097460138).
