### PR TITLE
Add election tree based committee extraction

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22238651fa78fcefcc99b649b4fb7ca205c9a07a3594cdea2715d6a1ed1b3252"
+checksum = "ec2c5df9869b303d13f3d00c070a6415cc60556872e04b76a4d1495908a31939"
 dependencies = [
  "chrono",
  "quick-xml 0.41.0",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,7 +77,7 @@ axum.workspace = true
 axum-extra.workspace = true
 chrono.workspace = true
 clap = { version = "4.6", default-features = false, features = ["derive", "std", "help", "env", "string"] }
-eml-nl = { version = "0.6.2" }
+eml-nl = { version = "0.7.0" }
 hyper = { version = "1", features = ["full"] }
 icu_collator = "2.2.0"
 icu_locale_core = "2.2.0"

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "eml-nl"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22238651fa78fcefcc99b649b4fb7ca205c9a07a3594cdea2715d6a1ed1b3252"
+checksum = "ec2c5df9869b303d13f3d00c070a6415cc60556872e04b76a4d1495908a31939"
 dependencies = [
  "chrono",
  "quick-xml",

--- a/backend/src/eml/committees.rs
+++ b/backend/src/eml/committees.rs
@@ -1,0 +1,717 @@
+use std::collections::HashMap;
+
+use eml_nl::{
+    EMLError,
+    common::Region,
+    documents::election_definition::ElectionDefinition,
+    utils::{ContestId, RegionNode},
+};
+
+use crate::domain::election::CommitteeCategory;
+
+mod expected {
+    // This is a module so that we can use these imports without conflicting
+    // with the Abacus-specific definitions.
+    use eml_nl::utils::{ElectionCategory, RegionCategory};
+
+    /// We expect a certain region category to be at the top of the election tree
+    /// for each different category of election. This maps those two together.
+    pub const CSB_REGION_CATEGORY: &[(ElectionCategory, RegionCategory)] = &[
+        (ElectionCategory::GR, RegionCategory::Municipality),
+        (ElectionCategory::PS, RegionCategory::Province),
+        (ElectionCategory::AB, RegionCategory::WaterAuthority),
+    ];
+}
+
+/// Category of a region, as defined by EML-NL
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RegionCategory {
+    /// The highest level of government, the 'staat'.
+    State,
+    /// A 'waterschap'
+    WaterAuthority,
+    /// A 'provincie'
+    Province,
+    /// A 'kieskring'
+    ElectoralDistrict,
+    /// A 'gemeente', the lowest level of government region in mainland Netherlands.
+    Municipality,
+    /// A 'stembureau' (note: only for eerste kamer elections)
+    PollingStation,
+}
+
+impl TryFrom<eml_nl::utils::RegionCategory> for RegionCategory {
+    type Error = EMLError;
+
+    fn try_from(value: eml_nl::utils::RegionCategory) -> Result<Self, Self::Error> {
+        Ok(match value {
+            eml_nl::utils::RegionCategory::State => RegionCategory::State,
+            eml_nl::utils::RegionCategory::WaterAuthority => RegionCategory::WaterAuthority,
+            eml_nl::utils::RegionCategory::Province => RegionCategory::Province,
+            eml_nl::utils::RegionCategory::ElectoralDistrict => RegionCategory::ElectoralDistrict,
+            eml_nl::utils::RegionCategory::Municipality => RegionCategory::Municipality,
+            eml_nl::utils::RegionCategory::PollingStation => RegionCategory::PollingStation,
+            other => {
+                return Err(EMLError::custom(format!(
+                    "Region category '{}' should not appear in Abacus",
+                    other.to_eml_value()
+                )));
+            }
+        })
+    }
+}
+
+/// Identifies a specific region from the election tree for usage within Abacus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RegionKey {
+    /// Category of the region, as defined by EML_NL
+    pub category: RegionCategory,
+    /// Identifier of the region, if it has one.
+    pub number: Option<u16>,
+}
+
+impl TryFrom<eml_nl::common::RegionKey> for RegionKey {
+    type Error = EMLError;
+
+    fn try_from(value: eml_nl::common::RegionKey) -> Result<Self, Self::Error> {
+        Ok(RegionKey {
+            category: RegionCategory::try_from(value.category)?,
+            number: value.number,
+        })
+    }
+}
+
+/// Identifies a specific region from the election tree for usage within Abacus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionDetails {
+    /// Name of the region
+    pub name: String,
+
+    /// Key of the region (combination of category and id)
+    pub key: RegionKey,
+
+    /// Whether this region uses roman numerals for its contest id.
+    pub roman_numerals: bool,
+
+    /// Whether this region allows Frisian export.
+    pub frisian_export_allowed: bool,
+}
+
+impl TryFrom<&Region> for RegionDetails {
+    type Error = EMLError;
+
+    fn try_from(region: &Region) -> Result<Self, Self::Error> {
+        let key = RegionKey::try_from(region.key)?;
+
+        Ok(RegionDetails {
+            name: region.name.to_string(),
+            key,
+            roman_numerals: region.roman_numerals,
+            frisian_export_allowed: region.frysian_export_allowed,
+        })
+    }
+}
+
+/// Which district this committee is contained within.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommitteeDistrict {
+    /// The election has no districts
+    None,
+    /// This committee operates over all districts
+    All,
+    /// This committee operates within a specific district
+    Specific(RegionDetails),
+}
+
+impl CommitteeDistrict {
+    /// Convert the committee district to a contest identifier, used for
+    /// EML_NL exports.
+    pub fn as_contest_identifier(&self) -> Result<eml_nl::common::ContestIdentifier, EMLError> {
+        eml_nl::common::ContestIdentifier::try_from(self)
+    }
+
+    /// Retrieve the region details from the district information if available.
+    ///
+    /// Note that when the committee district is set to all or none, this
+    /// information is not available.
+    pub fn region_details(&self) -> Option<&RegionDetails> {
+        match self {
+            Self::Specific(r) => Some(r),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<&CommitteeDistrict> for eml_nl::common::ContestIdentifier {
+    type Error = EMLError;
+
+    fn try_from(district: &CommitteeDistrict) -> Result<Self, Self::Error> {
+        Ok(match district {
+            CommitteeDistrict::None => eml_nl::common::ContestIdentifier::geen(),
+            CommitteeDistrict::All => eml_nl::common::ContestIdentifier::alle(),
+            CommitteeDistrict::Specific(region) => {
+                let id_number = region
+                    .key
+                    .number
+                    .ok_or(EMLError::custom("Missing region number"))?;
+
+                let id_str = if region.roman_numerals {
+                    to_roman_numeral(id_number)
+                } else {
+                    id_number.to_string()
+                };
+                eml_nl::common::ContestIdentifier::new(ContestId::new(id_str)?)
+                    .with_name(region.name.clone())
+            }
+        })
+    }
+}
+
+/// Convert a number to a roman numeral string. This is used for the contest
+/// id in the Limburg provincial elections.
+fn to_roman_numeral(mut num: u16) -> String {
+    const MAPPING: &[(u16, &str)] = &[
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ];
+
+    let mut result = String::new();
+    for &(val, sym) in MAPPING {
+        while num >= val {
+            result.push_str(sym);
+            num -= val;
+        }
+    }
+    result
+}
+
+/// Details of a possible committee in this election
+#[derive(Debug, Clone)]
+pub struct CommitteeDetails {
+    /// Details of the region this committee is responsible for
+    pub responsible_region: RegionDetails,
+
+    /// Details of the region where the electoral committee is seated.
+    pub seat_region: RegionDetails,
+
+    /// The district this committee operates within
+    pub district: CommitteeDistrict,
+
+    /// Category for the committee (i.e. GSB, HSB, CSB)
+    pub category: CommitteeCategory,
+
+    /// If this committee has a specific name, it will be set here.
+    ///
+    /// Note: most committees do not have specific names.
+    pub name: Option<String>,
+
+    /// Managing authority id for this committee (i.e. `CSB`, `HSB1` or `0123`)
+    pub managing_authority_id: String,
+}
+
+impl CommitteeDetails {
+    /// Create new committee details based on the information provided
+    fn new(
+        responsible_region: &Region,
+        seat_region: &Region,
+        district: CommitteeDistrict,
+        category: CommitteeCategory,
+        name: Option<String>,
+    ) -> Result<CommitteeDetails, EMLError> {
+        let responsible_region: RegionDetails = responsible_region.try_into()?;
+        Ok(CommitteeDetails {
+            managing_authority_id: managing_authority_id(category, responsible_region.key)?,
+            responsible_region,
+            seat_region: seat_region.try_into()?,
+            district,
+            category,
+            name,
+        })
+    }
+
+    /// Create a new committee details for a CSB
+    fn new_csb(
+        root_region: &RegionNode,
+        has_districts: bool,
+    ) -> Result<CommitteeDetails, EMLError> {
+        // Find the CSB seat region
+        let (csb_seat_region, csb_name) =
+            find_committee(root_region, eml_nl::utils::CommitteeCategory::CSB);
+        CommitteeDetails::new(
+            root_region.region(),
+            csb_seat_region,
+            if has_districts {
+                CommitteeDistrict::All
+            } else {
+                CommitteeDistrict::None
+            },
+            CommitteeCategory::CSB,
+            csb_name,
+        )
+    }
+
+    pub fn managing_authority_name(&self) -> String {
+        self.name
+            .clone()
+            .unwrap_or_else(|| self.responsible_region.name.clone())
+    }
+
+    /// Get the location that the committee sessions will take place
+    pub fn location(&self) -> String {
+        self.seat_region.name.clone()
+    }
+}
+
+/// Details of the election tree relevant to Abacus
+#[derive(Debug, Clone)]
+pub struct ElectionTreeDetails {
+    /// Details of the CSB committee for this election.
+    pub csb: CommitteeDetails,
+    other_committees: HashMap<CommitteeCategory, Vec<CommitteeDetails>>,
+}
+
+impl ElectionTreeDetails {
+    /// Splits out the committees into different sets for different categories.
+    fn new(csb: CommitteeDetails, other_committees: Vec<CommitteeDetails>) -> ElectionTreeDetails {
+        let mut map = HashMap::new();
+        for c in other_committees {
+            map.entry(c.category).or_insert(vec![]).push(c);
+        }
+
+        ElectionTreeDetails {
+            csb,
+            other_committees: map,
+        }
+    }
+
+    /// Create election tree details given an election definition.
+    pub fn from_definition(
+        definition: &ElectionDefinition,
+    ) -> Result<ElectionTreeDetails, EMLError> {
+        ElectionTreeDetails::try_from(definition)
+    }
+
+    /// Which categories of committees are available. The returned categories
+    /// are not sorted.
+    ///
+    /// Note this does not include the CSB.
+    pub fn available_categories(&self) -> impl Iterator<Item = CommitteeCategory> {
+        self.other_committees.keys().copied()
+    }
+
+    /// Get the possible committees for a given category of committee.
+    /// This returns an empty list if there are no committees of the given
+    /// category.
+    ///
+    /// Note: cannot be used to get the CSB, use [`Self::csb`] instead.
+    pub fn get_committees(&self, category: CommitteeCategory) -> &[CommitteeDetails] {
+        self.other_committees
+            .get(&category)
+            .map(|v| &v[..])
+            .unwrap_or(&[])
+    }
+
+    /// Iterate over all committees, including the CSB.
+    pub fn all_committees(&self) -> impl Iterator<Item = &CommitteeDetails> {
+        std::iter::once(&self.csb).chain(self.other_committees.values().flatten())
+    }
+}
+
+impl TryFrom<&ElectionDefinition> for ElectionTreeDetails {
+    type Error = EMLError;
+
+    fn try_from(definition: &ElectionDefinition) -> Result<Self, Self::Error> {
+        use eml_nl::utils::{ElectionCategory, ElectionSubcategory};
+
+        let election_identifier = &definition.election_event.election.identifier;
+        let election_hierarchy = definition
+            .election_event
+            .election
+            .election_tree
+            .hierarchy()?;
+        let election_category = election_identifier.category.copied_value()?;
+        let election_sub_category = election_identifier.subcategory.copied_value()?;
+        let root_region = election_hierarchy.root();
+
+        // Check if the root region is of the exepected category
+        if !expected::CSB_REGION_CATEGORY
+            .iter()
+            .any(|(ec, rc)| *ec == election_category && *rc == root_region.key.category)
+        {
+            return Err(EMLError::custom(format!(
+                "The root region does not match an election of category '{}'",
+                election_category.to_eml_value()
+            )));
+        }
+
+        let (committees, has_districts) = match (election_category, election_sub_category) {
+            // election within a municipality
+            (ElectionCategory::GR, _) => (
+                vec![CommitteeDetails::new(
+                    root_region.region(),
+                    root_region.region(),
+                    CommitteeDistrict::None,
+                    CommitteeCategory::GSB,
+                    None,
+                )?],
+                false,
+            ),
+            // elections without a HSB, but larger than a municipality
+            (ElectionCategory::AB, _) | (ElectionCategory::PS, ElectionSubcategory::PS1) => {
+                (committees_single_electoral_district(root_region)?, false)
+            }
+
+            // Elections with HSBs
+            (ElectionCategory::PS, ElectionSubcategory::PS2) => {
+                (committees_multiple_electoral_districts(root_region)?, true)
+            }
+
+            _ => return Err(EMLError::custom("Unsupported election type")),
+        };
+        let csb = CommitteeDetails::new_csb(root_region, has_districts)?;
+
+        Ok(ElectionTreeDetails::new(csb, committees))
+    }
+}
+
+fn committees_single_electoral_district(
+    root_region: &RegionNode,
+) -> Result<Vec<CommitteeDetails>, EMLError> {
+    let mut committees = vec![];
+
+    // there should be only a single child under the root region
+    if root_region.children().len() != 1 {
+        return Err(EMLError::custom(
+            "Election should not have HSB but has multiple regions suitable for a HSB",
+        ));
+    }
+
+    // technically not a HSB, but we will find all our GSBs under this region
+    let hsb_region = &root_region.children()[0];
+    if hsb_region.key.category != eml_nl::utils::RegionCategory::ElectoralDistrict {
+        return Err(EMLError::custom("Expected to find an electoral district"));
+    }
+
+    // Add all the GSBs
+    for gsb_region in hsb_region.children() {
+        if gsb_region.key.category != eml_nl::utils::RegionCategory::Municipality {
+            return Err(EMLError::custom("GSB on a non-municipal region"));
+        }
+        committees.push(CommitteeDetails::new(
+            gsb_region.region(),
+            gsb_region.region(),
+            CommitteeDistrict::None,
+            CommitteeCategory::GSB,
+            None,
+        )?);
+    }
+
+    Ok(committees)
+}
+
+fn committees_multiple_electoral_districts(
+    root_region: &RegionNode,
+) -> Result<Vec<CommitteeDetails>, EMLError> {
+    let mut committees = vec![];
+    for hsb_region in root_region.children() {
+        if hsb_region.key.category != eml_nl::utils::RegionCategory::ElectoralDistrict {
+            return Err(EMLError::custom("Expected to find an electoral district"));
+        }
+
+        let hsb_region_details: RegionDetails = hsb_region.region().try_into()?;
+        let district = CommitteeDistrict::Specific(hsb_region_details.clone());
+        // TODO: rest of Abacus needs to support HSB first
+        // let (hsb_seat_region, hsb_name) =
+        //     find_committee(hsb_region, eml_nl::utils::CommitteeCategory::HSB);
+        // committees.push(CommitteeDetails::new(
+        //     hsb_region.region(),
+        //     hsb_seat_region,
+        //     district,
+        //     CommitteeCategory::HSB,
+        //     hsb_name,
+        // )?);
+
+        for gsb_region in hsb_region.children() {
+            if gsb_region.key.category != eml_nl::utils::RegionCategory::Municipality {
+                return Err(EMLError::custom("GSB on a non-municipal region"));
+            }
+            committees.push(CommitteeDetails::new(
+                gsb_region.region(),
+                gsb_region.region(),
+                district.clone(),
+                CommitteeCategory::GSB,
+                None,
+            )?);
+        }
+    }
+
+    Ok(committees)
+}
+
+/// Find a specific committee within a (sub)tree of the election tree. This is
+/// either the first region encountered that thas the committee category
+/// specified. If none of those exist, the highest region in the (sub)tree is
+/// returned instead.
+fn find_committee(
+    tree: &RegionNode,
+    category: eml_nl::utils::CommitteeCategory,
+) -> (&Region, Option<String>) {
+    // this checks descendants but also the node itself
+    for node in tree.iter() {
+        let committees = &node.region().committees;
+        if let Some(committee) = committees.iter().find(|c| c.category == category) {
+            let committee_name = committee.name.as_ref().map(|n| n.to_string());
+            return (node.region(), committee_name);
+        }
+    }
+
+    (tree.region(), None)
+}
+
+fn managing_authority_id(category: CommitteeCategory, key: RegionKey) -> Result<String, EMLError> {
+    Ok(match category {
+        CommitteeCategory::CSB => "CSB".to_string(),
+        // TODO: rest of Abacus first needs to support HSB
+        // CommitteeCategory::HSB => format!(
+        //     "HSB{}",
+        //     key.id
+        //         .ok_or(EMLError::custom("Missing region id for HSB"))?
+        // ),
+        CommitteeCategory::GSB => format!(
+            "{:04}",
+            key.number
+                .ok_or(EMLError::custom("Missing region id for GSB"))?
+        ),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use eml_nl::io::{EMLParsingMode, EMLRead as _};
+
+    use super::*;
+
+    #[test]
+    fn test_convert_managing_authority() {
+        assert_eq!(
+            managing_authority_id(
+                CommitteeCategory::CSB,
+                RegionKey {
+                    category: RegionCategory::Municipality,
+                    number: Some(10)
+                }
+            )
+            .unwrap(),
+            "CSB"
+        );
+        assert_eq!(
+            managing_authority_id(
+                CommitteeCategory::CSB,
+                RegionKey {
+                    category: RegionCategory::WaterAuthority,
+                    number: Some(11)
+                }
+            )
+            .unwrap(),
+            "CSB"
+        );
+        assert_eq!(
+            managing_authority_id(
+                CommitteeCategory::GSB,
+                RegionKey {
+                    category: RegionCategory::Municipality,
+                    number: Some(12)
+                }
+            )
+            .unwrap(),
+            "0012"
+        );
+
+        assert!(
+            managing_authority_id(
+                CommitteeCategory::GSB,
+                RegionKey {
+                    category: RegionCategory::State,
+                    number: None
+                }
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_to_roman_numeral() {
+        assert_eq!(to_roman_numeral(99), "XCIX");
+        assert_eq!(to_roman_numeral(1), "I");
+        assert_eq!(to_roman_numeral(2), "II");
+        assert_eq!(to_roman_numeral(55), "LV");
+        assert_eq!(to_roman_numeral(21), "XXI");
+        assert_eq!(to_roman_numeral(1999), "MCMXCIX");
+    }
+
+    #[test]
+    fn test_water_authority_election_tree() {
+        let definition_str =
+            include_str!("tests/definitions/Verkiezingsdefinitie_AB2023_Limburg.eml.xml");
+        let definition =
+            ElectionDefinition::parse_eml(definition_str, EMLParsingMode::Strict).unwrap();
+
+        let details = ElectionTreeDetails::from_definition(&definition).unwrap();
+        assert_eq!(details.csb.responsible_region.name, "Limburg");
+        assert_eq!(details.csb.managing_authority_id, "CSB");
+        assert_eq!(details.csb.managing_authority_name(), "Limburg");
+        assert_eq!(details.csb.location(), "Limburg");
+        assert_eq!(details.csb.district, CommitteeDistrict::None);
+
+        assert_eq!(details.get_committees(CommitteeCategory::GSB).len(), 31);
+
+        let gsb_beek = details
+            .get_committees(CommitteeCategory::GSB)
+            .get(1)
+            .expect("Missing GSB");
+        assert_eq!(gsb_beek.responsible_region.name, "Beek");
+        assert_eq!(gsb_beek.managing_authority_id, "0888");
+        assert_eq!(gsb_beek.managing_authority_name(), "Beek");
+        assert_eq!(gsb_beek.location(), "Beek");
+        assert_eq!(gsb_beek.district, CommitteeDistrict::None);
+    }
+
+    #[test]
+    fn test_municipal_election_tree() {
+        let definition_str =
+            include_str!("tests/definitions/Verkiezingsdefinitie_GR2026_Stadskanaal.eml.xml");
+        let definition =
+            ElectionDefinition::parse_eml(definition_str, EMLParsingMode::Strict).unwrap();
+        let details = ElectionTreeDetails::from_definition(&definition).unwrap();
+
+        assert_eq!(details.csb.responsible_region.name, "Stadskanaal");
+        assert_eq!(details.csb.managing_authority_id, "CSB");
+        assert_eq!(details.csb.managing_authority_name(), "Stadskanaal");
+        assert_eq!(details.csb.location(), "Stadskanaal");
+        assert_eq!(details.csb.district, CommitteeDistrict::None);
+
+        assert_eq!(details.get_committees(CommitteeCategory::GSB).len(), 1);
+        let gsb = details
+            .get_committees(CommitteeCategory::GSB)
+            .first()
+            .expect("Missing GSB");
+        assert_eq!(gsb.responsible_region.name, "Stadskanaal");
+        assert_eq!(gsb.managing_authority_id, "0037");
+        assert_eq!(gsb.managing_authority_name(), "Stadskanaal");
+        assert_eq!(gsb.location(), "Stadskanaal");
+        assert_eq!(gsb.district, CommitteeDistrict::None);
+    }
+
+    #[test]
+    fn test_provincial_council_election_tree_single_district() {
+        let definition_str =
+            include_str!("tests/definitions/Verkiezingsdefinitie_PS2023_Drenthe.eml.xml");
+        let definition =
+            ElectionDefinition::parse_eml(definition_str, EMLParsingMode::Strict).unwrap();
+        let details = ElectionTreeDetails::from_definition(&definition).unwrap();
+
+        assert_eq!(details.csb.responsible_region.name, "Drenthe");
+        assert_eq!(details.csb.managing_authority_id, "CSB");
+        assert_eq!(details.csb.managing_authority_name(), "Drenthe");
+        assert_eq!(details.csb.location(), "Assen");
+        assert_eq!(details.csb.district, CommitteeDistrict::None);
+
+        assert_eq!(details.get_committees(CommitteeCategory::GSB).len(), 12);
+
+        let gsb_coev = details
+            .get_committees(CommitteeCategory::GSB)
+            .get(1)
+            .expect("Missing GSB");
+        assert_eq!(gsb_coev.responsible_region.name, "Coevorden");
+        assert_eq!(gsb_coev.managing_authority_id, "0109");
+        assert_eq!(gsb_coev.managing_authority_name(), "Coevorden");
+        assert_eq!(gsb_coev.location(), "Coevorden");
+        assert_eq!(gsb_coev.district, CommitteeDistrict::None);
+    }
+
+    #[test]
+    fn test_provincial_council_election_tree_multiple_districts() {
+        let definition_str =
+            include_str!("tests/definitions/Verkiezingsdefinitie_PS2023_Gelderland.eml.xml");
+        let definition =
+            ElectionDefinition::parse_eml(definition_str, EMLParsingMode::Strict).unwrap();
+        let details = ElectionTreeDetails::from_definition(&definition).unwrap();
+
+        assert_eq!(details.csb.responsible_region.name, "Gelderland");
+        assert_eq!(details.csb.managing_authority_id, "CSB");
+        assert_eq!(details.csb.managing_authority_name(), "Gelderland");
+        assert_eq!(details.csb.location(), "Arnhem");
+        assert_eq!(details.csb.district, CommitteeDistrict::All);
+
+        // assert_eq!(details.get_committees(CommitteeCategory::HSB).len(), 2);
+        // let hsb_arnhem = details
+        //     .get_committees(CommitteeCategory::HSB)
+        //     .get(0)
+        //     .expect("Missing HSB");
+        // assert_eq!(hsb_arnhem.responsible_region.name, "Arnhem");
+        // assert_eq!(hsb_arnhem.managing_authority_id, "HSB1");
+        // assert_eq!(hsb_arnhem.managing_authority_name(), "Arnhem");
+        // assert_eq!(hsb_arnhem.location(), "Arnhem");
+        // assert_eq!(hsb_arnhem.district.region_details().unwrap().name, "Arnhem");
+
+        assert_eq!(details.get_committees(CommitteeCategory::GSB).len(), 51);
+
+        let gsb_apel = details
+            .get_committees(CommitteeCategory::GSB)
+            .get(1)
+            .expect("Missing GSB");
+        assert_eq!(gsb_apel.responsible_region.name, "Apeldoorn");
+        assert_eq!(gsb_apel.managing_authority_id, "0200");
+        assert_eq!(gsb_apel.managing_authority_name(), "Apeldoorn");
+        assert_eq!(gsb_apel.location(), "Apeldoorn");
+        assert_eq!(gsb_apel.district.region_details().unwrap().name, "Arnhem");
+    }
+
+    #[test]
+    fn test_provincial_council_election_tree_limburg() {
+        let definition_str =
+            include_str!("tests/definitions/Verkiezingsdefinitie_PS2023_Limburg.eml.xml");
+        let definition =
+            ElectionDefinition::parse_eml(definition_str, EMLParsingMode::Strict).unwrap();
+        let details = ElectionTreeDetails::from_definition(&definition).unwrap();
+
+        assert_eq!(details.csb.responsible_region.name, "Limburg");
+        assert_eq!(details.csb.managing_authority_id, "CSB");
+        assert_eq!(details.csb.managing_authority_name(), "Limburg");
+        assert_eq!(details.csb.location(), "Maastricht");
+        assert_eq!(details.csb.district, CommitteeDistrict::All);
+
+        // assert_eq!(details.get_committees(CommitteeCategory::HSB).len(), 2);
+        // let hsb_venlo = details
+        //     .get_committees(CommitteeCategory::HSB)
+        //     .get(1)
+        //     .expect("Missing HSB");
+        // assert_eq!(hsb_venlo.responsible_region.name, "Venlo");
+        // assert_eq!(hsb_venlo.managing_authority_id, "HSB2");
+        // assert_eq!(hsb_venlo.managing_authority_name(), "Venlo");
+        // assert_eq!(hsb_venlo.location(), "Venlo");
+        // assert_eq!(hsb_venlo.district.region_details().unwrap().name, "Venlo");
+        // assert_eq!(
+        //     hsb_venlo
+        //         .district
+        //         .as_contest_identifier()
+        //         .unwrap()
+        //         .id
+        //         .raw()
+        //         .to_string(),
+        //     "II"
+        // );
+        assert_eq!(details.get_committees(CommitteeCategory::GSB).len(), 31);
+    }
+}

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -1,5 +1,6 @@
 use std::{num::NonZeroU64, str::FromStr as _};
 
+pub mod committees;
 mod error;
 pub mod hash;
 

--- a/backend/src/eml/tests/definitions/Verkiezingsdefinitie_AB2023_Limburg.eml.xml
+++ b/backend/src/eml/tests/definitions/Verkiezingsdefinitie_AB2023_Limburg.eml.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2023-02-09</IssueDate>
+    <kr:CreationDateTime>2023-02-09T15:12:25.983</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="AB2023_Limburg">
+                <ElectionName>Algemeen bestuur van het waterschap Limburg 2023</ElectionName>
+                <ElectionCategory>AB</ElectionCategory>
+                <kr:ElectionSubcategory>AB2</kr:ElectionSubcategory>
+                <kr:ElectionDomain Id="25">Limburg</kr:ElectionDomain>
+                <kr:ElectionDate>2023-03-15</kr:ElectionDate>
+                <kr:NominationDate>2023-01-30</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="geen"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>26</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="25" RegionCategory="WATERSCHAP">
+                    <kr:RegionName>Limburg</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1" RegionCategory="KIESKRING" SuperiorRegionNumber="25" SuperiorRegionCategory="WATERSCHAP">
+                    <kr:RegionName>Limburg</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+                <kr:Region RegionNumber="882" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Landgraaf</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="888" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beek</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="889" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beesel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="893" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Bergen (L)</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="899" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Brunssum</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="907" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Gennep</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="917" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Heerlen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="928" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Kerkrade</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="935" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Maastricht</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="938" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Meerssen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="944" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Mook en Middelaar</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="946" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Nederweert</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="957" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Roermond</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="965" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Simpelveld</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="971" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Stein</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="981" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Vaals</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="983" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Venlo</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="984" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Venray</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="986" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Voerendaal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="988" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Weert</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="994" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Valkenburg aan de Geul</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1507" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Horst aan de Maas</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1640" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Leudal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1641" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Maasgouw</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1669" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Roerdalen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1711" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Echt-Susteren</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1729" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Gulpen-Wittem</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1883" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Sittard-Geleen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1894" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Peel en Maas</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1903" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Eijsden-Margraten</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1954" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beekdaelen</kr:RegionName>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Parkstad</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Water Natuurlijk</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Westelijke Mijnstreek</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Midden-Limburg</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Heuvelland</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Lokaal Limburg</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Venlo</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Land van Weert + Leudal</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Maastricht</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Venray en Maasduinen</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Waterbelang Horst-Helden-Beesel</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>50PLUS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Belang van Nederland (BVNL)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>AWP voor water, klimaat en natuur</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>BBB</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor Water Veiligheid</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Dieren</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/backend/src/eml/tests/definitions/Verkiezingsdefinitie_GR2026_Stadskanaal.eml.xml
+++ b/backend/src/eml/tests/definitions/Verkiezingsdefinitie_GR2026_Stadskanaal.eml.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2026-02-06</IssueDate>
+    <kr:CreationDateTime>2026-02-06T17:11:55.207</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="GR2026_Stadskanaal">
+                <ElectionName>Gemeenteraad Stadskanaal 2026</ElectionName>
+                <ElectionCategory>GR</ElectionCategory>
+                <kr:ElectionSubcategory>GR2</kr:ElectionSubcategory>
+                <kr:ElectionDomain Id="0037">Stadskanaal</kr:ElectionDomain>
+                <kr:ElectionDate>2026-03-18</kr:ElectionDate>
+                <kr:NominationDate>2026-02-02</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="geen"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>23</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="37" RegionCategory="GEMEENTE">
+                    <kr:RegionName>Stadskanaal</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ChristenUnie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>CDA</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Lokaal Betrokken</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Arbeid (PvdA) / GROENLINKS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>SP (Socialistische Partij)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>D66</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>PVV (Partij voor de Vrijheid)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Staatkundig Gereformeerde Partij (SGP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Rechtsstaat</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/backend/src/eml/tests/definitions/Verkiezingsdefinitie_PS2023_Drenthe.eml.xml
+++ b/backend/src/eml/tests/definitions/Verkiezingsdefinitie_PS2023_Drenthe.eml.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2023-02-03</IssueDate>
+    <kr:CreationDateTime>2023-02-03T17:46:24.541</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="PS2023_Drenthe">
+                <ElectionName>Provinciale Staten Drenthe 2023</ElectionName>
+                <ElectionCategory>PS</ElectionCategory>
+                <kr:ElectionSubcategory>PS1</kr:ElectionSubcategory>
+                <kr:ElectionDomain>Drenthe</kr:ElectionDomain>
+                <kr:ElectionDate>2023-03-15</kr:ElectionDate>
+                <kr:NominationDate>2023-01-30</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="geen"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>43</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="3" RegionCategory="PROVINCIE">
+                    <kr:RegionName>Drenthe</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1" RegionCategory="KIESKRING" SuperiorRegionNumber="3" SuperiorRegionCategory="PROVINCIE">
+                    <kr:RegionName>Assen</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+                <kr:Region RegionNumber="106" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Assen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="109" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Coevorden</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="114" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Emmen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="118" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Hoogeveen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="119" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Meppel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1680" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Aa en Hunze</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1681" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Borger-Odoorn</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1690" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>De Wolden</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1699" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Noordenveld</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1701" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Westerveld</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1730" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Tynaarlo</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1731" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Midden-Drenthe</kr:RegionName>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Arbeid (P.v.d.A.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Forum voor Democratie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>CDA</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GROENLINKS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>PVV (Partij voor de Vrijheid)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ChristenUnie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>SP (Socialistische Partij)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>D66</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Sterk Lokaal Drenthe</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>50PLUS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Dieren</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Volt</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JEZUS LEEFT</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JA21</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Staatkundig Gereformeerde Partij (SGP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Alliantie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Belang van Nederland (BVNL)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>BBB</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/backend/src/eml/tests/definitions/Verkiezingsdefinitie_PS2023_Gelderland.eml.xml
+++ b/backend/src/eml/tests/definitions/Verkiezingsdefinitie_PS2023_Gelderland.eml.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2023-02-07</IssueDate>
+    <kr:CreationDateTime>2023-02-07T09:27:30.717</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="PS2023_Gelderland">
+                <ElectionName>Provinciale Staten Gelderland 2023</ElectionName>
+                <ElectionCategory>PS</ElectionCategory>
+                <kr:ElectionSubcategory>PS2</kr:ElectionSubcategory>
+                <kr:ElectionDomain>Gelderland</kr:ElectionDomain>
+                <kr:ElectionDate>2023-03-15</kr:ElectionDate>
+                <kr:NominationDate>2023-01-30</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="alle"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>55</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="6" RegionCategory="PROVINCIE">
+                    <kr:RegionName>Gelderland</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1" RegionCategory="KIESKRING" SuperiorRegionNumber="6" SuperiorRegionCategory="PROVINCIE">
+                    <kr:RegionName>Arnhem</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB" AcceptCentralSubmissions="true"/>
+                </kr:Region>
+                <kr:Region RegionNumber="2" RegionCategory="KIESKRING" SuperiorRegionNumber="6" SuperiorRegionCategory="PROVINCIE">
+                    <kr:RegionName>Nijmegen</kr:RegionName>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+                <kr:Region RegionNumber="197" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Aalten</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="200" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Apeldoorn</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="202" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Arnhem</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="203" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Barneveld</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="213" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Brummen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="221" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Doesburg</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="222" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Doetinchem</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="226" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Duiven</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="228" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Ede</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="230" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Elburg</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="232" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Epe</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="233" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Ermelo</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="243" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Harderwijk</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="244" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Hattem</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="246" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Heerde</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="262" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Lochem</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="267" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Nijkerk</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="269" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Oldebroek</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="273" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Putten</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="274" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Renkum</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="275" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Rheden</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="277" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Rozendaal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="279" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Scherpenzeel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="285" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Voorst</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="289" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Wageningen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="293" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Westervoort</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="294" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Winterswijk</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="299" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Zevenaar</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="301" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Zutphen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="302" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Nunspeet</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1509" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Oude IJsselstreek</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1586" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Oost Gelre</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1705" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Lingewaard</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1734" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Overbetuwe</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1859" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Berkelland</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1876" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Bronckhorst</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1955" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Montferland</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="209" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beuningen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="214" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Buren</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="216" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Culemborg</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="225" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Druten</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="252" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Heumen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="263" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Maasdriel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="268" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Nijmegen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="281" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Tiel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="296" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Wijchen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="297" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Zaltbommel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="668" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>West Maas en Waal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1740" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Neder-Betuwe</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1945" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Berg en Dal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1960" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>West Betuwe</kr:RegionName>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Forum voor Democratie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>CDA</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GROENLINKS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Arbeid (P.v.d.A.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>D66</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ChristenUnie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>PVV (Partij voor de Vrijheid)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>SP (Socialistische Partij)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Staatkundig Gereformeerde Partij (SGP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Dieren</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>50PLUS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ONS Gelderland</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Volt</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>BBB</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Lokale Partijen Gelderland</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JA21</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Belang van Nederland (BVNL)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>

--- a/backend/src/eml/tests/definitions/Verkiezingsdefinitie_PS2023_Limburg.eml.xml
+++ b/backend/src/eml/tests/definitions/Verkiezingsdefinitie_PS2023_Limburg.eml.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EML xmlns:xnl="urn:oasis:names:tc:ciq:xsdschema:xNL:2.0" xmlns="urn:oasis:names:tc:evs:schema:eml" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kr="http://www.kiesraad.nl/extensions" Id="110a" SchemaVersion="5">
+    <TransactionId>1</TransactionId>
+    <IssueDate>2023-02-03</IssueDate>
+    <kr:CreationDateTime>2023-02-03T17:30:40.792</kr:CreationDateTime>
+    <ElectionEvent>
+        <EventIdentifier/>
+        <Election>
+            <ElectionIdentifier Id="PS2023_Limburg">
+                <ElectionName>Provinciale Staten Limburg 2023</ElectionName>
+                <ElectionCategory>PS</ElectionCategory>
+                <kr:ElectionSubcategory>PS2</kr:ElectionSubcategory>
+                <kr:ElectionDomain>Limburg</kr:ElectionDomain>
+                <kr:ElectionDate>2023-03-15</kr:ElectionDate>
+                <kr:NominationDate>2023-01-30</kr:NominationDate>
+            </ElectionIdentifier>
+            <Contest>
+                <ContestIdentifier Id="alle"/>
+                <VotingMethod>SPV</VotingMethod>
+                <MaxVotes></MaxVotes>
+            </Contest>
+            <kr:NumberOfSeats>47</kr:NumberOfSeats>
+            <kr:PreferenceThreshold>25</kr:PreferenceThreshold>
+            <kr:ElectionTree>
+                <kr:Region RegionNumber="12" RegionCategory="PROVINCIE">
+                    <kr:RegionName>Limburg</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1" RegionCategory="KIESKRING" RomanNumerals="true" SuperiorRegionNumber="12" SuperiorRegionCategory="PROVINCIE">
+                    <kr:RegionName>Maastricht</kr:RegionName>
+                    <kr:Committee CommitteeCategory="CSB"/>
+                    <kr:Committee CommitteeCategory="HSB" AcceptCentralSubmissions="true"/>
+                </kr:Region>
+                <kr:Region RegionNumber="2" RegionCategory="KIESKRING" RomanNumerals="true" SuperiorRegionNumber="12" SuperiorRegionCategory="PROVINCIE">
+                    <kr:RegionName>Venlo</kr:RegionName>
+                    <kr:Committee CommitteeCategory="HSB"/>
+                </kr:Region>
+                <kr:Region RegionNumber="882" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Landgraaf</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="888" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beek</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="899" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Brunssum</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="917" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Heerlen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="928" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Kerkrade</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="935" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Maastricht</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="938" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Meerssen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="965" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Simpelveld</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="971" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Stein</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="981" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Vaals</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="986" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Voerendaal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="994" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Valkenburg aan de Geul</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1729" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Gulpen-Wittem</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1883" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Sittard-Geleen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1903" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Eijsden-Margraten</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1954" RegionCategory="GEMEENTE" SuperiorRegionNumber="1" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beekdaelen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="889" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Beesel</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="893" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Bergen (L)</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="907" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Gennep</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="944" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Mook en Middelaar</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="946" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Nederweert</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="957" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Roermond</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="983" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Venlo</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="984" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Venray</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="988" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Weert</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1507" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Horst aan de Maas</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1640" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Leudal</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1641" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Maasgouw</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1669" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Roerdalen</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1711" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Echt-Susteren</kr:RegionName>
+                </kr:Region>
+                <kr:Region RegionNumber="1894" RegionCategory="GEMEENTE" SuperiorRegionNumber="2" SuperiorRegionCategory="KIESKRING">
+                    <kr:RegionName>Peel en Maas</kr:RegionName>
+                </kr:Region>
+            </kr:ElectionTree>
+            <kr:RegisteredParties>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>CDA</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Forum voor Democratie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>PVV (Partij voor de Vrijheid)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>VVD</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>SP (Socialistische Partij)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>GROENLINKS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij van de Arbeid (P.v.d.A.)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>D66</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>LOKAAL-LIMBURG</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Partij voor de Dieren</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>50PLUS</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Limburgse Senioren Partij (LSP)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Omzien!</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JA21</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>AWP voor Water, Klimaat en Natuur</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>ChristenUnie</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Belang van Nederland (BVNL)</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>BBB</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>Hart voor Vrijheid</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+                <kr:RegisteredParty>
+                    <kr:RegisteredAppellation>JEZUS LEEFT</kr:RegisteredAppellation>
+                </kr:RegisteredParty>
+            </kr:RegisteredParties>
+        </Election>
+    </ElectionEvent>
+</EML>


### PR DESCRIPTION
## What & why

Fixes #3845 This introduces the initial types needed for extracting the information needed by Abacus from the election tree from the election definition EML file. In general the idea is:

- Abacus needs to know what committees there are in an election
- Committees have a responsible region, region they are seated in and tell something about the district they are in.
- Districts come in three variants: None (this election does not contain any districts), All (this election contains districts, but this specific committee concerns all of them at the same time), or Specific to point to a specific district

## How to test

Best tested by running the unit tests from the committees.rs file. Other than that this does not integrate into anything Abacus yet.

## Reviewer notes

Most changes are in the new file committees.rs, most of the added lines are due to me adding several existing election definitions from previous elections verbatim.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->