### PR TITLE
Added empty models to backend and added links to election overview

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3084,6 +3084,188 @@
         ]
       }
     },
+    "/api/elections/{election_id}/download_n_10_1": {
+      "get": {
+        "summary": "administrator, coordinator_gsb",
+        "operationId": "election_download_n_10_1",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "attachment; filename=\"filename.zip\""
+              }
+            },
+            "content": {
+              "application/zip": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request cannot be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "administrator",
+              "coordinator_gsb"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/elections/{election_id}/download_n_10_1_inlegvel": {
+      "get": {
+        "summary": "administrator, coordinator_gsb",
+        "operationId": "election_download_n_10_1_inlegvel",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "attachment; filename=\"filename.zip\""
+              }
+            },
+            "content": {
+              "application/zip": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request cannot be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "administrator",
+              "coordinator_gsb"
+            ]
+          }
+        ]
+      }
+    },
     "/api/elections/{election_id}/download_n_10_2": {
       "get": {
         "summary": "administrator, coordinator_gsb",
@@ -3112,6 +3294,188 @@
             },
             "content": {
               "application/zip": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request cannot be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "administrator",
+              "coordinator_gsb"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/elections/{election_id}/download_na_14_1_versie1": {
+      "get": {
+        "summary": "administrator, coordinator_gsb",
+        "operationId": "election_download_na_14_1_versie1",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "attachment; filename=\"filename.zip\""
+              }
+            },
+            "content": {
+              "application/zip": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request cannot be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "administrator",
+              "coordinator_gsb"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/elections/{election_id}/download_na_31_1_inlegvel": {
+      "get": {
+        "summary": "administrator, coordinator_gsb",
+        "operationId": "election_download_na_31_1_inlegvel",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF",
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "attachment; filename=\"filename.pdf\""
+              }
+            },
+            "content": {
+              "application/pdf": {}
             }
           },
           "401": {

--- a/backend/src/api/document.rs
+++ b/backend/src/api/document.rs
@@ -101,7 +101,7 @@ async fn election_download_n_10_1(
         election.election_date.year(),
         election.location
     );
-
+    let candidates_tables = CandidatesTables::new(&election)?;
     let models = polling_stations
         .iter()
         .map(|ps| {
@@ -113,7 +113,7 @@ async fn election_download_n_10_1(
             );
 
             Ok(ModelN10_1Input {
-                candidates_tables: CandidatesTables::new(&election)?,
+                candidates_tables: candidates_tables.clone(),
                 election: election.clone().into(),
                 polling_station: ps.clone(),
             }
@@ -381,7 +381,7 @@ async fn election_download_na_14_1_versie1(
         election.election_date.year(),
         election.location
     );
-
+    let candidates_tables = CandidatesTables::new(&election)?;
     let models = polling_stations
         .iter()
         .map(|ps| {
@@ -394,7 +394,7 @@ async fn election_download_na_14_1_versie1(
 
             Ok(ModelNa14_1Versie1Input {
                 committee_session: current_committee_session.clone(),
-                candidates_tables: CandidatesTables::new(&election)?,
+                candidates_tables: candidates_tables.clone(),
                 election: election.clone().into(),
                 polling_station: ps.clone(),
             }
@@ -527,7 +527,7 @@ async fn election_download_na_31_2_bijlage1(
         election.election_date.year(),
         election.location
     );
-
+    let candidates_tables = CandidatesTables::new(&election)?;
     let models = polling_stations
         .iter()
         .map(|ps| {
@@ -539,7 +539,7 @@ async fn election_download_na_31_2_bijlage1(
             );
 
             Ok(ModelNa31_2Bijlage1Input {
-                candidates_tables: CandidatesTables::new(&election)?,
+                candidates_tables: candidates_tables.clone(),
                 election: election.clone().into(),
                 polling_station: ps.clone(),
             }

--- a/backend/src/api/document.rs
+++ b/backend/src/api/document.rs
@@ -15,8 +15,9 @@ use crate::{
     domain::{
         election::{CommitteeCategory, ElectionId, VoteCountingMethod},
         models::{
-            ModelN10_2Input, ModelNa31_2Bijlage1Input, ModelNa31_2InlegvelInput, ToPdfFileModel,
-            votes_table::CandidatesTables,
+            ModelN10_1InlegvelInput, ModelN10_1Input, ModelN10_2Input, ModelNa14_1Versie1Input,
+            ModelNa31_1InlegvelInput, ModelNa31_2Bijlage1Input, ModelNa31_2InlegvelInput,
+            ToPdfFileModel, votes_table::CandidatesTables,
         },
         role::Role,
     },
@@ -31,9 +32,194 @@ pub fn router() -> OpenApiRouter<AppState> {
     const ALLOWED_ROLES: &[Role] = &[Administrator, CoordinatorGSB];
 
     OpenApiRouter::default()
+        .routes(routes!(election_download_n_10_1).authorize(ALLOWED_ROLES))
+        .routes(routes!(election_download_n_10_1_inlegvel).authorize(ALLOWED_ROLES))
         .routes(routes!(election_download_n_10_2).authorize(ALLOWED_ROLES))
+        .routes(routes!(election_download_na_14_1_versie1).authorize(ALLOWED_ROLES))
+        .routes(routes!(election_download_na_31_1_inlegvel).authorize(ALLOWED_ROLES))
         .routes(routes!(election_download_na_31_2_bijlage1).authorize(ALLOWED_ROLES))
         .routes(routes!(election_download_na_31_2_inlegvel).authorize(ALLOWED_ROLES))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/download_n_10_1",
+    responses(
+        (
+            status = 200,
+            description = "ZIP",
+            content_type = "application/zip",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.zip\"")
+            )
+        ),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+async fn election_download_n_10_1(
+    user: User,
+    State(pool): State<SqlitePool>,
+    Path(election_id): Path<ElectionId>,
+) -> Result<impl IntoResponse, APIError> {
+    let mut conn = pool.acquire().await?;
+    let election = election_repo::get(&mut conn, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::DSO)
+    {
+        return Err(APIError::NotFound(
+            "N 10-1 is only available for GSB DSO elections".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let current_committee_session =
+        committee_session_repo::get_election_committee_session(&mut conn, election.id).await?;
+    let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
+        .await?
+        .into_polling_stations();
+    drop(conn);
+
+    let zip_filename = format!(
+        "{}{}_{}_n_10_1.zip",
+        election.category.to_eml_code(),
+        election.election_date.year(),
+        election.location
+    );
+
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let models = polling_stations
+        .iter()
+        .map(|ps| {
+            let name = format!(
+                "Model_N_10_1_{}{}_Stembureau_{}.pdf",
+                election.category.to_eml_code(),
+                election.election_date.year(),
+                ps.number
+            );
+
+            Ok(ModelN10_1Input {
+                candidates_tables: CandidatesTables::new(&election)?,
+                election: election.clone().into(),
+                polling_station: ps.clone(),
+            }
+            .to_pdf_file_model(name))
+        })
+        .collect::<Result<Vec<_>, APIError>>()?;
+
+    let (zip_response, zip_writer) = ZipResponse::new(&zip_filename);
+
+    tokio::spawn(async move {
+        if let Err(e) = generate_pdfs(models, zip_writer).await {
+            error!("Failed to generate PDFs: {e:?}");
+        }
+    });
+
+    Ok(zip_response)
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/download_n_10_1_inlegvel",
+    responses(
+        (
+            status = 200,
+            description = "ZIP",
+            content_type = "application/zip",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.zip\"")
+            )
+        ),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+async fn election_download_n_10_1_inlegvel(
+    user: User,
+    State(pool): State<SqlitePool>,
+    Path(election_id): Path<ElectionId>,
+) -> Result<impl IntoResponse, APIError> {
+    let mut conn = pool.acquire().await?;
+    let election = election_repo::get(&mut conn, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::DSO)
+    {
+        return Err(APIError::NotFound(
+            "N 10-1 Inlegvel is only available for GSB DSO elections".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let current_committee_session =
+        committee_session_repo::get_election_committee_session(&mut conn, election.id).await?;
+    let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
+        .await?
+        .into_polling_stations();
+    drop(conn);
+
+    let zip_filename = format!(
+        "{}{}_{}_n_10_1_Inlegvel.zip",
+        election.category.to_eml_code(),
+        election.election_date.year(),
+        election.location
+    );
+
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let models = polling_stations
+        .iter()
+        .map(|ps| {
+            let name = format!(
+                "Model_N_10_1_Inlegvel_{}{}_Stembureau_{}.pdf",
+                election.category.to_eml_code(),
+                election.election_date.year(),
+                ps.number
+            );
+
+            Ok(ModelN10_1InlegvelInput {
+                election: election.clone().into(),
+                polling_station: ps.clone(),
+            }
+            .to_pdf_file_model(name))
+        })
+        .collect::<Result<Vec<_>, APIError>>()?;
+
+    let (zip_response, zip_writer) = ZipResponse::new(&zip_filename);
+
+    tokio::spawn(async move {
+        if let Err(e) = generate_pdfs(models, zip_writer).await {
+            error!("Failed to generate PDFs: {e:?}");
+        }
+    });
+
+    Ok(zip_response)
 }
 
 #[utoipa::path(
@@ -124,6 +310,153 @@ async fn election_download_n_10_2(
     });
 
     Ok(zip_response)
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/download_na_14_1_versie1",
+    responses(
+        (
+            status = 200,
+            description = "ZIP",
+            content_type = "application/zip",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.zip\"")
+            )
+        ),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+async fn election_download_na_14_1_versie1(
+    user: User,
+    State(pool): State<SqlitePool>,
+    Path(election_id): Path<ElectionId>,
+) -> Result<impl IntoResponse, APIError> {
+    let mut conn = pool.acquire().await?;
+    let election = election_repo::get(&mut conn, election_id).await?;
+    user.role().is_authorized(election.committee_category)?;
+
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::DSO)
+    {
+        return Err(APIError::NotFound(
+            "Na 14-1 versie 1 is only available for GSB DSO elections".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let current_committee_session =
+        committee_session_repo::get_election_committee_session(&mut conn, election.id).await?;
+    let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
+        .await?
+        .into_polling_stations();
+    drop(conn);
+
+    let zip_filename = format!(
+        "{}{}_{}_na_14_1_versie1.zip",
+        election.category.to_eml_code(),
+        election.election_date.year(),
+        election.location
+    );
+
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let models = polling_stations
+        .iter()
+        .map(|ps| {
+            let name = format!(
+                "Model_Na14-1_versie_1_{}{}_Stembureau_{}.pdf",
+                election.category.to_eml_code(),
+                election.election_date.year(),
+                ps.number
+            );
+
+            Ok(ModelNa14_1Versie1Input {
+                committee_session: current_committee_session.clone(),
+                candidates_tables: CandidatesTables::new(&election)?,
+                election: election.clone().into(),
+                polling_station: ps.clone(),
+            }
+            .to_pdf_file_model(name))
+        })
+        .collect::<Result<Vec<_>, APIError>>()?;
+
+    let (zip_response, zip_writer) = ZipResponse::new(&zip_filename);
+
+    tokio::spawn(async move {
+        if let Err(e) = generate_pdfs(models, zip_writer).await {
+            error!("Failed to generate PDFs: {e:?}");
+        }
+    });
+
+    Ok(zip_response)
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/elections/{election_id}/download_na_31_1_inlegvel",
+    responses(
+        (
+            status = 200,
+            description = "PDF",
+            content_type = "application/pdf",
+            headers(
+                ("Content-Disposition", description = "attachment; filename=\"filename.pdf\"")
+            )
+        ),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Request cannot be completed", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+async fn election_download_na_31_1_inlegvel(
+    user: User,
+    State(pool): State<SqlitePool>,
+    Path(election_id): Path<ElectionId>,
+) -> Result<impl IntoResponse, APIError> {
+    let mut conn = pool.acquire().await?;
+    let election = election_repo::get(&mut conn, election_id).await?;
+    drop(conn);
+
+    user.role().is_authorized(election.committee_category)?;
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::DSO)
+    {
+        return Err(APIError::NotFound(
+            "Na 31-1 Inlegvel is only available for GSB DSO elections".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let name = "Model_Na_31_1_Inlegvel.pdf".to_string();
+
+    let input = ModelNa31_1InlegvelInput {
+        election: election.into(),
+    }
+    .to_pdf_file_model(name.clone());
+
+    let content = generate_pdf(input).await?;
+
+    Ok(Attachment::new(content.buffer)
+        .filename(&name)
+        .content_type("application/pdf"))
 }
 
 #[utoipa::path(
@@ -307,6 +640,23 @@ mod tests {
         results
     }
 
+    async fn call_dso_handlers(
+        pool: SqlitePool,
+        coordinator_role: Role,
+        election_id: ElectionId,
+    ) -> Vec<(&'static str, Response)> {
+        let user = User::test_user(coordinator_role, UserId::from(1));
+
+        #[rustfmt::skip]
+        let results = vec![
+            ("download_n_10_1", election_download_n_10_1(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ("download_n_10_1_inlegvel", election_download_n_10_1_inlegvel(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ("download_na_14_1_versie1", election_download_na_14_1_versie1(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+            ("download_na_31_1_inlegvel", election_download_na_31_1_inlegvel(user.clone(), State(pool.clone()), Path(election_id)).await.into_response()),
+        ];
+        results
+    }
+
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_cso_documents_committee_category_authorization_err(pool: SqlitePool) {
         let results = call_cso_handlers(pool, Role::CoordinatorCSB, ElectionId::from(2)).await;
@@ -328,6 +678,30 @@ mod tests {
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
     async fn test_cso_documents_counting_method_authorization_ok(pool: SqlitePool) {
         let results = call_cso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(2)).await;
+        assert_counting_method_authorization_ok(results);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso"))))]
+    async fn test_dso_documents_committee_category_authorization_err(pool: SqlitePool) {
+        let results = call_dso_handlers(pool, Role::CoordinatorCSB, ElectionId::from(11)).await;
+        assert_committee_category_authorization_err(results).await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso"))))]
+    async fn test_dso_documents_committee_category_authorization_ok(pool: SqlitePool) {
+        let results = call_dso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(11)).await;
+        assert_committee_category_authorization_ok(results);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_dso_documents_counting_method_authorization_err(pool: SqlitePool) {
+        let results = call_dso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(2)).await;
+        assert_counting_method_authorization_err(results, VoteCountingMethod::DSO).await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso"))))]
+    async fn test_dso_documents_counting_method_authorization_ok(pool: SqlitePool) {
+        let results = call_dso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(11)).await;
         assert_counting_method_authorization_ok(results);
     }
 }

--- a/backend/src/api/document.rs
+++ b/backend/src/api/document.rs
@@ -13,6 +13,7 @@ use crate::{
     APIError, AppState, ErrorResponse,
     api::middleware::authentication::RouteAuthorization,
     domain::{
+        committee_session::CommitteeSession,
         election::{CommitteeCategory, ElectionId, VoteCountingMethod},
         models::{
             ModelN10_1InlegvelInput, ModelN10_1Input, ModelN10_2Input, ModelNa14_1Versie1Input,
@@ -86,6 +87,12 @@ async fn election_download_n_10_1(
     let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
         .await?
         .into_polling_stations();
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
     drop(conn);
 
     let zip_filename = format!(
@@ -94,13 +101,6 @@ async fn election_download_n_10_1(
         election.election_date.year(),
         election.location
     );
-
-    if polling_stations.is_empty() {
-        return Err(APIError::NotFound(
-            "No polling stations found".into(),
-            ErrorReference::EntryNotFound,
-        ));
-    }
 
     let models = polling_stations
         .iter()
@@ -177,6 +177,12 @@ async fn election_download_n_10_1_inlegvel(
     let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
         .await?
         .into_polling_stations();
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
     drop(conn);
 
     let zip_filename = format!(
@@ -185,13 +191,6 @@ async fn election_download_n_10_1_inlegvel(
         election.election_date.year(),
         election.location
     );
-
-    if polling_stations.is_empty() {
-        return Err(APIError::NotFound(
-            "No polling stations found".into(),
-            ErrorReference::EntryNotFound,
-        ));
-    }
 
     let models = polling_stations
         .iter()
@@ -267,6 +266,12 @@ async fn election_download_n_10_2(
     let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
         .await?
         .into_polling_stations();
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
     drop(conn);
 
     let zip_filename = format!(
@@ -275,13 +280,6 @@ async fn election_download_n_10_2(
         election.election_date.year(),
         election.location
     );
-
-    if polling_stations.is_empty() {
-        return Err(APIError::NotFound(
-            "No polling stations found".into(),
-            ErrorReference::EntryNotFound,
-        ));
-    }
 
     let models = polling_stations
         .iter()
@@ -310,6 +308,16 @@ async fn election_download_n_10_2(
     });
 
     Ok(zip_response)
+}
+
+fn verify_committee_session_details(committee_session: &CommitteeSession) -> Result<(), APIError> {
+    if committee_session.start_date_time.is_none() || committee_session.location.is_empty() {
+        return Err(APIError::NotFound(
+            "Committee session is missing start date, start time and location details".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+    Ok(())
 }
 
 #[utoipa::path(
@@ -354,9 +362,17 @@ async fn election_download_na_14_1_versie1(
 
     let current_committee_session =
         committee_session_repo::get_election_committee_session(&mut conn, election.id).await?;
+    verify_committee_session_details(&current_committee_session)?;
+
     let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
         .await?
         .into_polling_stations();
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
     drop(conn);
 
     let zip_filename = format!(
@@ -365,13 +381,6 @@ async fn election_download_na_14_1_versie1(
         election.election_date.year(),
         election.location
     );
-
-    if polling_stations.is_empty() {
-        return Err(APIError::NotFound(
-            "No polling stations found".into(),
-            ErrorReference::EntryNotFound,
-        ));
-    }
 
     let models = polling_stations
         .iter()
@@ -504,6 +513,12 @@ async fn election_download_na_31_2_bijlage1(
     let polling_stations = list_polling_stations_for_session(&mut conn, &current_committee_session)
         .await?
         .into_polling_stations();
+    if polling_stations.is_empty() {
+        return Err(APIError::NotFound(
+            "No polling stations found".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
     drop(conn);
 
     let zip_filename = format!(
@@ -512,13 +527,6 @@ async fn election_download_na_31_2_bijlage1(
         election.election_date.year(),
         election.location
     );
-
-    if polling_stations.is_empty() {
-        return Err(APIError::NotFound(
-            "No polling stations found".into(),
-            ErrorReference::EntryNotFound,
-        ));
-    }
 
     let models = polling_stations
         .iter()
@@ -609,8 +617,10 @@ async fn election_download_na_31_2_inlegvel(
 mod tests {
     use axum::{
         extract::{Path, State},
+        http::StatusCode,
         response::{IntoResponse, Response},
     };
+    use http_body_util::BodyExt;
     use test_log::test;
 
     use super::*;
@@ -703,5 +713,40 @@ mod tests {
     async fn test_dso_documents_counting_method_authorization_ok(pool: SqlitePool) {
         let results = call_dso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(11)).await;
         assert_counting_method_authorization_ok(results);
+    }
+
+    #[test(sqlx::test(fixtures(
+        path = "../../fixtures",
+        scripts("election_12_dso_with_results")
+    )))]
+    async fn test_na_14_1_versie_1_committee_session_missing_details_err(pool: SqlitePool) {
+        let user = User::test_user(Role::CoordinatorGSB, UserId::from(1));
+        let response = election_download_na_14_1_versie1(
+            user.clone(),
+            State(pool.clone()),
+            Path(ElectionId::from(12)),
+        )
+        .await
+        .into_response();
+        let status = response.status();
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "handler 'download_na_14_1_versie1'"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ErrorResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            error.reference,
+            ErrorReference::EntryNotFound,
+            "handler 'download_na_14_1_versie1'"
+        );
+        let expected_error =
+            "Committee session is missing start date, start time and location details";
+        assert!(
+            error.error.contains(expected_error),
+            "handler 'download_na_14_1_versie1'"
+        );
     }
 }

--- a/backend/src/api/document.rs
+++ b/backend/src/api/document.rs
@@ -13,7 +13,7 @@ use crate::{
     APIError, AppState, ErrorResponse,
     api::middleware::authentication::RouteAuthorization,
     domain::{
-        election::{CommitteeCategory, ElectionId},
+        election::{CommitteeCategory, ElectionId, VoteCountingMethod},
         models::{
             ModelN10_2Input, ModelNa31_2Bijlage1Input, ModelNa31_2InlegvelInput, ToPdfFileModel,
             votes_table::CandidatesTables,
@@ -67,9 +67,11 @@ async fn election_download_n_10_2(
     let election = election_repo::get(&mut conn, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    if election.committee_category != CommitteeCategory::GSB {
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::CSO)
+    {
         return Err(APIError::NotFound(
-            "N 10-2 is only available for GSB elections".into(),
+            "N 10-2 is only available for GSB CSO elections".into(),
             ErrorReference::EntryNotFound,
         ));
     }
@@ -155,9 +157,11 @@ async fn election_download_na_31_2_bijlage1(
     let election = election_repo::get(&mut conn, election_id).await?;
     user.role().is_authorized(election.committee_category)?;
 
-    if election.committee_category != CommitteeCategory::GSB {
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::CSO)
+    {
         return Err(APIError::NotFound(
-            "Na 31-2 Bijlage 1 is only available for GSB elections".into(),
+            "Na 31-2 Bijlage 1 is only available for GSB CSO elections".into(),
             ErrorReference::EntryNotFound,
         ));
     }
@@ -245,9 +249,11 @@ async fn election_download_na_31_2_inlegvel(
     drop(conn);
 
     user.role().is_authorized(election.committee_category)?;
-    if election.committee_category != CommitteeCategory::GSB {
+    if election.committee_category != CommitteeCategory::GSB
+        || election.counting_method != Some(VoteCountingMethod::CSO)
+    {
         return Err(APIError::NotFound(
-            "Na 31-2 Inlegvel is only available for GSB elections".into(),
+            "Na 31-2 Inlegvel is only available for GSB CSO elections".into(),
             ErrorReference::EntryNotFound,
         ));
     }
@@ -277,18 +283,20 @@ mod tests {
     use super::*;
     use crate::{
         api::tests::{
-            assert_committee_category_authorization_err, assert_committee_category_authorization_ok,
+            assert_committee_category_authorization_err,
+            assert_committee_category_authorization_ok, assert_counting_method_authorization_err,
+            assert_counting_method_authorization_ok,
         },
         domain::role::Role,
         repository::user_repo::{User, UserId},
     };
 
-    async fn call_handlers(
+    async fn call_cso_handlers(
         pool: SqlitePool,
         coordinator_role: Role,
+        election_id: ElectionId,
     ) -> Vec<(&'static str, Response)> {
         let user = User::test_user(coordinator_role, UserId::from(1));
-        let election_id = ElectionId::from(2);
 
         #[rustfmt::skip]
         let results = vec![
@@ -300,14 +308,26 @@ mod tests {
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_committee_category_authorization_err(pool: SqlitePool) {
-        let results = call_handlers(pool, Role::CoordinatorCSB).await;
+    async fn test_cso_documents_committee_category_authorization_err(pool: SqlitePool) {
+        let results = call_cso_handlers(pool, Role::CoordinatorCSB, ElectionId::from(2)).await;
         assert_committee_category_authorization_err(results).await;
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
-    async fn test_committee_category_authorization_ok(pool: SqlitePool) {
-        let results = call_handlers(pool, Role::CoordinatorGSB).await;
+    async fn test_cso_documents_committee_category_authorization_ok(pool: SqlitePool) {
+        let results = call_cso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(2)).await;
         assert_committee_category_authorization_ok(results);
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso"))))]
+    async fn test_cso_documents_counting_method_authorization_err(pool: SqlitePool) {
+        let results = call_cso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(11)).await;
+        assert_counting_method_authorization_err(results, VoteCountingMethod::CSO).await;
+    }
+
+    #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2"))))]
+    async fn test_cso_documents_counting_method_authorization_ok(pool: SqlitePool) {
+        let results = call_cso_handlers(pool, Role::CoordinatorGSB, ElectionId::from(2)).await;
+        assert_counting_method_authorization_ok(results);
     }
 }

--- a/backend/src/api/tests.rs
+++ b/backend/src/api/tests.rs
@@ -1,7 +1,7 @@
 use axum::{http::StatusCode, response::Response};
 use http_body_util::BodyExt;
 
-use crate::{ErrorResponse, error::ErrorReference};
+use crate::{ErrorResponse, domain::election::VoteCountingMethod, error::ErrorReference};
 
 pub async fn assert_committee_category_authorization_err(results: Vec<(&'static str, Response)>) {
     for (handler, response) in results {
@@ -24,6 +24,37 @@ pub fn assert_committee_category_authorization_ok(results: Vec<(&'static str, Re
         assert_ne!(
             response.status(),
             StatusCode::FORBIDDEN,
+            "handler '{handler}'"
+        );
+    }
+}
+
+pub async fn assert_counting_method_authorization_err(
+    results: Vec<(&'static str, Response)>,
+    counting_method: VoteCountingMethod,
+) {
+    for (handler, response) in results {
+        let status = response.status();
+        assert_eq!(status, StatusCode::NOT_FOUND, "handler '{handler}'");
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ErrorResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            error.reference,
+            ErrorReference::EntryNotFound,
+            "handler '{handler}'"
+        );
+        let counting_method = format!("{counting_method}").to_uppercase();
+        let expected_error = format!("is only available for GSB {counting_method} elections");
+        assert!(error.error.contains(&expected_error), "handler '{handler}'");
+    }
+}
+
+pub fn assert_counting_method_authorization_ok(results: Vec<(&'static str, Response)>) {
+    for (handler, response) in results {
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
             "handler '{handler}'"
         );
     }

--- a/backend/src/api/tests.rs
+++ b/backend/src/api/tests.rs
@@ -52,10 +52,6 @@ pub async fn assert_counting_method_authorization_err(
 
 pub fn assert_counting_method_authorization_ok(results: Vec<(&'static str, Response)>) {
     for (handler, response) in results {
-        assert_ne!(
-            response.status(),
-            StatusCode::NOT_FOUND,
-            "handler '{handler}'"
-        );
+        assert_eq!(response.status(), StatusCode::OK, "handler '{handler}'");
     }
 }

--- a/backend/src/domain/models/votes_table.rs
+++ b/backend/src/domain/models/votes_table.rs
@@ -14,7 +14,7 @@ use crate::domain::{
 
 const DEFAULT_CANDIDATES_PER_COLUMN: [usize; 4] = [25, 25, 15, 15];
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CandidatesTables(Vec<VotesTable>);
 
 impl CandidatesTables {
@@ -151,7 +151,7 @@ fn get_votes_for_candidate(
     Ok(Some(candidate_vote.votes))
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VotesTable {
     /// Political group number
     number: PGNumber,
@@ -278,7 +278,7 @@ impl VotesTable {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VotesTableColumn {
     /// Sum of votes in this column
     column_total: Option<Count>,
@@ -288,7 +288,7 @@ pub struct VotesTableColumn {
     votes: Vec<CandidateVotes>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CandidateVotes {
     /// Candidate information
     candidate: Candidate,

--- a/backend/tests/integration_tests/election_integration_test.rs
+++ b/backend/tests/integration_tests/election_integration_test.rs
@@ -279,6 +279,96 @@ async fn test_election_number_of_voters_change_not_found(pool: SqlitePool) {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+#[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso", "users"))))]
+async fn test_election_n_10_1_download(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorGSB).await;
+
+    let url = format!("http://{addr}/api/elections/11/download_n_10_1");
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/zip");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    assert_eq!(
+        &content_disposition_string[21..],
+        "\"AB2026_Heemdamseburg_n_10_1.zip\""
+    );
+
+    let bytes = response.bytes().await.unwrap();
+    assert!(bytes.len() > 1024);
+
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
+
+    let reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_N_10_1_AB2026_Stembureau_33.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+
+    let reader = archive.reader_with_entry(1).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_N_10_1_AB2026_Stembureau_34.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+}
+
+#[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso", "users"))))]
+async fn test_election_n_10_1_inlegvel_download(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorGSB).await;
+
+    let url = format!("http://{addr}/api/elections/11/download_n_10_1_inlegvel");
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/zip");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    assert_eq!(
+        &content_disposition_string[21..],
+        "\"AB2026_Heemdamseburg_n_10_1_Inlegvel.zip\""
+    );
+
+    let bytes = response.bytes().await.unwrap();
+    assert!(bytes.len() > 1024);
+
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
+
+    let reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_N_10_1_Inlegvel_AB2026_Stembureau_33.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+
+    let reader = archive.reader_with_entry(1).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_N_10_1_Inlegvel_AB2026_Stembureau_34.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+}
+
 #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2", "users"))))]
 async fn test_election_n_10_2_download(pool: SqlitePool) {
     let addr = serve_api(pool).await;
@@ -322,6 +412,83 @@ async fn test_election_n_10_2_download(pool: SqlitePool) {
         "Model_N_10_2_GR2024_Stembureau_34.pdf"
     );
     assert!(reader.entry().uncompressed_size() > 1024);
+}
+
+#[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_11_dso", "users"))))]
+async fn test_election_na_14_1_versie1_download(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorGSB).await;
+
+    let url = format!("http://{addr}/api/elections/11/download_na_14_1_versie1");
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/zip");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    assert_eq!(
+        &content_disposition_string[21..],
+        "\"AB2026_Heemdamseburg_na_14_1_versie1.zip\""
+    );
+
+    let bytes = response.bytes().await.unwrap();
+    assert!(bytes.len() > 1024);
+
+    let archive = ZipFileReader::new(bytes.to_vec()).await.unwrap();
+
+    let reader = archive.reader_with_entry(0).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_Na14-1_versie_1_AB2026_Stembureau_33.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+
+    let reader = archive.reader_with_entry(1).await.unwrap();
+    assert_eq!(
+        reader.entry().filename().as_str().unwrap(),
+        "Model_Na14-1_versie_1_AB2026_Stembureau_34.pdf"
+    );
+    assert!(reader.entry().uncompressed_size() > 1024);
+}
+
+#[test(sqlx::test(fixtures(
+    path = "../../fixtures",
+    scripts("election_12_dso_with_results", "users")
+)))]
+async fn test_election_na_31_1_inlegvel_download(pool: SqlitePool) {
+    let addr = serve_api(pool).await;
+    let coordinator_cookie = login(&addr, CoordinatorGSB).await;
+
+    let url = format!("http://{addr}/api/elections/12/download_na_31_1_inlegvel");
+    let response = reqwest::Client::new()
+        .get(&url)
+        .header("cookie", coordinator_cookie)
+        .send()
+        .await
+        .unwrap();
+    let content_disposition = response.headers().get("Content-Disposition");
+    let content_type = response.headers().get("Content-Type");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(content_type.unwrap(), "application/pdf");
+
+    let content_disposition_string = content_disposition.unwrap().to_str().unwrap();
+    assert_eq!(&content_disposition_string[..21], "attachment; filename=");
+    assert_eq!(
+        &content_disposition_string[21..],
+        "\"Model_Na_31_1_Inlegvel.pdf\""
+    );
+
+    let bytes = response.bytes().await.unwrap();
+    assert!(bytes.len() > 1024);
 }
 
 #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_2", "users"))))]

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -379,61 +379,64 @@ describe("ElectionHomePage", () => {
       ]);
     });
 
-    test("Shows empty documents section for first committee session", async () => {
-      server.use(ElectionRequestHandler);
+    describe("CSO", () => {
+      test("Shows empty documents section for first committee session", async () => {
+        server.use(ElectionRequestHandler);
 
-      await renderGSBPage("coordinator_gsb");
+        await renderGSBPage("coordinator_gsb");
 
-      expect(
-        await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
-      ).toBeVisible();
-      expect(screen.getByText("Na 31-2 Bijlage 1")).toBeVisible();
-      expect(screen.getByText("N 10-2")).toBeVisible();
-    });
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).toBeVisible();
+        expect(screen.getByText("Na 31-2 Bijlage 1")).toBeVisible();
+        expect(screen.getByText("N 10-2")).toBeVisible();
+      });
 
-    test("Shows empty document section for second committee session", async () => {
-      const electionDataSecondSession = getElectionMockData({}, { id: 2, number: 2 });
-      electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(2, 3);
-      server.use(
-        http.get("/api/elections/1", () =>
-          HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
-        ),
-      );
+      test("Shows empty document section for second committee session", async () => {
+        const electionDataSecondSession = getElectionMockData({}, { id: 2, number: 2 });
+        electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(2, 3);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
 
-      await renderGSBPage("coordinator_gsb");
+        await renderGSBPage("coordinator_gsb");
 
-      expect(
-        await screen.findByRole("heading", { level: 3, name: "Leeg inlegvel voor deze verkiezing" }),
-      ).toBeVisible();
-      expect(screen.getByText("Na 31-2 Inlegvel")).toBeVisible();
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Leeg inlegvel voor deze verkiezing" }),
+        ).toBeVisible();
+        expect(screen.getByText("Na 31-2 Inlegvel")).toBeVisible();
 
-      expect(
-        screen.queryByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText("Na 31-2 Bijlage 1")).not.toBeInTheDocument();
-      expect(screen.queryByText("N 10-2")).not.toBeInTheDocument();
-    });
+        expect(
+          screen.queryByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText("Na 31-2 Bijlage 1")).not.toBeInTheDocument();
+        expect(screen.queryByText("N 10-2")).not.toBeInTheDocument();
+      });
 
-    test("Does not show empty documents section for third committee session", async () => {
-      const electionDataSecondSession = getElectionMockData({}, { id: 2, number: 3 });
-      electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(1, 3);
-      server.use(
-        http.get("/api/elections/1", () =>
-          HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
-        ),
-      );
+      test("Shows empty document section for third committee session", async () => {
+        const electionDataSecondSession = getElectionMockData({}, { id: 2, number: 3 });
+        electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(1, 3);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
 
-      await renderGSBPage("coordinator_gsb");
+        await renderGSBPage("coordinator_gsb");
 
-      expect(
-        screen.queryByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("heading", { level: 3, name: "Leeg inlegvel voor deze verkiezing" }),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText("Na 31-2 Bijlage 1")).not.toBeInTheDocument();
-      expect(screen.queryByText("N 10-2")).not.toBeInTheDocument();
-      expect(screen.queryByText("Na 31-2 Inlegvel")).not.toBeInTheDocument();
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Leeg inlegvel voor deze verkiezing" }),
+        ).toBeVisible();
+        expect(screen.getByText("Na 31-2 Inlegvel")).toBeVisible();
+
+        expect(
+          screen.queryByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText("Na 31-2 Bijlage 1")).not.toBeInTheDocument();
+        expect(screen.queryByText("N 10-2")).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -2,9 +2,9 @@ import { render as rtlRender } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
+import * as ReactRouter from "react-router";
 import { RouterProvider } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-
 import { ApiProvider } from "@/api/ApiProvider";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { electionManagementRoutes } from "@/features/election_management/routes";
@@ -25,8 +25,9 @@ import { overrideOnce, server } from "@/testing/server";
 import { TestUserProvider } from "@/testing/TestUserProvider";
 import { expectConflictErrorPage, render, screen, setupTestRouter, spyOnHandler, within } from "@/testing/test-utils";
 import type { CommitteeSession, ElectionDetailsResponse, ErrorResponse, Role } from "@/types/generated/openapi";
-
 import { ElectionHomePage } from "./ElectionHomePage";
+
+const navigate = vi.fn();
 
 const renderGSBPage = async (userRole: Role) => {
   render(
@@ -460,6 +461,7 @@ describe("ElectionHomePage", () => {
     describe("DSO", () => {
       test("Shows empty documents section for first committee session", async () => {
         const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" });
+        vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
         server.use(
           http.get("/api/elections/1", () =>
             HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
@@ -484,6 +486,71 @@ describe("ElectionHomePage", () => {
           ["N 10-1", "Inlegvellen controles en correcties per stembureau"],
           ["Na 14-1, versie 1", "Corrigenda eerste zitting per stembureau"],
         ]);
+      });
+
+      test("Shows modal on clicking download Na 14-1 versie 1 when committee session details missing", async () => {
+        const user = userEvent.setup();
+        const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" });
+        vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
+
+        await renderGSBPage("coordinator_gsb");
+
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).toBeVisible();
+        const downloadSection = screen.getByTestId("DSO-first-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        const rows = within(table).getAllByRole("row");
+        await user.click(rows[3]!);
+
+        const modal = await screen.findByRole("dialog");
+        expect(modal).toBeVisible();
+        const title = within(modal).getByText("Vul eerst de details van de zitting in");
+        expect(title).toBeVisible();
+
+        const enter_details_button = within(modal).getByRole("button", { name: "Details invullen" });
+        expect(enter_details_button).toBeVisible();
+        await user.click(enter_details_button);
+
+        expect(navigate).toHaveBeenCalledExactlyOnceWith("details");
+      });
+
+      test("Does not show modal on clicking download Na 14-1 versie 1 when committee session details present", async () => {
+        const user = userEvent.setup();
+        const electionDataSecondSession = getElectionMockData(
+          { counting_method: "DSO" },
+          { location: "Den Haag", start_date_time: "2026-03-18T21:36:00" },
+        );
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
+
+        await renderGSBPage("coordinator_gsb");
+
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).toBeVisible();
+        const downloadSection = screen.getByTestId("DSO-first-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        const rows = within(table).getAllByRole("row");
+        await user.click(rows[3]!);
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
 
       test("Shows empty document section for second committee session", async () => {

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -553,6 +553,41 @@ describe("ElectionHomePage", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
 
+      test("Shows modal on clicking download Na 14-1 versie 1 when committee session details missing for administrator", async () => {
+        const user = userEvent.setup();
+        const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" });
+        vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
+
+        await renderGSBPage("administrator");
+
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).toBeVisible();
+        const downloadSection = screen.getByTestId("DSO-first-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        const rows = within(table).getAllByRole("row");
+        await user.click(rows[3]!);
+
+        const modal = await screen.findByRole("dialog");
+        expect(modal).toBeVisible();
+        const title = within(modal).getByText("Vul eerst de details van de zitting in");
+        expect(title).toBeVisible();
+        const instruction = within(modal).getByText("Vraag de coördinator om de details van de zitting in te vullen.");
+        expect(instruction).toBeVisible();
+
+        const enter_details_button = within(modal).queryByRole("button", { name: "Details invullen" });
+        expect(enter_details_button).not.toBeInTheDocument();
+      });
+
       test("Shows empty document section for second committee session", async () => {
         const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" }, { id: 2, number: 2 });
         electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(2, 3);

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -388,8 +388,18 @@ describe("ElectionHomePage", () => {
         expect(
           await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
         ).toBeVisible();
-        expect(screen.getByText("Na 31-2 Bijlage 1")).toBeVisible();
-        expect(screen.getByText("N 10-2")).toBeVisible();
+        const downloadSection = screen.getByTestId("CSO-first-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        expect(table).toBeVisible();
+        expect(table).toHaveTableContent([
+          ["Model", "Doel"],
+          ["N 10-2", "Processen-verbaal per stembureau"],
+          ["Na 31-2 Bijlage 1", "Verslagen van tellingen van stembureau"],
+        ]);
       });
 
       test("Shows empty document section for second committee session", async () => {
@@ -406,13 +416,17 @@ describe("ElectionHomePage", () => {
         expect(
           await screen.findByRole("heading", { level: 3, name: "Leeg inlegvel voor deze verkiezing" }),
         ).toBeVisible();
-        expect(screen.getByText("Na 31-2 Inlegvel")).toBeVisible();
-
-        expect(
-          screen.queryByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
-        ).not.toBeInTheDocument();
-        expect(screen.queryByText("Na 31-2 Bijlage 1")).not.toBeInTheDocument();
-        expect(screen.queryByText("N 10-2")).not.toBeInTheDocument();
+        const downloadSection = screen.getByTestId("CSO-next-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaand model is relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        expect(table).toBeVisible();
+        expect(table).toHaveTableContent([
+          ["Model", "Doel"],
+          ["Na 31-2 inlegvel", "Inlegvel controles en correcties"],
+        ]);
       });
 
       test("Shows empty document section for third committee session", async () => {
@@ -429,13 +443,103 @@ describe("ElectionHomePage", () => {
         expect(
           await screen.findByRole("heading", { level: 3, name: "Leeg inlegvel voor deze verkiezing" }),
         ).toBeVisible();
-        expect(screen.getByText("Na 31-2 Inlegvel")).toBeVisible();
+        const downloadSection = screen.getByTestId("CSO-next-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaand model is relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        expect(table).toBeVisible();
+        expect(table).toHaveTableContent([
+          ["Model", "Doel"],
+          ["Na 31-2 inlegvel", "Inlegvel controles en correcties"],
+        ]);
+      });
+    });
+
+    describe("DSO", () => {
+      test("Shows empty documents section for first committee session", async () => {
+        const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" });
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
+
+        await renderGSBPage("coordinator_gsb");
 
         expect(
-          screen.queryByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
-        ).not.toBeInTheDocument();
-        expect(screen.queryByText("Na 31-2 Bijlage 1")).not.toBeInTheDocument();
-        expect(screen.queryByText("N 10-2")).not.toBeInTheDocument();
+          await screen.findByRole("heading", { level: 3, name: "Lege processen-verbaal voor deze verkiezing" }),
+        ).toBeVisible();
+        const downloadSection = screen.getByTestId("DSO-first-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        expect(table).toBeVisible();
+        expect(table).toHaveTableContent([
+          ["Model", "Doel"],
+          ["N 10-1", "Processen-verbaal per stembureau"],
+          ["N 10-1", "Inlegvellen controles en correcties per stembureau"],
+          ["Na 14-1, versie 1", "Corrigenda eerste zitting per stembureau"],
+        ]);
+      });
+
+      test("Shows empty document section for second committee session", async () => {
+        const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" }, { id: 2, number: 2 });
+        electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(2, 3);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
+
+        await renderGSBPage("coordinator_gsb");
+
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Lege inlegvellen voor deze verkiezing" }),
+        ).toBeVisible();
+        const downloadSection = screen.getByTestId("DSO-next-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        expect(table).toBeVisible();
+        expect(table).toHaveTableContent([
+          ["Model", "Doel"],
+          ["N 10-1", "Inlegvellen controles en correcties per stembureau"],
+          ["Na 31-1 inlegvel", "Inlegvel controles en correcties bij GSB proces-verbaal"],
+        ]);
+      });
+
+      test("Shows empty document section for third committee session", async () => {
+        const electionDataSecondSession = getElectionMockData({ counting_method: "DSO" }, { id: 2, number: 3 });
+        electionDataSecondSession.committee_sessions = getCommitteeSessionListMockData().slice(1, 3);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(electionDataSecondSession satisfies ElectionDetailsResponse, { status: 200 }),
+          ),
+        );
+
+        await renderGSBPage("coordinator_gsb");
+
+        expect(
+          await screen.findByRole("heading", { level: 3, name: "Lege inlegvellen voor deze verkiezing" }),
+        ).toBeVisible();
+        const downloadSection = screen.getByTestId("DSO-next-session-download-section");
+        expect(downloadSection).toBeVisible();
+        expect(within(downloadSection).getByRole("paragraph")).toHaveTextContent(
+          "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+        );
+        const table = within(downloadSection).getByRole("table");
+        expect(table).toBeVisible();
+        expect(table).toHaveTableContent([
+          ["Model", "Doel"],
+          ["N 10-1", "Inlegvellen controles en correcties per stembureau"],
+          ["Na 31-1 inlegvel", "Inlegvel controles en correcties bij GSB proces-verbaal"],
+        ]);
       });
     });
   });

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -16,12 +16,12 @@ import { t } from "@/i18n/translate";
 import type {
   COMMITTEE_SESSION_CREATE_REQUEST_PATH,
   COMMITTEE_SESSION_DELETE_REQUEST_PATH,
+  CommitteeSession,
   Election,
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
 import { committeeSessionLabel } from "@/utils/committeeSession";
 import { hasBooleanProperty } from "@/utils/typeChecks";
-
 import { directDownload } from "../utils/download";
 import { CommitteeSessionCard } from "./CommitteeSessionCard";
 import { ElectionInformationTable } from "./ElectionInformationTable";
@@ -29,13 +29,14 @@ import cls from "./ElectionManagement.module.css";
 
 interface DownloadSectionProps {
   election: Election;
+  committeeSession: CommitteeSession;
 }
 
 function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
   return (
-    <div id="CSO-first-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+    <div id="CSO-first-session-download-section" className="mt-xl">
       <h3 className={cls.tableTitle}>{t("election_management.empty_documents_first_session")}</h3>
-      <p>{t("election_management.empty_document_description.plural")}</p>
+      <p className={cls.downloadDescription}>{t("election_management.empty_document_description.plural")}</p>
       <Table className={cn(cls.electionInformationTable)} variant="information">
         <Table.Header>
           <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
@@ -66,11 +67,14 @@ function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
   );
 }
 
-function DSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
+function DSOFirstSessionDownloadSection({ election, committeeSession }: DownloadSectionProps) {
+  const navigate = useNavigate();
+  const [showMissingCommitteeSessionDetailsModal, setShowMissingCommitteeSessionDetailsModal] = useState(false);
+
   return (
-    <div id="DSO-first-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+    <div id="DSO-first-session-download-section" className="mt-xl">
       <h3 className={cls.tableTitle}>{t("election_management.empty_documents_first_session")}</h3>
-      <p>{t("election_management.empty_document_description.plural")}</p>
+      <p className={cls.downloadDescription}>{t("election_management.empty_document_description.plural")}</p>
       <Table className={cn(cls.electionInformationTable)} variant="information">
         <Table.Header>
           <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
@@ -98,7 +102,11 @@ function DSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
           <Table.ClickRow
             downloadIcon
             onClick={() => {
-              directDownload(`/api/elections/${election.id}/download_na_14_1_versie1`);
+              if (committeeSession.start_date_time !== undefined && committeeSession.location !== "") {
+                directDownload(`/api/elections/${election.id}/download_na_14_1_versie1`);
+              } else {
+                setShowMissingCommitteeSessionDetailsModal(true);
+              }
             }}
           >
             <Table.Cell>Na 14-1, versie 1</Table.Cell>
@@ -106,15 +114,44 @@ function DSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
           </Table.ClickRow>
         </Table.Body>
       </Table>
+      {showMissingCommitteeSessionDetailsModal && (
+        <Modal
+          title={t("election_management.missing_committee_session_details_modal.title")}
+          onClose={() => {
+            setShowMissingCommitteeSessionDetailsModal(false);
+          }}
+        >
+          <p>{t("election_management.missing_committee_session_details_modal.content")}</p>
+          <nav>
+            <Button
+              size="xl"
+              onClick={() => {
+                void navigate("details");
+              }}
+            >
+              {t("election_management.missing_committee_session_details_modal.enter_details_button")}
+            </Button>
+            <Button
+              variant="secondary"
+              size="xl"
+              onClick={() => {
+                setShowMissingCommitteeSessionDetailsModal(false);
+              }}
+            >
+              {t("cancel")}
+            </Button>
+          </nav>
+        </Modal>
+      )}
     </div>
   );
 }
 
 function CSONextSessionDownloadSection({ election }: DownloadSectionProps) {
   return (
-    <div id="CSO-next-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+    <div id="CSO-next-session-download-section" className="mt-xl">
       <h3 className={cls.tableTitle}>{t("election_management.empty_document_next_session.singular")}</h3>
-      <p>{t("election_management.empty_document_description.singular")}</p>
+      <p className={cls.downloadDescription}>{t("election_management.empty_document_description.singular")}</p>
       <Table className={cn(cls.electionInformationTable)} variant="information">
         <Table.Header>
           <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
@@ -138,9 +175,9 @@ function CSONextSessionDownloadSection({ election }: DownloadSectionProps) {
 
 function DSONextSessionDownloadSection({ election }: DownloadSectionProps) {
   return (
-    <div id="DSO-next-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+    <div id="DSO-next-session-download-section" className="mt-xl">
       <h3 className={cls.tableTitle}>{t("election_management.empty_document_next_session.plural")}</h3>
-      <p>{t("election_management.empty_document_description.plural")}</p>
+      <p className={cls.downloadDescription}>{t("election_management.empty_document_description.plural")}</p>
       <Table className={cn(cls.electionInformationTable)} variant="information">
         <Table.Header>
           <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
@@ -345,14 +382,14 @@ export function ElectionHomePage() {
           {election.committee_category === "GSB" &&
             (currentCommitteeSession.number === 1 ? (
               election.counting_method === "CSO" ? (
-                <CSOFirstSessionDownloadSection election={election} />
+                <CSOFirstSessionDownloadSection election={election} committeeSession={currentCommitteeSession} />
               ) : (
-                <DSOFirstSessionDownloadSection election={election} />
+                <DSOFirstSessionDownloadSection election={election} committeeSession={currentCommitteeSession} />
               )
             ) : election.counting_method === "CSO" ? (
-              <CSONextSessionDownloadSection election={election} />
+              <CSONextSessionDownloadSection election={election} committeeSession={currentCommitteeSession} />
             ) : (
-              <DSONextSessionDownloadSection election={election} />
+              <DSONextSessionDownloadSection election={election} committeeSession={currentCommitteeSession} />
             ))}
         </article>
       </main>

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -20,7 +20,7 @@ import type {
   Election,
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
-import { committeeSessionLabel } from "@/utils/committeeSession";
+import { committee_session_details_present, committeeSessionLabel } from "@/utils/committeeSession";
 import { hasBooleanProperty } from "@/utils/typeChecks";
 import { directDownload } from "../utils/download";
 import { CommitteeSessionCard } from "./CommitteeSessionCard";
@@ -102,7 +102,7 @@ function DSOFirstSessionDownloadSection({ election, committeeSession }: Download
           <Table.ClickRow
             downloadIcon
             onClick={() => {
-              if (committeeSession.start_date_time !== undefined && committeeSession.location !== "") {
+              if (committee_session_details_present(committeeSession)) {
                 directDownload(`/api/elections/${election.id}/download_na_14_1_versie1`);
               } else {
                 setShowMissingCommitteeSessionDetailsModal(true);

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -16,6 +16,7 @@ import { t } from "@/i18n/translate";
 import type {
   COMMITTEE_SESSION_CREATE_REQUEST_PATH,
   COMMITTEE_SESSION_DELETE_REQUEST_PATH,
+  Election,
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
 import { committeeSessionLabel } from "@/utils/committeeSession";
@@ -25,6 +26,71 @@ import { directDownload } from "../utils/download";
 import { CommitteeSessionCard } from "./CommitteeSessionCard";
 import { ElectionInformationTable } from "./ElectionInformationTable";
 import cls from "./ElectionManagement.module.css";
+
+interface DownloadSectionProps {
+  election: Election;
+}
+
+function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
+  return (
+    <div className={cn(cls.downloadModels, "mt-xl")}>
+      <h3 className={cls.tableTitle}>{t("election_management.empty_documents_title")}</h3>
+      <p>{t("election_management.empty_documents_description")}</p>
+      <Table className={cn(cls.electionInformationTable)} variant="information">
+        <Table.Header>
+          <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
+          <Table.HeaderCell scope="col">{t("election_management.document_purpose")}</Table.HeaderCell>
+        </Table.Header>
+        <Table.Body>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_na_31_2_bijlage1`);
+            }}
+          >
+            <Table.Cell>Na 31-2 Bijlage 1</Table.Cell>
+            <Table.Cell>{t("election_management.document_na_31_2_bijlage_1")}</Table.Cell>
+          </Table.ClickRow>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_n_10_2`);
+            }}
+          >
+            <Table.Cell>N 10-2</Table.Cell>
+            <Table.Cell>{t("election_management.document_n_10_2")}</Table.Cell>
+          </Table.ClickRow>
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
+
+function CSONextSessionDownloadSection({ election }: DownloadSectionProps) {
+  return (
+    <div className={cn(cls.downloadModels, "mt-xl")}>
+      <h3 className={cls.tableTitle}>{t("election_management.empty_document_title")}</h3>
+      <p>{t("election_management.empty_document_description")}</p>
+      <Table className={cn(cls.electionInformationTable)} variant="information">
+        <Table.Header>
+          <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
+          <Table.HeaderCell scope="col">{t("election_management.document_purpose")}</Table.HeaderCell>
+        </Table.Header>
+        <Table.Body>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_na_31_2_inlegvel`);
+            }}
+          >
+            <Table.Cell>Na 31-2 Inlegvel</Table.Cell>
+            <Table.Cell>{t("election_management.document_na_31_2_inlegvel")}</Table.Cell>
+          </Table.ClickRow>
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
 export function ElectionHomePage() {
@@ -199,60 +265,9 @@ export function ElectionHomePage() {
           </div>
           {election.committee_category === "GSB" &&
             (currentCommitteeSession.number === 1 ? (
-              <div className={cn(cls.downloadModels, "mt-xl")}>
-                <h3 className={cls.tableTitle}>{t("election_management.empty_documents_title")}</h3>
-                <p>{t("election_management.empty_documents_description")}</p>
-                <Table className={cn(cls.electionInformationTable)} variant="information">
-                  <Table.Header>
-                    <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">{t("election_management.document_purpose")}</Table.HeaderCell>
-                  </Table.Header>
-                  <Table.Body>
-                    <Table.ClickRow
-                      downloadIcon
-                      onClick={() => {
-                        directDownload(`/api/elections/${election.id}/download_na_31_2_bijlage1`);
-                      }}
-                    >
-                      <Table.Cell>Na 31-2 Bijlage 1</Table.Cell>
-                      <Table.Cell>{t("election_management.document_na_31_2_bijlage_1")}</Table.Cell>
-                    </Table.ClickRow>
-                    <Table.ClickRow
-                      downloadIcon
-                      onClick={() => {
-                        directDownload(`/api/elections/${election.id}/download_n_10_2`);
-                      }}
-                    >
-                      <Table.Cell>N 10-2</Table.Cell>
-                      <Table.Cell>{t("election_management.document_n_10_2")}</Table.Cell>
-                    </Table.ClickRow>
-                  </Table.Body>
-                </Table>
-              </div>
+              <CSOFirstSessionDownloadSection election={election} />
             ) : (
-              currentCommitteeSession.number === 2 && (
-                <div className={cn(cls.downloadModels, "mt-xl")}>
-                  <h3 className={cls.tableTitle}>{t("election_management.empty_document_title")}</h3>
-                  <p>{t("election_management.empty_document_description")}</p>
-                  <Table className={cn(cls.electionInformationTable)} variant="information">
-                    <Table.Header>
-                      <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
-                      <Table.HeaderCell scope="col">{t("election_management.document_purpose")}</Table.HeaderCell>
-                    </Table.Header>
-                    <Table.Body>
-                      <Table.ClickRow
-                        downloadIcon
-                        onClick={() => {
-                          directDownload(`/api/elections/${election.id}/download_na_31_2_inlegvel`);
-                        }}
-                      >
-                        <Table.Cell>Na 31-2 Inlegvel</Table.Cell>
-                        <Table.Cell>{t("election_management.document_na_31_2_inlegvel")}</Table.Cell>
-                      </Table.ClickRow>
-                    </Table.Body>
-                  </Table>
-                </div>
-              )
+              currentCommitteeSession.number > 1 && <CSONextSessionDownloadSection election={election} />
             ))}
         </article>
       </main>

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -20,7 +20,7 @@ import type {
   Election,
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
-import { committee_session_details_present, committeeSessionLabel } from "@/utils/committeeSession";
+import { committeeSessionDetailsPresent, committeeSessionLabel } from "@/utils/committeeSession";
 import { hasBooleanProperty } from "@/utils/typeChecks";
 import { directDownload } from "../utils/download";
 import { CommitteeSessionCard } from "./CommitteeSessionCard";
@@ -103,7 +103,7 @@ function DSOFirstSessionDownloadSection({ election, committeeSession }: Download
           <Table.ClickRow
             downloadIcon
             onClick={() => {
-              if (committee_session_details_present(committeeSession)) {
+              if (committeeSessionDetailsPresent(committeeSession)) {
                 directDownload(`/api/elections/${election.id}/download_na_14_1_versie1`);
               } else {
                 setShowMissingCommitteeSessionDetailsModal(true);

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -33,9 +33,9 @@ interface DownloadSectionProps {
 
 function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
   return (
-    <div className={cn(cls.downloadModels, "mt-xl")}>
-      <h3 className={cls.tableTitle}>{t("election_management.empty_documents_title")}</h3>
-      <p>{t("election_management.empty_documents_description")}</p>
+    <div id="CSO-first-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+      <h3 className={cls.tableTitle}>{t("election_management.empty_documents_first_session")}</h3>
+      <p>{t("election_management.empty_document_description.plural")}</p>
       <Table className={cn(cls.electionInformationTable)} variant="information">
         <Table.Header>
           <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
@@ -45,20 +45,64 @@ function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
           <Table.ClickRow
             downloadIcon
             onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_n_10_2`);
+            }}
+          >
+            <Table.Cell>N 10-2</Table.Cell>
+            <Table.Cell>{t("election_management.document_n_10_1_and_n_10_2")}</Table.Cell>
+          </Table.ClickRow>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
               directDownload(`/api/elections/${election.id}/download_na_31_2_bijlage1`);
             }}
           >
             <Table.Cell>Na 31-2 Bijlage 1</Table.Cell>
             <Table.Cell>{t("election_management.document_na_31_2_bijlage_1")}</Table.Cell>
           </Table.ClickRow>
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
+
+function DSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
+  return (
+    <div id="DSO-first-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+      <h3 className={cls.tableTitle}>{t("election_management.empty_documents_first_session")}</h3>
+      <p>{t("election_management.empty_document_description.plural")}</p>
+      <Table className={cn(cls.electionInformationTable)} variant="information">
+        <Table.Header>
+          <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
+          <Table.HeaderCell scope="col">{t("election_management.document_purpose")}</Table.HeaderCell>
+        </Table.Header>
+        <Table.Body>
           <Table.ClickRow
             downloadIcon
             onClick={() => {
-              directDownload(`/api/elections/${election.id}/download_n_10_2`);
+              directDownload(`/api/elections/${election.id}/download_n_10_1`);
             }}
           >
-            <Table.Cell>N 10-2</Table.Cell>
-            <Table.Cell>{t("election_management.document_n_10_2")}</Table.Cell>
+            <Table.Cell>N 10-1</Table.Cell>
+            <Table.Cell>{t("election_management.document_n_10_1_and_n_10_2")}</Table.Cell>
+          </Table.ClickRow>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_n_10_1_inlegvel`);
+            }}
+          >
+            <Table.Cell>N 10-1</Table.Cell>
+            <Table.Cell>{t("election_management.document_n_10_1_inlegvel")}</Table.Cell>
+          </Table.ClickRow>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_na_14_1_versie1`);
+            }}
+          >
+            <Table.Cell>Na 14-1, versie 1</Table.Cell>
+            <Table.Cell>{t("election_management.document_na_14_1_versie_1")}</Table.Cell>
           </Table.ClickRow>
         </Table.Body>
       </Table>
@@ -68,9 +112,9 @@ function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
 
 function CSONextSessionDownloadSection({ election }: DownloadSectionProps) {
   return (
-    <div className={cn(cls.downloadModels, "mt-xl")}>
-      <h3 className={cls.tableTitle}>{t("election_management.empty_document_title")}</h3>
-      <p>{t("election_management.empty_document_description")}</p>
+    <div id="CSO-next-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+      <h3 className={cls.tableTitle}>{t("election_management.empty_document_next_session.singular")}</h3>
+      <p>{t("election_management.empty_document_description.singular")}</p>
       <Table className={cn(cls.electionInformationTable)} variant="information">
         <Table.Header>
           <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
@@ -83,8 +127,43 @@ function CSONextSessionDownloadSection({ election }: DownloadSectionProps) {
               directDownload(`/api/elections/${election.id}/download_na_31_2_inlegvel`);
             }}
           >
-            <Table.Cell>Na 31-2 Inlegvel</Table.Cell>
+            <Table.Cell>Na 31-2 inlegvel</Table.Cell>
             <Table.Cell>{t("election_management.document_na_31_2_inlegvel")}</Table.Cell>
+          </Table.ClickRow>
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
+
+function DSONextSessionDownloadSection({ election }: DownloadSectionProps) {
+  return (
+    <div id="DSO-next-session-download-section" className={cn(cls.downloadModels, "mt-xl")}>
+      <h3 className={cls.tableTitle}>{t("election_management.empty_document_next_session.plural")}</h3>
+      <p>{t("election_management.empty_document_description.plural")}</p>
+      <Table className={cn(cls.electionInformationTable)} variant="information">
+        <Table.Header>
+          <Table.HeaderCell scope="col">{t("election_management.document_model")}</Table.HeaderCell>
+          <Table.HeaderCell scope="col">{t("election_management.document_purpose")}</Table.HeaderCell>
+        </Table.Header>
+        <Table.Body>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_n_10_1_inlegvel`);
+            }}
+          >
+            <Table.Cell>N 10-1</Table.Cell>
+            <Table.Cell>{t("election_management.document_n_10_1_inlegvel")}</Table.Cell>
+          </Table.ClickRow>
+          <Table.ClickRow
+            downloadIcon
+            onClick={() => {
+              directDownload(`/api/elections/${election.id}/download_na_31_1_inlegvel`);
+            }}
+          >
+            <Table.Cell>Na 31-1 inlegvel</Table.Cell>
+            <Table.Cell>{t("election_management.document_na_31_1_inlegvel")}</Table.Cell>
           </Table.ClickRow>
         </Table.Body>
       </Table>
@@ -265,9 +344,15 @@ export function ElectionHomePage() {
           </div>
           {election.committee_category === "GSB" &&
             (currentCommitteeSession.number === 1 ? (
-              <CSOFirstSessionDownloadSection election={election} />
+              election.counting_method === "CSO" ? (
+                <CSOFirstSessionDownloadSection election={election} />
+              ) : (
+                <DSOFirstSessionDownloadSection election={election} />
+              )
+            ) : election.counting_method === "CSO" ? (
+              <CSONextSessionDownloadSection election={election} />
             ) : (
-              currentCommitteeSession.number > 1 && <CSONextSessionDownloadSection election={election} />
+              <DSONextSessionDownloadSection election={election} />
             ))}
         </article>
       </main>

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -68,6 +68,7 @@ function CSOFirstSessionDownloadSection({ election }: DownloadSectionProps) {
 }
 
 function DSOFirstSessionDownloadSection({ election, committeeSession }: DownloadSectionProps) {
+  const { isAdministrator, isCoordinator } = useUserRole();
   const navigate = useNavigate();
   const [showMissingCommitteeSessionDetailsModal, setShowMissingCommitteeSessionDetailsModal] = useState(false);
 
@@ -122,25 +123,28 @@ function DSOFirstSessionDownloadSection({ election, committeeSession }: Download
           }}
         >
           <p>{t("election_management.missing_committee_session_details_modal.content")}</p>
-          <nav>
-            <Button
-              size="xl"
-              onClick={() => {
-                void navigate("details");
-              }}
-            >
-              {t("election_management.missing_committee_session_details_modal.enter_details_button")}
-            </Button>
-            <Button
-              variant="secondary"
-              size="xl"
-              onClick={() => {
-                setShowMissingCommitteeSessionDetailsModal(false);
-              }}
-            >
-              {t("cancel")}
-            </Button>
-          </nav>
+          {isAdministrator && <p>{t("election_management.missing_committee_session_details_modal.ask_coordinator")}</p>}
+          {isCoordinator && (
+            <nav>
+              <Button
+                size="xl"
+                onClick={() => {
+                  void navigate("details");
+                }}
+              >
+                {t("election_management.missing_committee_session_details_modal.enter_details_button")}
+              </Button>
+              <Button
+                variant="secondary"
+                size="xl"
+                onClick={() => {
+                  setShowMissingCommitteeSessionDetailsModal(false);
+                }}
+              >
+                {t("cancel")}
+              </Button>
+            </nav>
+          )}
         </Modal>
       )}
     </div>

--- a/frontend/src/features/election_management/components/ElectionManagement.module.css
+++ b/frontend/src/features/election_management/components/ElectionManagement.module.css
@@ -24,11 +24,9 @@
   width: 58.5rem;
 }
 
-.downloadModels {
-  p {
-    width: 32rem;
-    margin-bottom: var(--space-md);
-  }
+.downloadDescription {
+  width: 32rem;
+  margin-bottom: var(--space-md);
 }
 
 main.reportMain {

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
@@ -11,7 +11,7 @@ import { Icon } from "@/components/ui/Icon/Icon";
 import { useElection } from "@/hooks/election/useElection";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { t } from "@/i18n/translate";
-import { committeeSessionLabel } from "@/utils/committeeSession";
+import { committee_session_details_present, committeeSessionLabel } from "@/utils/committeeSession";
 
 import cls from "../ElectionManagement.module.css";
 import { CSBElectionReportSection } from "./CSBElectionReportSection";
@@ -29,7 +29,7 @@ export function ElectionReportPage() {
   }
 
   // Redirect to update details page if committee session details have not been filled in
-  if (committeeSession.location === "" || !committeeSession.start_date_time) {
+  if (!committee_session_details_present(committeeSession)) {
     return <Navigate to={`/elections/${election.id}/details#redirect-to-report`} />;
   }
 

--- a/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
+++ b/frontend/src/features/election_management/components/report/ElectionReportPage.tsx
@@ -11,7 +11,7 @@ import { Icon } from "@/components/ui/Icon/Icon";
 import { useElection } from "@/hooks/election/useElection";
 import { useNumericParam } from "@/hooks/useNumericParam";
 import { t } from "@/i18n/translate";
-import { committee_session_details_present, committeeSessionLabel } from "@/utils/committeeSession";
+import { committeeSessionDetailsPresent, committeeSessionLabel } from "@/utils/committeeSession";
 
 import cls from "../ElectionManagement.module.css";
 import { CSBElectionReportSection } from "./CSBElectionReportSection";
@@ -29,7 +29,7 @@ export function ElectionReportPage() {
   }
 
   // Redirect to update details page if committee session details have not been filled in
-  if (!committee_session_details_present(committeeSession)) {
+  if (!committeeSessionDetailsPresent(committeeSession)) {
     return <Navigate to={`/elections/${election.id}/details#redirect-to-report`} />;
   }
 

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -81,6 +81,7 @@
   "investigation_ordered_by_csb": "Onderzoek in opdracht van het CSB?",
   "lists_and_candidates": "Lijsten en kandidaten",
   "missing_committee_session_details_modal": {
+    "ask_coordinator": "Vraag de coördinator om de details van de zitting in te vullen.",
     "content": "Op het corrigendum worden de plaats en tijd van de zitting weergegeven. Deze zijn nog niet ingevuld. Om het corrigendum te kunnen gebruiken, moeten deze gegevens eerst ingevuld worden.",
     "enter_details_button": "Details invullen",
     "title": "Vul eerst de details van de zitting in"

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -16,7 +16,10 @@
   "delete_investigations_first": "Verwijder eerst onderzoeken",
   "delete_investigations_first_are_you_sure": "Er zijn onderzoeken toegevoegd aan deze zitting. Verwijder eerst de onderzoeken voor je de zitting verwijdert.",
   "document_model": "Model",
-  "document_n_10_2": "Processen-verbaal per stembureau",
+  "document_n_10_1_and_n_10_2": "Processen-verbaal per stembureau",
+  "document_n_10_1_inlegvel": "Inlegvellen controles en correcties per stembureau",
+  "document_na_14_1_versie_1": "Corrigenda eerste zitting per stembureau",
+  "document_na_31_1_inlegvel": "Inlegvel controles en correcties bij GSB proces-verbaal",
   "document_na_31_2_bijlage_1": "Verslagen van tellingen van stembureau",
   "document_na_31_2_inlegvel": "Inlegvel controles en correcties",
   "document_purpose": "Doel",
@@ -62,10 +65,15 @@
     "upload_the_zip": "Upload alle ZIP-bestanden naar het overdrachtsplatform."
   },
   "electoral_area": "Kiesgebied",
-  "empty_documents_description": "Onderstaande documenten zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige documenten zijn te downloaden via de toolkit van de Kiesraad.",
-  "empty_documents_title": "Lege processen-verbaal voor deze verkiezing",
-  "empty_document_description": "Onderstaand document is relevant voor de huidige zitting van het gemeentelijk stembureau. Overige documenten zijn te downloaden via de toolkit van de Kiesraad.",
-  "empty_document_title": "Leeg inlegvel voor deze verkiezing",
+  "empty_document_description": {
+    "singular": "Onderstaand model is relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad.",
+    "plural": "Onderstaande modellen zijn relevant voor de huidige zitting van het gemeentelijk stembureau. Overige modellen zijn te downloaden via de toolkit van de Kiesraad."
+  },
+  "empty_document_next_session": {
+    "singular": "Leeg inlegvel voor deze verkiezing",
+    "plural": "Lege inlegvellen voor deze verkiezing"
+  },
+  "empty_documents_first_session": "Lege processen-verbaal voor deze verkiezing",
   "enter_a_number": "Voer een getal in",
   "enter_number_of_voters": "Voer het aantal kiesgerechtigden voor deze verkiezing in zoals door de burgemeester en wethouders aan het gemeentelijk stembureau is doorgegeven.",
   "how_many_voters": "Hoeveel kiesgerechtigden telt het GSB?",

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -80,6 +80,11 @@
   "if_gsb_correction": "Wil het gemeentelijk stembureau zelf een fout herstellen en is de zitting nog niet afgesloten door de voorzitter? Ga dan verder in de eerste zitting.",
   "investigation_ordered_by_csb": "Onderzoek in opdracht van het CSB?",
   "lists_and_candidates": "Lijsten en kandidaten",
+  "missing_committee_session_details_modal": {
+    "content": "Op het corrigendum worden de plaats en tijd van de zitting weergegeven. Deze zijn nog niet ingevuld. Om het corrigendum te kunnen gebruiken, moeten deze gegevens eerst ingevuld worden.",
+    "enter_details_button": "Details invullen",
+    "title": "Vul eerst de details van de zitting in"
+  },
   "no_polling_stations": "Geen stembureaus",
   "only_add_if_ordered": "Voeg alleen een nieuwe zitting toe als het centraal stembureau hier opdracht voor heeft gegeven.",
   "prepare_new_session": "Nieuwe zitting voorbereiden",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -228,11 +228,35 @@ export type COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH =
   `/api/elections/${ElectionId}/committee_sessions/${CommitteeSessionId}/status`;
 export type COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = CommitteeSessionStatusChangeRequest;
 
+// /api/elections/{election_id}/download_n_10_1
+export interface ELECTION_DOWNLOAD_N_10_1_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type ELECTION_DOWNLOAD_N_10_1_REQUEST_PATH = `/api/elections/${ElectionId}/download_n_10_1`;
+
+// /api/elections/{election_id}/download_n_10_1_inlegvel
+export interface ELECTION_DOWNLOAD_N_10_1_INLEGVEL_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type ELECTION_DOWNLOAD_N_10_1_INLEGVEL_REQUEST_PATH = `/api/elections/${ElectionId}/download_n_10_1_inlegvel`;
+
 // /api/elections/{election_id}/download_n_10_2
 export interface ELECTION_DOWNLOAD_N_10_2_REQUEST_PARAMS {
   election_id: ElectionId;
 }
 export type ELECTION_DOWNLOAD_N_10_2_REQUEST_PATH = `/api/elections/${ElectionId}/download_n_10_2`;
+
+// /api/elections/{election_id}/download_na_14_1_versie1
+export interface ELECTION_DOWNLOAD_NA_14_1_VERSIE1_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type ELECTION_DOWNLOAD_NA_14_1_VERSIE1_REQUEST_PATH = `/api/elections/${ElectionId}/download_na_14_1_versie1`;
+
+// /api/elections/{election_id}/download_na_31_1_inlegvel
+export interface ELECTION_DOWNLOAD_NA_31_1_INLEGVEL_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type ELECTION_DOWNLOAD_NA_31_1_INLEGVEL_REQUEST_PATH = `/api/elections/${ElectionId}/download_na_31_1_inlegvel`;
 
 // /api/elections/{election_id}/download_na_31_2_bijlage1
 export interface ELECTION_DOWNLOAD_NA_31_2_BIJLAGE1_REQUEST_PARAMS {

--- a/frontend/src/utils/committeeSession.test.ts
+++ b/frontend/src/utils/committeeSession.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { getCommitteeSessionMockData } from "@/testing/api-mocks/CommitteeSessionMockData";
 import type { CommitteeSession } from "@/types/generated/openapi";
-import { committee_session_details_present, committeeSessionLabel } from "./committeeSession";
+import { committeeSessionDetailsPresent, committeeSessionLabel } from "./committeeSession";
 
 describe("CommitteeSessionLabel util", () => {
   test.each([
@@ -35,6 +35,6 @@ test.each([
   [getCommitteeSessionMockData({ location: "Juinen", start_date_time: "" }), false],
   [getCommitteeSessionMockData({ location: "", start_date_time: "2026-03-18T21:36:00" }), false],
   [getCommitteeSessionMockData({ location: "Juinen", start_date_time: "2026-03-18T21:36:00" }), true],
-])("committee_session_details_present with committeeSession %s to be %s", (input: CommitteeSession, expected: boolean) => {
-  expect(committee_session_details_present(input)).toBe(expected);
+])("committeeSessionDetailsPresent with committeeSession %s to be %s", (input: CommitteeSession, expected: boolean) => {
+  expect(committeeSessionDetailsPresent(input)).toBe(expected);
 });

--- a/frontend/src/utils/committeeSession.test.ts
+++ b/frontend/src/utils/committeeSession.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
-
-import { committeeSessionLabel } from "./committeeSession";
+import { getCommitteeSessionMockData } from "@/testing/api-mocks/CommitteeSessionMockData";
+import type { CommitteeSession } from "@/types/generated/openapi";
+import { committee_session_details_present, committeeSessionLabel } from "./committeeSession";
 
 describe("CommitteeSessionLabel util", () => {
   test.each([
@@ -25,4 +26,15 @@ describe("CommitteeSessionLabel util", () => {
   ])("CSB: Format committeeSessionLabel with number %s as %s", (input: number, expected: string) => {
     expect(committeeSessionLabel("CSB", input)).toBe(expected);
   });
+});
+
+test.each([
+  [getCommitteeSessionMockData({ location: "", start_date_time: undefined }), false],
+  [getCommitteeSessionMockData({ location: "Juinen", start_date_time: undefined }), false],
+  [getCommitteeSessionMockData({ location: "", start_date_time: "" }), false],
+  [getCommitteeSessionMockData({ location: "Juinen", start_date_time: "" }), false],
+  [getCommitteeSessionMockData({ location: "", start_date_time: "2026-03-18T21:36:00" }), false],
+  [getCommitteeSessionMockData({ location: "Juinen", start_date_time: "2026-03-18T21:36:00" }), true],
+])("committee_session_details_present with committeeSession %s to be %s", (input: CommitteeSession, expected: boolean) => {
+  expect(committee_session_details_present(input)).toBe(expected);
 });

--- a/frontend/src/utils/committeeSession.ts
+++ b/frontend/src/utils/committeeSession.ts
@@ -1,5 +1,5 @@
 import { hasTranslation, t } from "@/i18n/translate";
-import type { CommitteeCategory } from "@/types/generated/openapi";
+import type { CommitteeCategory, CommitteeSession } from "@/types/generated/openapi";
 
 export function committeeSessionLabel(
   committeeCategory: CommitteeCategory,
@@ -28,4 +28,12 @@ export function committeeSessionLabel(
   }
 
   return label;
+}
+
+export function committee_session_details_present(committeeSession: CommitteeSession) {
+  return (
+    committeeSession.start_date_time !== undefined &&
+    committeeSession.start_date_time !== "" &&
+    committeeSession.location !== ""
+  );
 }

--- a/frontend/src/utils/committeeSession.ts
+++ b/frontend/src/utils/committeeSession.ts
@@ -30,7 +30,7 @@ export function committeeSessionLabel(
   return label;
 }
 
-export function committee_session_details_present(committeeSession: CommitteeSession) {
+export function committeeSessionDetailsPresent(committeeSession: CommitteeSession) {
   return (
     committeeSession.start_date_time !== undefined &&
     committeeSession.start_date_time !== "" &&


### PR DESCRIPTION
Closes #3697 

## What & why

### Backend
- Added check for counting method CSO to existing endpoints for downloading CSO documents
- Added API endpoints for downloading DSO documents
- Added check for committee session details present in na 14-1 versie 1 download in the backend
- Added check for committee session details present in na 14-1 versie 1 download in the frontend
  - Show [modal](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=25035-9472&m=dev) if details are missing
- Added tests

### Frontend
- Split CSO download sections into separate functions
- Adjusted only 2nd session CSO download to next session download (as it should be)
- Added DSO download sections
- Improved and added tests

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Using the dev page non-corrigendum elections: test the first session downloads
  - CSO: verify that the CSO downloads still work
  - DSO: Na 14-1 versie 1 download only works once details of the committee session have been filled in, verify a modal is shown linking to committee session details page using a generated test election
    - Fill in committee session details and verify download now works
- Using the dev page corrigendum elections: test the next session downloads
  - CSO: Verify that the CSO downloads still work
  - DSO: Verify that the DSO downloads now work

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->