### PR TITLE
Let Biome exit with an error code on warnings

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run Biome
-        run: pnpm biome ci
+        run: pnpm biome ci --error-on-warnings
       - name: Run TypeScript compiler
         run: pnpm lint:tsc
       - name: Run ESLint

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "build": "vite build --config vite-prod.config.ts",
     "build:msw": "cross-env API_MODE=mock vite build && cp mockServiceWorker.js dist/",
     "lint": "pnpm lint:biome && pnpm lint:tsc && pnpm lint:eslint",
-    "lint:biome": "biome check",
+    "lint:biome": "biome check --error-on-warnings",
     "lint:tsc": "tsc",
     "lint:eslint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "biome format --write",


### PR DESCRIPTION
## What & why

Let Biome exit with an error code on warnings to prevent mistakes like a stale `console.log` (e.g. https://github.com/kiesraad/abacus/pull/3782/commits/30c2b16308a6c9a308e218ae472e02418d33c1f0). This gets logged by Biome as a warning, but Lefthook and CI don't fail on this.

## How to test

Try to commit a `console.log` and check that Lefthook prevents you from doing so.
