### PR TITLE
Resolve differences save section

### DIFF
--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.correct-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.correct-differences.e2e.ts
@@ -75,6 +75,7 @@ test.describe("data entry - correct differences", () => {
     // Save section with warning
     await dataEntryPage.progressList.votersAndVotes.click();
     const votersAndVotesPage = new VotersAndVotesPage(typist);
+    await expect(votersAndVotesPage.fieldset).toBeVisible();
     await votersAndVotesPage.next.click();
 
     // All progress list icons are shown again

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.correct-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.correct-differences.e2e.ts
@@ -19,18 +19,8 @@ test.describe("data entry - correct differences", () => {
     const typist = typistOneGSB.page;
     await typist.goto(`/elections/${dataEntry.election_id}/data-entry/${dataEntry.id}/1`);
 
-    // Assert progress icons
-    const dataEntryPage = new DataEntryBasePage(typist);
-    await expect(dataEntryPage.progressList.extraInvestigationIcon).toHaveAccessibleName("je bent hier");
-    await expect(dataEntryPage.progressList.countingDifferencesPollingStationIcon).toHaveAccessibleName("opgeslagen");
-    await expect(dataEntryPage.progressList.votersAndVotesIcon).toHaveAccessibleName("bevat een waarschuwing");
-    await expect(dataEntryPage.progressList.differencesIcon).toHaveAccessibleName("opgeslagen");
-    await expect(dataEntryPage.progressList.listIcon(1)).toHaveAccessibleName("opgeslagen");
-    await expect(dataEntryPage.progressList.listIcon(2)).toHaveAccessibleName("opgeslagen");
-    await expect(dataEntryPage.progressList.listIcon(3)).toHaveAccessibleName("leeg");
-    await expect(dataEntryPage.progressList.checkAndSaveIcon).toHaveAccessibleName("nog niet afgerond");
-
     // Go to section with warning
+    const dataEntryPage = new DataEntryBasePage(typist);
     await dataEntryPage.progressList.votersAndVotes.click();
     const votersAndVotesPage = new VotersAndVotesPage(typist);
     await expect(votersAndVotesPage.fieldset).toBeVisible();
@@ -61,6 +51,41 @@ test.describe("data entry - correct differences", () => {
     await expect(votersAndVotesPage.pollCardCount).toHaveAttribute("aria-errormessage", "feedback-error");
     await expect(votersAndVotesPage.proxyCertificateCount).toHaveAttribute("aria-errormessage", "feedback-error");
     await expect(votersAndVotesPage.totalAdmittedVotersCount).toHaveAttribute("aria-errormessage", "feedback-error");
+  });
+
+  test("show only correction warnings in the progress list", async ({
+    typistOneGSB,
+    dataEntryGSBFirstEntryCorrection: dataEntry,
+  }) => {
+    // Start data entry correction
+    const typist = typistOneGSB.page;
+    await typist.goto(`/elections/${dataEntry.election_id}/data-entry/${dataEntry.id}/1`);
+
+    // Assert only correction warning progress list icons shown
+    const dataEntryPage = new DataEntryBasePage(typist);
+    await expect(dataEntryPage.progressList.extraInvestigationIcon).toHaveAccessibleName("je bent hier");
+    await expect(dataEntryPage.progressList.countingDifferencesPollingStationIcon).toBeHidden();
+    await expect(dataEntryPage.progressList.votersAndVotesIcon).toHaveAccessibleName("bevat een waarschuwing");
+    await expect(dataEntryPage.progressList.differencesIcon).toBeHidden();
+    await expect(dataEntryPage.progressList.listIcon(1)).toBeHidden();
+    await expect(dataEntryPage.progressList.listIcon(2)).toBeHidden();
+    await expect(dataEntryPage.progressList.listIcon(3)).toBeHidden();
+    await expect(dataEntryPage.progressList.checkAndSaveIcon).toBeHidden();
+
+    // Save section with warning
+    await dataEntryPage.progressList.votersAndVotes.click();
+    const votersAndVotesPage = new VotersAndVotesPage(typist);
+    await votersAndVotesPage.next.click();
+
+    // All progress list icons are shown again
+    await expect(dataEntryPage.progressList.extraInvestigationIcon).toHaveAccessibleName("opgeslagen");
+    await expect(dataEntryPage.progressList.countingDifferencesPollingStationIcon).toHaveAccessibleName("opgeslagen");
+    await expect(dataEntryPage.progressList.votersAndVotesIcon).toHaveAccessibleName("je bent hier");
+    await expect(dataEntryPage.progressList.differencesIcon).toHaveAccessibleName("opgeslagen");
+    await expect(dataEntryPage.progressList.listIcon(1)).toHaveAccessibleName("opgeslagen");
+    await expect(dataEntryPage.progressList.listIcon(2)).toHaveAccessibleName("opgeslagen");
+    await expect(dataEntryPage.progressList.listIcon(3)).toHaveAccessibleName("leeg");
+    await expect(dataEntryPage.progressList.checkAndSaveIcon).toHaveAccessibleName("nog niet afgerond");
   });
 
   test.describe("assert correction result", () => {

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB.e2e.ts
@@ -578,9 +578,11 @@ test.describe("full flow GSB", () => {
       await firstCandidatesPage.next.click();
 
       const secondCandidatesPage = new CandidatesListPage(page, 1, secondListName!);
+      await expect(secondCandidatesPage.fieldset).toBeVisible();
       await secondCandidatesPage.next.click();
 
       const thirdCandidatesPage = new CandidatesListPage(page, 2, thirdListName!);
+      await expect(thirdCandidatesPage.fieldset).toBeVisible();
       await thirdCandidatesPage.next.click();
 
       const checkAndSavePage = new CheckAndSavePage(page);

--- a/frontend/src/components/ui/Icon/StatusIcon.tsx
+++ b/frontend/src/components/ui/Icon/StatusIcon.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import {
   IconArrowNarrowRight,
   IconCheckmark,
@@ -9,7 +10,7 @@ import {
 import { t } from "@/i18n/translate";
 import type { MenuStatus } from "@/types/ui";
 
-export function StatusIcon({ status }: { status: MenuStatus }) {
+export function StatusIcon({ status }: { status: MenuStatus }): ReactElement | null {
   switch (status) {
     case "active":
       return <IconArrowNarrowRight aria-label={t("you_are_here")} aria-hidden="false" />; // "Actief"
@@ -23,7 +24,7 @@ export function StatusIcon({ status }: { status: MenuStatus }) {
       return <IconEdit aria-label={t("not_yet_finished")} aria-hidden="false" />; // "Niet opgeslagen wijzigingen"
     case "error":
       return <IconError aria-label={t("contains_error")} aria-hidden="false" />; // "Ingevoerd, met openstaande fouten"
-    default:
+    case "idle":
       return null;
   }
 }

--- a/frontend/src/features/data_entry/components/DataEntryPage.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryPage.tsx
@@ -7,7 +7,7 @@ import { useElection } from "@/hooks/election/useElection";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { useUser } from "@/hooks/user/useUser";
 import type { FormSectionId } from "@/types/types";
-import { CheckAndSaveForm } from "./check_and_save/CheckAndSaveForm";
+import { CheckAndSaveSection } from "./check_and_save/CheckAndSaveSection";
 import { DataEntryProgress } from "./DataEntryProgress";
 import { DataEntryProvider } from "./DataEntryProvider";
 import { DataEntrySection } from "./DataEntrySection";
@@ -39,7 +39,7 @@ export function DataEntryPage() {
         <article>
           {sectionId &&
             (sectionId === "save" ? (
-              <CheckAndSaveForm />
+              <CheckAndSaveSection />
             ) : (
               <DataEntrySection key={sectionId} committeeCategory={election.committee_category} />
             ))}

--- a/frontend/src/features/data_entry/components/DataEntryProgress.test.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.test.tsx
@@ -283,4 +283,54 @@ describe("DataEntryProgress", () => {
 
     expect(screen.queryByTestId("list-item-pg-3")).not.toBeInTheDocument();
   });
+
+  test("Show only correction warnings if there is some section with a correction warning", async () => {
+    vi.spyOn(ReactRouter, "useParams").mockReturnValue({ dataEntryId: "1", sectionId: "save" });
+    const formState = getDefaultFormState();
+
+    formState.sections.voters_votes_counts!.correctionWarning = validationResultMockData.W002;
+
+    overrideServerClaimDataEntryResponse({
+      formState: formState,
+      results: results,
+      continueToNextSection: false,
+      validationResults: {
+        errors: [validationResultMockData.F301],
+        warnings: [],
+      },
+    });
+    renderForm();
+
+    await waitFor(() => {
+      expect(screen.getByText("Aantal kiezers en stemmen")).toBeVisible();
+    });
+
+    const votersAndVotes = screen.getByTestId("list-item-voters_votes_counts");
+    const differences = screen.getByTestId("list-item-differences_counts");
+    const list1 = screen.getByTestId("list-item-political_group_votes_1");
+    const list2 = screen.getByTestId("list-item-political_group_votes_2");
+    const checkAndSave = screen.getByTestId("list-item-save");
+
+    expect(votersAndVotes).toHaveClass("warning");
+    expect(votersAndVotes).toHaveAttribute("aria-current", "false");
+    const votersAndVotesIcon = within(votersAndVotes).getByRole("img");
+    expect(votersAndVotesIcon).toHaveAccessibleName("bevat een waarschuwing");
+
+    expect(differences).toHaveClass("idle");
+    expect(differences).toHaveAttribute("aria-current", "false");
+    expect(within(differences).queryByRole("img")).not.toBeInTheDocument();
+
+    expect(list1).toHaveClass("idle");
+    expect(list1).toHaveAttribute("aria-current", "false");
+    expect(within(list1).queryByRole("img")).not.toBeInTheDocument();
+
+    expect(list2).toHaveClass("idle");
+    expect(list2).toHaveAttribute("aria-current", "false");
+    expect(within(list2).queryByRole("img")).not.toBeInTheDocument();
+
+    expect(checkAndSave).toHaveClass("idle");
+    expect(checkAndSave).toHaveAttribute("aria-current", "step");
+    const checkAndSaveIcon = within(checkAndSave).getByRole("img");
+    expect(checkAndSaveIcon).toHaveAccessibleName("je bent hier");
+  });
 });

--- a/frontend/src/features/data_entry/components/DataEntryProgress.tsx
+++ b/frontend/src/features/data_entry/components/DataEntryProgress.tsx
@@ -22,6 +22,8 @@ export function DataEntryProgress() {
   const params = useParams<{ sectionId: FormSectionId }>();
   const sectionId = params.sectionId ?? null;
 
+  const someCorrectionWarning = Object.values(formState.sections).some((s) => s.correctionWarning !== undefined);
+
   const menuStatusForFormSection = useCallback(
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO function should be refactored
     (formSection?: FormSection): Exclude<MenuStatus, "active"> => {
@@ -29,6 +31,10 @@ export function DataEntryProgress() {
 
       if (formSection.correctionWarning) {
         return "warning";
+      }
+
+      if (someCorrectionWarning) {
+        return "idle";
       }
 
       if (!formSection.errors.isEmpty()) {
@@ -56,7 +62,7 @@ export function DataEntryProgress() {
 
       return "idle";
     },
-    [formState, results, dataEntryStructure],
+    [formState, results, dataEntryStructure, someCorrectionWarning],
   );
 
   const currentIndex = formState.sections[formState.furthest]?.index || 0;

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.test.tsx
@@ -16,7 +16,7 @@ import {
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
 import { overrideOnce, server } from "@/testing/server";
 import { renderReturningRouter, screen, spyOnHandler, within } from "@/testing/test-utils";
-import type { DataEntryStatusResponse, ErrorResponse } from "@/types/generated/openapi";
+import type { DataEntryStatusResponse } from "@/types/generated/openapi";
 import { ValidationResultSet } from "@/utils/ValidationResults";
 
 import { getDefaultDataEntryState, getEmptyDataEntryRequest, getInitialValues } from "../../testing/mock-data";
@@ -358,34 +358,5 @@ describe("Test CheckAndSaveForm summary", () => {
     const votersItem = screen.getByTestId("section-status-voters_votes_counts");
     expect(votersItem).toHaveTextContent("Controleer waarschuwingen bij");
     expect(within(votersItem).getByRole("img", { name: "bevat een waarschuwing" })).toBeInTheDocument();
-  });
-
-  test("Alert when committee session is paused is shown on save and then logs out", async () => {
-    const user = userEvent.setup();
-    overrideOnce("post", "/api/data_entries/1/1/finalise", 409, {
-      error: "Committee session data entry is paused",
-      fatal: true,
-      reference: "CommitteeSessionPaused",
-    } satisfies ErrorResponse);
-
-    const router = renderForm();
-
-    // Wait for the page to be loaded
-    const title = await screen.findByText("Controleren en opslaan");
-    expect(title).toBeInTheDocument();
-
-    const submitButton = screen.getByRole("button", { name: "Opslaan" });
-    await user.click(submitButton);
-
-    const pausedModal = await screen.findByRole("dialog");
-    expect(within(pausedModal).getByRole("heading", { level: 3, name: "Invoer gepauzeerd" })).toBeVisible();
-    expect(within(pausedModal).getByRole("paragraph")).toHaveTextContent(
-      "De coördinator heeft het invoeren van stemmen gepauzeerd. Je kan niet meer verder. [Je laatste wijzigingen worden niet opgeslagen.]",
-    );
-    expect(within(pausedModal).getByRole("link", { name: "Naar startscherm" })).toBeVisible();
-    const logoutButton = within(pausedModal).getByRole("link", { name: "Afmelden" });
-    await user.click(logoutButton);
-
-    expect(router.state.location.pathname).toEqual("/account/logout");
   });
 });

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveForm.tsx
@@ -2,9 +2,6 @@ import { type ReactElement, type SubmitEvent, useCallback, useEffect, useMemo, u
 
 import { Link, useNavigate, useParams } from "react-router";
 
-import { ApiError, FatalApiError } from "@/api/ApiResult";
-import { CommitteeSessionPausedModal } from "@/components/data_entry/CommitteeSessionPausedModal";
-import { ErrorModal } from "@/components/error/ErrorModal";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { BottomBar } from "@/components/ui/BottomBar/BottomBar";
 import { Button } from "@/components/ui/Button/Button";
@@ -21,10 +18,8 @@ import { getTranslations } from "@/utils/ValidationResults";
 
 import { useDataEntryContext } from "../../hooks/useDataEntryContext";
 import { useFormKeyboardNavigation } from "../../hooks/useFormKeyboardNavigation";
-import type { SubmitCurrentFormOptions } from "../../types/types";
 import type { DataEntryFormSectionStatus } from "../../utils/dataEntryUtils";
 import { getUrlForFormSectionID } from "../../utils/utils";
-import { DataEntryNavigation } from "../DataEntryNavigation";
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO function should be refactored
@@ -36,7 +31,7 @@ export function CheckAndSaveForm() {
   const { election } = useElection();
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isConfirmedError, setIsConfirmedError] = useState<string | null>(null);
-  const { error, dataEntryStructure, formState, onSubmitForm, status, onFinaliseDataEntry, dataEntryId, entryNumber } =
+  const { dataEntryStructure, formState, status, onFinaliseDataEntry, dataEntryId, entryNumber } =
     useDataEntryContext();
   const acceptCheckboxRef = useRef<HTMLInputElement>(null);
 
@@ -88,11 +83,6 @@ export function CheckAndSaveForm() {
       });
     }
   }, [isConfirmedError]);
-
-  // save the current state, without finalising (for the abort dialog)
-  const onSubmit = async (options?: SubmitCurrentFormOptions) => {
-    return await onSubmitForm("save", {}, options);
-  };
 
   // finalise the data entry and navigate away
   // this also includes stopping the data entry with errors, this is handled by the server.
@@ -149,13 +139,6 @@ export function CheckAndSaveForm() {
       ref={formRef}
       aria-disabled={(hasErrors || hasWarnings) && !allFeedbackAccepted}
     >
-      <DataEntryNavigation onSubmit={onSubmit} />
-
-      {error instanceof FatalApiError && error.reference === "CommitteeSessionPaused" && (
-        <CommitteeSessionPausedModal showUnsavedChanges committeeCategory={election.committee_category} />
-      )}
-      {error instanceof ApiError && <ErrorModal error={error} />}
-
       {hasErrors && allFeedbackAccepted ? (
         <>
           <p className="md">{t("check_and_save.accepted_errors")}</p>

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveSection.test.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveSection.test.tsx
@@ -1,0 +1,110 @@
+import { userEvent } from "@testing-library/user-event";
+import * as ReactRouter from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { CheckAndSaveSection } from "@/features/data_entry/components/check_and_save/CheckAndSaveSection";
+import { ElectionProvider } from "@/hooks/election/ElectionProvider";
+import { MessagesProvider } from "@/hooks/messages/MessagesProvider";
+import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { pollingStationMockData } from "@/testing/api-mocks/PollingStationMockData";
+import { DataEntryClaimHandler, ElectionRequestHandler } from "@/testing/api-mocks/RequestHandlers";
+import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
+import { overrideOnce, server } from "@/testing/server";
+import { renderReturningRouter, screen, within } from "@/testing/test-utils";
+import type { ErrorResponse } from "@/types/generated/openapi";
+import { getDefaultDataEntryState, getInitialValues } from "../../testing/mock-data";
+import { overrideServerClaimDataEntryResponse } from "../../testing/test.utils";
+import type { FormState } from "../../types/types";
+import { DataEntryProvider } from "../DataEntryProvider";
+
+function renderForm() {
+  // Mock useParams to provide the sectionId
+  vi.spyOn(ReactRouter, "useParams").mockReturnValue({ sectionId: "save" });
+
+  return renderReturningRouter(
+    <ElectionProvider electionId={1}>
+      <MessagesProvider>
+        <DataEntryProvider
+          election={electionMockData}
+          dataEntryId={pollingStationMockData[0]!.data_entry_id!}
+          entryNumber={1}
+        >
+          <CheckAndSaveSection />
+        </DataEntryProvider>
+      </MessagesProvider>
+    </ElectionProvider>,
+  );
+}
+
+describe("Test CheckAndSaveSection", () => {
+  beforeEach(() => {
+    server.use(ElectionRequestHandler, DataEntryClaimHandler);
+  });
+
+  test("Show correction warning message when some correction warning has to be resolved", async () => {
+    const formState: FormState = {
+      ...getDefaultDataEntryState().formState,
+      furthest: "save",
+    };
+
+    formState.sections.voters_votes_counts!.correctionWarning = validationResultMockData.W002;
+
+    overrideServerClaimDataEntryResponse({
+      formState,
+      results: getInitialValues(),
+      validationResults: { errors: [validationResultMockData.F201], warnings: [validationResultMockData.W201] },
+    });
+
+    renderForm();
+    expect(await screen.findByText("Controleren en opslaan")).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(
+        [
+          "Je kan de resultaten van dit stembureau nog niet opslaan.",
+          "Los onderstaande waarschuwingen op om verder te gaan.",
+        ].join(" "),
+      ),
+    ).toBeVisible();
+
+    const votersVotesSection = await screen.findByRole("region", {
+      name: "Toegelaten kiezers en uitgebrachte stemmen",
+    });
+    expect(votersVotesSection).toBeVisible();
+
+    expect(await within(votersVotesSection).findByRole("list")).toHaveTextContent(
+      "W.002 Verschil met andere invoer. Nieuwe invoer nodig",
+    );
+    expect(await within(votersVotesSection).findByRole("img")).toHaveAccessibleName("bevat een waarschuwing");
+
+    expect(screen.queryByRole("button", { name: "Opslaan" })).not.toBeInTheDocument();
+  });
+
+  test("Alert when committee session is paused is shown on save and then logs out", async () => {
+    const user = userEvent.setup();
+    overrideOnce("post", "/api/data_entries/1/1/finalise", 409, {
+      error: "Committee session data entry is paused",
+      fatal: true,
+      reference: "CommitteeSessionPaused",
+    } satisfies ErrorResponse);
+
+    const router = renderForm();
+
+    // Wait for the page to be loaded
+    const title = await screen.findByText("Controleren en opslaan");
+    expect(title).toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", { name: "Opslaan" });
+    await user.click(submitButton);
+
+    const pausedModal = await screen.findByRole("dialog");
+    expect(within(pausedModal).getByRole("heading", { level: 3, name: "Invoer gepauzeerd" })).toBeVisible();
+    expect(within(pausedModal).getByRole("paragraph")).toHaveTextContent(
+      "De coördinator heeft het invoeren van stemmen gepauzeerd. Je kan niet meer verder. [Je laatste wijzigingen worden niet opgeslagen.]",
+    );
+    expect(within(pausedModal).getByRole("link", { name: "Naar startscherm" })).toBeVisible();
+    const logoutButton = within(pausedModal).getByRole("link", { name: "Afmelden" });
+    await user.click(logoutButton);
+
+    expect(router.state.location.pathname).toEqual("/account/logout");
+  });
+});

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveSection.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveSection.tsx
@@ -1,0 +1,90 @@
+import { Link } from "react-router";
+import { ApiError, FatalApiError } from "@/api/ApiResult";
+import { CommitteeSessionPausedModal } from "@/components/data_entry/CommitteeSessionPausedModal";
+import { ErrorModal } from "@/components/error/ErrorModal";
+import { StatusList } from "@/components/ui/StatusList/StatusList";
+import { CheckAndSaveForm } from "@/features/data_entry/components/check_and_save/CheckAndSaveForm";
+import { DataEntryNavigation } from "@/features/data_entry/components/DataEntryNavigation";
+import { useDataEntryContext } from "@/features/data_entry/hooks/useDataEntryContext";
+import type { FormSection, SubmitCurrentFormOptions } from "@/features/data_entry/types/types";
+import { getUrlForFormSectionID } from "@/features/data_entry/utils/utils";
+import { useElection } from "@/hooks/election/useElection";
+import { t } from "@/i18n/translate";
+import type { ValidationResult } from "@/types/generated/openapi";
+import { getTranslations } from "@/utils/ValidationResults";
+
+interface CorrectWarningSection {
+  id: string;
+  title: string;
+  url: string;
+  warning: { code: string; title: string };
+}
+
+/**
+ * Rendered when some section has a correction warning.
+ */
+function CheckAndSaveCorrectWarnings({ sections }: { sections: CorrectWarningSection[] }) {
+  return (
+    <>
+      <legend>
+        <h2>{t("check_and_save.title")}</h2>
+      </legend>
+      <p className="md">{t("check_and_save.correction_warnings")}</p>
+      <StatusList.Wrapper>
+        {sections.map((section) => (
+          <StatusList.Section key={section.id} aria-labelledby={`${section.id}_title`}>
+            <StatusList.Title id={`${section.id}_title`}>
+              <Link to={section.url}>{section.title}</Link>
+            </StatusList.Title>
+            <StatusList id={`save-form-summary-list-${section.id}`} gap="sm">
+              <StatusList.Item key={section.warning.code} status="warning">
+                <strong>{section.warning.code}</strong>&nbsp;{section.warning.title}
+              </StatusList.Item>
+            </StatusList>
+          </StatusList.Section>
+        ))}
+      </StatusList.Wrapper>
+    </>
+  );
+}
+
+/** Returns if section has a correctionWarning, and let TypeScript know */
+function hasCorrectionWarning(section: FormSection): section is FormSection & { correctionWarning: ValidationResult } {
+  return section.correctionWarning !== undefined;
+}
+
+export function CheckAndSaveSection() {
+  const { election } = useElection();
+  const { error, dataEntryStructure, formState, onSubmitForm, dataEntryId, entryNumber } = useDataEntryContext();
+
+  // save the current state, without finalising (for the abort dialog)
+  const onSubmit = async (options?: SubmitCurrentFormOptions) => {
+    return await onSubmitForm("save", {}, options);
+  };
+
+  const correctWarningSections = Object.values(formState.sections)
+    .filter(hasCorrectionWarning)
+    .map((section) => ({
+      id: section.id,
+      title: dataEntryStructure.find((s) => s.id === section.id)?.title || section.id,
+      url: getUrlForFormSectionID(election.id, dataEntryId, entryNumber, section.id),
+      warning: getTranslations(election, section.correctionWarning, "typist"),
+    }));
+
+  return (
+    <>
+      <DataEntryNavigation onSubmit={onSubmit} />
+
+      {error instanceof FatalApiError && error.reference === "CommitteeSessionPaused" && (
+        <CommitteeSessionPausedModal showUnsavedChanges committeeCategory={election.committee_category} />
+      )}
+      {error instanceof ApiError && <ErrorModal error={error} />}
+
+      {correctWarningSections.length > 0 ? (
+        <CheckAndSaveCorrectWarnings sections={correctWarningSections} />
+      ) : (
+        <CheckAndSaveForm />
+      )}
+    </>
+  );
+}

--- a/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveSection.tsx
+++ b/frontend/src/features/data_entry/components/check_and_save/CheckAndSaveSection.tsx
@@ -26,9 +26,7 @@ interface CorrectWarningSection {
 function CheckAndSaveCorrectWarnings({ sections }: { sections: CorrectWarningSection[] }) {
   return (
     <>
-      <legend>
-        <h2>{t("check_and_save.title")}</h2>
-      </legend>
+      <h2>{t("check_and_save.title")}</h2>
       <p className="md">{t("check_and_save.correction_warnings")}</p>
       <StatusList.Wrapper>
         {sections.map((section) => (

--- a/frontend/src/i18n/locales/nl/check_and_save.json
+++ b/frontend/src/i18n/locales/nl/check_and_save.json
@@ -1,5 +1,6 @@
 {
   "title": "Controleren en opslaan",
+  "correction_warnings": "Je kan de resultaten van dit stembureau nog niet opslaan. Los onderstaande waarschuwingen op om verder te gaan.",
   "counts_add_up": {
     "warnings": "De aantallen die je hebt ingevoerd in de verschillende stappen spreken elkaar niet tegen. Er zijn waarschuwingen die moeten worden gecontroleerd.",
     "no_warnings": "De aantallen die je hebt ingevoerd in de verschillende stappen spreken elkaar niet tegen. Er zijn geen blokkerende fouten of waarschuwingen."

--- a/frontend/src/testing/api-mocks/ValidationResultMockData.ts
+++ b/frontend/src/testing/api-mocks/ValidationResultMockData.ts
@@ -104,10 +104,7 @@ export const validationResultMockData: ErrorWarningsMap<ValidationResultCode> = 
   },
   W001: { fields: ["data.voters_counts.poll_card_count"], code: "W001" },
   W002: {
-    fields: [
-      "data.political_group_votes.0.candidate_votes.0.votes",
-      "data.political_group_votes.0.candidate_votes.1.votes",
-    ],
+    fields: ["data.voters_counts.poll_card_count", "data.voters_counts.proxy_certificate_count"],
     code: "W002",
   },
   W201: { fields: ["data.votes_counts.blank_votes_count"], code: "W201" },


### PR DESCRIPTION
## What & why

Resolves https://github.com/kiesraad/abacus/issues/3780

When there is some section with a correction warning:
- Show different check and save section
- Show in the progress list only correction warnings and "you are here", no other progress status icons

## How to test

Create a difference with two typists, return one data entry for correction as a coordinator, see as that typist that it works as described above.

## Reviewer notes

To avoid changing the logic in the existing check and save form, I've wrapped it in a new CheckAndSaveSection and moved the functionality of showing errors and navigating away to that section (including one test).

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->