### PR TITLE
Show empty fields when correcting data entry differences in a next session

### DIFF
--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -1,7 +1,13 @@
 import { readFile } from "node:fs/promises";
 import { type APIRequestContext, test as base, expect, type Page } from "@playwright/test";
 import { DataEntryApiClient } from "e2e-tests/helpers-utils/api-clients";
-import { completeDataEntries, resolveDifferences } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
+import {
+  changeCommitteeSessionStatus,
+  completeDataEntries,
+  createCommitteeSession,
+  createInvestigation,
+  resolveDifferences,
+} from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import { createRandomUsername } from "e2e-tests/helpers-utils/e2e-test-utils";
 import {
   type Eml230b,
@@ -17,15 +23,14 @@ import {
   dataEntryRequestGSBTriggeringDrawingLotsForP9,
   dataEntryWithDifferencesRequest,
   dataEntryWithErrorRequest,
+  nextSessionResults,
+  nextSessionResultsWithDifferences,
   pollingStationRequests,
 } from "e2e-tests/test-data/request-response-templates";
 import type {
-  COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY,
-  COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH,
   COMMITTEE_SESSION_UPDATE_REQUEST_BODY,
   COMMITTEE_SESSION_UPDATE_REQUEST_PATH,
   CommitteeSession,
-  ELECTION_DETAILS_REQUEST_PATH,
   ELECTION_IMPORT_REQUEST_PATH,
   ELECTION_STATUS_REQUEST_PATH,
   Election,
@@ -78,12 +83,16 @@ type Fixtures = {
   electionCSBSmallCouncil: ElectionDetailsResponse;
   // First data entry of the GSB election
   dataEntryGSB: DataEntry;
+  // GSB election with one investigation in the second committee session
+  dataEntryNextSession: DataEntry;
   // First data entry of the GSB election with entry claimed by typist one
   dataEntryGSBFirstEntryClaimed: DataEntry;
   // First data entry of the GSB election with first data entry done
   dataEntryGSBFirstEntryDone: DataEntry;
   // First data entry correction of the GSB election after resolve differences
   dataEntryGSBFirstEntryCorrection: DataEntry;
+  // First data entry correction of the next session of a GSB election after resolve differences
+  dataEntryNextSessionFirstEntryCorrection: DataEntry;
   // Second data entry correction of the GSB election after resolve differences
   dataEntryGSBSecondEntryCorrection: DataEntry;
   // First data entry of the GSB election with first data entry with errors
@@ -220,20 +229,11 @@ export const test = base.extend<Fixtures>({
       expect(pollingStationResponse.ok()).toBeTruthy();
     }
 
-    // get election details
-    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionGSB.id}`;
-    const electionResponse = await adminOne.request.get(electionUrl);
-    expect(electionResponse.ok()).toBeTruthy();
-    const response = (await electionResponse.json()) as ElectionDetailsResponse;
-
     // Set committee session status to DataEntry
-    const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}/status`;
-    const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status: "data_entry" };
-    const statusChangeResponse = await coordinatorOneGSB.request.put(statusChangeUrl, { data: statusChangeData });
-    expect(statusChangeResponse.ok()).toBeTruthy();
+    const electionDetails = await changeCommitteeSessionStatus(coordinatorOneGSB, emptyElectionGSB.id, "data_entry");
 
     // Fill in committee session details
-    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}`;
+    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${emptyElectionGSB.id}/committee_sessions/${electionDetails.current_committee_session.id}`;
     const detailsUpdateData: COMMITTEE_SESSION_UPDATE_REQUEST_BODY = {
       location: "Den Haag",
       start_date: "2026-03-18",
@@ -242,23 +242,16 @@ export const test = base.extend<Fixtures>({
     const detailsUpdateResponse = await coordinatorOneGSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
     expect(detailsUpdateResponse.ok()).toBeTruthy();
 
-    await use(response);
+    await use(electionDetails);
   },
-  electionCSBLargeCouncil: async ({ adminOne, coordinatorOneCSB, emptyElectionCSBLargeCouncil }, use) => {
-    // get election details
-    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionCSBLargeCouncil.id}`;
-    const electionResponse = await adminOne.request.get(electionUrl);
-    expect(electionResponse.ok()).toBeTruthy();
-    const response = (await electionResponse.json()) as ElectionDetailsResponse;
+  electionCSBLargeCouncil: async ({ coordinatorOneCSB, emptyElectionCSBLargeCouncil }, use) => {
+    const electionId = emptyElectionCSBLargeCouncil.id;
 
     // Set committee session status to DataEntry
-    const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}/status`;
-    const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status: "data_entry" };
-    const statusChangeResponse = await coordinatorOneCSB.request.put(statusChangeUrl, { data: statusChangeData });
-    expect(statusChangeResponse.ok()).toBeTruthy();
+    const electionDetails = await changeCommitteeSessionStatus(coordinatorOneCSB, electionId, "data_entry");
 
     // Fill in committee session details
-    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}`;
+    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${electionId}/committee_sessions/${electionDetails.current_committee_session.id}`;
     const detailsUpdateData: COMMITTEE_SESSION_UPDATE_REQUEST_BODY = {
       location: "Den Haag",
       start_date: "2026-03-18",
@@ -267,23 +260,16 @@ export const test = base.extend<Fixtures>({
     const detailsUpdateResponse = await coordinatorOneCSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
     expect(detailsUpdateResponse.ok()).toBeTruthy();
 
-    await use(response);
+    await use(electionDetails);
   },
-  electionCSBSmallCouncil: async ({ adminOne, coordinatorOneCSB, emptyElectionCSBSmallCouncil }, use) => {
-    // get election details
-    const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${emptyElectionCSBSmallCouncil.id}`;
-    const electionResponse = await adminOne.request.get(electionUrl);
-    expect(electionResponse.ok()).toBeTruthy();
-    const response = (await electionResponse.json()) as ElectionDetailsResponse;
+  electionCSBSmallCouncil: async ({ coordinatorOneCSB, emptyElectionCSBSmallCouncil }, use) => {
+    const electionId = emptyElectionCSBSmallCouncil.id;
 
     // Set committee session status to DataEntry
-    const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}/status`;
-    const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status: "data_entry" };
-    const statusChangeResponse = await coordinatorOneCSB.request.put(statusChangeUrl, { data: statusChangeData });
-    expect(statusChangeResponse.ok()).toBeTruthy();
+    const electionDetails = await changeCommitteeSessionStatus(coordinatorOneCSB, electionId, "data_entry");
 
     // Fill in committee session details
-    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${response.current_committee_session.election_id}/committee_sessions/${response.current_committee_session.id}`;
+    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${electionId}/committee_sessions/${electionDetails.current_committee_session.id}`;
     const detailsUpdateData: COMMITTEE_SESSION_UPDATE_REQUEST_BODY = {
       location: "Den Haag",
       start_date: "2026-03-18",
@@ -292,7 +278,7 @@ export const test = base.extend<Fixtures>({
     const detailsUpdateResponse = await coordinatorOneCSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
     expect(detailsUpdateResponse.ok()).toBeTruthy();
 
-    await use(response);
+    await use(electionDetails);
   },
   dataEntryGSB: async ({ adminOne, electionGSB }, use) => {
     const { request } = adminOne;
@@ -308,6 +294,20 @@ export const test = base.extend<Fixtures>({
       id: electionStatus.data_entry_id,
       name: electionStatus.source.name,
       number: electionStatus.source.number.toString(),
+    });
+  },
+  dataEntryNextSession: async ({ coordinatorOneGSB, completedElectionGSB }, use) => {
+    await changeCommitteeSessionStatus(coordinatorOneGSB, completedElectionGSB.id, "completed");
+    const electionDetails = await createCommitteeSession(coordinatorOneGSB, completedElectionGSB.id);
+
+    const pollingStation = electionDetails.polling_stations[0]!;
+    const investigation = await createInvestigation(coordinatorOneGSB, pollingStation.id);
+
+    await use({
+      election_id: electionDetails.election.id,
+      id: investigation.data_entry_id!,
+      name: pollingStation.name,
+      number: String(pollingStation.number),
     });
   },
   dataEntryGSBFirstEntryClaimed: async ({ typistOneGSB, dataEntryGSB }, use) => {
@@ -328,6 +328,21 @@ export const test = base.extend<Fixtures>({
   dataEntryGSBFirstEntryCorrection: async ({ coordinatorOneGSB, dataEntryGSBEntriesDifferent }, use) => {
     await resolveDifferences(coordinatorOneGSB, dataEntryGSBEntriesDifferent.id, "keep_second_and_correct_first");
     await use(dataEntryGSBEntriesDifferent);
+  },
+  dataEntryNextSessionFirstEntryCorrection: async (
+    { typistOneGSB, typistTwoGSB, coordinatorOneGSB, dataEntryNextSession },
+    use,
+  ) => {
+    await completeDataEntries(
+      dataEntryNextSession.id,
+      typistOneGSB.request,
+      typistTwoGSB.request,
+      { data: nextSessionResults, progress: 100, client_state: {} },
+      { data: nextSessionResultsWithDifferences, progress: 100, client_state: {} },
+    );
+
+    await resolveDifferences(coordinatorOneGSB, dataEntryNextSession.id, "keep_second_and_correct_first");
+    await use(dataEntryNextSession);
   },
   dataEntryGSBSecondEntryCorrection: async ({ coordinatorOneGSB, dataEntryGSBEntriesDifferent }, use) => {
     await resolveDifferences(coordinatorOneGSB, dataEntryGSBEntriesDifferent.id, "keep_first_and_correct_second");

--- a/frontend/e2e-tests/helpers-utils/e2e-test-api-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-api-helpers.ts
@@ -2,9 +2,22 @@ import { type APIRequestContext, expect } from "@playwright/test";
 import { dataEntryRequest } from "e2e-tests/test-data/request-response-templates";
 import type { TestUser } from "e2e-tests/test-data/users";
 import type {
+  COMMITTEE_SESSION_CREATE_REQUEST_PATH,
+  COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY,
+  COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH,
+  CommitteeSessionStatus,
   DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_BODY,
   DATA_ENTRY_RESOLVE_DIFFERENCES_REQUEST_PATH,
   DataEntryId,
+  ELECTION_DETAILS_REQUEST_PATH,
+  ElectionDetailsResponse,
+  ElectionId,
+  POLLING_STATION_INVESTIGATION_CONCLUDE_REQUEST_BODY,
+  POLLING_STATION_INVESTIGATION_CONCLUDE_REQUEST_PATH,
+  POLLING_STATION_INVESTIGATION_CREATE_REQUEST_BODY,
+  POLLING_STATION_INVESTIGATION_UPDATE_REQUEST_PATH,
+  PollingStationId,
+  PollingStationInvestigation,
   ResolveDifferencesAction,
 } from "@/types/generated/openapi";
 import { DataEntryApiClient } from "./api-clients";
@@ -80,4 +93,59 @@ export async function resolveDifferences(
   const response = await coordinator.request.post(url, { data, headers: { "content-type": "application/json" } });
   expect(response.ok(), `Unexpected response: ${response.statusText()}`).toBeTruthy();
   return response.status();
+}
+
+export async function getElectionDetails(user: { request: APIRequestContext }, electionId: ElectionId) {
+  const electionUrl: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${electionId}`;
+  const electionResponse = await user.request.get(electionUrl);
+  expect(electionResponse.ok()).toBeTruthy();
+  return (await electionResponse.json()) as ElectionDetailsResponse;
+}
+
+/**
+ * Change the election's current committee session status and return the election details.
+ */
+export async function changeCommitteeSessionStatus(
+  user: { request: APIRequestContext },
+  electionId: ElectionId,
+  status: CommitteeSessionStatus,
+) {
+  const electionDetails = await getElectionDetails(user, electionId);
+
+  const statusChangeUrl: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH = `/api/elections/${electionId}/committee_sessions/${electionDetails.current_committee_session.id}/status`;
+  const statusChangeData: COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = { status };
+  const statusChangeResponse = await user.request.put(statusChangeUrl, { data: statusChangeData });
+  expect(statusChangeResponse.ok()).toBeTruthy();
+
+  return electionDetails;
+}
+
+/**
+ * Create a new committee session and return election details.
+ */
+export async function createCommitteeSession(user: { request: APIRequestContext }, electionId: ElectionId) {
+  const createSessionUrl: COMMITTEE_SESSION_CREATE_REQUEST_PATH = `/api/elections/${electionId}/committee_sessions`;
+  const createSessionResponse = await user.request.post(createSessionUrl);
+  expect(createSessionResponse.ok()).toBeTruthy();
+
+  return await getElectionDetails(user, electionId);
+}
+
+/**
+ * Create and conclude an investigation with corrected results.
+ */
+export async function createInvestigation(user: { request: APIRequestContext }, pollingStationId: PollingStationId) {
+  const createUrl: POLLING_STATION_INVESTIGATION_UPDATE_REQUEST_PATH = `/api/polling_stations/${pollingStationId}/investigation`;
+  const createData: POLLING_STATION_INVESTIGATION_CREATE_REQUEST_BODY = { reason: "Een aanleiding" };
+  const createResponse = await user.request.post(createUrl, { data: createData });
+  expect(createResponse.ok()).toBeTruthy();
+
+  const concludeUrl: POLLING_STATION_INVESTIGATION_CONCLUDE_REQUEST_PATH = `${createUrl}/conclude`;
+  const concludeData: POLLING_STATION_INVESTIGATION_CONCLUDE_REQUEST_BODY = {
+    findings: "Foutje bedankt",
+    corrected_results: true,
+  };
+  const concludeResponse = await user.request.post(concludeUrl, { data: concludeData });
+  expect(concludeResponse.ok()).toBeTruthy();
+  return (await concludeResponse.json()) as PollingStationInvestigation;
 }

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -2,6 +2,7 @@ import type {
   CSOFirstSessionResults,
   DataEntry,
   GSBResults,
+  NextSessionResults,
   PollingStationRequest,
   Results,
   SaveDataEntryResponse,
@@ -1195,6 +1196,36 @@ export const noRecountNoDifferencesDrawingLotsForP9DataEntryGSB: GSBResults & { 
       ],
     },
   ],
+};
+
+export const nextSessionResults: NextSessionResults & { model: "CSONextSession" } = {
+  model: "CSONextSession",
+  voters_counts: {
+    poll_card_count: noRecountNoDifferencesDataEntry.voters_counts.poll_card_count,
+    proxy_certificate_count: noRecountNoDifferencesDataEntry.voters_counts.proxy_certificate_count + 10,
+    total_admitted_voters_count: noRecountNoDifferencesDataEntry.voters_counts.total_admitted_voters_count + 10,
+  },
+  votes_counts: {
+    political_group_total_votes: noRecountNoDifferencesDataEntry.votes_counts.political_group_total_votes,
+    total_votes_candidates_count: noRecountNoDifferencesDataEntry.votes_counts.total_votes_candidates_count,
+    blank_votes_count: noRecountNoDifferencesDataEntry.votes_counts.blank_votes_count,
+    invalid_votes_count: noRecountNoDifferencesDataEntry.votes_counts.invalid_votes_count + 10,
+    total_votes_cast_count: noRecountNoDifferencesDataEntry.votes_counts.total_votes_cast_count + 10,
+  },
+  differences_counts: noRecountNoDifferencesDataEntry.differences_counts,
+  political_group_votes: noRecountNoDifferencesDataEntry.political_group_votes,
+};
+
+export const nextSessionResultsWithDifferences: NextSessionResults & { model: "CSONextSession" } = {
+  model: "CSONextSession",
+  voters_counts: {
+    poll_card_count: nextSessionResults.voters_counts.poll_card_count - 20,
+    proxy_certificate_count: nextSessionResults.voters_counts.proxy_certificate_count + 20,
+    total_admitted_voters_count: nextSessionResults.voters_counts.total_admitted_voters_count,
+  },
+  votes_counts: nextSessionResults.votes_counts,
+  differences_counts: nextSessionResults.differences_counts,
+  political_group_votes: nextSessionResults.political_group_votes,
 };
 
 export const dataEntryRequest: DataEntry = {

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry.correct-differences.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry.correct-differences.e2e.ts
@@ -6,7 +6,11 @@ import { DataEntryHomePage } from "e2e-tests/page-objects/data_entry/DataEntryHo
 import { DifferencesPage } from "e2e-tests/page-objects/data_entry/DifferencesPgObj";
 import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
 import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
-import { dataEntryRequest, dataEntryWithDifferencesRequest } from "e2e-tests/test-data/request-response-templates";
+import {
+  dataEntryRequest,
+  dataEntryWithDifferencesRequest,
+  nextSessionResultsWithDifferences,
+} from "e2e-tests/test-data/request-response-templates";
 import type { Results } from "@/types/generated/openapi";
 import { type DataEntry, test } from "../../fixtures";
 
@@ -44,6 +48,49 @@ test.describe("data entry - correct differences", () => {
     await expect(votersAndVotesPage.pollCardCount).toHaveValue("");
     await expect(votersAndVotesPage.proxyCertificateCount).toHaveValue("");
     await expect(votersAndVotesPage.totalAdmittedVotersCount).toHaveValue("3607");
+
+    // Save section without making corrections, assert error that was hidden by W.002
+    await votersAndVotesPage.next.click();
+    await expect(votersAndVotesPage.error).toContainText("Controleer je antwoorden");
+    await expect(votersAndVotesPage.pollCardCount).toHaveAttribute("aria-errormessage", "feedback-error");
+    await expect(votersAndVotesPage.proxyCertificateCount).toHaveAttribute("aria-errormessage", "feedback-error");
+    await expect(votersAndVotesPage.totalAdmittedVotersCount).toHaveAttribute("aria-errormessage", "feedback-error");
+  });
+
+  test("corrigendum correction empty fields", async ({
+    typistOneGSB,
+    dataEntryNextSessionFirstEntryCorrection: dataEntry,
+  }) => {
+    // Start data entry correction
+    const typist = typistOneGSB.page;
+    await typist.goto(`/elections/${dataEntry.election_id}/data-entry/${dataEntry.id}/1`);
+
+    // Go to section with warning
+    const dataEntryPage = new DataEntryBasePage(typist);
+    await dataEntryPage.progressList.votersAndVotes.click();
+    const votersAndVotesPage = new VotersAndVotesPage(typist);
+    await expect(votersAndVotesPage.fieldset).toBeVisible();
+
+    // Assert warning message only
+    await expect(votersAndVotesPage.error).toBeHidden();
+    await expect(votersAndVotesPage.warning).toContainText(
+      [
+        "Verschil met andere invoer. Nieuwe invoer nodig",
+        "W.002",
+        "Een coördinator heeft beide invoeren vergeleken, en aangegeven dat in deze invoer fouten zijn gemaakt.",
+      ].join(""),
+    );
+
+    // Assert field icons
+    await expect(votersAndVotesPage.pollCardCount).toHaveAttribute("aria-errormessage", "feedback-warning");
+    await expect(votersAndVotesPage.proxyCertificateCount).toHaveAttribute("aria-errormessage", "feedback-warning");
+    await expect(votersAndVotesPage.totalAdmittedVotersCount).not.toHaveAttribute("aria-errormessage");
+
+    // Assert different fields empty
+    await expect(votersAndVotesPage.pollCardCount).toHaveValue("");
+    await expect(votersAndVotesPage.proxyCertificateCount).toHaveValue("");
+    // Assert different from first session, but not different from other data entry, filled
+    await expect(votersAndVotesPage.totalAdmittedVotersCount).toHaveValue("3617");
 
     // Save section without making corrections, assert error that was hidden by W.002
     await votersAndVotesPage.next.click();
@@ -211,6 +258,22 @@ test.describe("data entry - correct differences", () => {
         entry: 2,
         correction: secondDataEntry,
         expectResolved: false,
+      });
+    });
+
+    // eslint-disable-next-line playwright/expect-expect
+    test("corrigendum correction differences resolved", async ({
+      coordinatorOneGSB,
+      typistOneGSB,
+      dataEntryNextSessionFirstEntryCorrection,
+    }) => {
+      await testCorrection({
+        coordinator: coordinatorOneGSB.page,
+        typist: typistOneGSB.page,
+        dataEntry: dataEntryNextSessionFirstEntryCorrection,
+        entry: 1,
+        correction: nextSessionResultsWithDifferences,
+        expectResolved: true,
       });
     });
   });

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.test.ts
@@ -510,7 +510,7 @@ describe("correction warnings", () => {
       "data.political_group_votes.0.candidate_votes.0.votes",
     ];
 
-    resetFieldValues(structure, correctionWarnings, data);
+    resetFieldValues(structure, correctionWarnings, undefined, data);
 
     expect(data).toStrictEqual({
       voters_counts: {

--- a/frontend/src/features/data_entry/utils/dataEntryUtils.ts
+++ b/frontend/src/features/data_entry/utils/dataEntryUtils.ts
@@ -85,7 +85,7 @@ export function resetDisabledSectionValues(dataEntryStructure: DataEntryStructur
     .flatMap((section) => [...extractFieldInfoFromSection(section).keys()]);
 
   if (fields.length > 0) {
-    resetFieldValues(dataEntryStructure, fields, results);
+    resetFieldValues(dataEntryStructure, fields, undefined, results);
   }
 }
 
@@ -347,12 +347,17 @@ export function addCorrectionWarnings(dataEntryStructure: DataEntryStructure, fi
   }
 }
 
-export function resetFieldValues(dataEntryStructure: DataEntryStructure, fields: string[], results: DataEntryResults) {
+export function resetFieldValues(
+  dataEntryStructure: DataEntryStructure,
+  fields: string[],
+  previousResults: DataEntryResults | undefined,
+  results: DataEntryResults,
+) {
   for (const section of dataEntryStructure) {
     const sectionFields = fields.filter((field) => isFieldInSection(field, section));
 
     for (const field of sectionFields) {
-      resetValueAtPath(section, results, field);
+      resetValueAtPath(section, previousResults, results, field);
     }
   }
 }

--- a/frontend/src/features/data_entry/utils/reducer.ts
+++ b/frontend/src/features/data_entry/utils/reducer.ts
@@ -73,7 +73,12 @@ export default function dataEntryReducer(state: DataEntryState, action: DataEntr
 
         if (action.dataEntry.correction_warnings) {
           addCorrectionWarnings(dataEntryStructure, action.dataEntry.correction_warnings, formState);
-          resetFieldValues(dataEntryStructure, action.dataEntry.correction_warnings, results);
+          resetFieldValues(
+            dataEntryStructure,
+            action.dataEntry.correction_warnings,
+            action.dataEntry.previous_results,
+            results,
+          );
         }
       } else {
         targetFormSectionId = formState.furthest;

--- a/frontend/src/utils/dataEntryMapping.test.ts
+++ b/frontend/src/utils/dataEntryMapping.test.ts
@@ -885,13 +885,44 @@ test("resetValueAtPath", () => {
     radio_struct: { field: "OptionA" },
   };
 
-  resetValueAtPath(mixedSection, data, "data.numbers_struct.row_b");
-  resetValueAtPath(mixedSection, data, "data.checkbox_struct.field");
-  resetValueAtPath(mixedSection, data, "data.radio_struct.field");
+  resetValueAtPath(mixedSection, undefined, data, "data.numbers_struct.row_b");
+  resetValueAtPath(mixedSection, undefined, data, "data.checkbox_struct.field");
+  resetValueAtPath(mixedSection, undefined, data, "data.radio_struct.field");
 
   expect(data).toStrictEqual({
     numbers_struct: { row_a: 10, row_b: 0 },
     checkbox_struct: { field: { option_a: false, option_b: false } },
     radio_struct: { field: null },
+  });
+});
+
+test("resetValueAtPath with previousResults", () => {
+  const mixedSection: DataEntrySection = {
+    id: "mixed_section",
+    title: "Mixed Section",
+    short_title: "Mixed",
+    subsections: [
+      ...createInputGridSection().subsections,
+      { type: "message", message: "Please select things" },
+      ...createCheckboxesSection().subsections,
+    ],
+  };
+
+  const previousResults = {
+    numbers_struct: { row_a: 12, row_b: 18 },
+    checkbox_struct: { field: { option_a: false, option_b: true } },
+  };
+
+  const data = {
+    numbers_struct: { row_a: 10, row_b: 20 },
+    checkbox_struct: { field: { option_a: true, option_b: false } },
+  };
+
+  resetValueAtPath(mixedSection, previousResults, data, "data.numbers_struct.row_b");
+  resetValueAtPath(mixedSection, previousResults, data, "data.checkbox_struct.field");
+
+  expect(data).toStrictEqual({
+    numbers_struct: { row_a: 10, row_b: 18 },
+    checkbox_struct: { field: { option_a: false, option_b: false } },
   });
 });

--- a/frontend/src/utils/dataEntryMapping.ts
+++ b/frontend/src/utils/dataEntryMapping.ts
@@ -128,7 +128,12 @@ export function setValueAtPath(
 /**
  * Reset the value at the specified path to its empty value.
  */
-export function resetValueAtPath(section: DataEntrySection, data: DataEntryResults, path: ResultsPath) {
+export function resetValueAtPath(
+  section: DataEntrySection,
+  previousResults: DataEntryResults | undefined,
+  data: DataEntryResults,
+  path: ResultsPath,
+) {
   const normalizedPath = normalizeFieldName(path);
 
   // Check if the path refers to a checkboxes subsection by its error_path,
@@ -139,13 +144,31 @@ export function resetValueAtPath(section: DataEntrySection, data: DataEntryResul
 
   if (checkboxes) {
     for (const option of checkboxes.options) {
+      // Checkboxes are always unset
       setValueAtPath(data, option.path, "", "boolean");
     }
   } else {
+    const value = getValueForReset(previousResults, normalizedPath);
     const fieldInfoMap = extractFieldInfoFromSection(section);
     const valueType = fieldInfoMap.get(normalizedPath);
-    setValueAtPath(data, normalizedPath, "", valueType);
+    setValueAtPath(data, normalizedPath, value, valueType);
   }
+}
+
+function getValueForReset(previousResults: DataEntryResults | undefined, path: ResultsPath): string {
+  if (previousResults === undefined) {
+    // When there is no corrigendum, set to empty string
+    return "";
+  }
+
+  // Try to get value from previous results
+  const value = getValueAtPath(previousResults, path);
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  // Return as string
+  return String(value);
 }
 
 /**


### PR DESCRIPTION
## What & why

Resolves https://github.com/kiesraad/abacus/issues/3779

Instead of setting the fields to zero (as we do to make them empty in a first committee session), we have to set the field for a next committee session to the result from the first session to make the input field empty.

<img width="829" height="717" alt="image" src="https://github.com/user-attachments/assets/f11ab97a-4dc9-4573-80c4-96ff7f1e9c35" />

## How to test

- Complete a first committee session (e.g. by completing the _Corrigendum 2026_ election)
- Start a new committee session
- Create an investigation for an already existing polling station, and conclude it with corrected results
- Finalise two data entries with differences from the first committee session and also different from each other (e.g. change A and B for the first entry, and B and C for the second entry)
- As coordinator, resolve the differences by returning the data entry for correction to the typist
- Assert that the data entry now works as expected

## Reviewer notes

For the e2e tests, we did not have any fixtures yet for next committee sessions, so these are also added to be able to extend the `data-entry.correct-differences.e2e` with corrigendum tests.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->