### PR TITLE
CI fixes (partial backport of #3744 and #3794)

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           workspaces: "backend -> target"
       - name: Build
-        run: cargo --verbose --locked build --target=x86_64-unknown-linux-musl --no-default-features --features openapi,dev-database,memory-serve,embed-typst,storybook --bin abacus
+        run: cargo build --verbose --locked --target=x86_64-unknown-linux-musl --no-default-features --features openapi,dev-database,memory-serve,embed-typst,storybook --bin abacus
       - uses: actions/upload-artifact@v7
         with:
           name: abacus
@@ -122,17 +122,17 @@ jobs:
         run: mkdir -p dist dist-storybook
         working-directory: ./frontend
       - name: Check rustfmt
-        run: cargo --verbose --locked fmt --all -- --check
+        run: cargo fmt --verbose --all -- --check
       - name: Check Clippy with default features
-        run: cargo --verbose --locked clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --verbose --locked --workspace --all-targets -- -D warnings
       - name: Check Clippy with all features
-        run: cargo --verbose --locked clippy --target=x86_64-unknown-linux-musl --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --verbose --locked --target=x86_64-unknown-linux-musl --workspace --all-targets --all-features -- -D warnings
       - name: Install Nextest
         run: cargo binstall cargo-nextest
       - name: Remove sqlx test directory
         run: rm -rf target/sqlx
       - name: Run tests
-        run: cargo --verbose --locked nextest run --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst,tls
+        run: cargo nextest run --verbose --locked --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation
         run: cargo doc --workspace --no-deps --all-features --document-private-items
         env:
@@ -282,10 +282,10 @@ jobs:
         working-directory: ./backend/fuzz
         run: cargo install cargo-fuzz
       - name: Check Clippy for ./backend/fuzz
-        run: cargo --verbose --locked clippy -- -D warnings
+        run: cargo clippy --verbose --locked -- -D warnings
         working-directory: ./backend/fuzz
       - name: Check Clippy for ./backend/apportionment/fuzz
-        run: cargo --verbose --locked clippy -- -D warnings
+        run: cargo clippy --verbose --locked -- -D warnings
         working-directory: ./backend/apportionment/fuzz
       - name: Run data entry fuzzer
         working-directory: ./backend/fuzz

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -129,6 +129,8 @@ jobs:
         run: cargo --verbose --locked clippy --target=x86_64-unknown-linux-musl --workspace --all-targets --all-features -- -D warnings
       - name: Install Nextest
         run: cargo binstall cargo-nextest
+      - name: Remove sqlx test directory
+        run: rm -rf target/sqlx
       - name: Run tests
         run: cargo --verbose --locked nextest run --target=x86_64-unknown-linux-musl --workspace --exclude pdf_gen_dylib --no-default-features --features openapi,dev-database,embed-typst,tls
       - name: Build documentation

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -72,6 +72,8 @@ jobs:
         run: cargo binstall cargo-llvm-cov
       - name: Install Nextest
         run: cargo binstall cargo-nextest
+      - name: Remove sqlx test directory
+        run: rm -rf target/sqlx
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --workspace --branch --profile ci --features embed-typst,airgap-detection --cobertura --output-path ./target/llvm-cov-target/codecov.json
       - name: Upload coverage to Codecov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,17 +80,17 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Run tests
-        run: cargo --locked test --release --workspace --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
+        run: cargo test --locked --release --workspace --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
       # no airgap detection build
       - name: Build without airgap detection
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v7
         with:
           name: abacus-${{ matrix.target.os }}-no-airgap-detection
           path: ${{ matrix.target.binary }}
       # airgap detection build
       - name: Build
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst,airgap-detection,tls --target=${{ matrix.target.name }}
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Get build date
         run: |
           BUILD_DATE=$(date -u +'%Y-%m-%d')
-          echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_ENV
+          echo "BUILD_DATE=$BUILD_DATE" >> "$GITHUB_ENV"
       - name: Create release directory
         run: mkdir -p release
       - name: Download abacus
@@ -186,7 +186,7 @@ jobs:
           rmdir abacus-release-windows-latest
         working-directory: release
       - name: Create a SHA256SUMS file
-        run: sha256sum -b * > SHA256SUMS
+        run: sha256sum -b -- * > SHA256SUMS
         working-directory: release
       - name: Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v2

--- a/.github/workflows/weekly-e2e-tests.yml
+++ b/.github/workflows/weekly-e2e-tests.yml
@@ -74,7 +74,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target.os == 'ubuntu-latest'
       - name: Build without airgap detection
-        run: cargo --locked build --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
+        run: cargo build --locked --release --no-default-features --features memory-serve,embed-typst --target=${{ matrix.target.name }}
       - uses: actions/upload-artifact@v7
         with:
           name: abacus-${{ matrix.target.os }}-weekly

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e44b143a6a48317033079275252e49eb0da3214728b16e3e61144d43eadd39"
+checksum = "22238651fa78fcefcc99b649b4fb7ca205c9a07a3594cdea2715d6a1ed1b3252"
 dependencies = [
  "chrono",
  "quick-xml",


### PR DESCRIPTION
## What & why

Partial backport of changes in #3744 and #3794:
- [Remove sqlx test directory in CI](https://github.com/kiesraad/abacus/commit/571b6dadd8b4117db5b579b832d3b8843c0fee62) to fix [broken CI buids](https://github.com/kiesraad/abacus/actions/runs/31367092838/job/93414515483).
- [Update `backend/fuzz/Cargo.lock`](https://github.com/kiesraad/abacus/pull/3794/changes/577a91c1a09f9834e1e8c45c64766b08ffed6ab1) because it was out of date.
- [Use Cargo `--locked option` in correct position](https://github.com/kiesraad/abacus/pull/3794/commits/def1254574b8a107c9ba376a4f28b3b1648c494a)
- [Fix actionlint findings](https://github.com/kiesraad/abacus/pull/3744/changes/9495eba6b9ca049754484c6cad152563292526bb) in release workflow

## How to test

CI passes (again).

## Reviewer notes

Review per commit.