### PR TITLE
Backend adjust claim to return DSO model

### DIFF
--- a/backend/fixtures/election_11_dso.sql
+++ b/backend/fixtures/election_11_dso.sql
@@ -1,0 +1,60 @@
+INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
+-- number_of_seats explicitly set to a value less than 19, to be used in elections with less than 19 seats
+VALUES (11, 'Municipal Election', 'GSB', 'DSO', 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 'GR1', 15, 2000, '2024-11-30', '2024-11-01',
+        '[
+          {
+            "number": 1,
+            "registered_name": "Political Group A",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "A.",
+                "first_name": "Alice",
+                "last_name": "Foo",
+                "locality": "Amsterdam",
+                "gender": "Female"
+              },
+              {
+                "number": 2,
+                "initials": "C.",
+                "first_name": "Charlie",
+                "last_name": "Doe",
+                "locality": "Rotterdam",
+                "gender": null
+              }
+            ]
+          },{
+            "number": 2,
+            "registered_name": "Political Group B",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "A.",
+                "first_name": "Alice",
+                "last_name": "Foo",
+                "locality": "Amsterdam",
+                "gender": "Female"
+              },
+              {
+                "number": 2,
+                "initials": "C.",
+                "first_name": "Charlie",
+                "last_name": "Doe",
+                "locality": "Rotterdam",
+                "gender": null
+              }
+            ]
+          }
+        ]');
+
+INSERT INTO committee_sessions (id, number, election_id, status, location, start_date_time)
+VALUES (11, 1, 11, 'data_entry', 'Heemdamseburg', '2024-12-05 09:15:00');
+
+INSERT INTO data_entries (id, state, updated_at)
+VALUES (1101, '{"status":"Empty"}', '2024-12-05 09:15:00'),
+       (1102, '{"status":"Empty"}', '2024-12-05 09:15:00');
+
+INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type, address,
+                              postal_code, locality)
+VALUES (1111, 11, NULL, 1101, 'Op Rolletjes', 33, NULL, 'Mobile', 'Rijksweg A12 1', '1234 YQ', 'Den Haag'),
+       (1112, 11, NULL, 1102, 'Testplek', 34, 1000, 'Special', 'Teststraat 2b', '1234 QY', 'Testdorp');

--- a/backend/fixtures/election_12_dso_with_results.sql
+++ b/backend/fixtures/election_12_dso_with_results.sql
@@ -1,0 +1,482 @@
+INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
+VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', '0000', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
+        '[
+          {
+            "number": 1,
+            "registered_name": "Political Group A",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "L.",
+                "first_name": "Lidewij",
+                "last_name": "Oud",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 2,
+                "initials": "J.",
+                "first_name": "Johan",
+                "last_name": "Oud",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 3,
+                "initials": "M.",
+                "first_name": "Marijke",
+                "last_name": "Oud",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 4,
+                "initials": "A.",
+                "first_name": "Arie",
+                "last_name": "Jansen",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 5,
+                "initials": "H.",
+                "first_name": "Henk",
+                "last_name_prefix": "van der",
+                "last_name": "Weijden",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 6,
+                "initials": "B.",
+                "first_name": "Berta",
+                "last_name_prefix": "van der",
+                "last_name": "Weijden",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 7,
+                "initials": "K.",
+                "first_name": "Klaas",
+                "last_name": "Oud",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 8,
+                "initials": "S.",
+                "first_name": "Sophie",
+                "last_name": "Bakker",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 9,
+                "initials": "J.",
+                "first_name": "Johan",
+                "last_name_prefix": "de",
+                "last_name": "Vries",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 10,
+                "initials": "M.",
+                "first_name": "Marijke",
+                "last_name_prefix": "van den",
+                "last_name": "Berg",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 11,
+                "initials": "R.",
+                "first_name": "Rolf",
+                "last_name_prefix": "de",
+                "last_name": "Jong",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 12,
+                "initials": "K.",
+                "first_name": "Karin",
+                "last_name": "Kok",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 13,
+                "initials": "G.",
+                "first_name": "Gert",
+                "last_name": "Smit",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 14,
+                "initials": "E.",
+                "first_name": "Eva",
+                "last_name": "Koster",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 15,
+                "initials": "L.",
+                "first_name": "Leon",
+                "last_name": "Hofman",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 16,
+                "initials": "S.",
+                "first_name": "Sophie",
+                "last_name": "Visser",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 17,
+                "initials": "D.",
+                "first_name": "Dirk",
+                "last_name": "Bakker",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 18,
+                "initials": "P.",
+                "first_name": "Piet",
+                "last_name": "Jansen",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 19,
+                "initials": "A.",
+                "first_name": "Annelies",
+                "last_name_prefix": "van",
+                "last_name": "Loon",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 20,
+                "initials": "T.J.",
+                "first_name": "Tessa",
+                "last_name": "Jansen",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 21,
+                "initials": "H.J.",
+                "first_name": "Hans",
+                "last_name": "Jansen",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 22,
+                "initials": "W.J.",
+                "first_name": "Willem",
+                "last_name": "Janssen",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 23,
+                "initials": "B.",
+                "first_name": "Bert",
+                "last_name": "Meyer",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 24,
+                "initials": "M.M.",
+                "first_name": "Mieke",
+                "last_name": "Meyer",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 25,
+                "initials": "J.V.",
+                "first_name": "Jan",
+                "last_name_prefix": "van",
+                "last_name": "Dijk",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 26,
+                "initials": "S.D.",
+                "first_name": "Suzan",
+                "last_name_prefix": "de",
+                "last_name": "Wit",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 27,
+                "initials": "K.V.",
+                "first_name": "Koen",
+                "last_name_prefix": "van der",
+                "last_name": "Meer",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 28,
+                "initials": "L.S.",
+                "first_name": "Laura",
+                "last_name": "Smit",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              {
+                "number": 29,
+                "initials": "F.K.",
+                "first_name": "Frank",
+                "last_name": "Kool",
+                "locality": "Juinen",
+                "gender": "Male"
+              },
+              {
+                "number": 30,
+                "initials": "C.R.",
+                "first_name": "Claudia",
+                "last_name": "Reinders",
+                "locality": "Juinen",
+                "gender": "Female"
+              }
+            ]
+          },
+          {
+            "number": 2,
+            "registered_name": "Political Group B",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "T.",
+                "first_name": "Tinus",
+                "last_name": "Bakker",
+                "locality": "Test Location",
+                "gender": "Male",
+                "country_code": "BE"
+              },
+              {
+                "number": 2,
+                "initials": "D.",
+                "last_name": "Po",
+                "locality": "Test Location",
+                "gender": "X"
+              },
+              {
+                "number": 3,
+                "initials": "W.",
+                "first_name": "Willem",
+                "last_name_prefix": "de",
+                "last_name": "Vries",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 4,
+                "initials": "K.",
+                "first_name": "Klaas",
+                "last_name": "Kloosterboer",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 5,
+                "initials": "L.",
+                "first_name": "Liesbeth",
+                "last_name": "Jansen",
+                "locality": "Test Location",
+                "gender": "Female"
+              },
+              {
+                "number": 6,
+                "initials": "H.",
+                "first_name": "Henk",
+                "last_name_prefix": "van den",
+                "last_name": "Berg",
+                "locality": "Test Location",
+                "gender": "Male"
+              }
+            ]
+          }, {
+            "number": 3,
+            "registered_name": "Political Group C",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "A.",
+                "first_name": "Adelbert",
+                "last_name_prefix": "van",
+                "last_name": "Doorn",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 2,
+                "initials": "M.",
+                "first_name": "Margriet",
+                "last_name_prefix": "van der",
+                "last_name": "Linden",
+                "locality": "Test Location",
+                "gender": "Female"
+              },
+              {
+                "number": 3,
+                "initials": "P.",
+                "first_name": "Paul",
+                "last_name": "Veldkamp",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 4,
+                "initials": "S.",
+                "first_name": "Sophie",
+                "last_name_prefix": "de",
+                "last_name": "Groot",
+                "locality": "Test Location",
+                "gender": "Female"
+              },
+              {
+                "number": 5,
+                "initials": "R.",
+                "first_name": "Rik",
+                "last_name_prefix": "de",
+                "last_name": "Ruiter",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 6,
+                "initials": "N.",
+                "first_name": "Nico",
+                "last_name": "Ruiter",
+                "locality": "Test Location",
+                "gender": "Male"
+              }
+            ]
+          }, {
+            "number": 4,
+            "registered_name": "Political Group D",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "G.",
+                "first_name": "Gerard",
+                "last_name": "Bogaert",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 2,
+                "initials": "J.",
+                "first_name": "Jan",
+                "last_name": "Stevens",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 3,
+                "initials": "E.",
+                "first_name": "Els",
+                "last_name": "Groot",
+                "locality": "Test Location",
+                "gender": "Female"
+              },
+              {
+                "number": 4,
+                "initials": "B.",
+                "first_name": "Bart",
+                "last_name": "Smit",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 5,
+                "initials": "F.",
+                "first_name": "Frits",
+                "last_name": "Veldman",
+                "locality": "Test Location",
+                "gender": "Male"
+              }
+            ]
+          }, {
+            "number": 5,
+            "registered_name": "",
+            "candidates": [
+              {
+                "number": 1,
+                "initials": "G.",
+                "first_name": "Gert",
+                "last_name": "Smit",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 2,
+                "initials": "E.",
+                "first_name": "Eva",
+                "last_name": "Koster",
+                "locality": "Test Location",
+                "gender": "Female"
+              },
+              {
+                "number": 3,
+                "initials": "L.",
+                "first_name": "Leon",
+                "last_name": "Hofman",
+                "locality": "Test Location",
+                "gender": "Male"
+              },
+              {
+                "number": 4,
+                "initials": "S.",
+                "first_name": "Sophie",
+                "last_name": "Visser",
+                "locality": "Test Location",
+                "gender": "Female"
+              }
+            ]
+          }
+        ]');
+
+INSERT INTO committee_sessions (id, number, election_id, status, location, start_date_time)
+VALUES (12, 1, 12, 'completed', 'Grote Stad', '2026-03-19 09:15:00'),
+       (13, 2, 12, 'data_entry', '', NULL);
+
+INSERT INTO
+    data_entries (id, state, updated_at)
+VALUES
+    (
+        1201,
+        '{"status":"Definitive","state":{"first_entry_user_id":5,"second_entry_user_id":6,"finished_at":"2026-03-20T17:07:31.223365436Z","finalised_with_warnings":false,"results":{"model":"DSOFirstSession","about_report":{"corrigendum_present":"TwoDocuments","checks_and_corrections_present":"PagePresent"},"checks_and_corrections":{"reason_investigation_own_initiative":{"unaccounted_difference":true,"other_error":true},"corrected_results_own_initiative":{"yes":false,"no":true},"corrected_results_csb_request":{"yes":true,"no":false}},"voters_counts":{"poll_card_count":1203,"proxy_certificate_count":2,"total_admitted_voters_count":1205},"votes_counts":{"political_group_total_votes":[{"number":1,"total":600},{"number":2,"total":302},{"number":3,"total":98},{"number":4,"total":99},{"number":5,"total":101}],"total_votes_candidates_count":1200,"blank_votes_count":3,"invalid_votes_count":2,"total_votes_cast_count":1205},"differences_counts":{"compare_votes_cast_admitted_voters":{"admitted_voters_equal_votes_cast":true,"votes_cast_greater_than_admitted_voters":false,"votes_cast_smaller_than_admitted_voters":false},"more_ballots_count":0,"fewer_ballots_count":0,"difference_completely_accounted_for":{"yes":false,"no":false}},"political_group_votes":[{"number":1,"total":600,"candidate_votes":[{"number":1,"votes":78},{"number":2,"votes":20},{"number":3,"votes":55},{"number":4,"votes":45},{"number":5,"votes":50},{"number":6,"votes":0},{"number":7,"votes":60},{"number":8,"votes":40},{"number":9,"votes":30},{"number":10,"votes":20},{"number":11,"votes":50},{"number":12,"votes":0},{"number":13,"votes":0},{"number":14,"votes":0},{"number":15,"votes":0},{"number":16,"votes":0},{"number":17,"votes":0},{"number":18,"votes":0},{"number":19,"votes":0},{"number":20,"votes":0},{"number":21,"votes":0},{"number":22,"votes":0},{"number":23,"votes":0},{"number":24,"votes":0},{"number":25,"votes":0},{"number":26,"votes":0},{"number":27,"votes":0},{"number":28,"votes":0},{"number":29,"votes":0},{"number":30,"votes":152}]},{"number":2,"total":302,"candidate_votes":[{"number":1,"votes":150},{"number":2,"votes":50},{"number":3,"votes":22},{"number":4,"votes":10},{"number":5,"votes":30},{"number":6,"votes":40}]},{"number":3,"total":98,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":15},{"number":3,"votes":25},{"number":4,"votes":3},{"number":5,"votes":2},{"number":6,"votes":33}]},{"number":4,"total":99,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":15},{"number":3,"votes":25},{"number":4,"votes":24},{"number":5,"votes":15}]},{"number":5,"total":101,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":31},{"number":3,"votes":10},{"number":4,"votes":40}]}]}}}',
+        '2026-03-20 17:07:31'
+    ),
+    (
+        1202,
+        '{"status":"Empty"}',
+        '2026-03-20 17:25:12'
+    );
+
+INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type,
+                              address, postal_code, locality)
+VALUES (1218, 12, NULL, 1201, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad'),
+       (1229, 13, 1201, NULL, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad'),
+       (12211, 13, NULL, 1202, 'Test ander gebouw', 42, NULL, 'FixedLocation', 'Testweg 4', '1234 QA', 'Grote Stad');
+
+UPDATE polling_stations
+SET investigation_state = '{"status":"ConcludedWithNewResults","state":{"reason":"reason","findings":"findings"}}'
+WHERE id = 12211;

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -304,7 +304,7 @@ async fn get_previous_results(
                 Results::DSOFirstSession(r) => Some(r.as_common()),
                 Results::CSONextSession(r) => Some(r.as_common()),
                 Results::DSONextSession(r) => Some(r.as_common()),
-                _ => None,
+                Results::GSB(_) => None,
             },
             _ => None,
         },

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -1383,7 +1383,6 @@ mod tests {
         assert_eq!(status, DataEntryStatusName::FirstEntryInProgress);
     }
 
-    // TODO: This will work once #3687 is implemented
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso"))))]
     async fn test_claim_data_entry_dso_ok(pool: SqlitePool) {
         let data_entry_id = DataEntryId::from(1101);
@@ -1520,31 +1519,19 @@ mod tests {
         assert!(ps_has_data_entry(&mut conn, polling_station_id).await);
     }
 
-    // TODO: Add new fixture with results and then add this test
-    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
+    #[test(sqlx::test(fixtures(
+        path = "../../fixtures",
+        scripts("election_12_dso_with_results")
+    )))]
     async fn test_claim_data_entry_dso_next_session_ok(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
-        let polling_station_id = PollingStationId::from(742);
-        // Insert investigation with corrected_results and create empty data entry
-        // (simulates what the investigation conclude flow does)
-        create_test_investigation(&mut conn, polling_station_id, Some(true))
-            .await
-            .unwrap();
-        let ps = polling_station_repo::get(&mut conn, polling_station_id)
-            .await
-            .unwrap();
-        let data_entry_id = ps
-            .data_entry_id()
-            .expect("data entry should be set after creating investigation with corrected results");
 
-        change_status_committee_session(
+        let response = claim(
             pool.clone(),
-            CommitteeSessionId::from(704),
-            CommitteeSessionStatus::DataEntry,
+            DataEntryId::from(1202),
+            EntryNumber::FirstEntry,
         )
         .await;
-
-        let response = claim(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
@@ -1559,7 +1546,7 @@ mod tests {
         assert_eq!(status, DataEntryStatusName::FirstEntryInProgress);
 
         // Check that row exists
-        assert!(ps_has_data_entry(&mut conn, polling_station_id).await);
+        assert!(ps_has_data_entry(&mut conn, PollingStationId::from(12211)).await);
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]

--- a/backend/src/api/data_entry.rs
+++ b/backend/src/api/data_entry.rs
@@ -301,7 +301,9 @@ async fn get_previous_results(
             // Match polling station results only and get the common results
             DataEntryStatus::Definitive(d) => match d.results {
                 Results::CSOFirstSession(r) => Some(r.as_common()),
+                Results::DSOFirstSession(r) => Some(r.as_common()),
                 Results::CSONextSession(r) => Some(r.as_common()),
+                Results::DSONextSession(r) => Some(r.as_common()),
                 _ => None,
             },
             _ => None,
@@ -1381,6 +1383,25 @@ mod tests {
         assert_eq!(status, DataEntryStatusName::FirstEntryInProgress);
     }
 
+    // TODO: This will work once #3687 is implemented
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso"))))]
+    async fn test_claim_data_entry_dso_ok(pool: SqlitePool) {
+        let data_entry_id = DataEntryId::from(1101);
+        let response = claim(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ClaimDataEntryResponse {
+            data,
+            source,
+            status,
+            ..
+        } = serde_json::from_slice(&body).unwrap();
+        assert!(matches!(data, Results::DSOFirstSession(_)));
+        assert!(matches!(source, DataEntrySource::PollingStation(_)));
+        assert_eq!(status, DataEntryStatusName::FirstEntryInProgress);
+    }
+
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_9_csb"))))]
     async fn test_claim_data_entry_gsb_ok(pool: SqlitePool) {
         let data_entry_id = DataEntryId::from(901);
@@ -1459,7 +1480,7 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
-    async fn test_claim_data_entry_next_session_ok(pool: SqlitePool) {
+    async fn test_claim_data_entry_cso_next_session_ok(pool: SqlitePool) {
         let mut conn = pool.acquire().await.unwrap();
         let polling_station_id = PollingStationId::from(742);
         // Insert investigation with corrected_results and create empty data entry
@@ -1483,6 +1504,59 @@ mod tests {
 
         let response = claim(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
         assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ClaimDataEntryResponse {
+            data,
+            source,
+            status,
+            ..
+        } = serde_json::from_slice(&body).unwrap();
+        assert!(matches!(data, Results::CSONextSession(_)));
+        assert!(matches!(source, DataEntrySource::PollingStation(_)));
+        assert_eq!(status, DataEntryStatusName::FirstEntryInProgress);
+
+        // Check that row exists
+        assert!(ps_has_data_entry(&mut conn, polling_station_id).await);
+    }
+
+    // TODO: Add new fixture with results and then add this test
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_7_four_sessions"))))]
+    async fn test_claim_data_entry_dso_next_session_ok(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let polling_station_id = PollingStationId::from(742);
+        // Insert investigation with corrected_results and create empty data entry
+        // (simulates what the investigation conclude flow does)
+        create_test_investigation(&mut conn, polling_station_id, Some(true))
+            .await
+            .unwrap();
+        let ps = polling_station_repo::get(&mut conn, polling_station_id)
+            .await
+            .unwrap();
+        let data_entry_id = ps
+            .data_entry_id()
+            .expect("data entry should be set after creating investigation with corrected results");
+
+        change_status_committee_session(
+            pool.clone(),
+            CommitteeSessionId::from(704),
+            CommitteeSessionStatus::DataEntry,
+        )
+        .await;
+
+        let response = claim(pool.clone(), data_entry_id, EntryNumber::FirstEntry).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ClaimDataEntryResponse {
+            data,
+            source,
+            status,
+            ..
+        } = serde_json::from_slice(&body).unwrap();
+        assert!(matches!(data, Results::DSONextSession(_)));
+        assert!(matches!(source, DataEntrySource::PollingStation(_)));
+        assert_eq!(status, DataEntryStatusName::FirstEntryInProgress);
 
         // Check that row exists
         assert!(ps_has_data_entry(&mut conn, polling_station_id).await);

--- a/backend/src/domain/election.rs
+++ b/backend/src/domain/election.rs
@@ -455,7 +455,11 @@ pub(crate) mod tests {
             id: ElectionId::from(1),
             name: "Test".to_string(),
             committee_category,
-            counting_method: Some(VoteCountingMethod::CSO),
+            counting_method: if committee_category == CommitteeCategory::GSB {
+                Some(VoteCountingMethod::CSO)
+            } else {
+                None
+            },
             election_id: "GR2023_Test".to_string(),
             location: "Test".to_string(),
             domain_id: "0000".to_string(),

--- a/backend/src/domain/results/mod.rs
+++ b/backend/src/domain/results/mod.rs
@@ -11,7 +11,9 @@ use votes_counts::VotesCounts;
 use crate::domain::{
     committee_session::CommitteeSession,
     compare::Compare,
-    election::{CommitteeCategory, ElectionWithPoliticalGroups, PoliticalGroup},
+    election::{
+        CommitteeCategory, ElectionWithPoliticalGroups, PoliticalGroup, VoteCountingMethod,
+    },
     field_path::FieldPath,
     results::{
         count::Count, dso_first_session_results::DSOFirstSessionResults, gsb_results::GSBResults,
@@ -87,7 +89,11 @@ impl Results {
             committee_session.is_next_session(),
         ) {
             (CommitteeCategory::GSB, false) => {
-                Results::CSOFirstSession(CSOFirstSessionResults::empty(election))
+                if election.counting_method == Some(VoteCountingMethod::CSO) {
+                    Results::CSOFirstSession(CSOFirstSessionResults::empty(election))
+                } else {
+                    Results::DSOFirstSession(DSOFirstSessionResults::empty(election))
+                }
             }
             (CommitteeCategory::GSB, true) => {
                 if let Some(prev) = previous_results {
@@ -103,9 +109,17 @@ impl Results {
                     copy.differences_counts.difference_completely_accounted_for =
                         Default::default();
 
-                    Results::CSONextSession(copy)
+                    if election.counting_method == Some(VoteCountingMethod::CSO) {
+                        Results::CSONextSession(copy)
+                    } else {
+                        Results::DSONextSession(copy)
+                    }
                 } else {
-                    Results::CSONextSession(NextSessionResults::empty(election))
+                    if election.counting_method == Some(VoteCountingMethod::CSO) {
+                        Results::CSONextSession(NextSessionResults::empty(election))
+                    } else {
+                        Results::DSONextSession(NextSessionResults::empty(election))
+                    }
                 }
             }
             (CommitteeCategory::CSB, _) => Results::GSB(GSBResults::empty(election)),
@@ -313,6 +327,35 @@ impl PollingStationResults for CSOFirstSessionResults {
         Self {
             extra_investigation: Default::default(),
             counting_differences_polling_station: Default::default(),
+            voters_counts: Results::default_voters_counts(election),
+            votes_counts: VotesCounts {
+                political_group_total_votes: Results::default_political_group_total_votes(
+                    &election.political_groups,
+                ),
+                ..Default::default()
+            },
+            differences_counts: Default::default(),
+            political_group_votes: Results::default_political_group_votes(
+                &election.political_groups,
+            ),
+        }
+    }
+}
+
+impl PollingStationResults for DSOFirstSessionResults {
+    fn as_common(&self) -> CommonPollingStationResults {
+        CommonPollingStationResults {
+            voters_counts: self.voters_counts.clone(),
+            votes_counts: self.votes_counts.clone(),
+            differences_counts: self.differences_counts.clone(),
+            political_group_votes: self.political_group_votes.to_vec(),
+        }
+    }
+
+    fn empty(election: &ElectionWithPoliticalGroups) -> Self {
+        Self {
+            about_report: Default::default(),
+            checks_and_corrections: Default::default(),
             voters_counts: Results::default_voters_counts(election),
             votes_counts: VotesCounts {
                 political_group_total_votes: Results::default_political_group_total_votes(

--- a/backend/src/domain/results/mod.rs
+++ b/backend/src/domain/results/mod.rs
@@ -88,13 +88,15 @@ impl Results {
             election.committee_category,
             committee_session.is_next_session(),
         ) {
-            (CommitteeCategory::GSB, false) => {
-                if election.counting_method == Some(VoteCountingMethod::CSO) {
+            (CommitteeCategory::GSB, false) => match election.counting_method {
+                Some(VoteCountingMethod::CSO) => {
                     Results::CSOFirstSession(CSOFirstSessionResults::empty(election))
-                } else {
+                }
+                Some(VoteCountingMethod::DSO) => {
                     Results::DSOFirstSession(DSOFirstSessionResults::empty(election))
                 }
-            }
+                None => panic!("Invalid election {election:?}"),
+            },
             (CommitteeCategory::GSB, true) => {
                 if let Some(prev) = previous_results {
                     let mut copy = NextSessionResults {
@@ -109,16 +111,20 @@ impl Results {
                     copy.differences_counts.difference_completely_accounted_for =
                         Default::default();
 
-                    if election.counting_method == Some(VoteCountingMethod::CSO) {
-                        Results::CSONextSession(copy)
-                    } else {
-                        Results::DSONextSession(copy)
+                    match election.counting_method {
+                        Some(VoteCountingMethod::CSO) => Results::CSONextSession(copy),
+                        Some(VoteCountingMethod::DSO) => Results::DSONextSession(copy),
+                        None => panic!("Invalid election {election:?}"),
                     }
                 } else {
-                    if election.counting_method == Some(VoteCountingMethod::CSO) {
-                        Results::CSONextSession(NextSessionResults::empty(election))
-                    } else {
-                        Results::DSONextSession(NextSessionResults::empty(election))
+                    match election.counting_method {
+                        Some(VoteCountingMethod::CSO) => {
+                            Results::CSONextSession(NextSessionResults::empty(election))
+                        }
+                        Some(VoteCountingMethod::DSO) => {
+                            Results::DSONextSession(NextSessionResults::empty(election))
+                        }
+                        None => panic!("Invalid election {election:?}"),
                     }
                 }
             }
@@ -603,5 +609,109 @@ pub mod tests {
 
         assert!(matches!(results, Results::CSONextSession(_)));
         assert_eq!(results.voters_counts().voter_card_count, Some(5));
+    }
+
+    #[test]
+    fn test_results_new_gsb_first_session_cso() {
+        let first_session = CommitteeSession::first_session();
+        let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        let results = Results::new(&election, &first_session, None);
+
+        assert!(matches!(results, Results::CSOFirstSession(_)));
+    }
+
+    #[test]
+    fn test_results_new_gsb_first_session_dso() {
+        let first_session = CommitteeSession::first_session();
+        let mut election =
+            election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        election.counting_method = Some(VoteCountingMethod::DSO);
+        let results = Results::new(&election, &first_session, None);
+
+        assert!(matches!(results, Results::DSOFirstSession(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid election")]
+    fn test_results_new_gsb_first_session_with_invalid_counting_method() {
+        let first_session = CommitteeSession::first_session();
+        let mut election =
+            election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        election.counting_method = None;
+        Results::new(&election, &first_session, None);
+    }
+
+    #[test]
+    fn test_results_new_gsb_next_session_cso_with_previous_results() {
+        let next_session = CommitteeSession::next_session();
+        let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        let previous_results = CSOFirstSessionResults::empty(&election).as_common();
+        let results = Results::new(&election, &next_session, Some(&previous_results));
+
+        assert!(matches!(results, Results::CSONextSession(_)));
+    }
+
+    #[test]
+    fn test_results_new_gsb_next_session_dso_with_previous_results() {
+        let next_session = CommitteeSession::next_session();
+        let mut election =
+            election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        election.counting_method = Some(VoteCountingMethod::DSO);
+        let previous_results = DSOFirstSessionResults::empty(&election).as_common();
+        let results = Results::new(&election, &next_session, Some(&previous_results));
+
+        assert!(matches!(results, Results::DSONextSession(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid election")]
+    fn test_results_new_gsb_next_session_with_invalid_counting_method_and_with_previous_results() {
+        let next_session = CommitteeSession::next_session();
+        let mut election =
+            election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        election.counting_method = None;
+        let previous_results = CSOFirstSessionResults::empty(&election).as_common();
+        Results::new(&election, &next_session, Some(&previous_results));
+    }
+
+    #[test]
+    fn test_results_new_gsb_next_session_cso_without_previous_results() {
+        let next_session = CommitteeSession::next_session();
+        let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        let results = Results::new(&election, &next_session, None);
+
+        assert!(matches!(results, Results::CSONextSession(_)));
+    }
+
+    #[test]
+    fn test_results_new_gsb_next_session_dso_without_previous_results() {
+        let next_session = CommitteeSession::next_session();
+        let mut election =
+            election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        election.counting_method = Some(VoteCountingMethod::DSO);
+        let results = Results::new(&election, &next_session, None);
+
+        assert!(matches!(results, Results::DSONextSession(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid election")]
+    fn test_results_new_gsb_next_session_with_invalid_counting_method_and_without_previous_results()
+    {
+        let next_session = CommitteeSession::next_session();
+        let mut election =
+            election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        election.counting_method = None;
+        Results::new(&election, &next_session, None);
+    }
+
+    #[test]
+    fn test_results_new_csb() {
+        let first_session = CommitteeSession::first_session();
+        let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::CSB, &[2]);
+
+        let results = Results::new(&election, &first_session, None);
+
+        assert!(matches!(results, Results::GSB(_)));
     }
 }

--- a/backend/src/domain/results/mod.rs
+++ b/backend/src/domain/results/mod.rs
@@ -490,6 +490,7 @@ pub mod tests {
         },
         valid_default::ValidDefault,
     };
+    use core::assert_matches;
 
     pub fn example_results() -> Results {
         Results::CSOFirstSession(CSOFirstSessionResults {
@@ -607,7 +608,7 @@ pub mod tests {
             Some(&previous_results),
         );
 
-        assert!(matches!(results, Results::CSONextSession(_)));
+        assert_matches!(results, Results::CSONextSession(_));
         assert_eq!(results.voters_counts().voter_card_count, Some(5));
     }
 
@@ -617,7 +618,7 @@ pub mod tests {
         let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
         let results = Results::new(&election, &first_session, None);
 
-        assert!(matches!(results, Results::CSOFirstSession(_)));
+        assert_matches!(results, Results::CSOFirstSession(_));
     }
 
     #[test]
@@ -628,7 +629,7 @@ pub mod tests {
         election.counting_method = Some(VoteCountingMethod::DSO);
         let results = Results::new(&election, &first_session, None);
 
-        assert!(matches!(results, Results::DSOFirstSession(_)));
+        assert_matches!(results, Results::DSOFirstSession(_));
     }
 
     #[test]
@@ -648,7 +649,7 @@ pub mod tests {
         let previous_results = CSOFirstSessionResults::empty(&election).as_common();
         let results = Results::new(&election, &next_session, Some(&previous_results));
 
-        assert!(matches!(results, Results::CSONextSession(_)));
+        assert_matches!(results, Results::CSONextSession(_));
     }
 
     #[test]
@@ -660,7 +661,7 @@ pub mod tests {
         let previous_results = DSOFirstSessionResults::empty(&election).as_common();
         let results = Results::new(&election, &next_session, Some(&previous_results));
 
-        assert!(matches!(results, Results::DSONextSession(_)));
+        assert_matches!(results, Results::DSONextSession(_));
     }
 
     #[test]
@@ -680,7 +681,7 @@ pub mod tests {
         let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
         let results = Results::new(&election, &next_session, None);
 
-        assert!(matches!(results, Results::CSONextSession(_)));
+        assert_matches!(results, Results::CSONextSession(_));
     }
 
     #[test]
@@ -691,7 +692,7 @@ pub mod tests {
         election.counting_method = Some(VoteCountingMethod::DSO);
         let results = Results::new(&election, &next_session, None);
 
-        assert!(matches!(results, Results::DSONextSession(_)));
+        assert_matches!(results, Results::DSONextSession(_));
     }
 
     #[test]
@@ -712,6 +713,6 @@ pub mod tests {
 
         let results = Results::new(&election, &first_session, None);
 
-        assert!(matches!(results, Results::GSB(_)));
+        assert_matches!(results, Results::GSB(_));
     }
 }


### PR DESCRIPTION
Closes #3728 

## What & why

- Added `DSOFirstSession` and `DSONextSession` to `Results::new` and `get_previous_results` (the latter is used in `claim`)
- Implemented `PollingstationResults` for `DSOFirstSessionResults`
- Added DSO election fixture without results
- Added DSO election fixture with results
- Added test for claim in first session and claim in next session
- Added tests for all cases of `Results::new`

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Verify the added tests
- Claim a data entry for a DSO election

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->