### PR TITLE
Remove the extra space displayed before refs in models

### DIFF
--- a/backend/templates/common/style.typ
+++ b/backend/templates/common/style.typ
@@ -114,7 +114,8 @@
 
 // Document header numbering
 #let document_numbering(doc) = [
-  #set heading(numbering: "1.1", hanging-indent: 0pt, supplement: "")
+  // Note: `supplement: none` removes the default "Hoofdstuk" prefix (`supplement: ""` will render an empty space)
+  #set heading(numbering: "1.1", hanging-indent: 0pt, supplement: none)
   #show heading.where(level: 1): set heading(numbering: "Deel 1.1 -", supplement: "Deel")
   #show heading.where(level: 3): it => [
     #block(
@@ -131,7 +132,8 @@
 
 // Attachment header numbering
 #let attachment_numbering(doc, prefix) = [
-  #set heading(numbering: "1.1", hanging-indent: 0pt, supplement: "")
+  // Note: `supplement: none` removes the default "Hoofdstuk" prefix (`supplement: ""` will render an empty space)
+  #set heading(numbering: "1.1", hanging-indent: 0pt, supplement: none)
 
   #show heading: it => {
     if it.level >= 4 {


### PR DESCRIPTION
## What & why

Addresses a finding from: https://github.com/kiesraad/abacus/issues/3789

Refs were rendering with an double space:

```typst
Neem dit totaal over in rubriek #ref(<cast_votes>) bij de juiste lijst.
```

would render as:

<img width="586" height="50" alt="image" src="https://github.com/user-attachments/assets/e39e872d-e5a1-4c85-83b5-2e1c325e239b" />

## How to test

Use `visual-diff.sh` or `diff-pdf` to see that the extra spaces are removed. E.g.:

<img width="293" height="31" alt="image" src="https://github.com/user-attachments/assets/42724ec2-a9c8-4511-b2f2-48233ea3239c" />


## Reviewer notes

None.