### PR TITLE
Update Sigrid config

### DIFF
--- a/.github/workflows/sigrid-pr-feedback.yml
+++ b/.github/workflows/sigrid-pr-feedback.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 0
       - name: Sigrid CI
         uses: Software-Improvement-Group/sigridci@43db8e59cdda5f92e640b3c6f6aa1646e870d633 # main
+        continue-on-error: true
         with:
           customer: kiesraad
           system: abacus

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -53,6 +53,8 @@ dependencychecker:
     # Marvin Attack on RSA crate, which we do not use (Cargo weak dependency, https://github.com/rust-lang/cargo/issues/10801)
     - vulnerability: "CVE-2023-49092"
 
+component_depth: 1
+
 architecture:
   enabled: true
 


### PR DESCRIPTION
## What & why

Update Sigrid config to not fail CI when score is low and to set component depth to 1, similar to kiesraad/e-ks#1055.

## How to test

CI passes. Sigrid config impact can only be seen after merge.
