### PR TITLE
Rename summary to tabulation and totals

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6753,6 +6753,23 @@
         },
         "additionalProperties": false
       },
+      "DifferencesTotals": {
+        "type": "object",
+        "description": "Contains the totals of the differences, containing which polling stations had differences.",
+        "required": [
+          "more_ballots_count",
+          "fewer_ballots_count"
+        ],
+        "properties": {
+          "fewer_ballots_count": {
+            "$ref": "#/components/schemas/SumCount"
+          },
+          "more_ballots_count": {
+            "$ref": "#/components/schemas/SumCount"
+          }
+        },
+        "additionalProperties": false
+      },
       "DisplayFraction": {
         "type": "object",
         "description": "Fraction with the integer part split out for display purposes",
@@ -6896,15 +6913,15 @@
         "required": [
           "seat_assignment",
           "candidate_nomination",
-          "election_summary",
+          "election_totals",
           "warnings"
         ],
         "properties": {
           "candidate_nomination": {
             "$ref": "#/components/schemas/CandidateNomination"
           },
-          "election_summary": {
-            "$ref": "#/components/schemas/ElectionSummary"
+          "election_totals": {
+            "$ref": "#/components/schemas/ElectionTotals"
           },
           "seat_assignment": {
             "$ref": "#/components/schemas/SeatAssignment"
@@ -7223,9 +7240,9 @@
           "PS2"
         ]
       },
-      "ElectionSummary": {
+      "ElectionTotals": {
         "type": "object",
-        "description": "Contains a summary of the election results, added up from the votes of all polling stations.",
+        "description": "Contains the totals of the election results, added up from the votes of all polling stations.",
         "required": [
           "voters_counts",
           "votes_counts",
@@ -7235,7 +7252,7 @@
         ],
         "properties": {
           "differences_counts": {
-            "$ref": "#/components/schemas/SummaryDifferencesCounts",
+            "$ref": "#/components/schemas/DifferencesTotals",
             "description": "The differences between voters and votes"
           },
           "number_of_voters": {
@@ -7249,7 +7266,7 @@
             "items": {
               "$ref": "#/components/schemas/PoliticalGroupCandidateVotes"
             },
-            "description": "The summary votes for each political group (and each candidate within)"
+            "description": "The total votes for each political group (and each candidate within)"
           },
           "polling_station_investigations": {
             "$ref": "#/components/schemas/PollingStationInvestigations",
@@ -8867,13 +8884,13 @@
           {
             "type": "object",
             "required": [
-              "election_summary",
+              "election_totals",
               "seat_assignment",
               "status"
             ],
             "properties": {
-              "election_summary": {
-                "$ref": "#/components/schemas/ElectionSummary"
+              "election_totals": {
+                "$ref": "#/components/schemas/ElectionTotals"
               },
               "seat_assignment": {
                 "$ref": "#/components/schemas/SeatAssignment"
@@ -9355,7 +9372,7 @@
       },
       "SumCount": {
         "type": "object",
-        "description": "Contains a summary count, containing both the count and a list of polling\nstations that contributed to it.",
+        "description": "Contains a sum count, containing both the count and a list of polling\nstations that contributed to it.",
         "required": [
           "count",
           "data_entry_sources"
@@ -9371,23 +9388,6 @@
             "items": {
               "$ref": "#/components/schemas/DataEntrySourceNumber"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SummaryDifferencesCounts": {
-        "type": "object",
-        "description": "Contains a summary of the differences, containing which polling stations had differences.",
-        "required": [
-          "more_ballots_count",
-          "fewer_ballots_count"
-        ],
-        "properties": {
-          "fewer_ballots_count": {
-            "$ref": "#/components/schemas/SumCount"
-          },
-          "more_ballots_count": {
-            "$ref": "#/components/schemas/SumCount"
           }
         },
         "additionalProperties": false

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -13,7 +13,7 @@ use crate::{
     domain::{
         apportionment::SeatAssignment,
         election::{Election, ElectionId},
-        summary::ElectionSummary,
+        tabulation::ElectionTotals,
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType},
     repository::{election_repo, user_repo::User},
@@ -34,7 +34,7 @@ impl AsAuditEvent for ApportionmentProcessed {
 pub enum ProcessApportionmentResponse {
     Finalised(ElectionApportionmentResponse),
     DrawingLotsRequired {
-        election_summary: ElectionSummary,
+        election_totals: ElectionTotals,
         seat_assignment: SeatAssignment,
     },
 }
@@ -71,10 +71,10 @@ pub async fn process_apportionment(
     let apportionment_result = service::process_apportionment(&mut conn, &election).await?;
     let apportionment_output = match apportionment_result {
         ApportionmentResult::Ok(apportionment_output) => Finalised(apportionment_output),
-        ApportionmentResult::ListDrawingLotsRequired(_, election_summary, seat_assignment)
-        | ApportionmentResult::CandidateDrawingLotsRequired(_, election_summary, seat_assignment) => {
+        ApportionmentResult::ListDrawingLotsRequired(_, election_totals, seat_assignment)
+        | ApportionmentResult::CandidateDrawingLotsRequired(_, election_totals, seat_assignment) => {
             DrawingLotsRequired {
-                election_summary,
+                election_totals,
                 seat_assignment,
             }
         }

--- a/backend/src/api/apportionment/structs.rs
+++ b/backend/src/api/apportionment/structs.rs
@@ -14,7 +14,7 @@ use crate::domain::{
     apportionment_state::DeceasedCandidate,
     election::{CandidateNumber, PGNumber},
     results::political_group_candidate_votes::{CandidateVotes, PoliticalGroupCandidateVotes},
-    summary::ElectionSummary,
+    tabulation::ElectionTotals,
 };
 
 #[derive(Clone, Debug)]
@@ -212,6 +212,6 @@ impl apportionment::CandidateDrawn<PGNumber, CandidateNumber> for CandidateDrawn
 pub struct ElectionApportionmentResponse {
     pub seat_assignment: SeatAssignment,
     pub candidate_nomination: CandidateNomination,
-    pub election_summary: ElectionSummary,
+    pub election_totals: ElectionTotals,
     pub warnings: Vec<ApportionmentWarning>,
 }

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -15,7 +15,7 @@ use abacus::{
         polling_station::PollingStation,
         report::DEFAULT_DATE_TIME_FORMAT,
         results::Results,
-        summary::ElectionSummary,
+        tabulation::ElectionTotals,
     },
     test_data_gen::{GenerateElectionArgs, RandomRange, create_test_election, parse_range},
 };
@@ -298,12 +298,12 @@ async fn export_election(
         .expect("Failed to write polling stations file");
 
     if export_results_json {
-        let election_summary = ElectionSummary::from_results(election, &results)
-            .expect("Failed to create election summary");
+        let election_totals =
+            ElectionTotals::tabulate(election, &results).expect("Failed to create election totals");
         let input = ModelNa31_2Input {
-            votes_tables: VotesTables::new(election, &election_summary)
+            votes_tables: VotesTables::new(election, &election_totals)
                 .expect("Failed to create votes tables"),
-            summary: election_summary.into(),
+            summary: election_totals.into(),
             committee_session: committee_session.clone(),
             polling_stations: polling_stations.iter().map(Clone::clone).collect(),
             election: election.clone().into(),

--- a/backend/src/domain/mod.rs
+++ b/backend/src/domain/mod.rs
@@ -16,7 +16,7 @@ pub mod report;
 pub mod results;
 pub mod role;
 pub mod sub_committee;
-pub mod summary;
+pub mod tabulation;
 #[cfg(test)]
 pub mod valid_default;
 pub mod validate;

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -4,7 +4,7 @@ use crate::domain::{
     apportionment::{DisplayFraction, ListSeatAssignment, SeatAssignment, SeatChangeStep},
     election::PGNumber,
     models::error::ModelsError,
-    summary::ElectionSummaryCSB,
+    tabulation::ElectionTotalsCSB,
 };
 
 struct InitialSteps<'a> {
@@ -143,7 +143,7 @@ impl EnrichedSeatAssignment {
     }
 
     fn get_list_seat_assignments(
-        summary: &ElectionSummaryCSB,
+        totals: &ElectionTotalsCSB,
         seat_assignment: &SeatAssignment,
     ) -> Result<ListSeatAssignments, ModelsError> {
         let mut enriched_list_seat_assignments = Vec::new();
@@ -159,7 +159,7 @@ impl EnrichedSeatAssignment {
             )
         };
 
-        for pg_votes in &summary.votes_counts.political_group_total_votes {
+        for pg_votes in &totals.votes_counts.political_group_total_votes {
             let initial_full_seats = Self::get_initial_full_seats(seat_assignment, pg_votes.number);
             let largest_remainder = if initial_steps.initial_largest_remainder_steps.is_empty() {
                 None
@@ -195,10 +195,10 @@ impl EnrichedSeatAssignment {
 
     pub fn new(
         number_of_seats: u32,
-        summary: &ElectionSummaryCSB,
+        totals: &ElectionTotalsCSB,
         seat_assignment: &SeatAssignment,
     ) -> Result<Self, ModelsError> {
-        let list_seat_assignments = Self::get_list_seat_assignments(summary, seat_assignment)?;
+        let list_seat_assignments = Self::get_list_seat_assignments(totals, seat_assignment)?;
         Ok(EnrichedSeatAssignment {
             quota: seat_assignment.quota,
             list_seat_assignment: list_seat_assignments.enriched_list_seat_assignments,
@@ -271,14 +271,14 @@ mod tests {
                 political_group_total_votes::PoliticalGroupTotalVotes, voters_counts::VotersCounts,
                 votes_counts::VotesCounts,
             },
-            summary::{ElectionSummary, ElectionSummaryCSB, SumCount, SummaryDifferencesCounts},
+            tabulation::{DifferencesTotals, ElectionTotals, ElectionTotalsCSB, SumCount},
         },
     };
 
-    fn get_election_summary(
+    fn get_election_totals(
         election: &ElectionWithPoliticalGroups,
         candidate_votes: &[Vec<u32>],
-    ) -> ElectionSummary {
+    ) -> ElectionTotals {
         let total_votes_candidates_count = candidate_votes.iter().flatten().sum::<u32>();
         let political_group_votes =
             create_political_group_candidate_votes(&election.political_groups, candidate_votes);
@@ -289,7 +289,7 @@ mod tests {
                 total: pg_votes.total,
             })
             .collect();
-        ElectionSummary {
+        ElectionTotals {
             voters_counts: VotersCounts {
                 poll_card_count: total_votes_candidates_count,
                 proxy_certificate_count: 0,
@@ -303,7 +303,7 @@ mod tests {
                 invalid_votes_count: 0,
                 total_votes_cast_count: total_votes_candidates_count,
             },
-            differences_counts: SummaryDifferencesCounts {
+            differences_counts: DifferencesTotals {
                 more_ballots_count: SumCount::zero(),
                 fewer_ballots_count: SumCount::zero(),
             },
@@ -333,11 +333,11 @@ mod tests {
             10,
         );
         let political_groups = &election.political_groups;
-        let summary = get_election_summary(&election, &candidate_votes);
-        let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
+        let totals = get_election_totals(&election, &candidate_votes);
+        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups);
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
-            &summary.political_group_votes,
+            &totals.political_group_votes,
             &[],
             &[],
             &[],
@@ -349,7 +349,7 @@ mod tests {
 
         let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result =
-            EnrichedSeatAssignment::new(election.number_of_seats, &summary_csb, &seat_assignment)
+            EnrichedSeatAssignment::new(election.number_of_seats, &totals_csb, &seat_assignment)
                 .expect("EnrichedSeatAssignment::new should succeed");
 
         assert!(result.initial_highest_average_steps.is_none());
@@ -457,11 +457,11 @@ mod tests {
             24,
         );
         let political_groups = &election.political_groups;
-        let summary = get_election_summary(&election, &candidate_votes);
-        let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
+        let totals = get_election_totals(&election, &candidate_votes);
+        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups);
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
-            &summary.political_group_votes,
+            &totals.political_group_votes,
             &[],
             &[],
             &[],
@@ -473,7 +473,7 @@ mod tests {
 
         let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result =
-            EnrichedSeatAssignment::new(election.number_of_seats, &summary_csb, &seat_assignment)
+            EnrichedSeatAssignment::new(election.number_of_seats, &totals_csb, &seat_assignment)
                 .expect("EnrichedSeatAssignment::new should succeed");
         assert!(result.initial_highest_average_steps.is_some());
         let initial_highest_average_steps = result.initial_highest_average_steps.unwrap();
@@ -549,11 +549,11 @@ mod tests {
             15,
         );
         let political_groups = &election.political_groups;
-        let summary = get_election_summary(&election, &candidate_votes);
-        let summary_csb = ElectionSummaryCSB::new(&summary, political_groups);
+        let totals = get_election_totals(&election, &candidate_votes);
+        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups);
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
-            &summary.political_group_votes,
+            &totals.political_group_votes,
             &[],
             &[],
             &[],
@@ -565,7 +565,7 @@ mod tests {
 
         let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
         let result =
-            EnrichedSeatAssignment::new(election.number_of_seats, &summary_csb, &seat_assignment)
+            EnrichedSeatAssignment::new(election.number_of_seats, &totals_csb, &seat_assignment)
                 .expect("EnrichedSeatAssignment::new should succeed");
         assert!(result.initial_highest_average_steps.is_none());
         assert_eq!(result.initial_total_full_seats, 15);

--- a/backend/src/domain/models/model_na_14_2.rs
+++ b/backend/src/domain/models/model_na_14_2.rs
@@ -10,7 +10,7 @@ use crate::domain::{
     },
     polling_station::PollingStation,
     results::common_polling_station_results::CommonPollingStationResultsWithoutVotes,
-    summary::ElectionSummaryWithoutVotes,
+    tabulation::ElectionTotalsWithoutVotes,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -19,8 +19,8 @@ pub struct ModelNa14_2Input {
     pub committee_session: CommitteeSession,
     pub previous_committee_session: CommitteeSession,
     pub election: Election,
-    pub previous_summary: ElectionSummaryWithoutVotes,
-    pub summary: ElectionSummaryWithoutVotes,
+    pub previous_summary: ElectionTotalsWithoutVotes,
+    pub summary: ElectionTotalsWithoutVotes,
     pub hash: String,
     pub creation_date_time: String,
     pub votes_tables: VotesTablesWithPreviousVotes,

--- a/backend/src/domain/models/model_na_31_2.rs
+++ b/backend/src/domain/models/model_na_31_2.rs
@@ -8,7 +8,7 @@ use crate::domain::{
         votes_table::{CandidatesTables, VotesTables},
     },
     polling_station::PollingStation,
-    summary::ElectionSummaryWithoutVotes,
+    tabulation::ElectionTotalsWithoutVotes,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -16,7 +16,7 @@ use crate::domain::{
 pub struct ModelNa31_2Input {
     pub committee_session: CommitteeSession,
     pub election: Election,
-    pub summary: ElectionSummaryWithoutVotes,
+    pub summary: ElectionTotalsWithoutVotes,
     pub polling_stations: Vec<PollingStation>,
     pub hash: String,
     pub creation_date_time: String,

--- a/backend/src/domain/models/model_p_22_2.rs
+++ b/backend/src/domain/models/model_p_22_2.rs
@@ -8,7 +8,7 @@ use crate::domain::{
         enriched_candidate_nomination::EnrichedCandidateNomination,
         enriched_seat_assignment::EnrichedSeatAssignment, votes_table::VotesTables,
     },
-    summary::ElectionSummaryCSB,
+    tabulation::ElectionTotalsCSB,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -16,7 +16,7 @@ use crate::domain::{
 pub struct ModelP22_2Input {
     pub committee_session: CommitteeSession,
     pub election: Election,
-    pub summary: ElectionSummaryCSB,
+    pub summary: ElectionTotalsCSB,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub footnotes: Option<ApportionmentFootnotes>,
     pub seat_assignment: EnrichedSeatAssignment,

--- a/backend/src/domain/models/votes_table.rs
+++ b/backend/src/domain/models/votes_table.rs
@@ -9,7 +9,7 @@ use crate::domain::{
         common_polling_station_results::CommonPollingStationResults, count::Count,
         political_group_candidate_votes::PoliticalGroupCandidateVotes,
     },
-    summary::ElectionSummary,
+    tabulation::ElectionTotals,
 };
 
 const DEFAULT_CANDIDATES_PER_COLUMN: [usize; 4] = [25, 25, 15, 15];
@@ -36,17 +36,15 @@ pub struct VotesTables(Vec<VotesTable>);
 impl VotesTables {
     pub fn new(
         election: &ElectionWithPoliticalGroups,
-        summary: &ElectionSummary,
+        totals: &ElectionTotals,
     ) -> Result<Self, ModelsError> {
         Ok(VotesTables(
             election
                 .political_groups
                 .iter()
                 .map(|group| {
-                    let candidate_votes = get_votes_for_political_party(
-                        group.number,
-                        &summary.political_group_votes,
-                    )?;
+                    let candidate_votes =
+                        get_votes_for_political_party(group.number, &totals.political_group_votes)?;
                     VotesTable::new(
                         group,
                         Some(candidate_votes),
@@ -65,21 +63,19 @@ pub struct VotesTablesWithPreviousVotes(Vec<VotesTable>);
 impl VotesTablesWithPreviousVotes {
     pub fn new(
         election: &ElectionWithPoliticalGroups,
-        summary: &ElectionSummary,
-        previous_summary: &ElectionSummary,
+        totals: &ElectionTotals,
+        previous_totals: &ElectionTotals,
     ) -> Result<Self, ModelsError> {
         Ok(VotesTablesWithPreviousVotes(
             election
                 .political_groups
                 .iter()
                 .map(|group| {
-                    let candidate_votes = get_votes_for_political_party(
-                        group.number,
-                        &summary.political_group_votes,
-                    )?;
+                    let candidate_votes =
+                        get_votes_for_political_party(group.number, &totals.political_group_votes)?;
                     let previous_candidate_votes = get_votes_for_political_party(
                         group.number,
-                        &previous_summary.political_group_votes,
+                        &previous_totals.political_group_votes,
                     )?;
                     VotesTable::new(
                         group,
@@ -130,7 +126,7 @@ fn get_votes_for_political_party(
         .iter()
         .find(|pg_votes| pg_votes.number == political_group_number)
         .ok_or(ModelsError::DataIntegrityError(format!(
-            "No votes found for political group number {political_group_number} in summary",
+            "No votes found for political group number {political_group_number} in totals",
         )))
 }
 
@@ -380,18 +376,18 @@ mod tests {
     }
 
     #[test]
-    fn votes_tables_fails_when_group_missing_in_summary() {
+    fn votes_tables_fails_when_group_missing_in_totals() {
         let group = sample_group(1, &[1]);
         let election = sample_election(group);
-        let summary = ElectionSummary::zero(&election);
+        let totals = ElectionTotals::zero(&election);
 
-        let err = VotesTables::new(&election, &summary).unwrap_err();
+        let err = VotesTables::new(&election, &totals).unwrap_err();
 
         match err {
             ModelsError::DataIntegrityError(message) => {
                 assert_eq!(
                     message,
-                    "No votes found for political group number 1 in summary"
+                    "No votes found for political group number 1 in totals"
                 );
             }
         }

--- a/backend/src/domain/report/files.rs
+++ b/backend/src/domain/report/files.rs
@@ -111,7 +111,7 @@ async fn generate_and_save_files_csb_election(
 
     let apportionment_input = ApportionmentInputData::new(
         input_data.election.number_of_seats,
-        &input_data.summary.political_group_votes,
+        &input_data.totals.political_group_votes,
         state.get_deceased_candidates(),
         state.get_lists_drawn(),
         state.get_candidates_drawn(),

--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -25,7 +25,7 @@ use crate::{
         polling_station::PollingStation,
         report::DEFAULT_DATE_TIME_FORMAT,
         results::{Results, political_group_candidate_votes::PoliticalGroupCandidateVotes},
-        summary::{ElectionSummary, ElectionSummaryCSB},
+        tabulation::{ElectionTotals, ElectionTotalsCSB},
     },
     eml::EmlHash,
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType},
@@ -140,8 +140,8 @@ pub struct ResultsInputData {
     pub polling_stations: Vec<PollingStation>,
     pub investigations: Vec<PollingStationInvestigation>,
     pub results: Vec<(DataEntrySource, Results)>,
-    pub summary: ElectionSummary,
-    pub previous_summary: Option<ElectionSummary>,
+    pub totals: ElectionTotals,
+    pub previous_totals: Option<ElectionTotals>,
     pub previous_committee_session: Option<CommitteeSession>,
     pub created_at: DateTime<Local>,
 }
@@ -166,23 +166,23 @@ impl ResultsInputData {
             None
         };
 
-        // get the previous results summary from the previous committee session if it exists
-        let previous_summary = if let Some(previous_committee_session) = &previous_committee_session
+        // get the previous results totals from the previous committee session if it exists
+        let previous_totals = if let Some(previous_committee_session) = &previous_committee_session
         {
             let previous_results =
                 list_results_for_committee_session(conn, previous_committee_session.id).await?;
-            let previous_summary = ElectionSummary::from_results(&election, &previous_results)?;
-            Some(previous_summary)
+            let previous_totals = ElectionTotals::tabulate(&election, &previous_results)?;
+            Some(previous_totals)
         } else {
             None
         };
 
-        let summary = ElectionSummary::from_results(&election, &results)?;
+        let totals = ElectionTotals::tabulate(&election, &results)?;
 
         Ok(ResultsInputData {
             committee_session,
-            previous_summary,
-            summary,
+            previous_totals,
+            totals,
             created_at,
             election,
             polling_stations,
@@ -197,7 +197,7 @@ impl ResultsInputData {
             None,
             &self.committee_session,
             &self.results,
-            &self.summary,
+            &self.totals,
             self.created_at,
         )
     }
@@ -350,10 +350,13 @@ impl ResultsInputCSB {
     ) -> Result<PdfFileModel, APIError> {
         let data = &self.data;
 
-        let summary = ElectionSummaryCSB::new(&data.summary, &data.election.political_groups);
+        let totals_csb = ElectionTotalsCSB::new(&data.totals, &data.election.political_groups);
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
-        let enriched_seat_assignment =
-            EnrichedSeatAssignment::new(data.election.number_of_seats, &summary, &seat_assignment)?;
+        let enriched_seat_assignment = EnrichedSeatAssignment::new(
+            data.election.number_of_seats,
+            &totals_csb,
+            &seat_assignment,
+        )?;
         let candidate_nomination = map_candidate_nomination(
             &apportionment_result.candidate_nomination,
             &data.election.political_groups.clone(),
@@ -365,7 +368,7 @@ impl ResultsInputCSB {
         let pdf_file: PdfFileModel = ModelP22_2Input {
             committee_session: data.committee_session.clone(),
             election: data.election.clone().into(),
-            summary,
+            summary: totals_csb,
             footnotes,
             seat_assignment: enriched_seat_assignment,
             candidate_nomination: enriched_candidate_nomination,
@@ -384,7 +387,7 @@ impl ResultsInputCSB {
     ) -> Result<PdfFileModel, APIError> {
         let data = &self.data;
 
-        let votes_tables = VotesTables::new(&data.election, &data.summary)?;
+        let votes_tables = VotesTables::new(&data.election, &data.totals)?;
         let pdf_file = ModelP22_2Bijlage1Input {
             election: data.election.clone().into(),
             votes_tables,
@@ -440,9 +443,9 @@ impl ResultsInputGSB {
 
         let results_pdf_file_type = FileType::GsbResultsPdf;
         let results_pdf_model = if data.committee_session.is_next_session() {
-            let Some(previous_summary) = &data.previous_summary else {
+            let Some(previous_totals) = &data.previous_totals else {
                 return Err(APIError::DataIntegrityError(
-                "Previous summary is required for generating results PDF for next committee sessions"
+                "Previous totals are required for generating results PDF for next committee sessions"
                     .to_string(),
             ));
             };
@@ -455,7 +458,7 @@ impl ResultsInputGSB {
             };
 
             self.get_na14_2_pdf_file(
-                previous_summary,
+                previous_totals,
                 previous_committee_session,
                 xml_hash,
                 creation_date_time,
@@ -481,7 +484,7 @@ impl ResultsInputGSB {
 
     fn get_na14_2_pdf_file(
         &self,
-        previous_summary: &ElectionSummary,
+        previous_totals: &ElectionTotals,
         previous_committee_session: &CommitteeSession,
         hash: String,
         creation_date_time: String,
@@ -492,13 +495,13 @@ impl ResultsInputGSB {
         let pdf_file = ModelNa14_2Input {
             votes_tables: VotesTablesWithPreviousVotes::new(
                 &data.election,
-                &data.summary,
-                previous_summary,
+                &data.totals,
+                previous_totals,
             )?,
             committee_session: data.committee_session.clone(),
             election: data.election.clone().into(),
-            summary: data.summary.clone().into(),
-            previous_summary: previous_summary.clone().into(),
+            summary: data.totals.clone().into(),
+            previous_summary: previous_totals.clone().into(),
             previous_committee_session: previous_committee_session.clone(),
             hash,
             creation_date_time,
@@ -516,10 +519,10 @@ impl ResultsInputGSB {
         let data = &self.data;
 
         let pdf_file = ModelNa31_2Input {
-            votes_tables: VotesTables::new(&data.election, &data.summary)?,
+            votes_tables: VotesTables::new(&data.election, &data.totals)?,
             committee_session: data.committee_session.clone(),
             polling_stations: data.polling_stations.clone(),
-            summary: data.summary.clone().into(),
+            summary: data.totals.clone().into(),
             election: data.election.clone().into(),
             hash,
             creation_date_time,

--- a/backend/src/domain/tabulation.rs
+++ b/backend/src/domain/tabulation.rs
@@ -23,17 +23,17 @@ use crate::{
     error::ErrorReference,
 };
 
-/// Contains a summary of the election results, added up from the votes of all polling stations.
+/// Contains the totals of the election results, added up from the votes of all polling stations.
 #[derive(Serialize, Deserialize, Debug, ToSchema, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct ElectionSummary {
+pub struct ElectionTotals {
     /// The total number of voters
     pub voters_counts: VotersCounts,
     /// The total number of votes
     pub votes_counts: VotesCounts,
     /// The differences between voters and votes
-    pub differences_counts: SummaryDifferencesCounts,
-    /// The summary votes for each political group (and each candidate within)
+    pub differences_counts: DifferencesTotals,
+    /// The total votes for each political group (and each candidate within)
     pub political_group_votes: Vec<PoliticalGroupCandidateVotes>,
     /// Polling stations where results were investigated by the GSB
     pub polling_station_investigations: PollingStationInvestigations,
@@ -43,10 +43,10 @@ pub struct ElectionSummary {
     pub number_of_voters: Option<u32>,
 }
 
-impl ElectionSummary {
-    /// Initialize a new summary with all counts set to zero.
-    pub fn zero(election: &ElectionWithPoliticalGroups) -> ElectionSummary {
-        ElectionSummary {
+impl ElectionTotals {
+    /// Initialize new totals with all counts set to zero.
+    pub fn zero(election: &ElectionWithPoliticalGroups) -> ElectionTotals {
+        ElectionTotals {
             voters_counts: VotersCounts {
                 poll_card_count: 0,
                 proxy_certificate_count: 0,
@@ -60,7 +60,7 @@ impl ElectionSummary {
                 invalid_votes_count: 0,
                 total_votes_cast_count: 0,
             },
-            differences_counts: SummaryDifferencesCounts::zero(),
+            differences_counts: DifferencesTotals::zero(),
             polling_station_investigations: PollingStationInvestigations::default(),
             political_group_votes: vec![],
             number_of_voters: None,
@@ -70,8 +70,8 @@ impl ElectionSummary {
     fn process_results(
         election: &ElectionWithPoliticalGroups,
         results: &[(DataEntrySource, Results)],
-        totals: &mut ElectionSummary,
-    ) -> Result<ElectionSummary, APIError> {
+        totals: &mut ElectionTotals,
+    ) -> Result<ElectionTotals, APIError> {
         // list of polling stations for which we processed results
         let mut touched_data_sources: Vec<DataEntrySourceNumber> = vec![];
 
@@ -154,12 +154,12 @@ impl ElectionSummary {
 
     /// Add all the votes from the given polling stations together, using the
     /// data from the election for candidates and political groups.
-    pub fn from_results(
+    pub fn tabulate(
         election: &ElectionWithPoliticalGroups,
         results: &[(DataEntrySource, Results)],
-    ) -> Result<ElectionSummary, APIError> {
+    ) -> Result<ElectionTotals, APIError> {
         // running totals
-        let mut totals = ElectionSummary::zero(election);
+        let mut totals = ElectionTotals::zero(election);
 
         // initialize political group votes to zero
         for group in &election.political_groups {
@@ -193,18 +193,18 @@ impl ElectionSummary {
     }
 }
 
-/// Contains a summary of the differences, containing which polling stations had differences.
+/// Contains the totals of the differences, containing which polling stations had differences.
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct SummaryDifferencesCounts {
+pub struct DifferencesTotals {
     pub more_ballots_count: SumCount,
     pub fewer_ballots_count: SumCount,
 }
 
-impl SummaryDifferencesCounts {
+impl DifferencesTotals {
     /// Initialize a new differences count with all counts set to zero.
-    pub fn zero() -> SummaryDifferencesCounts {
-        SummaryDifferencesCounts {
+    pub fn zero() -> DifferencesTotals {
+        DifferencesTotals {
             more_ballots_count: SumCount::zero(),
             fewer_ballots_count: SumCount::zero(),
         }
@@ -223,7 +223,7 @@ impl SummaryDifferencesCounts {
     }
 }
 
-/// Contains a summary count, containing both the count and a list of polling
+/// Contains a sum count, containing both the count and a list of polling
 /// stations that contributed to it.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -242,7 +242,7 @@ impl SumCount {
         }
     }
 
-    /// Add the count for a specific polling station to this summary count.
+    /// Add the count for a specific polling station to this sum count.
     pub fn add(&mut self, data_source: &DataEntrySource, count: Count) {
         if count > 0 {
             self.count += count;
@@ -297,35 +297,35 @@ impl PollingStationInvestigations {
     }
 }
 
-/// A version of ElectionSummary without the political group votes.
+/// A version of ElectionTotals without the political group votes.
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ElectionSummaryWithoutVotes {
+pub struct ElectionTotalsWithoutVotes {
     /// The total number of voters
     pub voters_counts: VotersCounts,
     /// The total number of votes
     pub votes_counts: VotesCounts,
     /// The differences between voters and votes
-    pub differences_counts: SummaryDifferencesCounts,
+    pub differences_counts: DifferencesTotals,
     /// Polling stations where results were investigated by the GSB
     pub polling_station_investigations: PollingStationInvestigations,
 }
 
-impl From<ElectionSummary> for ElectionSummaryWithoutVotes {
-    fn from(summary: ElectionSummary) -> Self {
-        ElectionSummaryWithoutVotes {
-            voters_counts: summary.voters_counts,
-            votes_counts: summary.votes_counts,
-            differences_counts: summary.differences_counts,
-            polling_station_investigations: summary.polling_station_investigations,
+impl From<ElectionTotals> for ElectionTotalsWithoutVotes {
+    fn from(totals: ElectionTotals) -> Self {
+        ElectionTotalsWithoutVotes {
+            voters_counts: totals.voters_counts,
+            votes_counts: totals.votes_counts,
+            differences_counts: totals.differences_counts,
+            polling_station_investigations: totals.polling_station_investigations,
         }
     }
 }
 
-/// A version of ElectionSummary without the political group votes and investigations
+/// A version of ElectionTotals without the political group votes and investigations
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ElectionSummaryCSB {
+pub struct ElectionTotalsCSB {
     /// The number of voters (i.e. "Kiesgerechtigden")
     pub number_of_voters: u32,
     /// The total number of voters
@@ -333,18 +333,18 @@ pub struct ElectionSummaryCSB {
     /// The total number of votes
     pub votes_counts: EnrichedVotesCounts,
     /// The differences between voters and votes
-    pub differences_counts: SummaryDifferencesCounts,
+    pub differences_counts: DifferencesTotals,
 }
 
-impl ElectionSummaryCSB {
-    pub fn new(summary: &ElectionSummary, political_groups: &[PoliticalGroup]) -> Self {
-        ElectionSummaryCSB {
-            number_of_voters: summary
+impl ElectionTotalsCSB {
+    pub fn new(totals: &ElectionTotals, political_groups: &[PoliticalGroup]) -> Self {
+        ElectionTotalsCSB {
+            number_of_voters: totals
                 .number_of_voters
                 .expect("Number of voters needs to be filled in for CSB"),
-            voters_counts: summary.voters_counts.clone(),
+            voters_counts: totals.voters_counts.clone(),
             votes_counts: EnrichedVotesCounts {
-                political_group_total_votes: summary
+                political_group_total_votes: totals
                     .votes_counts
                     .political_group_total_votes
                     .iter()
@@ -359,12 +359,12 @@ impl ElectionSummaryCSB {
                         total: pg_votes.total,
                     })
                     .collect(),
-                total_votes_candidates_count: summary.votes_counts.total_votes_candidates_count,
-                blank_votes_count: summary.votes_counts.blank_votes_count,
-                invalid_votes_count: summary.votes_counts.invalid_votes_count,
-                total_votes_cast_count: summary.votes_counts.total_votes_cast_count,
+                total_votes_candidates_count: totals.votes_counts.total_votes_candidates_count,
+                blank_votes_count: totals.votes_counts.blank_votes_count,
+                invalid_votes_count: totals.votes_counts.invalid_votes_count,
+                total_votes_cast_count: totals.votes_counts.total_votes_cast_count,
             },
-            differences_counts: summary.differences_counts.clone(),
+            differences_counts: totals.differences_counts.clone(),
         }
     }
 }
@@ -562,7 +562,7 @@ mod tests {
 
     #[test]
     fn test_differences_counts_addition() {
-        let mut diff = SummaryDifferencesCounts::zero();
+        let mut diff = DifferencesTotals::zero();
         let diff2 = CommonDifferencesCounts {
             more_ballots_count: &1,
             fewer_ballots_count: &0,
@@ -602,7 +602,7 @@ mod tests {
             (test_ps_to_source(ps[0].clone()), results_fixture_a()),
             (test_ps_to_source(ps[1].clone()), results_fixture_b()),
         ];
-        let totals = ElectionSummary::from_results(&election, &results).unwrap();
+        let totals = ElectionTotals::tabulate(&election, &results).unwrap();
 
         // check values in the differences counts
         assert_eq!(totals.differences_counts.more_ballots_count.count, 1);
@@ -657,7 +657,7 @@ mod tests {
     #[test]
     fn test_adding_zero_polling_stations() {
         let election = election_fixture(ElectionCategory::Municipal, GSB, &[10, 20, 18]);
-        let totals = ElectionSummary::from_results(&election, &[]).unwrap();
+        let totals = ElectionTotals::tabulate(&election, &[]).unwrap();
         assert_eq!(totals.voters_counts.total_admitted_voters_count, 0);
         assert_eq!(totals.votes_counts.total_votes_cast_count, 0);
     }
@@ -671,7 +671,7 @@ mod tests {
             .iter()
             .map(|p| (test_ps_to_source(p.clone()), results_ps.clone()))
             .collect::<Vec<_>>();
-        let totals = ElectionSummary::from_results(&election, &results).unwrap();
+        let totals = ElectionTotals::tabulate(&election, &results).unwrap();
 
         assert_eq!(totals.voters_counts.total_admitted_voters_count, 20400);
         assert_eq!(totals.votes_counts.total_votes_cast_count, 21000);
@@ -720,7 +720,7 @@ mod tests {
             .iter()
             .map(|p| (test_ps_to_source(p.clone()), ps_results.clone()))
             .collect::<Vec<_>>();
-        let _totals = ElectionSummary::from_results(&election, &results);
+        let _totals = ElectionTotals::tabulate(&election, &results);
     }
 
     #[test]
@@ -731,7 +731,7 @@ mod tests {
         let mut ps_results2 = ps_results.clone();
         ps_results2.votes_counts_mut().total_votes_cast_count = 0;
 
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps_results),
@@ -746,7 +746,7 @@ mod tests {
     fn test_repeated_polling_stations() {
         let election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
         let ps = polling_stations_fixture(&[20, 20]);
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), results_fixture_a()),
@@ -768,7 +768,7 @@ mod tests {
             .votes_counts_mut()
             .political_group_total_votes
             .pop();
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -792,7 +792,7 @@ mod tests {
                 number: PGNumber::from(3),
                 total: 0,
             });
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -814,7 +814,7 @@ mod tests {
             .votes_counts_mut()
             .political_group_total_votes
             .push(pgvote_copy);
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -835,7 +835,7 @@ mod tests {
             number: PGNumber::from(3),
             total: 0,
         };
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -853,7 +853,7 @@ mod tests {
         let ps1_result = results_fixture_a();
         let mut ps2_result = results_fixture_b();
         ps2_result.political_group_votes_mut().pop();
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -873,7 +873,7 @@ mod tests {
         ps2_result.political_group_votes_mut().push(
             PoliticalGroupCandidateVotes::from_test_data_auto(PGNumber::from(3), &[0]),
         );
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -894,7 +894,7 @@ mod tests {
         let ps2_pgvote_copy = ps2_result.political_group_votes()[1].clone();
         ps1_result.political_group_votes_mut().push(ps1_pgvote_copy);
         ps2_result.political_group_votes_mut().push(ps2_pgvote_copy);
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -913,7 +913,7 @@ mod tests {
         let mut ps2_result = results_fixture_b();
         ps2_result.political_group_votes_mut()[1] =
             PoliticalGroupCandidateVotes::from_test_data_auto(PGNumber::from(3), &[0]);
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -933,7 +933,7 @@ mod tests {
         ps2_result.political_group_votes_mut()[1]
             .candidate_votes
             .pop();
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -950,7 +950,7 @@ mod tests {
         let ps = polling_stations_fixture(&[20, 20]);
         let ps1_result = results_fixture_a();
         let ps2_result = results_fixture_b();
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (test_ps_to_source(ps[0].clone()), ps1_result),
@@ -970,7 +970,7 @@ mod tests {
         let gsb1_result = gsb_results_fixture_a();
         let gsb2_result = gsb_results_fixture_b();
 
-        let totals = ElectionSummary::from_results(
+        let totals = ElectionTotals::tabulate(
             &election,
             &[
                 (

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -44,7 +44,7 @@ use crate::domain::{
         ElectionWithPoliticalGroups, NewElection, PGNumber, RegisteredPoliticalGroup,
     },
     results::political_group_candidate_votes::PoliticalGroupCandidateVotes,
-    summary::ElectionSummary,
+    tabulation::ElectionTotals,
 };
 
 fn max_votes(max_votes: &StringValue<NonZeroU64>) -> u32 {
@@ -564,7 +564,7 @@ impl ElectionWithPoliticalGroups {
             crate::domain::data_entry::DataEntrySource,
             crate::domain::results::Results,
         )],
-        summary: &ElectionSummary,
+        totals: &ElectionTotals,
         timestamp: DateTime<Local>,
     ) -> Result<ElectionCount, EMLError> {
         ElectionCount::builder()
@@ -582,7 +582,7 @@ impl ElectionWithPoliticalGroups {
                 CommitteeCategory::GSB => CountType::Municipal,
                 CommitteeCategory::CSB => CountType::Central,
             })
-            .contests([self.as_eml_count_contest(committee_session, results, summary)?])
+            .contests([self.as_eml_count_contest(committee_session, results, totals)?])
             .build()
     }
 
@@ -593,30 +593,30 @@ impl ElectionWithPoliticalGroups {
             crate::domain::data_entry::DataEntrySource,
             crate::domain::results::Results,
         )],
-        summary: &ElectionSummary,
+        totals: &ElectionTotals,
     ) -> Result<ElectionCountContest, EMLError> {
         let mut builder = ElectionCountContest::builder()
             .identifier(ContestIdentifier::geen())
-            .total_eligible_voter_count(self.get_eligible_voter_count(summary))
-            .total_candidate_votes_count(summary.votes_counts.total_votes_candidates_count)
+            .total_eligible_voter_count(self.get_eligible_voter_count(totals))
+            .total_candidate_votes_count(totals.votes_counts.total_votes_candidates_count)
             .total_rejected_votes(
                 RejectedVotesReason::Blank,
-                summary.votes_counts.blank_votes_count,
+                totals.votes_counts.blank_votes_count,
             )
             .total_rejected_votes(
                 RejectedVotesReason::Invalid,
-                summary.votes_counts.invalid_votes_count,
+                totals.votes_counts.invalid_votes_count,
             )
             .total_uncounted_votes(
                 UncountedVotesReason::ValidPollCards,
-                summary.voters_counts.poll_card_count,
+                totals.voters_counts.poll_card_count,
             )
             .total_uncounted_votes(
                 UncountedVotesReason::ValidProxyCertificates,
-                summary.voters_counts.proxy_certificate_count,
+                totals.voters_counts.proxy_certificate_count,
             );
 
-        if let Some(voter_card_count) = summary.voters_counts.voter_card_count {
+        if let Some(voter_card_count) = totals.voters_counts.voter_card_count {
             builder = builder
                 .total_uncounted_votes(UncountedVotesReason::ValidVoterCards, voter_card_count);
         }
@@ -624,17 +624,17 @@ impl ElectionWithPoliticalGroups {
         let builder = builder
             .total_uncounted_votes(
                 UncountedVotesReason::AdmittedVoters,
-                summary.voters_counts.total_admitted_voters_count,
+                totals.voters_counts.total_admitted_voters_count,
             )
             .total_uncounted_votes(
                 UncountedVotesReason::MoreBallotsCounted,
-                summary.differences_counts.more_ballots_count.count,
+                totals.differences_counts.more_ballots_count.count,
             )
             .total_uncounted_votes(
                 UncountedVotesReason::FewerBallotsCounted,
-                summary.differences_counts.fewer_ballots_count.count,
+                totals.differences_counts.fewer_ballots_count.count,
             )
-            .total_votes_selections(self.as_eml_count_selections(&summary.political_group_votes)?);
+            .total_votes_selections(self.as_eml_count_selections(&totals.political_group_votes)?);
 
         // GSB elections include reporting unit votes in the count
         let builder = if self.committee_category == CommitteeCategory::GSB {
@@ -660,11 +660,11 @@ impl ElectionWithPoliticalGroups {
         }
     }
 
-    /// Depending on the context of the summary coming from GSB or from CSB, the number of voters source is different.
-    /// In case of a GSB summary, the number of voters there should be the valid source.
+    /// Depending on the context of the totals coming from GSB or from CSB, the number of voters source is different.
+    /// In case of a GSB totals, the number of voters there should be the valid source.
     /// Otherwise, it is the given number of voters.
-    fn get_eligible_voter_count(&self, summary: &ElectionSummary) -> u32 {
-        summary.number_of_voters.unwrap_or(self.number_of_voters)
+    fn get_eligible_voter_count(&self, totals: &ElectionTotals) -> u32 {
+        totals.number_of_voters.unwrap_or(self.number_of_voters)
     }
 
     fn as_eml_count_selections(
@@ -1080,10 +1080,10 @@ mod tests {
     fn test_as_count_eml_csb() {
         let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::CSB, &[0]);
         let committee_session = committee_session_fixture(election.id);
-        let summary = ElectionSummary::from_results(&election, &[]).unwrap();
+        let totals = ElectionTotals::tabulate(&election, &[]).unwrap();
 
         let eml_count = election
-            .as_count_eml(None, &committee_session, &[], &summary, Local::now())
+            .as_count_eml(None, &committee_session, &[], &totals, Local::now())
             .unwrap();
         assert_eq!(
             eml_count
@@ -1101,10 +1101,10 @@ mod tests {
     fn test_as_count_eml_gsb() {
         let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[0]);
         let committee_session = committee_session_fixture(election.id);
-        let summary = ElectionSummary::from_results(&election, &[]).unwrap();
+        let totals = ElectionTotals::tabulate(&election, &[]).unwrap();
 
         let eml_count = election
-            .as_count_eml(None, &committee_session, &[], &summary, Local::now())
+            .as_count_eml(None, &committee_session, &[], &totals, Local::now())
             .unwrap();
         assert_eq!(
             eml_count
@@ -1191,10 +1191,10 @@ mod tests {
         let mut election =
             election_fixture(ElectionCategory::Municipal, CommitteeCategory::CSB, &[2]);
         let committee_session = committee_session_fixture(election.id);
-        let mut summary = ElectionSummary::from_results(&election, &[]).unwrap();
+        let mut totals = ElectionTotals::tabulate(&election, &[]).unwrap();
 
         let result_csb = election
-            .as_eml_count_contest(&committee_session, &[], &summary)
+            .as_eml_count_contest(&committee_session, &[], &totals)
             .unwrap();
         let total_votes_csb = result_csb.total_votes.unwrap();
         assert_eq!(
@@ -1209,13 +1209,9 @@ mod tests {
         assert!(result_csb.reporting_unit_votes.is_empty());
 
         election.committee_category = CommitteeCategory::GSB;
-        summary.number_of_voters = Some(1001);
+        totals.number_of_voters = Some(1001);
         let result_gsb = election
-            .as_eml_count_contest(
-                &committee_session,
-                &[source_and_results_gsb(None)],
-                &summary,
-            )
+            .as_eml_count_contest(&committee_session, &[source_and_results_gsb(None)], &totals)
             .unwrap();
 
         let total_votes_gsb = result_gsb.total_votes.unwrap();
@@ -1244,14 +1240,14 @@ mod tests {
     fn test_as_eml_count_contest_with_voter_cards() {
         let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
         let committee_session = committee_session_fixture(election.id);
-        let mut summary = ElectionSummary::from_results(&election, &[]).unwrap();
-        summary.voters_counts.voter_card_count = Some(42);
+        let mut totals = ElectionTotals::tabulate(&election, &[]).unwrap();
+        totals.voters_counts.voter_card_count = Some(42);
 
         let result = election
             .as_eml_count_contest(
                 &committee_session,
                 &[source_and_results_gsb(Some(17))],
-                &summary,
+                &totals,
             )
             .unwrap();
 

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -53,9 +53,9 @@ use crate::{
             votes_counts::{EnrichedVotesCounts, VotesCounts},
             yes_no::YesNo,
         },
-        summary::{
-            ElectionSummary, ElectionSummaryCSB, PollingStationInvestigations, SumCount,
-            SummaryDifferencesCounts,
+        tabulation::{
+            DifferencesTotals, ElectionTotals, ElectionTotalsCSB, PollingStationInvestigations,
+            SumCount,
         },
     },
 };
@@ -355,8 +355,8 @@ fn random_csb_result(
     election: &ElectionWithPoliticalGroups,
     data_sources: &[DataEntrySource],
     string_length: usize,
-) -> ElectionSummaryCSB {
-    ElectionSummaryCSB {
+) -> ElectionTotalsCSB {
+    ElectionTotalsCSB {
         number_of_voters: rng.random_range(3000..5000),
         voters_counts: VotersCounts {
             poll_card_count: rng.random_range(0..500),
@@ -379,7 +379,7 @@ fn random_csb_result(
             invalid_votes_count: rng.random_range(0..500),
             total_votes_cast_count: rng.random_range(0..500),
         },
-        differences_counts: SummaryDifferencesCounts {
+        differences_counts: DifferencesTotals {
             more_ballots_count: SumCount {
                 count: rng.random_range(0..500),
                 data_entry_sources: random_station_subset(rng, data_sources),
@@ -410,21 +410,21 @@ fn random_sum_count(rng: &mut impl RngExt, data_sources: &[DataEntrySource]) -> 
     }
 }
 
-fn random_election_summary(
+fn random_election_totals(
     rng: &mut impl RngExt,
     election: &ElectionWithPoliticalGroups,
     data_sources: &[DataEntrySource],
-) -> ElectionSummary {
+) -> ElectionTotals {
     let result = random_result(rng, election);
     let data_source_num = |n| match n {
         DataEntrySourceNumber::PollingStation(i) => i,
         DataEntrySourceNumber::SubCommittee(i) => i,
     };
 
-    ElectionSummary {
+    ElectionTotals {
         voters_counts: result.voters_counts,
         votes_counts: result.votes_counts,
-        differences_counts: SummaryDifferencesCounts {
+        differences_counts: DifferencesTotals {
             more_ballots_count: random_sum_count(rng, data_sources),
             fewer_ballots_count: random_sum_count(rng, data_sources),
         },
@@ -447,18 +447,18 @@ fn random_election_summary(
     }
 }
 
-fn random_election_summary_csb(
+fn random_election_totals_csb(
     rng: &mut impl RngExt,
     election: &ElectionWithPoliticalGroups,
     data_sources: &[DataEntrySource],
     string_length: usize,
-) -> ElectionSummaryCSB {
+) -> ElectionTotalsCSB {
     let result = random_csb_result(rng, election, data_sources, string_length);
-    ElectionSummaryCSB {
+    ElectionTotalsCSB {
         number_of_voters: result.number_of_voters,
         voters_counts: result.voters_counts,
         votes_counts: result.votes_counts,
-        differences_counts: SummaryDifferencesCounts {
+        differences_counts: DifferencesTotals {
             more_ballots_count: random_sum_count(rng, data_sources),
             fewer_ballots_count: random_sum_count(rng, data_sources),
         },
@@ -638,8 +638,8 @@ async fn test_na_14_2() {
         let polling_stations =
             random_polling_stations(&mut rng, string_length, none_where_possible);
         let data_sources = ps_as_first_data_entry_sources(&polling_stations);
-        let previous_summary = random_election_summary(&mut rng, &election, &data_sources);
-        let summary = random_election_summary(&mut rng, &election, &data_sources);
+        let previous_totals = random_election_totals(&mut rng, &election, &data_sources);
+        let totals = random_election_totals(&mut rng, &election, &data_sources);
 
         let hash = random_string(&mut rng, 64);
         let creation_date_time = random_date_time(&mut rng)
@@ -647,11 +647,11 @@ async fn test_na_14_2() {
             .to_string();
 
         let model = PdfModel::ModelNa14_2(Box::new(ModelNa14_2Input {
-            votes_tables: VotesTablesWithPreviousVotes::new(&election, &summary, &previous_summary)
+            votes_tables: VotesTablesWithPreviousVotes::new(&election, &totals, &previous_totals)
                 .unwrap(),
             election: election.into(),
-            previous_summary: previous_summary.into(),
-            summary: summary.into(),
+            previous_summary: previous_totals.into(),
+            summary: totals.into(),
             committee_session,
             previous_committee_session,
             hash,
@@ -733,17 +733,17 @@ async fn test_na_31_2() {
         let polling_stations =
             random_polling_stations(&mut rng, string_length, none_where_possible);
         let data_sources = ps_as_first_data_entry_sources(&polling_stations);
-        let summary = random_election_summary(&mut rng, &election, &data_sources);
+        let totals = random_election_totals(&mut rng, &election, &data_sources);
         let hash = random_string(&mut rng, 64);
         let creation_date_time = random_date_time(&mut rng)
             .format(DEFAULT_DATE_TIME_FORMAT)
             .to_string();
 
         let model = PdfModel::ModelNa31_2(Box::new(ModelNa31_2Input {
-            votes_tables: VotesTables::new(&election, &summary).unwrap(),
+            votes_tables: VotesTables::new(&election, &totals).unwrap(),
             committee_session,
             election: election.into(),
-            summary: summary.into(),
+            summary: totals.into(),
             polling_stations,
             hash,
             creation_date_time,
@@ -854,12 +854,12 @@ async fn test_p_22_2() {
     let committee_session = random_committee_session(&mut rng, election.id, string_length);
     let polling_stations = random_polling_stations(&mut rng, string_length, none_where_possible);
     let data_sources = ps_as_first_data_entry_sources(&polling_stations);
-    let summary_gsb = random_election_summary(&mut rng, &election, &data_sources);
-    let summary = random_election_summary_csb(&mut rng, &election, &data_sources, string_length);
+    let totals_gsb = random_election_totals(&mut rng, &election, &data_sources);
+    let totals_csb = random_election_totals_csb(&mut rng, &election, &data_sources, string_length);
 
     let apportionment_input = ApportionmentInputData::new(
         election.number_of_seats,
-        &summary_gsb.political_group_votes,
+        &totals_gsb.political_group_votes,
         &[],
         &[],
         &[],
@@ -871,7 +871,8 @@ async fn test_p_22_2() {
 
     let seat_assignment = map_seat_assignment(&apportionment.seat_assignment);
     let enriched_seat_assignment =
-        EnrichedSeatAssignment::new(election.number_of_seats, &summary, &seat_assignment).unwrap();
+        EnrichedSeatAssignment::new(election.number_of_seats, &totals_csb, &seat_assignment)
+            .unwrap();
     let candidate_nomination = map_candidate_nomination(
         &apportionment.candidate_nomination,
         &election.political_groups,
@@ -889,7 +890,7 @@ async fn test_p_22_2() {
     let model = PdfModel::ModelP22_2(Box::new(ModelP22_2Input {
         committee_session,
         election: election.into(),
-        summary,
+        summary: totals_csb,
         footnotes,
         seat_assignment: enriched_seat_assignment,
         candidate_nomination: enriched_candidate_nomination,
@@ -923,7 +924,7 @@ async fn test_p_22_2_no_votes_cast_regression_3669() {
     let committee_session = random_committee_session(&mut rng, election.id, string_length);
     let polling_stations = random_polling_stations(&mut rng, string_length, none_where_possible);
     let data_sources = ps_as_first_data_entry_sources(&polling_stations);
-    let summary = random_election_summary_csb(&mut rng, &election, &data_sources, string_length);
+    let totals_csb = random_election_totals_csb(&mut rng, &election, &data_sources, string_length);
 
     // Zero votes cast on any candidate/list
     let political_group_votes: Vec<PoliticalGroupCandidateVotes> = election
@@ -962,7 +963,8 @@ async fn test_p_22_2_no_votes_cast_regression_3669() {
     );
 
     let enriched_seat_assignment =
-        EnrichedSeatAssignment::new(election.number_of_seats, &summary, &seat_assignment).unwrap();
+        EnrichedSeatAssignment::new(election.number_of_seats, &totals_csb, &seat_assignment)
+            .unwrap();
     let candidate_nomination = map_candidate_nomination(
         &apportionment.candidate_nomination,
         &election.political_groups,
@@ -980,7 +982,7 @@ async fn test_p_22_2_no_votes_cast_regression_3669() {
     let model = PdfModel::ModelP22_2(Box::new(ModelP22_2Input {
         committee_session,
         election: election.into(),
-        summary,
+        summary: totals_csb,
         footnotes,
         seat_assignment: enriched_seat_assignment,
         candidate_nomination: enriched_candidate_nomination,
@@ -1005,8 +1007,8 @@ async fn test_p_22_2_bijlage_1() {
         let polling_stations =
             random_polling_stations(&mut rng, string_length, none_where_possible);
         let data_sources = ps_as_first_data_entry_sources(&polling_stations);
-        let summary = random_election_summary(&mut rng, &election, &data_sources);
-        let votes_tables = VotesTables::new(&election, &summary).unwrap();
+        let totals = random_election_totals(&mut rng, &election, &data_sources);
+        let votes_tables = VotesTables::new(&election, &totals).unwrap();
         let hash = random_string(&mut rng, 64);
         let creation_date_time = random_date_time(&mut rng)
             .format(DEFAULT_DATE_TIME_FORMAT)

--- a/backend/src/infra/pdf_gen/typst_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_tests.rs
@@ -13,7 +13,7 @@ use crate::domain::{
         votes_table::VotesTables,
     },
     polling_station::test_helpers::polling_stations_fixture,
-    summary::ElectionSummary,
+    tabulation::ElectionTotals,
 };
 
 #[test(tokio::test)]
@@ -35,11 +35,11 @@ async fn it_generates_a_pdf() {
         political_groups: vec![],
     };
 
-    let summary = ElectionSummary::zero(&election);
+    let totals = ElectionTotals::zero(&election);
     let content = generate_pdf(
         ModelNa31_2Input {
-            summary: summary.clone().into(),
-            votes_tables: VotesTables::new(&election, &summary).unwrap(),
+            summary: totals.clone().into(),
+            votes_tables: VotesTables::new(&election, &totals).unwrap(),
             committee_session: committee_session_fixture(ElectionId::from(1)),
             election: election.into(),
             polling_stations: vec![],
@@ -101,12 +101,12 @@ async fn it_generates_a_pdf_with_unsupported_chars() {
 async fn it_generates_a_pdf_with_polling_stations() {
     let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2, 3]);
     let committee_session = committee_session_fixture(election.id);
-    let summary = ElectionSummary::from_results(&election, &[]).unwrap();
+    let totals = ElectionTotals::tabulate(&election, &[]).unwrap();
 
     let content = generate_pdf(
         ModelNa31_2Input {
-            votes_tables: VotesTables::new(&election, &summary).unwrap(),
-            summary: summary.into(),
+            votes_tables: VotesTables::new(&election, &totals).unwrap(),
+            summary: totals.into(),
             polling_stations: polling_stations_fixture(&[100, 200, 300]),
             committee_session,
             election: election.into(),

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -20,7 +20,7 @@ use crate::{
         election::{
             CandidateNumber, CommitteeCategory, ElectionId, ElectionWithPoliticalGroups, PGNumber,
         },
-        summary::ElectionSummary,
+        tabulation::ElectionTotals,
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
     repository::{
@@ -125,8 +125,8 @@ pub async fn next_state(
 #[allow(clippy::large_enum_variant)]
 pub enum ApportionmentResult {
     Ok(ElectionApportionmentResponse),
-    ListDrawingLotsRequired(ListDrawingLotsVariant, ElectionSummary, SeatAssignment),
-    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant, ElectionSummary, SeatAssignment),
+    ListDrawingLotsRequired(ListDrawingLotsVariant, ElectionTotals, SeatAssignment),
+    CandidateDrawingLotsRequired(CandidateDrawingLotsVariant, ElectionTotals, SeatAssignment),
 }
 
 impl From<apportionment::CandidateDrawingLotsVariant<PGNumber, CandidateNumber>>
@@ -218,11 +218,11 @@ pub async fn process(
 
     let data_entry_results =
         data_entry_repo::list_results_for_committee_session(conn, committee_session_id).await?;
-    let election_summary = ElectionSummary::from_results(election, &data_entry_results)?;
+    let election_totals = ElectionTotals::tabulate(election, &data_entry_results)?;
 
     let input = ApportionmentInputData::new(
         election.number_of_seats,
-        &election_summary.political_group_votes,
+        &election_totals.political_group_votes,
         state.get_deceased_candidates(),
         state.get_lists_drawn(),
         state.get_candidates_drawn(),
@@ -236,7 +236,7 @@ pub async fn process(
                     &output.candidate_nomination,
                     &election.political_groups,
                 ),
-                election_summary: election_summary.clone(),
+                election_totals: election_totals.clone(),
                 warnings: output
                     .seat_assignment
                     .warnings()
@@ -248,14 +248,14 @@ pub async fn process(
         ApportionmentOutput::ListDrawingLotsRequired(variant, preliminary_seat_assignment) => {
             ApportionmentResult::ListDrawingLotsRequired(
                 variant.into(),
-                election_summary.clone(),
+                election_totals.clone(),
                 map_seat_assignment(&preliminary_seat_assignment),
             )
         }
         ApportionmentOutput::CandidateDrawingLotsRequired(variant, seat_assignment) => {
             ApportionmentResult::CandidateDrawingLotsRequired(
                 variant.into(),
-                election_summary.clone(),
+                election_totals.clone(),
                 map_seat_assignment(&seat_assignment),
             )
         }

--- a/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.test.tsx
@@ -101,7 +101,7 @@ describe("ApportionmentPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
@@ -139,7 +139,7 @@ describe("ApportionmentPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     server.use(GetApportionmentStateRequestHandler);
@@ -196,7 +196,7 @@ describe("ApportionmentPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, lt19Seats.state);
@@ -316,7 +316,7 @@ describe("ApportionmentPage", () => {
           {
             seat_assignment: lt19SeatsAndNotAllSeatsAssigned.seat_assignment,
             candidate_nomination: lt19SeatsAndNotAllSeatsAssigned.candidate_nomination,
-            election_summary: lt19SeatsAndNotAllSeatsAssigned.election_summary,
+            election_totals: lt19SeatsAndNotAllSeatsAssigned.election_totals,
             warnings: lt19SeatsAndNotAllSeatsAssigned.warnings,
           } satisfies ElectionApportionmentResponse,
           { status: 200 },
@@ -371,7 +371,7 @@ describe("ApportionmentPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: ["AbsoluteMajorityAndListExhaustion"],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, lt19Seats.state);
@@ -490,7 +490,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/7/apportionment", 200, {
         seat_assignment: lt19SeatsAndP7DrawingLots.seat_assignment,
-        election_summary: lt19SeatsAndP7DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP7DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/7/apportionment/state", 200, lt19SeatsAndP7DrawingLots.state);
 
@@ -566,7 +566,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/8/apportionment", 200, {
         seat_assignment: gte19SeatsAndP7DrawingLots.seat_assignment,
-        election_summary: gte19SeatsAndP7DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP7DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/8/apportionment/state", 200, gte19SeatsAndP7DrawingLots.state);
 
@@ -639,7 +639,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/8/apportionment", 200, {
         seat_assignment: gte19SeatsAndP7DrawingLots.seat_assignment_after_one_drawing_lots_seat_assigned,
-        election_summary: gte19SeatsAndP7DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP7DrawingLots.election_totals,
       });
       overrideOnce(
         "get",
@@ -707,7 +707,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/8/apportionment", 200, {
         seat_assignment: gte19SeatsAndP7DrawingLots.seat_assignment_after_two_drawing_lots_seats_assigned,
-        election_summary: gte19SeatsAndP7DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP7DrawingLots.election_totals,
       });
       overrideOnce(
         "get",
@@ -782,7 +782,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/9/apportionment", 200, {
         seat_assignment: lt19SeatsAndP9DrawingLots.seat_assignment,
-        election_summary: lt19SeatsAndP9DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP9DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/9/apportionment/state", 200, lt19SeatsAndP9DrawingLots.state);
 
@@ -850,7 +850,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/10/apportionment", 200, {
         seat_assignment: gte19SeatsAndP9DrawingLots.seat_assignment,
-        election_summary: gte19SeatsAndP9DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP9DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/10/apportionment/state", 200, gte19SeatsAndP9DrawingLots.state);
 
@@ -919,7 +919,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/10/apportionment", 200, {
         seat_assignment: gte19SeatsAndP9DrawingLots.seat_assignment_after_drawing_lots_seat_reassigned,
-        election_summary: gte19SeatsAndP9DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP9DrawingLots.election_totals,
       });
       overrideOnce(
         "get",
@@ -977,7 +977,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/11/apportionment", 200, {
         seat_assignment: lt19SeatsAndP15DrawingLots.seat_assignment,
-        election_summary: lt19SeatsAndP15DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP15DrawingLots.election_totals,
       });
       overrideOnce(
         "get",
@@ -1035,7 +1035,7 @@ describe("ApportionmentPage", () => {
       );
       overrideOnce("post", "/api/elections/11/apportionment", 200, {
         seat_assignment: lt19SeatsAndP15DrawingLots.seat_assignment,
-        election_summary: lt19SeatsAndP15DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP15DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/11/apportionment/state", 200, lt19SeatsAndP15DrawingLots.state);
 

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -11,7 +11,7 @@ import type {
   ApportionmentState,
   ApportionmentWarning,
   ChosenCandidate,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   PoliticalGroup,
   PreferenceThreshold,
@@ -285,7 +285,7 @@ function renderLinksToSeatAssignmentPages(seatAssignment: SeatAssignment) {
 }
 
 interface ElectionSummaryTableSectionProps {
-  electionSummary: ElectionSummary;
+  electionSummary: ElectionTotals;
   seatAssignment: SeatAssignment;
   election: ElectionWithPoliticalGroups;
   preferenceThreshold: PreferenceThreshold | undefined;

--- a/frontend/src/features/apportionment/components/ApportionmentProvider.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentProvider.tsx
@@ -36,7 +36,7 @@ export function ApportionmentProvider({ children, electionId }: ElectionApportio
       value={{
         seatAssignment: data?.seat_assignment,
         candidateNomination: data?.candidate_nomination,
-        electionSummary: data?.election_summary,
+        electionSummary: data?.election_totals,
         warnings: data?.warnings ?? [],
         state,
         error,

--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
@@ -8,10 +8,10 @@ export const DefaultWithNumberOfVoters: StoryObj = {
   render: () => {
     return (
       <ElectionSummaryTable
-        votesCounts={gte19Seats.election_summary.votes_counts}
+        votesCounts={gte19Seats.election_totals.votes_counts}
         seats={gte19Seats.seat_assignment.seats}
         quota={gte19Seats.seat_assignment.quota}
-        numberOfVoters={gte19Seats.election_summary.number_of_voters}
+        numberOfVoters={gte19Seats.election_totals.number_of_voters}
         preferenceThreshold={gte19Seats.candidate_nomination.preference_threshold}
         deceasedCandidatesInfo={
           {
@@ -44,7 +44,7 @@ export const DefaultWithoutNumberOfVoters: StoryObj = {
   render: () => {
     return (
       <ElectionSummaryTable
-        votesCounts={gte19Seats.election_summary.votes_counts}
+        votesCounts={gte19Seats.election_totals.votes_counts}
         seats={gte19Seats.seat_assignment.seats}
         quota={gte19Seats.seat_assignment.quota}
         numberOfVoters={undefined}
@@ -81,7 +81,7 @@ export const DefaultWithoutVotes: StoryObj = {
     return (
       <ElectionSummaryTable
         votesCounts={{
-          ...gte19Seats.election_summary.votes_counts,
+          ...gte19Seats.election_totals.votes_counts,
           blank_votes_count: 0,
           invalid_votes_count: 0,
           total_votes_candidates_count: 0,
@@ -89,7 +89,7 @@ export const DefaultWithoutVotes: StoryObj = {
         }}
         seats={gte19Seats.seat_assignment.seats}
         quota={gte19Seats.seat_assignment.quota}
-        numberOfVoters={gte19Seats.election_summary.number_of_voters}
+        numberOfVoters={gte19Seats.election_totals.number_of_voters}
         preferenceThreshold={gte19Seats.candidate_nomination.preference_threshold}
         deceasedCandidatesInfo={
           {

--- a/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/AddDeceasedCandidatePage.test.tsx
@@ -19,7 +19,7 @@ import {
   candidate_nomination,
   committee_session,
   election,
-  election_summary,
+  election_totals,
   seat_assignment,
 } from "../../testing/lt-19-seats";
 import { ApportionmentProvider } from "../ApportionmentProvider";
@@ -46,7 +46,7 @@ describe("AddDeceasedCandidatesPage", () => {
           {
             seat_assignment: seat_assignment,
             candidate_nomination: candidate_nomination,
-            election_summary: election_summary,
+            election_totals: election_totals,
             warnings: [],
           } satisfies ElectionApportionmentResponse,
           { status: 200 },

--- a/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/DeceasedCandidatesPage.test.tsx
@@ -31,7 +31,7 @@ import {
   candidate_nomination,
   committee_session,
   election,
-  election_summary,
+  election_totals,
   seat_assignment,
 } from "../../testing/lt-19-seats";
 import { ApportionmentProvider } from "../ApportionmentProvider";
@@ -63,7 +63,7 @@ describe("DeceasedCandidatesPage", () => {
           {
             seat_assignment: seat_assignment,
             candidate_nomination: candidate_nomination,
-            election_summary: election_summary,
+            election_totals: election_totals,
             warnings: [],
           } satisfies ElectionApportionmentResponse,
           { status: 200 },

--- a/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
+++ b/frontend/src/features/apportionment/components/deceased_candidates/IncludeAllCandidatesPage.test.tsx
@@ -20,7 +20,7 @@ import {
   candidate_nomination,
   committee_session,
   election,
-  election_summary,
+  election_totals,
   seat_assignment,
 } from "../../testing/lt-19-seats";
 import { ApportionmentProvider } from "../ApportionmentProvider";
@@ -46,7 +46,7 @@ describe("IncludeAllCandidatesPage", () => {
           {
             seat_assignment: seat_assignment,
             candidate_nomination: candidate_nomination,
-            election_summary: election_summary,
+            election_totals: election_totals,
             warnings: [],
           } satisfies ElectionApportionmentResponse,
           { status: 200 },

--- a/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/drawing_lots/DrawingLotsPage.test.tsx
@@ -95,7 +95,7 @@ describe("DrawingLotsPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
@@ -142,7 +142,7 @@ describe("DrawingLotsPage", () => {
         HttpResponse.json(
           {
             seat_assignment: gte19SeatsAndP7DrawingLots.seat_assignment,
-            election_summary: gte19SeatsAndP7DrawingLots.election_summary,
+            election_totals: gte19SeatsAndP7DrawingLots.election_totals,
             warnings: [],
           },
           { status: 200 },
@@ -232,7 +232,7 @@ describe("DrawingLotsPage", () => {
         HttpResponse.json(
           {
             seat_assignment: lt19SeatsAndP7DrawingLots.seat_assignment,
-            election_summary: lt19SeatsAndP7DrawingLots.election_summary,
+            election_totals: lt19SeatsAndP7DrawingLots.election_totals,
             warnings: [],
           },
           { status: 200 },
@@ -320,7 +320,7 @@ describe("DrawingLotsPage", () => {
         HttpResponse.json(
           {
             seat_assignment: gte19SeatsAndP9DrawingLots.seat_assignment,
-            election_summary: gte19SeatsAndP9DrawingLots.election_summary,
+            election_totals: gte19SeatsAndP9DrawingLots.election_totals,
             warnings: [],
           },
           { status: 200 },
@@ -411,7 +411,7 @@ describe("DrawingLotsPage", () => {
         HttpResponse.json(
           {
             seat_assignment: lt19SeatsAndP9DrawingLots.seat_assignment,
-            election_summary: lt19SeatsAndP9DrawingLots.election_summary,
+            election_totals: lt19SeatsAndP9DrawingLots.election_totals,
             warnings: [],
           },
           { status: 200 },
@@ -502,7 +502,7 @@ describe("DrawingLotsPage", () => {
         HttpResponse.json(
           {
             seat_assignment: lt19SeatsAndP15DrawingLots.seat_assignment,
-            election_summary: lt19SeatsAndP15DrawingLots.election_summary,
+            election_totals: lt19SeatsAndP15DrawingLots.election_totals,
             warnings: [],
           },
           { status: 200 },
@@ -592,7 +592,7 @@ describe("DrawingLotsPage", () => {
     );
     overrideOnce("post", "/api/elections/7/apportionment", 200, {
       seat_assignment: lt19SeatsAndP7DrawingLots.seat_assignment,
-      election_summary: lt19SeatsAndP7DrawingLots.election_summary,
+      election_totals: lt19SeatsAndP7DrawingLots.election_totals,
       warnings: [],
     });
     overrideOnce("get", "/api/elections/7/apportionment/state", 200, lt19SeatsAndP7DrawingLots.state);

--- a/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/full_seats/ApportionmentFullSeatsPage.test.tsx
@@ -69,7 +69,7 @@ describe("ApportionmentFullSeatsPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
@@ -91,7 +91,7 @@ describe("ApportionmentFullSeatsPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, lt19Seats.state);
@@ -141,7 +141,7 @@ describe("ApportionmentFullSeatsPage", () => {
     overrideOnce("post", "/api/elections/4/apportionment", 200, {
       seat_assignment: lt19SeatsAndP9AndP10.seat_assignment,
       candidate_nomination: lt19SeatsAndP9AndP10.candidate_nomination,
-      election_summary: lt19SeatsAndP9AndP10.election_summary,
+      election_totals: lt19SeatsAndP9AndP10.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/4/apportionment/state", 200, lt19SeatsAndP9AndP10.state);

--- a/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/list_details/ApportionmentListDetailsPage.test.tsx
@@ -43,7 +43,7 @@ describe("ApportionmentListDetailsPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
   });
@@ -323,7 +323,7 @@ describe("ApportionmentListDetailsPage", () => {
       overrideOnce("post", "/api/elections/11/apportionment", 200, {
         seat_assignment: lt19SeatsAndP15DrawingLots.seat_assignment,
         candidate_nomination: lt19SeatsAndP15DrawingLots.candidate_nomination,
-        election_summary: lt19SeatsAndP15DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP15DrawingLots.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce(

--- a/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
+++ b/frontend/src/features/apportionment/components/residual_seats/ApportionmentResidualSeatsPage.test.tsx
@@ -89,7 +89,7 @@ describe("ApportionmentResidualSeatsPage", () => {
     overrideOnce("post", "/api/elections/3/apportionment", 200, {
       seat_assignment: lt19Seats.seat_assignment,
       candidate_nomination: lt19Seats.candidate_nomination,
-      election_summary: lt19Seats.election_summary,
+      election_totals: lt19Seats.election_totals,
       warnings: [],
     } satisfies ElectionApportionmentResponse);
     overrideOnce("get", "/api/elections/3/apportionment/state", 200, state);
@@ -117,7 +117,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/2/apportionment", 200, {
         seat_assignment: gte19Seats.seat_assignment,
         candidate_nomination: gte19Seats.candidate_nomination,
-        election_summary: gte19Seats.election_summary,
+        election_totals: gte19Seats.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/2/apportionment/state", 200, gte19Seats.state);
@@ -159,7 +159,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/5/apportionment", 200, {
         seat_assignment: gte19SeatsAndP9.seat_assignment,
         candidate_nomination: gte19SeatsAndP9.candidate_nomination,
-        election_summary: gte19SeatsAndP9.election_summary,
+        election_totals: gte19SeatsAndP9.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/5/apportionment/state", 200, gte19SeatsAndP9.state);
@@ -287,7 +287,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/15/apportionment", 200, {
         seat_assignment: gte19AndP10FullSeatRemoval.seat_assignment,
         candidate_nomination: gte19AndP10FullSeatRemoval.candidate_nomination,
-        election_summary: gte19AndP10FullSeatRemoval.election_summary,
+        election_totals: gte19AndP10FullSeatRemoval.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/15/apportionment/state", 200, gte19AndP10FullSeatRemoval.state);
@@ -340,7 +340,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/3/apportionment", 200, {
         seat_assignment: lt19Seats.seat_assignment,
         candidate_nomination: lt19Seats.candidate_nomination,
-        election_summary: lt19Seats.election_summary,
+        election_totals: lt19Seats.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/3/apportionment/state", 200, lt19Seats.state);
@@ -395,7 +395,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/12/apportionment", 200, {
         seat_assignment: lt19SeatsAndP10AndDeceasedCandidates.seat_assignment,
         candidate_nomination: lt19SeatsAndP10AndDeceasedCandidates.candidate_nomination,
-        election_summary: lt19SeatsAndP10AndDeceasedCandidates.election_summary,
+        election_totals: lt19SeatsAndP10AndDeceasedCandidates.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/12/apportionment/state", 200, lt19SeatsAndP10AndDeceasedCandidates.state);
@@ -449,7 +449,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/11/apportionment", 200, {
         seat_assignment: lt19SeatsAndP15DrawingLots.seat_assignment,
         candidate_nomination: lt19SeatsAndP15DrawingLots.candidate_nomination,
-        election_summary: lt19SeatsAndP15DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP15DrawingLots.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/11/apportionment/state", 200, lt19SeatsAndP15DrawingLots.state);
@@ -490,7 +490,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/4/apportionment", 200, {
         seat_assignment: lt19SeatsAndP9AndP10.seat_assignment,
         candidate_nomination: lt19SeatsAndP9AndP10.candidate_nomination,
-        election_summary: lt19SeatsAndP9AndP10.election_summary,
+        election_totals: lt19SeatsAndP9AndP10.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/4/apportionment/state", 200, lt19SeatsAndP9AndP10.state);
@@ -549,7 +549,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/14/apportionment", 200, {
         seat_assignment: lt19SeatsAndP10AndDeceasedCandidate.seat_assignment,
         candidate_nomination: lt19SeatsAndP10AndDeceasedCandidate.candidate_nomination,
-        election_summary: lt19SeatsAndP10AndDeceasedCandidate.election_summary,
+        election_totals: lt19SeatsAndP10AndDeceasedCandidate.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/14/apportionment/state", 200, lt19SeatsAndP10AndDeceasedCandidate.state);
@@ -608,7 +608,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       overrideOnce("post", "/api/elections/6/apportionment", 200, {
         seat_assignment: lt19SeatsAndP10.seat_assignment,
         candidate_nomination: lt19SeatsAndP10.candidate_nomination,
-        election_summary: lt19SeatsAndP10.election_summary,
+        election_totals: lt19SeatsAndP10.election_totals,
         warnings: [],
       } satisfies ElectionApportionmentResponse);
       overrideOnce("get", "/api/elections/6/apportionment/state", 200, lt19SeatsAndP10.state);
@@ -670,7 +670,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       );
       overrideOnce("post", "/api/elections/7/apportionment", 200, {
         seat_assignment: lt19SeatsAndP7DrawingLots.seat_assignment,
-        election_summary: lt19SeatsAndP7DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP7DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/7/apportionment/state", 200, lt19SeatsAndP7DrawingLots.state);
 
@@ -722,7 +722,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       );
       overrideOnce("post", "/api/elections/8/apportionment", 200, {
         seat_assignment: gte19SeatsAndP7DrawingLots.seat_assignment,
-        election_summary: gte19SeatsAndP7DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP7DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/8/apportionment/state", 200, gte19SeatsAndP7DrawingLots.state);
 
@@ -782,7 +782,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       );
       overrideOnce("post", "/api/elections/9/apportionment", 200, {
         seat_assignment: lt19SeatsAndP9DrawingLots.seat_assignment,
-        election_summary: lt19SeatsAndP9DrawingLots.election_summary,
+        election_totals: lt19SeatsAndP9DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/9/apportionment/state", 200, lt19SeatsAndP9DrawingLots.state);
 
@@ -836,7 +836,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       );
       overrideOnce("post", "/api/elections/10/apportionment", 200, {
         seat_assignment: gte19SeatsAndP9DrawingLots.seat_assignment,
-        election_summary: gte19SeatsAndP9DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP9DrawingLots.election_totals,
       });
       overrideOnce("get", "/api/elections/10/apportionment/state", 200, gte19SeatsAndP9DrawingLots.state);
 
@@ -941,7 +941,7 @@ describe("ApportionmentResidualSeatsPage", () => {
       );
       overrideOnce("post", "/api/elections/10/apportionment", 200, {
         seat_assignment: gte19SeatsAndP9DrawingLots.seat_assignment_after_drawing_lots_seat_reassigned,
-        election_summary: gte19SeatsAndP9DrawingLots.election_summary,
+        election_totals: gte19SeatsAndP9DrawingLots.election_totals,
         warnings: [],
       });
       overrideOnce(

--- a/frontend/src/features/apportionment/hooks/ApportionmentProviderContext.tsx
+++ b/frontend/src/features/apportionment/hooks/ApportionmentProviderContext.tsx
@@ -5,14 +5,14 @@ import type {
   ApportionmentState,
   ApportionmentWarning,
   CandidateNomination,
-  ElectionSummary,
+  ElectionTotals,
   SeatAssignment,
 } from "@/types/generated/openapi";
 
 export interface iElectionApportionmentProviderContext {
   seatAssignment?: SeatAssignment;
   candidateNomination?: CandidateNomination;
-  electionSummary?: ElectionSummary;
+  electionSummary?: ElectionTotals;
   warnings: ApportionmentWarning[];
   state?: ApportionmentState;
   error?: ApiError;

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p10-full-seat-removal.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p10-full-seat-removal.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -635,7 +635,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   voters_counts: {
     poll_card_count: 8000,
     proxy_certificate_count: 0,

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p7-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p7-drawing-lots.ts
@@ -1,7 +1,7 @@
 import type {
   ApportionmentState,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   HighestAverageResidualSeatDrawingLots,
   SeatAssignment,
@@ -1153,7 +1153,7 @@ export const seat_assignment_after_two_drawing_lots_seats_assigned: SeatAssignme
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 1329,
   voters_counts: {
     poll_card_count: 1200,

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9-drawing-lots-and-deceased-candidates.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9-drawing-lots-and-deceased-candidates.ts
@@ -2,7 +2,7 @@ import type {
   AbsoluteMajorityDrawingLots,
   ApportionmentState,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -1362,7 +1362,7 @@ export const seat_assignment_after_drawing_lots_seat_reassigned: SeatAssignment 
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   voters_counts: {
     poll_card_count: 15001,
     proxy_certificate_count: 0,

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -1836,7 +1836,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 20000,
   voters_counts: {
     poll_card_count: 15001,

--- a/frontend/src/features/apportionment/testing/gte-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -1173,7 +1173,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 2000,
   voters_counts: {
     poll_card_count: 1203,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-not-all-seats-assigned.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-not-all-seats-assigned.ts
@@ -3,7 +3,7 @@ import type {
   ApportionmentWarning,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -705,7 +705,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   voters_counts: {
     poll_card_count: 60,
     proxy_certificate_count: 0,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidate.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidate.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -1426,7 +1426,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   voters_counts: {
     poll_card_count: 995,
     proxy_certificate_count: 0,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidates.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidates.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -2035,7 +2035,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 2000,
   voters_counts: {
     poll_card_count: 1203,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -773,7 +773,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 100,
   voters_counts: {
     poll_card_count: 60,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p15-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p15-drawing-lots.ts
@@ -3,7 +3,7 @@ import type {
   CandidateDrawingLotsVariant,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -903,7 +903,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   voters_counts: {
     poll_card_count: 8900,
     proxy_certificate_count: 0,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p7-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p7-drawing-lots.ts
@@ -1,7 +1,7 @@
 import type {
   ApportionmentState,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   LargestRemainderResidualSeatDrawingLots,
   SeatAssignment,
@@ -369,7 +369,7 @@ export const seat_assignment: SeatAssignment = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 2272,
   voters_counts: {
     poll_card_count: 1200,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -1428,7 +1428,7 @@ export const candidate_nomination: CandidateNomination = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 6000,
   voters_counts: {
     poll_card_count: 5104,

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-drawing-lots.ts
@@ -2,7 +2,7 @@ import type {
   AbsoluteMajorityDrawingLots,
   ApportionmentState,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   SeatAssignment,
 } from "@/types/generated/openapi";
@@ -693,7 +693,7 @@ export const seat_assignment_after_drawing_lots_seat_reassigned: SeatAssignment 
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   voters_counts: {
     poll_card_count: 5103,
     proxy_certificate_count: 0,

--- a/frontend/src/features/apportionment/testing/lt-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats.ts
@@ -2,7 +2,7 @@ import type {
   ApportionmentState,
   CandidateNomination,
   CommitteeSession,
-  ElectionSummary,
+  ElectionTotals,
   ElectionWithPoliticalGroups,
   ListCandidateNomination,
   PoliticalGroup,
@@ -1363,7 +1363,7 @@ export const political_group_1_votes: PoliticalGroupCandidateVotes = {
   ],
 };
 
-export const election_summary: ElectionSummary = {
+export const election_totals: ElectionTotals = {
   number_of_voters: 2000,
   voters_counts: {
     poll_card_count: 1203,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -917,6 +917,14 @@ export interface DifferencesCounts {
 }
 
 /**
+ * Contains the totals of the differences, containing which polling stations had differences.
+ */
+export interface DifferencesTotals {
+  fewer_ballots_count: SumCount;
+  more_ballots_count: SumCount;
+}
+
+/**
  * Fraction with the integer part split out for display purposes
  */
 export interface DisplayFraction {
@@ -950,7 +958,7 @@ export interface Election {
 
 export interface ElectionApportionmentResponse {
   candidate_nomination: CandidateNomination;
-  election_summary: ElectionSummary;
+  election_totals: ElectionTotals;
   seat_assignment: SeatAssignment;
   warnings: ApportionmentWarning[];
 }
@@ -1041,14 +1049,14 @@ export const electionSubCategoryValues = ["AB1", "AB2", "GR1", "GR2", "PS1", "PS
 export type ElectionSubCategory = (typeof electionSubCategoryValues)[number];
 
 /**
- * Contains a summary of the election results, added up from the votes of all polling stations.
+ * Contains the totals of the election results, added up from the votes of all polling stations.
  */
-export interface ElectionSummary {
+export interface ElectionTotals {
   /** The differences between voters and votes */
-  differences_counts: SummaryDifferencesCounts;
+  differences_counts: DifferencesTotals;
   /** The number of voters (i.e. "Kiesgerechtigden") */
   number_of_voters?: number;
-  /** The summary votes for each political group (and each candidate within) */
+  /** The total votes for each political group (and each candidate within) */
   political_group_votes: PoliticalGroupCandidateVotes[];
   /** Polling stations where results were investigated by the GSB */
   polling_station_investigations: PollingStationInvestigations;
@@ -1572,7 +1580,7 @@ export interface PreferenceThreshold {
 
 export type ProcessApportionmentResponse =
   | (ElectionApportionmentResponse & { status: "Finalised" })
-  | { election_summary: ElectionSummary; seat_assignment: SeatAssignment; status: "DrawingLotsRequired" };
+  | { election_totals: ElectionTotals; seat_assignment: SeatAssignment; status: "DrawingLotsRequired" };
 
 export type RandomRange = string;
 
@@ -1686,20 +1694,12 @@ export type SubCommitteeFirstSession = SubCommittee & {
 export type SubCommitteeId = number;
 
 /**
- * Contains a summary count, containing both the count and a list of polling
+ * Contains a sum count, containing both the count and a list of polling
  * stations that contributed to it.
  */
 export interface SumCount {
   count: number;
   data_entry_sources: DataEntrySourceNumber[];
-}
-
-/**
- * Contains a summary of the differences, containing which polling stations had differences.
- */
-export interface SummaryDifferencesCounts {
-  fewer_ballots_count: SumCount;
-  more_ballots_count: SumCount;
 }
 
 export interface UpdateUserRequest {


### PR DESCRIPTION
## What & why

Rename 'summary' to 'tabulation' and 'totals', from #3795:
> First the terminology: my opinion is that 'summary' doesn't quite cover how important this functionality is to Abacus. I suggest we use 'tabulation' for the process of adding up results, and 'totals' to name the structs that contain the result of that process. The [woordenlijst](https://github.com/kiesraad/abacus-documentatie/blob/f355bdb2a82567951275e9b780985fdc5c7e1e83/referentie/woordenlijst-NL-EN.md) also lists 'tabulation' as a translation for 'optelling'. Changing the terminology can be a straightforward mechanical rename.

## How to test

No functional changes expected, review diff.

## Reviewer notes

I've skipped renaming summary to totals in the reports (Typst models) to avoid conflicts with other open PRs, we can do this once the model changes have settled. This PR is the basis for the DSO election tabulation, issue #3795.