### PR TITLE
Show 50 candidates in Na 14-2 and adjust votes table explainer texts for corrigenda

### DIFF
--- a/backend/src/domain/models/votes_table.rs
+++ b/backend/src/domain/models/votes_table.rs
@@ -13,7 +13,6 @@ use crate::domain::{
 };
 
 const DEFAULT_CANDIDATES_PER_COLUMN: [usize; 4] = [25, 25, 15, 15];
-const JUSTIFIED_CANDIDATES_PER_COLUMN: [usize; 4] = [20, 20, 20, 20];
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CandidatesTables(Vec<VotesTable>);
@@ -81,7 +80,7 @@ impl VotesTablesWithPreviousVotes {
                         group,
                         Some(candidate_votes),
                         Some(previous_candidate_votes),
-                        JUSTIFIED_CANDIDATES_PER_COLUMN,
+                        DEFAULT_CANDIDATES_PER_COLUMN,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-GR.json
+++ b/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-GR.json
@@ -127,8 +127,8 @@
                 "locality": "Huisden",
                 "gender": "Female"
               },
-              "votes": 18207,
-              "previous_votes": 18206
+              "votes": 16209,
+              "previous_votes": 16208
             },
             {
               "candidate": {
@@ -342,13 +342,7 @@
               },
               "votes": 439,
               "previous_votes": 439
-            }
-          ]
-        },
-        {
-          "column_total": 5533,
-          "previous_column_total": 5533,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 21,
@@ -403,7 +397,13 @@
               },
               "votes": 343,
               "previous_votes": 343
-            },
+            }
+          ]
+        },
+        {
+          "column_total": 4736,
+          "previous_column_total": 4736,
+          "votes": [
             {
               "candidate": {
                 "number": 26,
@@ -424,8 +424,8 @@
                 "locality": "Huisden",
                 "gender": "X"
               },
-              "votes": 317,
-              "previous_votes": 317
+              "votes": 217,
+              "previous_votes": 217
             },
             {
               "candidate": {
@@ -447,8 +447,8 @@
                 "locality": "Heemdamseburg",
                 "gender": "X"
               },
-              "votes": 286,
-              "previous_votes": 286
+              "votes": 186,
+              "previous_votes": 186
             },
             {
               "candidate": {
@@ -470,8 +470,8 @@
                 "locality": "Juinen",
                 "gender": "X"
               },
-              "votes": 263,
-              "previous_votes": 263
+              "votes": 163,
+              "previous_votes": 163
             },
             {
               "candidate": {
@@ -514,8 +514,8 @@
                 "locality": "Heemdamseburg",
                 "gender": "Male"
               },
-              "votes": 215,
-              "previous_votes": 215
+              "votes": 115,
+              "previous_votes": 115
             },
             {
               "candidate": {
@@ -572,13 +572,7 @@
               },
               "votes": 168,
               "previous_votes": 168
-            }
-          ]
-        },
-        {
-          "column_total": 700,
-          "previous_column_total": 700,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 41,
@@ -635,6 +629,92 @@
               },
               "votes": 126,
               "previous_votes": 126
+            },
+            {
+              "candidate": {
+                "number": 46,
+                "initials": "X.",
+                "last_name_prefix": "van der",
+                "last_name": "Spek",
+                "locality": "Eemstricht",
+                "gender": "Female"
+              },
+              "votes": 100,
+              "previous_votes": 100
+            },
+            {
+              "candidate": {
+                "number": 47,
+                "initials": "I.X.B.",
+                "last_name_prefix": "van",
+                "last_name": "Bekking",
+                "locality": "Huisden",
+                "gender": "Male"
+              },
+              "votes": 180,
+              "previous_votes": 180
+            },
+            {
+              "candidate": {
+                "number": 48,
+                "initials": "A.P.",
+                "last_name": "Gopal",
+                "locality": "Huisden",
+                "gender": "X"
+              },
+              "votes": 178,
+              "previous_votes": 178
+            },
+            {
+              "candidate": {
+                "number": 49,
+                "initials": "R.",
+                "last_name_prefix": "van de",
+                "last_name": "Wal",
+                "locality": "Bloemstede",
+                "gender": "X"
+              },
+              "votes": 113,
+              "previous_votes": 113
+            },
+            {
+              "candidate": {
+                "number": 50,
+                "initials": "C.S.",
+                "last_name": "Aygün",
+                "locality": "Eemstricht",
+                "gender": "Male"
+              },
+              "votes": 230,
+              "previous_votes": 230
+            }
+          ]
+        },
+        {
+          "column_total": 1497,
+          "previous_column_total": 1497,
+          "votes": [
+            {
+              "candidate": {
+                "number": 51,
+                "initials": "A.",
+                "last_name": "Boermans",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              "votes": 97,
+              "previous_votes": 97
+            },
+            {
+              "candidate": {
+                "number": 52,
+                "initials": "A.G.",
+                "last_name": "Prakken",
+                "locality": "Heemdamseburg",
+                "gender": "Female"
+              },
+              "votes": 1400,
+              "previous_votes": 1400
             }
           ]
         }
@@ -877,13 +957,7 @@
               },
               "votes": 488,
               "previous_votes": 488
-            }
-          ]
-        },
-        {
-          "column_total": 2953,
-          "previous_column_total": 2953,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 21,
@@ -940,7 +1014,13 @@
               },
               "votes": 351,
               "previous_votes": 351
-            },
+            }
+          ]
+        },
+        {
+          "column_total": 2953,
+          "previous_column_total": 2953,
+          "votes": [
             {
               "candidate": {
                 "number": 26,

--- a/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-PS.json
+++ b/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-PS.json
@@ -129,8 +129,8 @@
                 "locality": "Huisden",
                 "gender": "Female"
               },
-              "votes": 18207,
-              "previous_votes": 18206
+              "votes": 16209,
+              "previous_votes": 16208
             },
             {
               "candidate": {
@@ -344,13 +344,7 @@
               },
               "votes": 439,
               "previous_votes": 439
-            }
-          ]
-        },
-        {
-          "column_total": 5533,
-          "previous_column_total": 5533,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 21,
@@ -405,7 +399,13 @@
               },
               "votes": 343,
               "previous_votes": 343
-            },
+            }
+          ]
+        },
+        {
+          "column_total": 4736,
+          "previous_column_total": 4736,
+          "votes": [
             {
               "candidate": {
                 "number": 26,
@@ -426,8 +426,8 @@
                 "locality": "Huisden",
                 "gender": "X"
               },
-              "votes": 317,
-              "previous_votes": 317
+              "votes": 217,
+              "previous_votes": 217
             },
             {
               "candidate": {
@@ -449,8 +449,8 @@
                 "locality": "Heemdamseburg",
                 "gender": "X"
               },
-              "votes": 286,
-              "previous_votes": 286
+              "votes": 186,
+              "previous_votes": 186
             },
             {
               "candidate": {
@@ -472,8 +472,8 @@
                 "locality": "Juinen",
                 "gender": "X"
               },
-              "votes": 263,
-              "previous_votes": 263
+              "votes": 163,
+              "previous_votes": 163
             },
             {
               "candidate": {
@@ -516,8 +516,8 @@
                 "locality": "Heemdamseburg",
                 "gender": "Male"
               },
-              "votes": 215,
-              "previous_votes": 215
+              "votes": 115,
+              "previous_votes": 115
             },
             {
               "candidate": {
@@ -574,13 +574,7 @@
               },
               "votes": 168,
               "previous_votes": 168
-            }
-          ]
-        },
-        {
-          "column_total": 700,
-          "previous_column_total": 700,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 41,
@@ -637,6 +631,92 @@
               },
               "votes": 126,
               "previous_votes": 126
+            },
+            {
+              "candidate": {
+                "number": 46,
+                "initials": "X.",
+                "last_name_prefix": "van der",
+                "last_name": "Spek",
+                "locality": "Eemstricht",
+                "gender": "Female"
+              },
+              "votes": 100,
+              "previous_votes": 100
+            },
+            {
+              "candidate": {
+                "number": 47,
+                "initials": "I.X.B.",
+                "last_name_prefix": "van",
+                "last_name": "Bekking",
+                "locality": "Huisden",
+                "gender": "Male"
+              },
+              "votes": 180,
+              "previous_votes": 180
+            },
+            {
+              "candidate": {
+                "number": 48,
+                "initials": "A.P.",
+                "last_name": "Gopal",
+                "locality": "Huisden",
+                "gender": "X"
+              },
+              "votes": 178,
+              "previous_votes": 178
+            },
+            {
+              "candidate": {
+                "number": 49,
+                "initials": "R.",
+                "last_name_prefix": "van de",
+                "last_name": "Wal",
+                "locality": "Bloemstede",
+                "gender": "X"
+              },
+              "votes": 113,
+              "previous_votes": 113
+            },
+            {
+              "candidate": {
+                "number": 50,
+                "initials": "C.S.",
+                "last_name": "Aygün",
+                "locality": "Eemstricht",
+                "gender": "Male"
+              },
+              "votes": 230,
+              "previous_votes": 230
+            }
+          ]
+        },
+        {
+          "column_total": 1497,
+          "previous_column_total": 1497,
+          "votes": [
+            {
+              "candidate": {
+                "number": 51,
+                "initials": "A.",
+                "last_name": "Boermans",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              "votes": 97,
+              "previous_votes": 97
+            },
+            {
+              "candidate": {
+                "number": 52,
+                "initials": "A.G.",
+                "last_name": "Prakken",
+                "locality": "Heemdamseburg",
+                "gender": "Female"
+              },
+              "votes": 1400,
+              "previous_votes": 1400
             }
           ]
         }
@@ -879,13 +959,7 @@
               },
               "votes": 488,
               "previous_votes": 488
-            }
-          ]
-        },
-        {
-          "column_total": 2953,
-          "previous_column_total": 2953,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 21,
@@ -942,7 +1016,13 @@
               },
               "votes": 351,
               "previous_votes": 351
-            },
+            }
+          ]
+        },
+        {
+          "column_total": 2953,
+          "previous_column_total": 2953,
+          "votes": [
             {
               "candidate": {
                 "number": 26,

--- a/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-WS.json
+++ b/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-WS.json
@@ -129,8 +129,8 @@
                 "locality": "Huisden",
                 "gender": "Female"
               },
-              "votes": 18207,
-              "previous_votes": 18206
+              "votes": 16209,
+              "previous_votes": 16208
             },
             {
               "candidate": {
@@ -344,13 +344,7 @@
               },
               "votes": 439,
               "previous_votes": 439
-            }
-          ]
-        },
-        {
-          "column_total": 5533,
-          "previous_column_total": 5533,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 21,
@@ -405,7 +399,13 @@
               },
               "votes": 343,
               "previous_votes": 343
-            },
+            }
+          ]
+        },
+        {
+          "column_total": 4736,
+          "previous_column_total": 4736,
+          "votes": [
             {
               "candidate": {
                 "number": 26,
@@ -426,8 +426,8 @@
                 "locality": "Huisden",
                 "gender": "X"
               },
-              "votes": 317,
-              "previous_votes": 317
+              "votes": 217,
+              "previous_votes": 217
             },
             {
               "candidate": {
@@ -449,8 +449,8 @@
                 "locality": "Heemdamseburg",
                 "gender": "X"
               },
-              "votes": 286,
-              "previous_votes": 286
+              "votes": 186,
+              "previous_votes": 186
             },
             {
               "candidate": {
@@ -472,8 +472,8 @@
                 "locality": "Juinen",
                 "gender": "X"
               },
-              "votes": 263,
-              "previous_votes": 263
+              "votes": 163,
+              "previous_votes": 163
             },
             {
               "candidate": {
@@ -516,8 +516,8 @@
                 "locality": "Heemdamseburg",
                 "gender": "Male"
               },
-              "votes": 215,
-              "previous_votes": 215
+              "votes": 115,
+              "previous_votes": 115
             },
             {
               "candidate": {
@@ -574,13 +574,7 @@
               },
               "votes": 168,
               "previous_votes": 168
-            }
-          ]
-        },
-        {
-          "column_total": 700,
-          "previous_column_total": 700,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 41,
@@ -637,6 +631,92 @@
               },
               "votes": 126,
               "previous_votes": 126
+            },
+            {
+              "candidate": {
+                "number": 46,
+                "initials": "X.",
+                "last_name_prefix": "van der",
+                "last_name": "Spek",
+                "locality": "Eemstricht",
+                "gender": "Female"
+              },
+              "votes": 100,
+              "previous_votes": 100
+            },
+            {
+              "candidate": {
+                "number": 47,
+                "initials": "I.X.B.",
+                "last_name_prefix": "van",
+                "last_name": "Bekking",
+                "locality": "Huisden",
+                "gender": "Male"
+              },
+              "votes": 180,
+              "previous_votes": 180
+            },
+            {
+              "candidate": {
+                "number": 48,
+                "initials": "A.P.",
+                "last_name": "Gopal",
+                "locality": "Huisden",
+                "gender": "X"
+              },
+              "votes": 178,
+              "previous_votes": 178
+            },
+            {
+              "candidate": {
+                "number": 49,
+                "initials": "R.",
+                "last_name_prefix": "van de",
+                "last_name": "Wal",
+                "locality": "Bloemstede",
+                "gender": "X"
+              },
+              "votes": 113,
+              "previous_votes": 113
+            },
+            {
+              "candidate": {
+                "number": 50,
+                "initials": "C.S.",
+                "last_name": "Aygün",
+                "locality": "Eemstricht",
+                "gender": "Male"
+              },
+              "votes": 230,
+              "previous_votes": 230
+            }
+          ]
+        },
+        {
+          "column_total": 1497,
+          "previous_column_total": 1497,
+          "votes": [
+            {
+              "candidate": {
+                "number": 51,
+                "initials": "A.",
+                "last_name": "Boermans",
+                "locality": "Juinen",
+                "gender": "Female"
+              },
+              "votes": 97,
+              "previous_votes": 97
+            },
+            {
+              "candidate": {
+                "number": 52,
+                "initials": "A.G.",
+                "last_name": "Prakken",
+                "locality": "Heemdamseburg",
+                "gender": "Female"
+              },
+              "votes": 1400,
+              "previous_votes": 1400
             }
           ]
         }
@@ -879,13 +959,7 @@
               },
               "votes": 488,
               "previous_votes": 488
-            }
-          ]
-        },
-        {
-          "column_total": 2953,
-          "previous_column_total": 2953,
-          "votes": [
+            },
             {
               "candidate": {
                 "number": 21,
@@ -942,7 +1016,13 @@
               },
               "votes": 351,
               "previous_votes": 351
-            },
+            }
+          ]
+        },
+        {
+          "column_total": 2953,
+          "previous_column_total": 2953,
+          "votes": [
             {
               "candidate": {
                 "number": 26,

--- a/backend/templates/model-na-14-1-versie-1.typ
+++ b/backend/templates/model-na-14-1-versie-1.typ
@@ -211,6 +211,8 @@ Vul alleen de gegevens in die anders zijn dan het oorspronkelijke proces-verbaal
 
 == Stemmen per lijst en per kandidaat <candidate_votes>
 
+#pagebreak(weak: true)
+
 #for political_group in input.candidates_tables {
   votes_table(
     title: [#political_group.number #political_group.name],

--- a/backend/templates/model-na-14-1-versie-2.typ
+++ b/backend/templates/model-na-14-1-versie-2.typ
@@ -201,6 +201,10 @@ verschil.]
 
 == Stemmen per lijst en per kandidaat <per_list_and_candidate>
 
+Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die door het stembureau of door het #location_type in een eerdere zitting zijn vastgesteld.
+
+#pagebreak(weak: true)
+
 #for political_group in input.votes_tables {
   votes_table(
     title: [#political_group.number #political_group.name],
@@ -212,9 +216,7 @@ verschil.]
     column_total: "Subtotaal kolom",
     sum_total: columns => [Totaal lijst (kolom #columns)],
     total_instruction: [Neem dit totaal over in rubriek #ref(<cast_votes>) bij de juiste lijst.],
-    explainer_text: [
-      Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die door het stembureau of door het #location_type in een eerdere zitting zijn vastgesteld.
-    ]
+    explainer_text: [Vul alléén de getallen in die veranderd zijn ten opzichte van de oorspronkelijke telling.]
   )
 }
 

--- a/backend/templates/model-na-14-2-bijlage-1.typ
+++ b/backend/templates/model-na-14-2-bijlage-1.typ
@@ -198,5 +198,6 @@ Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere tell
     column_total: "Subtotaal kolom",
     sum_total: columns => [Totaal lijst (kolom #columns)],
     total_instruction: [Neem dit totaal over in rubriek #ref(<cast_votes>) van deze bijlage bij de juiste lijst.],
+    explainer_text: [Vul alléén de getallen in die veranderd zijn ten opzichte van de oorspronkelijke telling.]
   )
 }

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -16,7 +16,7 @@
 
     Corrigendum van een #location_type \
     Model Na 14-2 (versie 2027)
-  ], margin-bottom: 3.2cm
+  ], margin-bottom: 2.9cm
 )
 
 #set heading(numbering: none)
@@ -167,6 +167,10 @@ Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere tell
 
 == Stemmen per lijst en per kandidaat
 
+De kolom ‘gecorrigeerd’ toont alléén de getallen die veranderd zijn ten opzichte van een eerdere telling. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
+
+#pagebreak(weak: true)
+
 #for political_group in input.votes_tables {
   votes_table(
     title: [#political_group.number #political_group.name],
@@ -179,9 +183,7 @@ Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere tell
     column_total: "Subtotaal kolom",
     sum_total: columns => [Totaal lijst (kolom #columns)],
     total_instruction: [Neem dit totaal over in rubriek #ref(<cast_votes>) van deze bijlage bij de juiste lijst.],
-    explainer_text: [
-      Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
-    ],
+    explainer_text: [De kolom ‘gecorrigeerd’ toont alléén de getallen die veranderd zijn ten opzichte van de oorspronkelijke telling.],
   )
 }
 

--- a/backend/templates/model-na-14-2.typ
+++ b/backend/templates/model-na-14-2.typ
@@ -102,7 +102,7 @@ vastgesteld.
 
 #pagebreak(weak: true)
 
-== Uitgebrachte stemmen <cast_votes>
+== Uitgebrachte stemmen
 Vul alléén de getallen in die veranderd zijn ten opzichte van een eerdere telling. Getallen die niet zijn veranderd, hoeven niet
 ingevuld te worden in de kolom ‘gecorrigeerd’. Onder ‘oorspronkelijk’ staan de getallen die in een eerdere zitting door het #location_type zijn vastgesteld.
 
@@ -182,7 +182,6 @@ De kolom ‘gecorrigeerd’ toont alléén de getallen die veranderd zijn ten op
     continue_on_next_page: [#sym.arrow.r De lijst gaat verder op de volgende pagina],
     column_total: "Subtotaal kolom",
     sum_total: columns => [Totaal lijst (kolom #columns)],
-    total_instruction: [Neem dit totaal over in rubriek #ref(<cast_votes>) van deze bijlage bij de juiste lijst.],
     explainer_text: [De kolom ‘gecorrigeerd’ toont alléén de getallen die veranderd zijn ten opzichte van de oorspronkelijke telling.],
   )
 }


### PR DESCRIPTION
Closes #3827 

## What & why

- Show 50 instead of 40 candidates in Na 14-2, to do this the margin-bottom for this footer had to be slightly adjusted from 3.2cm to 2.9cm
- Adjusted votes table explainer texts for all 4 corrigendum models
- Always have the chapter title on a separate page (also in Na 14-1 versie 1 and 2) to make sure 50 or less candidates on list 1 also fit on the page

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Verify the changes in the pdf diffs

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

- Decisions noted here: https://github.com/kiesraad/abacus-documentatie/pull/119
- Final footer changes made in: https://github.com/kiesraad/abacus/pull/3837

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->