### PR TITLE
Added DSO elections to dev page elections

### DIFF
--- a/backend/fixtures/election_1.sql
+++ b/backend/fixtures/election_1.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats,
                        number_of_voters, election_date, nomination_date, political_groups)
-VALUES (1, 'Gemeenteraad Juinen 2026', 'GSB', 'CSO', 'GRJuinen_2026', 'Juinen', '0035', 'Municipal', 'GR2', 29, 10000, '2026-11-30', '2026-11-01', '[
+VALUES (1, 'Gemeenteraad Juinen 2026', 'GSB', 'CSO', 'GR2026_Juinen', 'Juinen', '0035', 'Municipal', 'GR2', 29, 10000, '2026-11-30', '2026-11-01', '[
          {
            "number": 1,
            "registered_name": "Lijst Hekking",

--- a/backend/fixtures/election_1.sql
+++ b/backend/fixtures/election_1.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats,
                        number_of_voters, election_date, nomination_date, political_groups)
-VALUES (1, 'Gemeenteraad 2026', 'GSB', 'CSO', 'Juinen_2024', 'Juinen', '0000', 'Municipal', 'GR2', 29, 10000, '2024-11-30', '2024-11-01', '[
+VALUES (1, 'Gemeenteraad Juinen 2026', 'GSB', 'CSO', 'GRJuinen_2026', 'Juinen', '0035', 'Municipal', 'GR2', 29, 10000, '2026-11-30', '2026-11-01', '[
          {
            "number": 1,
            "registered_name": "Lijst Hekking",

--- a/backend/fixtures/election_1.sql
+++ b/backend/fixtures/election_1.sql
@@ -818,6 +818,5 @@ VALUES (104, '{"status":"Empty"}', '2024-12-05 09:15:00'),
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type, address,
                               postal_code, locality)
 VALUES (114, 1, NULL, 104, 'Studio The Rules', 1, NULL, 'FixedLocation', 'Gerontoplein 1', '1337 YQ', 'Juinen'),
-       (115, 1, NULL, 105, 'Buurtcentrum de Mattenklopper', 2, 1000, 'Special', 'Complexiteitslaan 2b', '1337 QY',
-        'Juinen'),
+       (115, 1, NULL, 105, 'Buurtcentrum de Mattenklopper', 2, 1000, 'Special', 'Complexiteitslaan 2b', '1337 QY', 'Juinen'),
        (116, 1, NULL, 106, 'Positivo Zaal', 3, NULL, NULL, 'Kerkweg 3', '1337 QA', 'Juinen');

--- a/backend/fixtures/election_10_csb.sql
+++ b/backend/fixtures/election_10_csb.sql
@@ -54,4 +54,4 @@ INSERT INTO data_entries (id, state, updated_at)
 VALUES (1001, '{"status":"Empty"}', '2024-12-05 09:15:00');
 
 INSERT INTO sub_committees (id, committee_session_id, data_entry_id, name, number, category)
-VALUES (1011, 1001, 1001, 'Juinen', 9102, 'GSB');
+VALUES (1011, 1001, 1001, 'Heemdamseburg', 0065, 'GSB');

--- a/backend/fixtures/election_10_csb.sql
+++ b/backend/fixtures/election_10_csb.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- copy of election_3 with committee_category changed to 'CSB' and subcommittee instead of polling station
-VALUES (10, 'Municipal Re-election', 'CSB', NULL, 'GR2024_Heemdamseburg', 'Heemdamseburg', '9102', 'Municipal', 'GR2', 29, 1, '2024-12-31', '2024-12-01',
+VALUES (10, 'Municipal Re-election', 'CSB', NULL, 'GR2024_Heemdamseburg', 'Heemdamseburg', '0065', 'Municipal', 'GR2', 29, 1, '2024-12-31', '2024-12-01',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_11_dso.sql
+++ b/backend/fixtures/election_11_dso.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- number_of_seats explicitly set to a value less than 19, to be used in elections with less than 19 seats
-VALUES (11, 'Municipal Election', 'GSB', 'DSO', 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 'GR1', 15, 2000, '2024-11-30', '2024-11-01',
+VALUES (11, 'Provinciale Staten Oost-Holland 2026', 'GSB', 'DSO', 'PS2026_Heemdamseburg', 'Heemdamseburg', '0065', 'Provincial', 'PS1', 15, 2000, '2026-11-30', '2026-11-01',
         '[
           {
             "number": 1,
@@ -56,5 +56,5 @@ VALUES (1101, '{"status":"Empty"}', '2024-12-05 09:15:00'),
 
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type, address,
                               postal_code, locality)
-VALUES (1111, 11, NULL, 1101, 'Op Rolletjes', 33, NULL, 'Mobile', 'Rijksweg A12 1', '1234 YQ', 'Den Haag'),
-       (1112, 11, NULL, 1102, 'Testplek', 34, 1000, 'Special', 'Teststraat 2b', '1234 QY', 'Testdorp');
+VALUES (1111, 11, NULL, 1101, 'Op Rolletjes', 33, NULL, 'Mobile', 'Rijksweg A12 1', '1234 YQ', 'Heemdamseburg'),
+       (1112, 11, NULL, 1102, 'Testplek', 34, 1000, 'Special', 'Teststraat 2b', '1234 QY', 'Heemdamseburg');

--- a/backend/fixtures/election_11_dso.sql
+++ b/backend/fixtures/election_11_dso.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- number_of_seats explicitly set to a value less than 19, to be used in elections with less than 19 seats
-VALUES (11, 'Provinciale Staten Oost-Holland 2026', 'GSB', 'DSO', 'PS2026_Heemdamseburg', 'Heemdamseburg', '0065', 'Provincial', 'PS1', 15, 2000, '2026-11-30', '2026-11-01',
+VALUES (11, 'Waterschap Rivier en Polder 2026', 'GSB', 'DSO', 'AB2026_Heemdamseburg', 'Heemdamseburg', '0065', 'WaterAuthority', 'AB1', 15, 2000, '2026-11-30', '2026-11-01',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_12_dso_with_results.sql
+++ b/backend/fixtures/election_12_dso_with_results.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', '0000', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
+VALUES (12, 'Corrigendum Provinciale Staten Oost-Holland 2026', 'GSB', 'DSO', 'PS2026_Juinen', 'Juinen', '0035', 'Provincial', 'PS1', 23, 15000, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,
@@ -265,7 +265,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "T.",
                 "first_name": "Tinus",
                 "last_name": "Bakker",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male",
                 "country_code": "BE"
               },
@@ -273,7 +273,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "number": 2,
                 "initials": "D.",
                 "last_name": "Po",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "X"
               },
               {
@@ -282,7 +282,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "first_name": "Willem",
                 "last_name_prefix": "de",
                 "last_name": "Vries",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -290,7 +290,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "K.",
                 "first_name": "Klaas",
                 "last_name": "Kloosterboer",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -298,7 +298,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "L.",
                 "first_name": "Liesbeth",
                 "last_name": "Jansen",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -307,7 +307,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "first_name": "Henk",
                 "last_name_prefix": "van den",
                 "last_name": "Berg",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               }
             ]
@@ -321,7 +321,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "first_name": "Adelbert",
                 "last_name_prefix": "van",
                 "last_name": "Doorn",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -330,7 +330,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "first_name": "Margriet",
                 "last_name_prefix": "van der",
                 "last_name": "Linden",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -338,7 +338,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "P.",
                 "first_name": "Paul",
                 "last_name": "Veldkamp",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -347,7 +347,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "first_name": "Sophie",
                 "last_name_prefix": "de",
                 "last_name": "Groot",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -356,7 +356,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "first_name": "Rik",
                 "last_name_prefix": "de",
                 "last_name": "Ruiter",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -364,7 +364,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "N.",
                 "first_name": "Nico",
                 "last_name": "Ruiter",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               }
             ]
@@ -377,7 +377,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "G.",
                 "first_name": "Gerard",
                 "last_name": "Bogaert",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -385,7 +385,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "J.",
                 "first_name": "Jan",
                 "last_name": "Stevens",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -393,7 +393,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "E.",
                 "first_name": "Els",
                 "last_name": "Groot",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -401,7 +401,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "B.",
                 "first_name": "Bart",
                 "last_name": "Smit",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -409,7 +409,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "F.",
                 "first_name": "Frits",
                 "last_name": "Veldman",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               }
             ]
@@ -422,7 +422,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "G.",
                 "first_name": "Gert",
                 "last_name": "Smit",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -430,7 +430,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "E.",
                 "first_name": "Eva",
                 "last_name": "Koster",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -438,7 +438,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "L.",
                 "first_name": "Leon",
                 "last_name": "Hofman",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -446,7 +446,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
                 "initials": "S.",
                 "first_name": "Sophie",
                 "last_name": "Visser",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               }
             ]
@@ -454,7 +454,7 @@ VALUES (12, 'Corrigendum 2026', 'GSB', 'DSO', 'GR2026_GroteStad', 'Grote Stad', 
         ]');
 
 INSERT INTO committee_sessions (id, number, election_id, status, location, start_date_time)
-VALUES (12, 1, 12, 'completed', 'Grote Stad', '2026-03-19 09:15:00'),
+VALUES (12, 1, 12, 'completed', 'Juinen', '2026-03-19 09:15:00'),
        (13, 2, 12, 'data_entry', '', NULL);
 
 INSERT INTO
@@ -462,7 +462,7 @@ INSERT INTO
 VALUES
     (
         1201,
-        '{"status":"Definitive","state":{"first_entry_user_id":5,"second_entry_user_id":6,"finished_at":"2026-03-20T17:07:31.223365436Z","finalised_with_warnings":false,"results":{"model":"DSOFirstSession","about_report":{"corrigendum_present":"TwoDocuments","checks_and_corrections_present":"PagePresent"},"checks_and_corrections":{"reason_investigation_own_initiative":{"unaccounted_difference":true,"other_error":true},"corrected_results_own_initiative":{"yes":false,"no":true},"corrected_results_csb_request":{"yes":true,"no":false}},"voters_counts":{"poll_card_count":1203,"proxy_certificate_count":2,"total_admitted_voters_count":1205},"votes_counts":{"political_group_total_votes":[{"number":1,"total":600},{"number":2,"total":302},{"number":3,"total":98},{"number":4,"total":99},{"number":5,"total":101}],"total_votes_candidates_count":1200,"blank_votes_count":3,"invalid_votes_count":2,"total_votes_cast_count":1205},"differences_counts":{"compare_votes_cast_admitted_voters":{"admitted_voters_equal_votes_cast":true,"votes_cast_greater_than_admitted_voters":false,"votes_cast_smaller_than_admitted_voters":false},"more_ballots_count":0,"fewer_ballots_count":0,"difference_completely_accounted_for":{"yes":false,"no":false}},"political_group_votes":[{"number":1,"total":600,"candidate_votes":[{"number":1,"votes":78},{"number":2,"votes":20},{"number":3,"votes":55},{"number":4,"votes":45},{"number":5,"votes":50},{"number":6,"votes":0},{"number":7,"votes":60},{"number":8,"votes":40},{"number":9,"votes":30},{"number":10,"votes":20},{"number":11,"votes":50},{"number":12,"votes":0},{"number":13,"votes":0},{"number":14,"votes":0},{"number":15,"votes":0},{"number":16,"votes":0},{"number":17,"votes":0},{"number":18,"votes":0},{"number":19,"votes":0},{"number":20,"votes":0},{"number":21,"votes":0},{"number":22,"votes":0},{"number":23,"votes":0},{"number":24,"votes":0},{"number":25,"votes":0},{"number":26,"votes":0},{"number":27,"votes":0},{"number":28,"votes":0},{"number":29,"votes":0},{"number":30,"votes":152}]},{"number":2,"total":302,"candidate_votes":[{"number":1,"votes":150},{"number":2,"votes":50},{"number":3,"votes":22},{"number":4,"votes":10},{"number":5,"votes":30},{"number":6,"votes":40}]},{"number":3,"total":98,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":15},{"number":3,"votes":25},{"number":4,"votes":3},{"number":5,"votes":2},{"number":6,"votes":33}]},{"number":4,"total":99,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":15},{"number":3,"votes":25},{"number":4,"votes":24},{"number":5,"votes":15}]},{"number":5,"total":101,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":31},{"number":3,"votes":10},{"number":4,"votes":40}]}]}}}',
+        '{"status":"Definitive","state":{"first_entry_user_id":5,"second_entry_user_id":6,"finished_at":"2026-03-20T17:07:31.223365436Z","finalised_with_warnings":false,"results":{"model":"DSOFirstSession","about_report":{"corrigendum_present":"TwoDocuments","checks_and_corrections_present":"PagePresent"},"checks_and_corrections":{"reason_investigation_own_initiative":{"unaccounted_difference":true,"other_error":true},"corrected_results_own_initiative":{"yes":false,"no":true},"corrected_results_csb_request":{"yes":true,"no":false}},"voters_counts":{"poll_card_count":1200,"proxy_certificate_count":2,"voter_card_count":3,"total_admitted_voters_count":1205},"votes_counts":{"political_group_total_votes":[{"number":1,"total":600},{"number":2,"total":302},{"number":3,"total":98},{"number":4,"total":99},{"number":5,"total":101}],"total_votes_candidates_count":1200,"blank_votes_count":3,"invalid_votes_count":2,"total_votes_cast_count":1205},"differences_counts":{"compare_votes_cast_admitted_voters":{"admitted_voters_equal_votes_cast":true,"votes_cast_greater_than_admitted_voters":false,"votes_cast_smaller_than_admitted_voters":false},"more_ballots_count":0,"fewer_ballots_count":0,"difference_completely_accounted_for":{"yes":false,"no":false}},"political_group_votes":[{"number":1,"total":600,"candidate_votes":[{"number":1,"votes":78},{"number":2,"votes":20},{"number":3,"votes":55},{"number":4,"votes":45},{"number":5,"votes":50},{"number":6,"votes":0},{"number":7,"votes":60},{"number":8,"votes":40},{"number":9,"votes":30},{"number":10,"votes":20},{"number":11,"votes":50},{"number":12,"votes":0},{"number":13,"votes":0},{"number":14,"votes":0},{"number":15,"votes":0},{"number":16,"votes":0},{"number":17,"votes":0},{"number":18,"votes":0},{"number":19,"votes":0},{"number":20,"votes":0},{"number":21,"votes":0},{"number":22,"votes":0},{"number":23,"votes":0},{"number":24,"votes":0},{"number":25,"votes":0},{"number":26,"votes":0},{"number":27,"votes":0},{"number":28,"votes":0},{"number":29,"votes":0},{"number":30,"votes":152}]},{"number":2,"total":302,"candidate_votes":[{"number":1,"votes":150},{"number":2,"votes":50},{"number":3,"votes":22},{"number":4,"votes":10},{"number":5,"votes":30},{"number":6,"votes":40}]},{"number":3,"total":98,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":15},{"number":3,"votes":25},{"number":4,"votes":3},{"number":5,"votes":2},{"number":6,"votes":33}]},{"number":4,"total":99,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":15},{"number":3,"votes":25},{"number":4,"votes":24},{"number":5,"votes":15}]},{"number":5,"total":101,"candidate_votes":[{"number":1,"votes":20},{"number":2,"votes":31},{"number":3,"votes":10},{"number":4,"votes":40}]}]}}}',
         '2026-03-20 17:07:31'
     ),
     (
@@ -473,9 +473,9 @@ VALUES
 
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type,
                               address, postal_code, locality)
-VALUES (1218, 12, NULL, 1201, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad'),
-       (1229, 13, 1201, NULL, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad'),
-       (12211, 13, NULL, 1202, 'Test ander gebouw', 42, NULL, 'FixedLocation', 'Testweg 4', '1234 QA', 'Grote Stad');
+VALUES (1218, 12, NULL, 1201, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Juinen'),
+       (1229, 13, 1201, NULL, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Juinen'),
+       (12211, 13, NULL, 1202, 'Test ander gebouw', 42, NULL, 'FixedLocation', 'Testweg 4', '1234 QA', 'Juinen');
 
 UPDATE polling_stations
 SET investigation_state = '{"status":"ConcludedWithNewResults","state":{"reason":"reason","findings":"findings"}}'

--- a/backend/fixtures/election_12_dso_with_results.sql
+++ b/backend/fixtures/election_12_dso_with_results.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (12, 'Corrigendum Provinciale Staten Oost-Holland 2026', 'GSB', 'DSO', 'PS2026_Juinen', 'Juinen', '0035', 'Provincial', 'PS1', 23, 15000, '2026-03-18', '2026-02-02',
+VALUES (12, 'Corrigendum Waterschap Rivier en Polder 2026', 'GSB', 'DSO', 'AB2026_Juinen', 'Juinen', '0035', 'WaterAuthority', 'AB2', 23, 15000, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_2.sql
+++ b/backend/fixtures/election_2.sql
@@ -11,7 +11,7 @@ VALUES (2, 'Municipal Election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdams
                 "initials": "A.",
                 "first_name": "Alice",
                 "last_name": "Foo",
-                "locality": "Amsterdam",
+                "locality": "Heemdamseburg",
                 "gender": "Female"
               },
               {
@@ -19,7 +19,7 @@ VALUES (2, 'Municipal Election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdams
                 "initials": "C.",
                 "first_name": "Charlie",
                 "last_name": "Doe",
-                "locality": "Rotterdam",
+                "locality": "Heemdamseburg",
                 "gender": null
               }
             ]
@@ -32,7 +32,7 @@ VALUES (2, 'Municipal Election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdams
                 "initials": "A.",
                 "first_name": "Alice",
                 "last_name": "Foo",
-                "locality": "Amsterdam",
+                "locality": "Heemdamseburg",
                 "gender": "Female"
               },
               {
@@ -40,7 +40,7 @@ VALUES (2, 'Municipal Election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdams
                 "initials": "C.",
                 "first_name": "Charlie",
                 "last_name": "Doe",
-                "locality": "Rotterdam",
+                "locality": "Heemdamseburg",
                 "gender": null
               }
             ]
@@ -56,5 +56,5 @@ VALUES (201, '{"status":"Empty"}', '2024-12-05 09:15:00'),
 
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type, address,
                               postal_code, locality)
-VALUES (211, 2, NULL, 201, 'Op Rolletjes', 33, NULL, 'Mobile', 'Rijksweg A12 1', '1234 YQ', 'Den Haag'),
-       (212, 2, NULL, 202, 'Testplek', 34, 1000, 'Special', 'Teststraat 2b', '1234 QY', 'Testdorp');
+VALUES (211, 2, NULL, 201, 'Op Rolletjes', 33, NULL, 'Mobile', 'Rijksweg A12 1', '1234 YQ', 'Heemdamseburg'),
+       (212, 2, NULL, 202, 'Testplek', 34, 1000, 'Special', 'Teststraat 2b', '1234 QY', 'Heemdamseburg');

--- a/backend/fixtures/election_2.sql
+++ b/backend/fixtures/election_2.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- number_of_seats explicitly set to a value less than 19, to be used in elections with less than 19 seats
-VALUES (2, 'Municipal Election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 'GR1', 15, 2000, '2024-11-30', '2024-11-01',
+VALUES (2, 'Municipal Election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdamseburg', '0065', 'Municipal', 'GR1', 15, 2000, '2024-11-30', '2024-11-01',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_3.sql
+++ b/backend/fixtures/election_3.sql
@@ -10,7 +10,7 @@ VALUES (3, 'Municipal Re-election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemd
                 "initials": "A.",
                 "first_name": "Alice",
                 "last_name": "Foo",
-                "locality": "Amsterdam",
+                "locality": "Heemdamseburg",
                 "gender": "Female"
               },
               {
@@ -18,7 +18,7 @@ VALUES (3, 'Municipal Re-election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemd
                 "initials": "C.",
                 "first_name": "Charlie",
                 "last_name": "Doe",
-                "locality": "Rotterdam",
+                "locality": "Heemdamseburg",
                 "gender": null
               }
             ]
@@ -31,7 +31,7 @@ VALUES (3, 'Municipal Re-election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemd
                 "initials": "A.",
                 "first_name": "Alice",
                 "last_name": "Foo",
-                "locality": "Amsterdam",
+                "locality": "Heemdamseburg",
                 "gender": "Female"
               },
               {
@@ -39,7 +39,7 @@ VALUES (3, 'Municipal Re-election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemd
                 "initials": "C.",
                 "first_name": "Charlie",
                 "last_name": "Doe",
-                "locality": "Rotterdam",
+                "locality": "Heemdamseburg",
                 "gender": null
               }
             ]
@@ -55,4 +55,4 @@ VALUES (303, '{"status":"Empty"}', '2024-12-05 09:15:00');
 
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type, address,
                               postal_code, locality)
-VALUES (313, 3, NULL, 303, 'Testgebouw', 35, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Teststad');
+VALUES (313, 3, NULL, 303, 'Testgebouw', 35, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Heemdamseburg');

--- a/backend/fixtures/election_3.sql
+++ b/backend/fixtures/election_3.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (3, 'Municipal Re-election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdamseburg', '0000', 'Municipal', 'GR2', 29, 2000, '2024-12-31', '2024-12-01',
+VALUES (3, 'Municipal Re-election', 'GSB', 'CSO', 'GR2024_Heemdamseburg', 'Heemdamseburg', '0065', 'Municipal', 'GR2', 29, 2000, '2024-12-31', '2024-12-01',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_4.sql
+++ b/backend/fixtures/election_4.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (4, 'Test Election < 19 seats', 'GSB', 'CSO', 'TestLocation_2026', 'Test Location', '0000', 'Municipal', 'GR1', 15, 3000, '2026-03-18', '2026-02-02',
+VALUES (4, 'Test Election < 19 seats', 'GSB', 'CSO', 'GR2026_TestLocation', 'Test Location', '9101', 'Municipal', 'GR1', 15, 3000, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,
@@ -419,4 +419,4 @@ VALUES (407, '{"status":"Empty"}', '2024-12-05 09:15:00');
 
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type, address,
                               postal_code, locality)
-VALUES (417, 4, NULL, 407, 'Testgebouw', 40, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Klein Dorp');
+VALUES (417, 4, NULL, 407, 'Testgebouw', 40, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Test Location');

--- a/backend/fixtures/election_5_with_results.sql
+++ b/backend/fixtures/election_5_with_results.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '0000', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
+VALUES (5, 'Corrigendum Gemeenteraad Juinen 2026 ', 'GSB', 'CSO', 'GR2026_Juinen', 'Juinen', '0035', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,
@@ -265,7 +265,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "T.",
                 "first_name": "Tinus",
                 "last_name": "Bakker",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male",
                 "country_code": "BE"
               },
@@ -273,7 +273,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "number": 2,
                 "initials": "D.",
                 "last_name": "Po",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "X"
               },
               {
@@ -282,7 +282,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "first_name": "Willem",
                 "last_name_prefix": "de",
                 "last_name": "Vries",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -290,7 +290,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "K.",
                 "first_name": "Klaas",
                 "last_name": "Kloosterboer",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -298,7 +298,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "L.",
                 "first_name": "Liesbeth",
                 "last_name": "Jansen",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -307,7 +307,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "first_name": "Henk",
                 "last_name_prefix": "van den",
                 "last_name": "Berg",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               }
             ]
@@ -321,7 +321,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "first_name": "Adelbert",
                 "last_name_prefix": "van",
                 "last_name": "Doorn",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -330,7 +330,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "first_name": "Margriet",
                 "last_name_prefix": "van der",
                 "last_name": "Linden",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -338,7 +338,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "P.",
                 "first_name": "Paul",
                 "last_name": "Veldkamp",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -347,7 +347,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "first_name": "Sophie",
                 "last_name_prefix": "de",
                 "last_name": "Groot",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -356,7 +356,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "first_name": "Rik",
                 "last_name_prefix": "de",
                 "last_name": "Ruiter",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -364,7 +364,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "N.",
                 "first_name": "Nico",
                 "last_name": "Ruiter",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               }
             ]
@@ -377,7 +377,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "G.",
                 "first_name": "Gerard",
                 "last_name": "Bogaert",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -385,7 +385,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "J.",
                 "first_name": "Jan",
                 "last_name": "Stevens",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -393,7 +393,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "E.",
                 "first_name": "Els",
                 "last_name": "Groot",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -401,7 +401,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "B.",
                 "first_name": "Bart",
                 "last_name": "Smit",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -409,7 +409,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "F.",
                 "first_name": "Frits",
                 "last_name": "Veldman",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               }
             ]
@@ -422,7 +422,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "G.",
                 "first_name": "Gert",
                 "last_name": "Smit",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -430,7 +430,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "E.",
                 "first_name": "Eva",
                 "last_name": "Koster",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               },
               {
@@ -438,7 +438,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "L.",
                 "first_name": "Leon",
                 "last_name": "Hofman",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Male"
               },
               {
@@ -446,7 +446,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
                 "initials": "S.",
                 "first_name": "Sophie",
                 "last_name": "Visser",
-                "locality": "Test Location",
+                "locality": "Juinen",
                 "gender": "Female"
               }
             ]
@@ -454,7 +454,7 @@ VALUES (5, 'Corrigendum 2026', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '
         ]');
 
 INSERT INTO committee_sessions (id, number, election_id, status, location, start_date_time)
-VALUES (5, 1, 5, 'completed', 'Grote Stad', '2026-03-19 09:15:00'),
+VALUES (5, 1, 5, 'completed', 'Juinen', '2026-03-19 09:15:00'),
        (6, 2, 5, 'data_entry', '', NULL);
 
 INSERT INTO
@@ -473,9 +473,9 @@ VALUES
 
 INSERT INTO polling_stations (id, committee_session_id, prev_data_entry_id, data_entry_id, name, number, number_of_voters, polling_station_type,
                               address, postal_code, locality)
-VALUES (518, 5, NULL, 501, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad'),
-       (529, 6, 501, NULL, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Grote Stad'),
-       (5211, 6, NULL, 502, 'Test ander gebouw', 42, NULL, 'FixedLocation', 'Testweg 4', '1234 QA', 'Grote Stad');
+VALUES (518, 5, NULL, 501, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Juinen'),
+       (529, 6, 501, NULL, 'Testgebouw', 41, NULL, 'FixedLocation', 'Testweg 3', '1234 QA', 'Juinen'),
+       (5211, 6, NULL, 502, 'Test ander gebouw', 42, NULL, 'FixedLocation', 'Testweg 4', '1234 QA', 'Juinen');
 
 UPDATE polling_stations
 SET investigation_state = '{"status":"ConcludedWithNewResults","state":{"reason":"reason","findings":"findings"}}'

--- a/backend/fixtures/election_5_with_results.sql
+++ b/backend/fixtures/election_5_with_results.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (5, 'Corrigendum Gemeenteraad Juinen 2026 ', 'GSB', 'CSO', 'GR2026_Juinen', 'Juinen', '0035', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
+VALUES (5, 'Corrigendum Gemeenteraad Juinen 2026', 'GSB', 'CSO', 'GR2026_Juinen', 'Juinen', '0035', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,

--- a/backend/fixtures/election_6_no_polling_stations.sql
+++ b/backend/fixtures/election_6_no_polling_stations.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (6, 'Nieuwe Verkiezing', 'GSB', 'CSO','KleinDorp_2024', 'KleinDorp', '0123', 'Municipal', 'GR2', 29, 2500, '2024-12-31', '2024-12-01',
+VALUES (6, 'Nieuwe Verkiezing', 'GSB', 'CSO','GR2024_KleinDorp', 'Klein Dorp', '0123', 'Municipal', 'GR2', 29, 2500, '2024-12-31', '2024-12-01',
         '[
           {
             "number": 1,
@@ -10,7 +10,7 @@ VALUES (6, 'Nieuwe Verkiezing', 'GSB', 'CSO','KleinDorp_2024', 'KleinDorp', '012
                 "initials": "A.",
                 "first_name": "Alice",
                 "last_name": "Foo",
-                "locality": "Amsterdam",
+                "locality": "Klein Dorp",
                 "gender": "Female"
               },
               {
@@ -18,7 +18,7 @@ VALUES (6, 'Nieuwe Verkiezing', 'GSB', 'CSO','KleinDorp_2024', 'KleinDorp', '012
                 "initials": "C.",
                 "first_name": "Charlie",
                 "last_name": "Doe",
-                "locality": "Rotterdam",
+                "locality": "Klein Dorp",
                 "gender": null
               }
             ]
@@ -31,7 +31,7 @@ VALUES (6, 'Nieuwe Verkiezing', 'GSB', 'CSO','KleinDorp_2024', 'KleinDorp', '012
                 "initials": "A.",
                 "first_name": "Alice",
                 "last_name": "Foo",
-                "locality": "Amsterdam",
+                "locality": "Klein Dorp",
                 "gender": "Female"
               },
               {
@@ -39,7 +39,7 @@ VALUES (6, 'Nieuwe Verkiezing', 'GSB', 'CSO','KleinDorp_2024', 'KleinDorp', '012
                 "initials": "C.",
                 "first_name": "Charlie",
                 "last_name": "Doe",
-                "locality": "Rotterdam",
+                "locality": "Klein Dorp",
                 "gender": null
               }
             ]

--- a/backend/fixtures/election_7_four_sessions.sql
+++ b/backend/fixtures/election_7_four_sessions.sql
@@ -1,5 +1,5 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
-VALUES (7, 'Test Election >= 19 seats', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '0000', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
+VALUES (7, 'Test Election >= 19 seats', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote Stad', '0099', 'Municipal', 'GR2', 23, 15000, '2026-03-18', '2026-02-02',
         '[
           {
             "number": 1,
@@ -9,14 +9,14 @@ VALUES (7, 'Test Election >= 19 seats', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote
                 "number": 1,
                 "initials": "A.",
                 "last_name": "A-Een",
-                "locality": "Test",
+                "locality": "Grote Stad",
                 "gender": "X"
               },
               {
                 "number": 2,
-                "initials": "B.",
+                "initials": "A.",
                 "last_name": "A-Twee",
-                "locality": "Test",
+                "locality": "Grote Stad",
                 "gender": "Male"
               }
             ]
@@ -29,14 +29,14 @@ VALUES (7, 'Test Election >= 19 seats', 'GSB', 'CSO', 'GR2026_GroteStad', 'Grote
                 "number": 1,
                 "initials": "B.",
                 "last_name": "B-Een",
-                "locality": "Test",
+                "locality": "Grote Stad",
                 "gender": "Female"
               },
               {
                 "number": 2,
                 "initials": "B.",
                 "last_name": "B-Twee",
-                "locality": "Test",
+                "locality": "Grote Stad",
                 "gender": "X"
               }
             ]

--- a/backend/fixtures/election_8_csb_with_results.sql
+++ b/backend/fixtures/election_8_csb_with_results.sql
@@ -1,6 +1,6 @@
 INSERT INTO elections (id, name, committee_category, counting_method, election_id, location, domain_id, category, sub_category, number_of_seats, number_of_voters, election_date, nomination_date, political_groups)
 -- CSB election for GSB election_5_with_results
-VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', '9100', 'Municipal', 'GR2', 23, 1, '2024-11-30', '2024-11-01', '[
+VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', '0035', 'Municipal', 'GR2', 23, 1, '2024-11-30', '2024-11-01', '[
          {
            "number": 1,
            "registered_name": "Political Group A",

--- a/backend/fixtures/election_8_csb_with_results.sql
+++ b/backend/fixtures/election_8_csb_with_results.sql
@@ -265,7 +265,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "T.",
                "first_name": "Tinus",
                "last_name": "Bakker",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male",
                "country_code": "BE"
              },
@@ -273,7 +273,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "number": 2,
                "initials": "D.",
                "last_name": "Po",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "X"
              },
              {
@@ -282,7 +282,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "first_name": "Willem",
                "last_name_prefix": "de",
                "last_name": "Vries",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -290,7 +290,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "K.",
                "first_name": "Klaas",
                "last_name": "Kloosterboer",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -298,7 +298,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "L.",
                "first_name": "Liesbeth",
                "last_name": "Jansen",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Female"
              },
              {
@@ -307,7 +307,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "first_name": "Henk",
                "last_name_prefix": "van den",
                "last_name": "Berg",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              }
            ]
@@ -321,7 +321,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "first_name": "Adelbert",
                "last_name_prefix": "van",
                "last_name": "Doorn",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -330,7 +330,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "first_name": "Margriet",
                "last_name_prefix": "van der",
                "last_name": "Linden",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Female"
              },
              {
@@ -338,7 +338,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "P.",
                "first_name": "Paul",
                "last_name": "Veldkamp",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -347,7 +347,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "first_name": "Sophie",
                "last_name_prefix": "de",
                "last_name": "Groot",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Female"
              },
              {
@@ -356,7 +356,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "first_name": "Rik",
                "last_name_prefix": "de",
                "last_name": "Ruiter",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -364,7 +364,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "N.",
                "first_name": "Nico",
                "last_name": "Ruiter",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              }
            ]
@@ -377,7 +377,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "G.",
                "first_name": "Gerard",
                "last_name": "Bogaert",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -385,7 +385,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "J.",
                "first_name": "Jan",
                "last_name": "Stevens",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -393,7 +393,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "E.",
                "first_name": "Els",
                "last_name": "Groot",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Female"
              },
              {
@@ -401,7 +401,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "B.",
                "first_name": "Bart",
                "last_name": "Smit",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -409,7 +409,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "F.",
                "first_name": "Frits",
                "last_name": "Veldman",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              }
            ]
@@ -422,7 +422,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "G.",
                "first_name": "Gert",
                "last_name": "Smit",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -430,7 +430,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "E.",
                "first_name": "Eva",
                "last_name": "Koster",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Female"
              },
              {
@@ -438,7 +438,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "L.",
                "first_name": "Leon",
                "last_name": "Hofman",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Male"
              },
              {
@@ -446,7 +446,7 @@ VALUES (8, 'Test Election >= 19 seats', 'CSB', NULL, 'GR2024_Juinen', 'Juinen', 
                "initials": "S.",
                "first_name": "Sophie",
                "last_name": "Visser",
-               "locality": "Test Location",
+               "locality": "Juinen",
                "gender": "Female"
              }
            ]
@@ -462,4 +462,4 @@ VALUES (801,
         '2026-03-20 17:07:31');
 
 INSERT INTO sub_committees (id, committee_session_id, data_entry_id, name, number, category)
-VALUES (811, 801, 801, 'Juinen', 9100, 'GSB');
+VALUES (811, 801, 801, 'Juinen', 0035, 'GSB');

--- a/backend/fixtures/election_9_csb.sql
+++ b/backend/fixtures/election_9_csb.sql
@@ -418,4 +418,4 @@ INSERT INTO data_entries (id, state, updated_at)
 VALUES (901, '{"status":"Empty"}', '2024-12-05 09:15:00');
 
 INSERT INTO sub_committees (id, committee_session_id, data_entry_id, name, number, category)
-VALUES (911, 901, 901, 'Juinen', 9101, 'GSB');
+VALUES (911, 901, 901, 'Test Location', 9101, 'GSB');

--- a/backend/src/domain/report/files.rs
+++ b/backend/src/domain/report/files.rs
@@ -317,9 +317,9 @@ mod tests {
             let csv = files.results_csv.expect("should have generated csv");
             let pdf = files.results_pdf.expect("should have generated pdf");
 
-            assert_eq!(eml.name, "Telling_GR2026_GroteStad.eml.xml");
+            assert_eq!(eml.name, "Telling_GR2026_Juinen.eml.xml");
             assert_eq!(eml.id, FileId::from(1));
-            assert_eq!(csv.name, "osv4-3_telling_gr2026_grotestad.csv");
+            assert_eq!(csv.name, "osv4-3_telling_gr2026_juinen.csv");
             assert_eq!(csv.id, FileId::from(2));
             assert_eq!(pdf.name, "Model_Na31-2.pdf");
             assert_eq!(pdf.id, FileId::from(3));

--- a/backend/src/infra/seed_data.rs
+++ b/backend/src/infra/seed_data.rs
@@ -27,6 +27,8 @@ const FIXTURES: &[Fixture] = load_fixtures!([
     "election_1",
     "election_5_with_results",
     "election_8_csb_with_results",
+    "election_11_dso",
+    "election_12_dso_with_results",
     "users"
 ]);
 

--- a/backend/src/service/sub_committee.rs
+++ b/backend/src/service/sub_committee.rs
@@ -83,9 +83,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(list.len(), 2);
-        assert_eq!(list[0].sub_committee.id, created.sub_committee.id);
-        assert_eq!(list[0].sub_committee.name, "Test GSB");
-        assert_eq!(list[0].sub_committee.category, CommitteeCategory::GSB);
-        assert_eq!(list[0].data_entry_id, created.data_entry_id);
+        assert_eq!(list[1].sub_committee.id, created.sub_committee.id);
+        assert_eq!(list[1].sub_committee.name, "Test GSB");
+        assert_eq!(list[1].sub_committee.category, CommitteeCategory::GSB);
+        assert_eq!(list[1].data_entry_id, created.data_entry_id);
     }
 }

--- a/backend/tests/integration_tests/apportionment_integration_test.rs
+++ b/backend/tests/integration_tests/apportionment_integration_test.rs
@@ -400,7 +400,7 @@ async fn test_api_output(pool: SqlitePool) {
             "initials": "T.",
             "first_name": "Tinus",
             "last_name": "Bakker",
-            "locality": "Test Location",
+            "locality": "Juinen",
             "gender": "Male",
             "country_code": "BE",
             "list_number": 2,
@@ -432,12 +432,12 @@ async fn test_api_output(pool: SqlitePool) {
     assert_eq!(
         second_list_nomination["updated_candidate_ranking"],
         json!([
-            { "number": 1, "initials": "T.", "first_name": "Tinus", "last_name": "Bakker", "locality": "Test Location", "gender": "Male", "country_code": "BE" },
-            { "number": 2, "initials": "D.", "last_name": "Po", "locality": "Test Location", "gender": "X" },
-            { "number": 6, "initials": "H.", "first_name": "Henk", "last_name_prefix": "van den", "last_name": "Berg", "locality": "Test Location", "gender": "Male" },
-            { "number": 5, "initials": "L.", "first_name": "Liesbeth", "last_name": "Jansen", "locality": "Test Location", "gender": "Female" },
-            { "number": 3, "initials": "W.", "first_name": "Willem", "last_name_prefix": "de", "last_name": "Vries", "locality": "Test Location", "gender": "Male" },
-            { "number": 4, "initials": "K.", "first_name": "Klaas", "last_name": "Kloosterboer", "locality": "Test Location", "gender": "Male" }
+            { "number": 1, "initials": "T.", "first_name": "Tinus", "last_name": "Bakker", "locality": "Juinen", "gender": "Male", "country_code": "BE" },
+            { "number": 2, "initials": "D.", "last_name": "Po", "locality": "Juinen", "gender": "X" },
+            { "number": 6, "initials": "H.", "first_name": "Henk", "last_name_prefix": "van den", "last_name": "Berg", "locality": "Juinen", "gender": "Male" },
+            { "number": 5, "initials": "L.", "first_name": "Liesbeth", "last_name": "Jansen", "locality": "Juinen", "gender": "Female" },
+            { "number": 3, "initials": "W.", "first_name": "Willem", "last_name_prefix": "de", "last_name": "Vries", "locality": "Juinen", "gender": "Male" },
+            { "number": 4, "initials": "K.", "first_name": "Klaas", "last_name": "Kloosterboer", "locality": "Juinen", "gender": "Male" }
         ])
     );
 }

--- a/backend/tests/integration_tests/election_integration_test.rs
+++ b/backend/tests/integration_tests/election_integration_test.rs
@@ -57,7 +57,10 @@ async fn test_election_details_works(pool: SqlitePool) {
     let body: serde_json::Value = response.json().await.unwrap();
     assert_eq!(body["current_committee_session"]["status"], "data_entry");
     assert_eq!(body["committee_sessions"].as_array().unwrap().len(), 2);
-    assert_eq!(body["election"]["name"], "Corrigendum 2026");
+    assert_eq!(
+        body["election"]["name"],
+        "Corrigendum Gemeenteraad Juinen 2026"
+    );
     let polling_stations = body["polling_stations"].as_array().unwrap();
     assert_eq!(polling_stations.len(), 2);
     assert!(polling_stations.iter().any(|ps| ps["name"] == "Testgebouw"));

--- a/backend/tests/integration_tests/report_integration_test.rs
+++ b/backend/tests/integration_tests/report_integration_test.rs
@@ -154,18 +154,18 @@ async fn test_gsb_election_next_session_zip_download_works(pool: SqlitePool) {
     let url = format!(
         "http://{addr}/api/elections/{election_id}/committee_sessions/{committee_session_id}/download_zip_results"
     );
-    let prefix = "\"correctie_gr2026_grotestad_gemeente_grote-stad-";
+    let prefix = "\"correctie_gr2026_juinen_gemeente_juinen-";
 
     let bytes = download_zip_assert(&cookie, &url, prefix).await;
     let archive = ZipFileReader::new(bytes).await.unwrap();
     assert_eq!(archive.file().entries().len(), 4);
     let pdf_hash1 = sha2::Sha256::digest(read_zip_entry(&archive, 0, "Model_Na14-2.pdf").await);
-    let xml_zip = read_zip_entry(&archive, 1, "Telling_GR2026_GroteStad.zip").await;
-    let csv = read_zip_entry(&archive, 2, "osv4-3_telling_gr2026_grotestad.csv").await;
+    let xml_zip = read_zip_entry(&archive, 1, "Telling_GR2026_Juinen.zip").await;
+    let csv = read_zip_entry(&archive, 2, "osv4-3_telling_gr2026_juinen.csv").await;
     let xml_archive = ZipFileReader::new(xml_zip).await.unwrap();
     assert_eq!(xml_archive.file().entries().len(), 1);
     let eml_hash1 = sha2::Sha256::digest(
-        read_zip_entry(&xml_archive, 0, "Telling_GR2026_GroteStad.eml.xml").await,
+        read_zip_entry(&xml_archive, 0, "Telling_GR2026_Juinen.eml.xml").await,
     );
     let pdf_overview_hash1 =
         sha2::Sha256::digest(read_zip_entry(&archive, 3, "Leeg_Model_P2a.pdf").await);
@@ -174,13 +174,13 @@ async fn test_gsb_election_next_session_zip_download_works(pool: SqlitePool) {
     let archive2 = ZipFileReader::new(bytes2).await.unwrap();
     assert_eq!(archive2.file().entries().len(), 4);
     let pdf_hash2 = sha2::Sha256::digest(read_zip_entry(&archive2, 0, "Model_Na14-2.pdf").await);
-    let xml_zip2 = read_zip_entry(&archive2, 1, "Telling_GR2026_GroteStad.zip").await;
-    let csv2 = read_zip_entry(&archive2, 2, "osv4-3_telling_gr2026_grotestad.csv").await;
+    let xml_zip2 = read_zip_entry(&archive2, 1, "Telling_GR2026_Juinen.zip").await;
+    let csv2 = read_zip_entry(&archive2, 2, "osv4-3_telling_gr2026_juinen.csv").await;
     assert_eq!(csv, csv2, "CSV count files should be the same");
     let xml_archive2 = ZipFileReader::new(xml_zip2).await.unwrap();
     assert_eq!(xml_archive2.file().entries().len(), 1);
     let eml_hash2 = sha2::Sha256::digest(
-        read_zip_entry(&xml_archive2, 0, "Telling_GR2026_GroteStad.eml.xml").await,
+        read_zip_entry(&xml_archive2, 0, "Telling_GR2026_Juinen.eml.xml").await,
     );
     let pdf_overview_hash2 =
         sha2::Sha256::digest(read_zip_entry(&archive2, 3, "Leeg_Model_P2a.pdf").await);


### PR DESCRIPTION
Closes #3823 

## What & why

- Cleaned up existing election fixtures
  - Made sure `election_id`s are correct
  - Made `domain_id`s consistent
  - Made `location`s consistent within fixtures
- Changed DSO elections to Water Authority elections
  - Added `voter_card_count` to data entry in `election_12_dso_with_results` fixture
- Added DSO elections to seed data to make sure they exist on the dev page

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Verify that the dev page now includes GSB DSO elections

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->