### PR TITLE
Extend data entry fuzzer with correction states

### DIFF
--- a/backend/fuzz/README.md
+++ b/backend/fuzz/README.md
@@ -4,9 +4,9 @@ We use [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html) for fuzzin
 
 ## Data entry status fuzz test
 
-The `data_entry_status` fuzz test tests that the data entry system matches the state machine described in the [docs](https://github.com/kiesraad/abacus/blob/main/documentatie/flowcharts/data-entry-state.md). The fuzzer checks that all possible transitions change the state as expected, or give the expected error.
+The `data_entry_status` fuzz test tests that the data entry system matches the state machine described in the [docs](https://github.com/kiesraad/abacus/blob/main/documentatie/state-machines/data-entry-state.md). The fuzzer checks that all possible transitions change the state as expected, or give the expected error.
 
-This fuzz test covers all possible states and all possible `DataEntryTransitionError` errors, except for the `FirstEntryAlreadyClaimed`, `ValidatorError` and `ValidationError` errors. The `FirstEntryAlreadyClaimed` error is not triggered by the fuzzer for simplicity, but this error is explicitly tested by the `first_entry_in_progress_claim_first_entry_other_user_error` unit test. The `ValidatorError` and `ValidationError` errors are not triggered by the fuzzer because the fuzzer does not test the API directly. Instead, the fuzzer only tests the internal functions to focus on verifying the data entry state machine. This fuzz test can be seen as a more complete extension of the unit tests that test individual transitions, which shows that no unexpected errors or transition can happen.
+This fuzz test covers all possible states, including the `FirstEntryCorrection` and `SecondEntryCorrection` states with their claim, save, finalise and discard transitions, and all possible `DataEntryTransitionError` errors except for the `ValidatorError` and `ValidationError` errors. The `ValidatorError` and `ValidationError` errors are not triggered by the fuzzer because the fuzzer does not test the API directly. Instead, the fuzzer only tests the internal functions to focus on verifying the data entry state machine. This fuzz test can be seen as a more complete extension of the unit tests that test individual transitions, which shows that no unexpected errors or transition can happen.
 
 To run the fuzzer, first install cargo-fuzz if you haven't already:
 
@@ -77,4 +77,4 @@ $(rustc +nightly --print sysroot)/lib/rustlib/$(rustc +nightly --print host-tupl
  -ignore-filename-regex="\.cargo|\.rustup|fuzz_target|\/rustc"
 ```
 
-Now you can open the generated `/tmp/coverage/index.html` in your browser to view which parts of Abacus were covered by the fuzzer. The coverage of the `src/data_entry/status.rs` is mainly relevant for this fuzz test, there you can see which error cases have and which have not been covered.
+Now you can open the generated `/tmp/coverage/index.html` in your browser to view which parts of Abacus were covered by the fuzzer. The coverage of the `src/domain/data_entry.rs` is mainly relevant for this fuzz test, there you can see which error cases have and which have not been covered.

--- a/backend/fuzz/fuzz_targets/data_entry_status.rs
+++ b/backend/fuzz/fuzz_targets/data_entry_status.rs
@@ -28,8 +28,13 @@ use libfuzzer_sys::{
     fuzz_target,
 };
 
-fn valid_result() -> Results {
-    Results::CSOFirstSession(CSOFirstSessionResults {
+/// A valid result without any votes
+fn valid_empty_result() -> Results {
+    Results::CSOFirstSession(valid_empty_cso_result())
+}
+
+fn valid_empty_cso_result() -> CSOFirstSessionResults {
+    CSOFirstSessionResults {
         extra_investigation: ExtraInvestigation {
             extra_investigation_other_reason: YesNo::default(),
             ballots_recounted_extra_investigation: YesNo::default(),
@@ -53,6 +58,27 @@ fn valid_result() -> Results {
             difference_completely_accounted_for: YesNo::yes(),
         },
         political_group_votes: vec![],
+    }
+}
+
+/// A valid result that is different from [`valid_empty_result`], so that two
+/// entries can have differences but no errors.
+fn valid_counted_result() -> Results {
+    Results::CSOFirstSession(CSOFirstSessionResults {
+        voters_counts: VotersCounts {
+            poll_card_count: 100,
+            proxy_certificate_count: 0,
+            voter_card_count: None,
+            total_admitted_voters_count: 100,
+        },
+        votes_counts: VotesCounts {
+            political_group_total_votes: vec![],
+            total_votes_candidates_count: 0,
+            blank_votes_count: 100,
+            invalid_votes_count: 0,
+            total_votes_cast_count: 100,
+        },
+        ..valid_empty_cso_result()
     })
 }
 
@@ -83,15 +109,33 @@ fn invalid_result() -> Results {
     })
 }
 
-fn update(user_id: UserId, correct_entry: bool) -> DataEntryUpdate {
+/// The possible values an entry can hold.
+#[derive(Arbitrary, Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryValue {
+    ValidEmpty,
+    ValidCounted,
+    Invalid,
+}
+
+impl EntryValue {
+    fn results(self) -> Results {
+        match self {
+            EntryValue::ValidEmpty => valid_empty_result(),
+            EntryValue::ValidCounted => valid_counted_result(),
+            EntryValue::Invalid => invalid_result(),
+        }
+    }
+
+    fn has_errors(self) -> bool {
+        matches!(self, EntryValue::Invalid)
+    }
+}
+
+fn update(user_id: UserId, entry: EntryValue) -> DataEntryUpdate {
     DataEntryUpdate {
         progress: 0,
         user_id,
-        entry: if correct_entry {
-            valid_result()
-        } else {
-            invalid_result()
-        },
+        entry: entry.results(),
         client_state: ClientState::default(),
     }
 }
@@ -117,10 +161,10 @@ fn election() -> ElectionWithPoliticalGroups {
 
 #[derive(Arbitrary, Debug)]
 enum Transition {
-    ClaimFirstEntry,
+    ClaimFirstEntry(bool),
     ClaimSecondEntry(bool),
-    UpdateFirstEntry(bool, bool),
-    UpdateSecondEntry(bool, bool),
+    UpdateFirstEntry(bool, EntryValue),
+    UpdateSecondEntry(bool, EntryValue),
     FinaliseFirstEntry(bool),
     FinaliseSecondEntry(bool),
     DiscardFirstEntryInProgress(bool),
@@ -130,32 +174,33 @@ enum Transition {
     DiscardEntries,
     KeepFirstEntry,
     KeepSecondEntry,
+    CorrectFirstEntry,
+    CorrectSecondEntry,
 }
 
 /// This matches the state machine described in:
-/// https://github.com/kiesraad/abacus/blob/main/documentatie/flowcharts/data-entry-state.md
+/// https://github.com/kiesraad/abacus/blob/main/documentatie/state-machines/data-entry-state.md
 ///
 /// It also contains some additional self loops which are not explicitly documented there:
-/// - the "save" (update) endpoints for FirstEntryInProgress and SecondEntryInProgress
-/// - re-invocations of "claim" for FirstEntryInProgress and SecondEntryInProgress
+/// - the "save" (update) endpoints for the in progress and correction states
+/// - re-invocations of "claim" for the in progress and correction states
 ///
-/// It also specifies the expected errors that the fuzzer might run in to
+/// It also specifies the expected errors that the fuzzer might run in to.
 fn is_as_expected(
     state: &DataEntryStatus,
     transition: &Transition,
     resulting_state: &Result<DataEntryStatus, DataEntryTransitionError>,
-    first_entry_correct: bool,
-    second_entry_correct: bool,
+    first_entry: EntryValue,
+    second_entry: EntryValue,
 ) -> bool {
     match (state, transition) {
-        // ClaimFirstEntry
-        (DataEntryStatus::Empty, Transition::ClaimFirstEntry) => matches!(
+        // ClaimFirstEntry: an unclaimed first entry can be claimed by any user
+        (DataEntryStatus::Empty, Transition::ClaimFirstEntry(_)) => matches!(
             resulting_state,
             Ok(DataEntryStatus::FirstEntryInProgress(_))
         ),
         // ClaimFirstEntry self loop, only allowed with same user
-        // (we currently don't test the already claimed error because we only use the correct user ID)
-        (DataEntryStatus::FirstEntryInProgress(_), Transition::ClaimFirstEntry) => matches!(
+        (DataEntryStatus::FirstEntryInProgress(_), Transition::ClaimFirstEntry(true)) => matches!(
             resulting_state,
             Ok(DataEntryStatus::FirstEntryInProgress(_))
         ),
@@ -175,11 +220,7 @@ fn is_as_expected(
         }
         // FinaliseFirstEntry
         (DataEntryStatus::FirstEntryInProgress(_), Transition::FinaliseFirstEntry(true)) => {
-            if first_entry_correct {
-                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
-            } else {
-                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryHasErrors(_)))
-            }
+            is_kept_as_expected(resulting_state, first_entry)
         }
         // DiscardFirstEntry
         (DataEntryStatus::FirstEntryHasErrors(_), Transition::DiscardFirstEntryWithErrors) => {
@@ -222,31 +263,105 @@ fn is_as_expected(
         }
         // FinaliseSecondEntry
         (DataEntryStatus::SecondEntryInProgress(_), Transition::FinaliseSecondEntry(true)) => {
-            if second_entry_correct {
-                matches!(resulting_state, Ok(DataEntryStatus::Definitive(_)))
-            } else {
-                matches!(resulting_state, Ok(DataEntryStatus::EntriesDifferent(_)))
-            }
+            is_finalised_as_expected(resulting_state, first_entry, second_entry)
         }
         // KeepFirstEntry
         (DataEntryStatus::EntriesDifferent(_), Transition::KeepFirstEntry) => {
-            if first_entry_correct {
-                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
-            } else {
-                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryHasErrors(_)))
-            }
+            is_kept_as_expected(resulting_state, first_entry)
         }
         // KeepSecondEntry
         (DataEntryStatus::EntriesDifferent(_), Transition::KeepSecondEntry) => {
-            if second_entry_correct {
-                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
-            } else {
-                matches!(resulting_state, Ok(DataEntryStatus::FirstEntryHasErrors(_)))
-            }
+            is_kept_as_expected(resulting_state, second_entry)
         }
         // DiscardBothEntries
         (DataEntryStatus::EntriesDifferent(_), Transition::DiscardEntries) => {
             matches!(resulting_state, Ok(DataEntryStatus::Empty))
+        }
+        // CorrectFirstEntry, only allowed when the second entry has no errors
+        (DataEntryStatus::EntriesDifferent(_), Transition::CorrectFirstEntry) => {
+            if second_entry.has_errors() {
+                matches!(
+                    resulting_state,
+                    Err(DataEntryTransitionError::CorrectionNotAllowed)
+                )
+            } else {
+                matches!(
+                    resulting_state,
+                    Ok(DataEntryStatus::FirstEntryCorrection(_))
+                )
+            }
+        }
+        // CorrectSecondEntry, only allowed when the first entry has no errors
+        (DataEntryStatus::EntriesDifferent(_), Transition::CorrectSecondEntry) => {
+            if first_entry.has_errors() {
+                matches!(
+                    resulting_state,
+                    Err(DataEntryTransitionError::CorrectionNotAllowed)
+                )
+            } else {
+                matches!(
+                    resulting_state,
+                    Ok(DataEntryStatus::SecondEntryCorrection(_))
+                )
+            }
+        }
+        // ClaimFirstEntry self loop, only allowed with same user
+        (DataEntryStatus::FirstEntryCorrection(_), Transition::ClaimFirstEntry(true)) => matches!(
+            resulting_state,
+            Ok(DataEntryStatus::FirstEntryCorrection(_))
+        ),
+        // UpdateFirstEntry self loop
+        (DataEntryStatus::FirstEntryCorrection(_), Transition::UpdateFirstEntry(true, _)) => {
+            matches!(
+                resulting_state,
+                Ok(DataEntryStatus::FirstEntryCorrection(_))
+            )
+        }
+        // FinaliseFirstEntry after correcting it
+        (DataEntryStatus::FirstEntryCorrection(_), Transition::FinaliseFirstEntry(true)) => {
+            is_finalised_as_expected(resulting_state, first_entry, second_entry)
+        }
+        // DiscardFirstEntry while correcting it: the kept second entry becomes the first entry
+        (
+            DataEntryStatus::FirstEntryCorrection(_),
+            Transition::DiscardFirstEntryInProgress(true),
+        ) => {
+            matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
+        }
+        // ClaimSecondEntry self loop, only allowed with same user
+        (DataEntryStatus::SecondEntryCorrection(_), Transition::ClaimSecondEntry(true)) => {
+            matches!(
+                resulting_state,
+                Ok(DataEntryStatus::SecondEntryCorrection(_))
+            )
+        }
+        // UpdateSecondEntry self loop
+        (DataEntryStatus::SecondEntryCorrection(_), Transition::UpdateSecondEntry(true, _)) => {
+            matches!(
+                resulting_state,
+                Ok(DataEntryStatus::SecondEntryCorrection(_))
+            )
+        }
+        // FinaliseSecondEntry after correcting it
+        (DataEntryStatus::SecondEntryCorrection(_), Transition::FinaliseSecondEntry(true)) => {
+            is_finalised_as_expected(resulting_state, first_entry, second_entry)
+        }
+        // DiscardSecondEntry while correcting it: the finalised first entry is kept unchanged
+        (
+            DataEntryStatus::SecondEntryCorrection(_),
+            Transition::DiscardSecondEntryInProgress(true),
+        ) => {
+            matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
+        }
+        // Expected error: FirstEntryAlreadyClaimed
+        (
+            DataEntryStatus::FirstEntryInProgress(_) | DataEntryStatus::FirstEntryCorrection(_),
+            Transition::ClaimFirstEntry(false),
+        ) => {
+            matches!(
+                resulting_state,
+                Err(DataEntryTransitionError::FirstEntryAlreadyClaimed)
+            )
         }
         // Expected error: SecondEntryNeedsDifferentUser
         (DataEntryStatus::FirstEntryFinalised(_), Transition::ClaimSecondEntry(false)) => {
@@ -256,27 +371,25 @@ fn is_as_expected(
             )
         }
         // Expected error: SecondEntryAlreadyClaimed
-        (DataEntryStatus::SecondEntryInProgress(_), Transition::ClaimSecondEntry(false)) => {
+        (
+            DataEntryStatus::SecondEntryInProgress(_) | DataEntryStatus::SecondEntryCorrection(_),
+            Transition::ClaimSecondEntry(false),
+        ) => {
             matches!(
                 resulting_state,
                 Err(DataEntryTransitionError::SecondEntryAlreadyClaimed)
             )
         }
-        // Expected error: CannotTransitionUsingDifferentUser for first entry
+        // Expected error: CannotTransitionUsingDifferentUser for the first and the second entry,
+        // both while entering them and while correcting them
         (
-            DataEntryStatus::FirstEntryInProgress(_),
+            DataEntryStatus::FirstEntryInProgress(_) | DataEntryStatus::FirstEntryCorrection(_),
             Transition::UpdateFirstEntry(false, _)
             | Transition::DiscardFirstEntryInProgress(false)
             | Transition::FinaliseFirstEntry(false),
-        ) => {
-            matches!(
-                resulting_state,
-                Err(DataEntryTransitionError::CannotTransitionUsingDifferentUser)
-            )
-        }
-        // Expected error: CannotTransitionUsingDifferentUser for second entry
-        (
-            DataEntryStatus::SecondEntryInProgress(_),
+        )
+        | (
+            DataEntryStatus::SecondEntryInProgress(_) | DataEntryStatus::SecondEntryCorrection(_),
             Transition::UpdateSecondEntry(false, _)
             | Transition::DiscardSecondEntryInProgress(false)
             | Transition::FinaliseSecondEntry(false),
@@ -288,13 +401,13 @@ fn is_as_expected(
         }
         // Expected error: FirstEntryAlreadyFinalised
         // oddity: SecondEntryInProgress --ClaimFirstEntry--> invalid instead of FirstEntryAlreadyFinalised
-        (DataEntryStatus::SecondEntryInProgress(_), Transition::ClaimFirstEntry) => {
+        (DataEntryStatus::SecondEntryInProgress(_), Transition::ClaimFirstEntry(_)) => {
             matches!(resulting_state, Err(DataEntryTransitionError::Invalid))
         }
         (
             DataEntryStatus::FirstEntryFinalised(_) | DataEntryStatus::SecondEntryInProgress(_),
             Transition::FinaliseFirstEntry(_)
-            | Transition::ClaimFirstEntry
+            | Transition::ClaimFirstEntry(_)
             | Transition::UpdateFirstEntry(_, _)
             | Transition::DiscardFirstEntryInProgress(_),
         ) => matches!(
@@ -305,7 +418,7 @@ fn is_as_expected(
         (
             DataEntryStatus::Definitive(_),
             Transition::FinaliseFirstEntry(_)
-            | Transition::ClaimFirstEntry
+            | Transition::ClaimFirstEntry(_)
             | Transition::UpdateFirstEntry(_, _)
             | Transition::DiscardFirstEntryInProgress(_)
             | Transition::FinaliseSecondEntry(_)
@@ -316,35 +429,99 @@ fn is_as_expected(
             resulting_state,
             Err(DataEntryTransitionError::SecondEntryAlreadyFinalised)
         ),
-        // All other state transitions should be invalid
-        (_, _) => matches!(resulting_state, Err(DataEntryTransitionError::Invalid)),
+        // All other state transitions should be invalid. Every state is listed explicitly, so
+        // that adding a state to DataEntryStatus does not compile until it is added to the fuzzer.
+        (
+            DataEntryStatus::Empty
+            | DataEntryStatus::FirstEntryInProgress(_)
+            | DataEntryStatus::FirstEntryHasErrors(_)
+            | DataEntryStatus::FirstEntryFinalised(_)
+            | DataEntryStatus::SecondEntryInProgress(_)
+            | DataEntryStatus::EntriesDifferent(_)
+            | DataEntryStatus::FirstEntryCorrection(_)
+            | DataEntryStatus::SecondEntryCorrection(_)
+            | DataEntryStatus::Definitive(_),
+            _,
+        ) => matches!(resulting_state, Err(DataEntryTransitionError::Invalid)),
     }
 }
 
-struct Users {
-    first: UserId,  // used for first entry
-    second: UserId, // used for second entry
+/// A single entry being finalised or kept while it is the only entry
+fn is_kept_as_expected(
+    resulting_state: &Result<DataEntryStatus, DataEntryTransitionError>,
+    entry: EntryValue,
+) -> bool {
+    if entry.has_errors() {
+        matches!(resulting_state, Ok(DataEntryStatus::FirstEntryHasErrors(_)))
+    } else {
+        matches!(resulting_state, Ok(DataEntryStatus::FirstEntryFinalised(_)))
+    }
 }
 
-impl Users {
-    fn first(&self, correct_user: bool) -> UserId {
-        if correct_user {
-            self.first
-        } else {
-            self.second
+/// All transitions that finalise an entry with both entries present
+fn is_finalised_as_expected(
+    resulting_state: &Result<DataEntryStatus, DataEntryTransitionError>,
+    first_entry: EntryValue,
+    second_entry: EntryValue,
+) -> bool {
+    if first_entry.results() != second_entry.results() {
+        matches!(resulting_state, Ok(DataEntryStatus::EntriesDifferent(_)))
+    } else if first_entry.has_errors() {
+        matches!(
+            resulting_state,
+            Err(DataEntryTransitionError::ValidationError(_))
+        )
+    } else {
+        matches!(resulting_state, Ok(DataEntryStatus::Definitive(_)))
+    }
+}
+
+/// Fuzz state shadowing the real state machine
+struct Model {
+    first_user: UserId,  // used for first entry
+    second_user: UserId, // used for second entry
+    first_entry: EntryValue,
+    second_entry: EntryValue,
+}
+
+impl Model {
+    fn new() -> Self {
+        Model {
+            first_user: UserId::from(0),
+            second_user: UserId::from(1),
+            first_entry: EntryValue::ValidEmpty,
+            second_entry: EntryValue::ValidEmpty,
         }
     }
 
-    fn second(&self, correct_user: bool) -> UserId {
+    fn first_user(&self, correct_user: bool) -> UserId {
         if correct_user {
-            self.second
+            self.first_user
         } else {
-            self.first
+            self.second_user
         }
     }
 
-    fn swap(&mut self) {
-        std::mem::swap(&mut self.first, &mut self.second);
+    fn second_user(&self, correct_user: bool) -> UserId {
+        if correct_user {
+            self.second_user
+        } else {
+            self.first_user
+        }
+    }
+
+    /// An unclaimed first entry can be claimed by any user.
+    fn claim_empty_first_entry(&mut self, correct_user: bool) {
+        if !correct_user {
+            std::mem::swap(&mut self.first_user, &mut self.second_user);
+        }
+        self.first_entry = EntryValue::ValidEmpty;
+    }
+
+    /// The second entry becomes the first entry, taking its typist along.
+    fn promote_second_entry(&mut self) {
+        std::mem::swap(&mut self.first_user, &mut self.second_user);
+        self.first_entry = self.second_entry;
     }
 }
 
@@ -352,74 +529,77 @@ impl Users {
 // every step matches the expected state machine defined above
 fuzz_target!(|transitions: Vec<Transition>| {
     let mut state = DataEntryStatus::default();
-
-    // Fuzz state to keep track of whether entries are correct, because this influences what
-    // happens when an entry is finalised
-    let mut first_entry_correct = true;
-    let mut second_entry_correct = true;
-
-    let mut users = Users {
-        first: UserId::from(0),
-        second: UserId::from(1),
-    };
+    let mut model = Model::new();
+    let election = election();
 
     for transition in transitions {
         let prev_state = state.clone();
 
         // Apply transition
         let next_state = match transition {
-            Transition::ClaimFirstEntry => {
-                if prev_state == DataEntryStatus::Empty {
-                    first_entry_correct = true;
-                }
-                state.claim_first_entry(users.first, valid_result())
-            }
-            Transition::UpdateFirstEntry(correct_user, correct_entry) => {
+            Transition::ClaimFirstEntry(correct_user) => {
                 let res =
-                    state.update_first_entry(update(users.first(correct_user), correct_entry));
+                    state.claim_first_entry(model.first_user(correct_user), valid_empty_result());
+                if res.is_ok() && prev_state == DataEntryStatus::Empty {
+                    model.claim_empty_first_entry(correct_user);
+                }
+                res
+            }
+            Transition::UpdateFirstEntry(correct_user, entry) => {
+                let res = state.update_first_entry(update(model.first_user(correct_user), entry));
                 if res.is_ok() {
-                    first_entry_correct = correct_entry
+                    model.first_entry = entry
                 };
                 res
             }
             Transition::FinaliseFirstEntry(correct_user) => {
-                state.finalise_first_entry(&election(), users.first(correct_user))
+                state.finalise_first_entry(&election, model.first_user(correct_user))
             }
             Transition::DiscardFirstEntryInProgress(correct_user) => {
-                state.discard_first_entry_in_progress(users.first(correct_user), &election())
+                let was_correction = matches!(prev_state, DataEntryStatus::FirstEntryCorrection(_));
+                let res = state
+                    .discard_first_entry_in_progress(model.first_user(correct_user), &election);
+                if res.is_ok() && was_correction {
+                    // discarding a correction keeps the second entry, which becomes the first
+                    model.promote_second_entry();
+                }
+                res
             }
             Transition::DiscardFirstEntryWithErrors => state.discard_first_entry_with_errors(),
             Transition::ClaimSecondEntry(correct_user) => {
-                if matches!(prev_state, DataEntryStatus::FirstEntryFinalised(_)) {
-                    second_entry_correct = true;
-                }
-                state.claim_second_entry(users.second(correct_user), valid_result())
-            }
-            Transition::UpdateSecondEntry(correct_user, correct_entry) => {
                 let res =
-                    state.update_second_entry(update(users.second(correct_user), correct_entry));
+                    state.claim_second_entry(model.second_user(correct_user), valid_empty_result());
+                if res.is_ok() && matches!(prev_state, DataEntryStatus::FirstEntryFinalised(_)) {
+                    // a newly claimed second entry starts out empty
+                    model.second_entry = EntryValue::ValidEmpty;
+                }
+                res
+            }
+            Transition::UpdateSecondEntry(correct_user, entry) => {
+                let res = state.update_second_entry(update(model.second_user(correct_user), entry));
                 if res.is_ok() {
-                    second_entry_correct = correct_entry
+                    model.second_entry = entry
                 };
                 res
             }
             Transition::DiscardSecondEntryInProgress(correct_user) => {
-                state.discard_second_entry_in_progress(users.second(correct_user), &election())
+                state.discard_second_entry_in_progress(model.second_user(correct_user), &election)
             }
             Transition::FinaliseSecondEntry(correct_user) => {
-                state.finalise_second_entry(&election(), users.second(correct_user))
+                state.finalise_second_entry(&election, model.second_user(correct_user))
             }
             Transition::ResumeFirstEntryWithErrors => state.resume_first_entry_with_errors(),
             Transition::DiscardEntries => state.discard_entries(),
-            Transition::KeepFirstEntry => state.keep_first_entry(&election()),
+            Transition::KeepFirstEntry => state.keep_first_entry(&election),
             Transition::KeepSecondEntry => {
-                let res = state.keep_second_entry(&election());
+                let res = state.keep_second_entry(&election);
                 if res.is_ok() {
-                    users.swap(); // second user becomes first, because second entry becomes first entry
-                    first_entry_correct = second_entry_correct;
+                    model.promote_second_entry();
                 }
                 res
             }
+            Transition::CorrectFirstEntry => state.correct_first_entry(&election),
+            Transition::CorrectSecondEntry => state.correct_second_entry(&election),
         };
 
         // Check that the applied transition matches what we expect from the state machine
@@ -427,11 +607,11 @@ fuzz_target!(|transitions: Vec<Transition>| {
             &prev_state,
             &transition,
             &next_state,
-            first_entry_correct,
-            second_entry_correct,
+            model.first_entry,
+            model.second_entry,
         ) {
             panic!(
-                "Prev: {:?}\n\nNext: {:?}\n\nInvalid transition: {} --{:?}--> {}\nfirst_entry_correct: {}\n",
+                "Prev: {:?}\n\nNext: {:?}\n\nInvalid transition: {} --{:?}--> {}\nfirst_entry: {:?}, second_entry: {:?}\n",
                 prev_state,
                 next_state,
                 prev_state.status_name(),
@@ -440,7 +620,8 @@ fuzz_target!(|transitions: Vec<Transition>| {
                     .as_ref()
                     .map(|s| s.status_name().to_string())
                     .unwrap_or_else(|e| e.to_string()),
-                first_entry_correct
+                model.first_entry,
+                model.second_entry
             )
         }
 

--- a/backend/fuzz/fuzz_targets/data_entry_status.rs
+++ b/backend/fuzz/fuzz_targets/data_entry_status.rs
@@ -446,7 +446,11 @@ fn is_as_expected(
     }
 }
 
-/// A single entry being finalised or kept while it is the only entry
+/// A single entry being finalised or kept while it is the only entry.
+/// 
+/// - Keeping the first entry will discard the second entry.
+/// - Keeping the second entry will discard the first entry, making the second entry the first entry.
+/// - The state transitions to `FirstEntryFinalised` if that data entry does not have errors and to `FirstEntryHasErrors` if it does.
 fn is_kept_as_expected(
     resulting_state: &Result<DataEntryStatus, DataEntryTransitionError>,
     entry: EntryValue,


### PR DESCRIPTION
## What & why

Extend data entry fuzzer with the `FirstEntryCorrection` and `SecondEntryCorrection` correction states, including the claim, save, finalise and discard transitions. Resolves #3642.

Also:
- Replace the `correct_entry` bool with a three-variant `EntryValue` to support both entries with errors and entries with differences.
- Replace the `users` and `*_entry_correct` variables with a new `Model` struct.
- List every state explicitly in the catch-all match arm, so a new `DataEntryStatus` state fails to compile until it is added to the fuzzer.

## How to test

Run fuzzer for a while, should not give any errors.