### PR TITLE
Implement DSO tabulation with new data types

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5939,6 +5939,45 @@
         },
         "additionalProperties": false
       },
+      "CSOInvestigations": {
+        "type": "object",
+        "description": "Polling stations where results were investigated by the GSB,\nas vectors of polling station numbers",
+        "required": [
+          "admitted_voters_recounted",
+          "investigated_other_reason",
+          "ballots_recounted"
+        ],
+        "properties": {
+          "admitted_voters_recounted": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Admitted voters were recounted\n(\"Toegelaten kiezers opnieuw vastgesteld?\")"
+          },
+          "ballots_recounted": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Ballots were (partially) recounted\n(\"Stembiljetten (deels) herteld?\")"
+          },
+          "investigated_other_reason": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Investigated for other reasons than unexplained difference\n(\"Onderzocht vanwege andere reden dan onverklaard verschil?\")"
+          }
+        },
+        "additionalProperties": false
+      },
       "Candidate": {
         "type": "object",
         "description": "Candidate",
@@ -6315,6 +6354,56 @@
         },
         "additionalProperties": false
       },
+      "CommitteeSpecificTotals": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GSBTotals",
+                "description": "Totals specific to a municipal electoral committee (gemeentelijk stembureau, GSB)"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "committee"
+                ],
+                "properties": {
+                  "committee": {
+                    "type": "string",
+                    "enum": [
+                      "GSB"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Totals specific to a municipal electoral committee (gemeentelijk stembureau, GSB)"
+          },
+          {
+            "type": "object",
+            "description": "Totals specific to a central electoral committee (centraal stembureau, CSB)",
+            "required": [
+              "number_of_voters",
+              "committee"
+            ],
+            "properties": {
+              "committee": {
+                "type": "string",
+                "enum": [
+                  "CSB"
+                ]
+              },
+              "number_of_voters": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The number of voters (\"Kiesgerechtigden\")",
+                "minimum": 0
+              }
+            }
+          }
+        ],
+        "description": "Committee specific totals, i.e. specific for GSB or CSB."
+      },
       "CommonPollingStationResults": {
         "type": "object",
         "description": "CommonPollingStationResults contains the common fields for polling station results,",
@@ -6473,6 +6562,45 @@
             "description": "Votes counts (\"2. Aantal getelde stembiljetten\")"
           }
         }
+      },
+      "DSOInvestigations": {
+        "type": "object",
+        "description": "Polling stations where results were investigated by the GSB,\nas vectors of polling station numbers",
+        "required": [
+          "unaccounted_difference",
+          "other_error",
+          "corrected_results"
+        ],
+        "properties": {
+          "corrected_results": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Results were corrected\n(\"Uitslag gecorrigeerd?\")"
+          },
+          "other_error": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Investigated because of a (suspected) other error\n(\"Onderzocht vanwege (het vermoeden van) een andere fout?\")"
+          },
+          "unaccounted_difference": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Investigated because of an unaccounted-for difference\n(\"Onderzocht vanwege een onverklaard verschil?\")"
+          }
+        },
+        "additionalProperties": false
       },
       "DataEntry": {
         "type": "object",
@@ -7248,18 +7376,16 @@
           "votes_counts",
           "differences_counts",
           "political_group_votes",
-          "polling_station_investigations"
+          "committee_specific"
         ],
         "properties": {
+          "committee_specific": {
+            "$ref": "#/components/schemas/CommitteeSpecificTotals",
+            "description": "Totals specific to the committee (GSB or CSB) of the election"
+          },
           "differences_counts": {
             "$ref": "#/components/schemas/DifferencesTotals",
             "description": "The differences between voters and votes"
-          },
-          "number_of_voters": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The number of voters (i.e. \"Kiesgerechtigden\")",
-            "minimum": 0
           },
           "political_group_votes": {
             "type": "array",
@@ -7267,10 +7393,6 @@
               "$ref": "#/components/schemas/PoliticalGroupCandidateVotes"
             },
             "description": "The total votes for each political group (and each candidate within)"
-          },
-          "polling_station_investigations": {
-            "$ref": "#/components/schemas/PollingStationInvestigations",
-            "description": "Polling stations where results were investigated by the GSB"
           },
           "voters_counts": {
             "$ref": "#/components/schemas/VotersCounts",
@@ -7627,6 +7749,57 @@
           }
         },
         "additionalProperties": false
+      },
+      "GSBTotals": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CSOInvestigations",
+                "description": "Totals specific to centrally counted (centrale stemopneming, CSO) results"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "counting_method"
+                ],
+                "properties": {
+                  "counting_method": {
+                    "type": "string",
+                    "enum": [
+                      "CSO"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Totals specific to centrally counted (centrale stemopneming, CSO) results"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DSOInvestigations",
+                "description": "Totals specific to decentrally counted (decentrale stemopneming, DSO) results"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "counting_method"
+                ],
+                "properties": {
+                  "counting_method": {
+                    "type": "string",
+                    "enum": [
+                      "DSO"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Totals specific to decentrally counted (decentrale stemopneming, DSO) results"
+          }
+        ],
+        "description": "GSB specific totals, depending on the vote counting method (CSO or DSO)."
       },
       "GenerateElectionArgs": {
         "type": "object",
@@ -8681,45 +8854,6 @@
           },
           "reason": {
             "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PollingStationInvestigations": {
-        "type": "object",
-        "description": "Polling stations where results were investigated by the GSB,\nas vectors of polling station numbers",
-        "required": [
-          "admitted_voters_recounted",
-          "investigated_other_reason",
-          "ballots_recounted"
-        ],
-        "properties": {
-          "admitted_voters_recounted": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
-            },
-            "description": "Admitted voters were recounted\n(\"Toegelaten kiezers opnieuw vastgesteld?\")"
-          },
-          "ballots_recounted": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
-            },
-            "description": "Ballots were (partially) recounted\n(\"Stembiljetten (deels) herteld?\")"
-          },
-          "investigated_other_reason": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
-            },
-            "description": "Investigated for other reasons than unexplained difference\n(\"Onderzocht vanwege andere reden dan onverklaard verschil?\")"
           }
         },
         "additionalProperties": false

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -302,8 +302,10 @@ async fn export_election(
             ElectionTotals::tabulate(election, &results).expect("Failed to create election totals");
         let input = ModelNa31_2Input {
             votes_tables: VotesTables::new(election, &election_totals)
-                .expect("Failed to create votes tables"),
-            summary: election_totals.into(),
+                .expect("Votes tables should be created"),
+            summary: election_totals
+                .try_into()
+                .expect("Election totals should be converted to summary"),
             committee_session: committee_session.clone(),
             polling_stations: polling_stations.iter().map(Clone::clone).collect(),
             election: election.clone().into(),

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -271,7 +271,10 @@ mod tests {
                 political_group_total_votes::PoliticalGroupTotalVotes, voters_counts::VotersCounts,
                 votes_counts::VotesCounts,
             },
-            tabulation::{DifferencesTotals, ElectionTotals, ElectionTotalsCSB, SumCount},
+            tabulation::{
+                CommitteeSpecificTotals, DifferencesTotals, ElectionTotals, ElectionTotalsCSB,
+                SumCount,
+            },
         },
     };
 
@@ -308,8 +311,9 @@ mod tests {
                 fewer_ballots_count: SumCount::zero(),
             },
             political_group_votes,
-            polling_station_investigations: Default::default(),
-            number_of_voters: Some(election.number_of_voters),
+            committee_specific: CommitteeSpecificTotals::CSB {
+                number_of_voters: election.number_of_voters,
+            },
         }
     }
 
@@ -334,7 +338,8 @@ mod tests {
         );
         let political_groups = &election.political_groups;
         let totals = get_election_totals(&election, &candidate_votes);
-        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups);
+        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups)
+            .expect("ElectionTotalsCSB::new should succeed");
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
             &totals.political_group_votes,
@@ -458,7 +463,8 @@ mod tests {
         );
         let political_groups = &election.political_groups;
         let totals = get_election_totals(&election, &candidate_votes);
-        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups);
+        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups)
+            .expect("ElectionTotalsCSB::new should succeed");
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
             &totals.political_group_votes,
@@ -550,7 +556,8 @@ mod tests {
         );
         let political_groups = &election.political_groups;
         let totals = get_election_totals(&election, &candidate_votes);
-        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups);
+        let totals_csb = ElectionTotalsCSB::new(&totals, political_groups)
+            .expect("ElectionTotalsCSB::new should succeed");
         let apportionment_input = ApportionmentInputData::new(
             election.number_of_seats,
             &totals.political_group_votes,

--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -350,7 +350,7 @@ impl ResultsInputCSB {
     ) -> Result<PdfFileModel, APIError> {
         let data = &self.data;
 
-        let totals_csb = ElectionTotalsCSB::new(&data.totals, &data.election.political_groups);
+        let totals_csb = ElectionTotalsCSB::new(&data.totals, &data.election.political_groups)?;
         let seat_assignment = map_seat_assignment(&apportionment_result.seat_assignment);
         let enriched_seat_assignment = EnrichedSeatAssignment::new(
             data.election.number_of_seats,
@@ -500,8 +500,8 @@ impl ResultsInputGSB {
             )?,
             committee_session: data.committee_session.clone(),
             election: data.election.clone().into(),
-            summary: data.totals.clone().into(),
-            previous_summary: previous_totals.clone().into(),
+            summary: data.totals.clone().try_into()?,
+            previous_summary: previous_totals.clone().try_into()?,
             previous_committee_session: previous_committee_session.clone(),
             hash,
             creation_date_time,
@@ -522,7 +522,7 @@ impl ResultsInputGSB {
             votes_tables: VotesTables::new(&data.election, &data.totals)?,
             committee_session: data.committee_session.clone(),
             polling_stations: data.polling_stations.clone(),
-            summary: data.totals.clone().into(),
+            summary: data.totals.clone().try_into()?,
             election: data.election.clone().into(),
             hash,
             creation_date_time,

--- a/backend/src/domain/tabulation.rs
+++ b/backend/src/domain/tabulation.rs
@@ -5,12 +5,15 @@ use crate::{
     APIError,
     domain::{
         data_entry::{DataEntrySource, DataEntrySourceNumber},
-        election::{ElectionWithPoliticalGroups, PoliticalGroup},
+        election::{
+            CommitteeCategory, ElectionWithPoliticalGroups, PoliticalGroup, VoteCountingMethod,
+        },
         polling_station::PollingStationForSession,
         results::{
             CommonDifferencesCounts, Results,
             count::Count,
             cso_first_session_results::CSOFirstSessionResults,
+            dso_first_session_results::DSOFirstSessionResults,
             political_group_candidate_votes::{CandidateVotes, PoliticalGroupCandidateVotes},
             political_group_total_votes::{
                 EnrichedPoliticalGroupTotalVotes, PoliticalGroupTotalVotes,
@@ -35,12 +38,8 @@ pub struct ElectionTotals {
     pub differences_counts: DifferencesTotals,
     /// The total votes for each political group (and each candidate within)
     pub political_group_votes: Vec<PoliticalGroupCandidateVotes>,
-    /// Polling stations where results were investigated by the GSB
-    pub polling_station_investigations: PollingStationInvestigations,
-    /// The number of voters (i.e. "Kiesgerechtigden")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
-    pub number_of_voters: Option<u32>,
+    /// Totals specific to the committee (GSB or CSB) of the election
+    pub committee_specific: CommitteeSpecificTotals,
 }
 
 impl ElectionTotals {
@@ -61,9 +60,8 @@ impl ElectionTotals {
                 total_votes_cast_count: 0,
             },
             differences_counts: DifferencesTotals::zero(),
-            polling_station_investigations: PollingStationInvestigations::default(),
             political_group_votes: vec![],
-            number_of_voters: None,
+            committee_specific: CommitteeSpecificTotals::zero(election),
         }
     }
 
@@ -120,31 +118,8 @@ impl ElectionTotals {
                 pg_total.add(pg)?;
             }
 
-            // For the first session CSO results, we need to add investigation status information to the totals
-            if let Results::CSOFirstSession(cso_first_result) = result {
-                // the data source must be a polling station at this point
-                let DataEntrySource::PollingStation(polling_station_source) = data_source else {
-                    return Err(APIError::AddError(
-                        format!(
-                            "Expected polling station data entry source, got {:?}",
-                            data_source
-                        ),
-                        ErrorReference::InvalidDataEntrySource,
-                    ));
-                };
-
-                // add checkbox states for this polling station
-                totals
-                    .polling_station_investigations
-                    .append_result(polling_station_source, cso_first_result);
-            }
-
-            // GSB results contain number of voters which need to be added
-            if let Results::GSB(gsb_result) = result {
-                // this retrieves the current total number of voters, or initializes it to zero if not yet set
-                // and then adds the number of voters for this result to it
-                *totals.number_of_voters.get_or_insert(0) += gsb_result.number_of_voters;
-            }
+            // add the result data that is specific to the committee (GSB, CSB)
+            totals.committee_specific.add_result(data_source, result)?;
 
             touched_data_sources.push(data_source.number());
         }
@@ -191,6 +166,112 @@ impl ElectionTotals {
 
         Ok(totals)
     }
+}
+
+/// Extract the polling station from a data entry source,
+/// returning an error for other kinds of data entry sources.
+fn polling_station_source(
+    data_source: &DataEntrySource,
+) -> Result<&PollingStationForSession, APIError> {
+    let DataEntrySource::PollingStation(polling_station_source) = data_source else {
+        return Err(APIError::AddError(
+            format!(
+                "Expected polling station data entry source, got {:?}",
+                data_source
+            ),
+            ErrorReference::InvalidDataEntrySource,
+        ));
+    };
+
+    Ok(polling_station_source)
+}
+
+/// Committee specific totals, i.e. specific for GSB or CSB.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq)]
+#[serde(tag = "committee")]
+pub enum CommitteeSpecificTotals {
+    /// Totals specific to a municipal electoral committee (gemeentelijk stembureau, GSB)
+    GSB(GSBTotals),
+    /// Totals specific to a central electoral committee (centraal stembureau, CSB)
+    CSB {
+        /// The number of voters ("Kiesgerechtigden")
+        number_of_voters: u32,
+    },
+}
+
+impl CommitteeSpecificTotals {
+    /// Initialize new committee specific totals for the committee and vote
+    /// counting method of the given election.
+    pub fn zero(election: &ElectionWithPoliticalGroups) -> CommitteeSpecificTotals {
+        match election.committee_category {
+            CommitteeCategory::GSB => match election.counting_method {
+                Some(VoteCountingMethod::CSO) => {
+                    CommitteeSpecificTotals::GSB(GSBTotals::CSO(CSOInvestigations::default()))
+                }
+                Some(VoteCountingMethod::DSO) => {
+                    CommitteeSpecificTotals::GSB(GSBTotals::DSO(DSOInvestigations::default()))
+                }
+                None => panic!("Invalid election"),
+            },
+            CommitteeCategory::CSB => CommitteeSpecificTotals::CSB {
+                number_of_voters: 0,
+            },
+        }
+    }
+
+    /// Add the result data that is specific to the committee (GSB or CSB).
+    fn add_result(
+        &mut self,
+        data_source: &DataEntrySource,
+        result: &Results,
+    ) -> Result<(), APIError> {
+        match (self, result) {
+            // for the first session results, we need to add investigation status information to the totals
+            (
+                CommitteeSpecificTotals::GSB(GSBTotals::CSO(investigations)),
+                Results::CSOFirstSession(cso_first_result),
+            ) => {
+                investigations
+                    .append_result(polling_station_source(data_source)?, cso_first_result);
+            }
+            (
+                CommitteeSpecificTotals::GSB(GSBTotals::DSO(investigations)),
+                Results::DSOFirstSession(dso_first_result),
+            ) => {
+                investigations
+                    .append_result(polling_station_source(data_source)?, dso_first_result);
+            }
+            // next session results contain no investigation status information
+            (CommitteeSpecificTotals::GSB(GSBTotals::CSO(_)), Results::CSONextSession(_))
+            | (CommitteeSpecificTotals::GSB(GSBTotals::DSO(_)), Results::DSONextSession(_)) => {}
+            // GSB results contain number of voters which need to be added
+            (CommitteeSpecificTotals::CSB { number_of_voters }, Results::GSB(gsb_result)) => {
+                *number_of_voters += gsb_result.number_of_voters;
+            }
+            // any other combination means the result model does not match the election
+            _ => {
+                return Err(APIError::AddError(
+                    format!(
+                        "Result model of data entry source {} does not match the election",
+                        data_source.number()
+                    ),
+                    ErrorReference::InvalidData,
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// GSB specific totals, depending on the vote counting method (CSO or DSO).
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq)]
+#[serde(tag = "counting_method")]
+pub enum GSBTotals {
+    /// Totals specific to centrally counted (centrale stemopneming, CSO) results
+    CSO(CSOInvestigations),
+    /// Totals specific to decentrally counted (decentrale stemopneming, DSO) results
+    DSO(DSOInvestigations),
 }
 
 /// Contains the totals of the differences, containing which polling stations had differences.
@@ -255,7 +336,7 @@ impl SumCount {
 /// as vectors of polling station numbers
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct PollingStationInvestigations {
+pub struct CSOInvestigations {
     /// Admitted voters were recounted
     /// ("Toegelaten kiezers opnieuw vastgesteld?")
     pub admitted_voters_recounted: Vec<u32>,
@@ -267,7 +348,7 @@ pub struct PollingStationInvestigations {
     pub ballots_recounted: Vec<u32>,
 }
 
-impl PollingStationInvestigations {
+impl CSOInvestigations {
     pub fn append_result(
         &mut self,
         polling_station: &PollingStationForSession,
@@ -297,6 +378,52 @@ impl PollingStationInvestigations {
     }
 }
 
+/// Polling stations where results were investigated by the GSB,
+/// as vectors of polling station numbers
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, Default, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct DSOInvestigations {
+    /// Investigated because of an unaccounted-for difference
+    /// ("Onderzocht vanwege een onverklaard verschil?")
+    pub unaccounted_difference: Vec<u32>,
+    /// Investigated because of a (suspected) other error
+    /// ("Onderzocht vanwege (het vermoeden van) een andere fout?")
+    pub other_error: Vec<u32>,
+    /// Results were corrected
+    /// ("Uitslag gecorrigeerd?")
+    pub corrected_results: Vec<u32>,
+}
+
+impl DSOInvestigations {
+    pub fn append_result(
+        &mut self,
+        polling_station: &PollingStationForSession,
+        result: &DSOFirstSessionResults,
+    ) {
+        let checks = &result.checks_and_corrections;
+
+        // investigation because of an unaccounted-for difference
+        if checks
+            .reason_investigation_own_initiative
+            .unaccounted_difference
+        {
+            self.unaccounted_difference.push(polling_station.number());
+        }
+
+        // investigation because of a (suspected) other error
+        if checks.reason_investigation_own_initiative.other_error {
+            self.other_error.push(polling_station.number());
+        }
+
+        // whether the investigation has led to corrected results
+        if checks.corrected_results_own_initiative.as_bool() == Some(true)
+            || checks.corrected_results_csb_request.as_bool() == Some(true)
+        {
+            self.corrected_results.push(polling_station.number());
+        }
+    }
+}
+
 /// A version of ElectionTotals without the political group votes.
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -308,17 +435,27 @@ pub struct ElectionTotalsWithoutVotes {
     /// The differences between voters and votes
     pub differences_counts: DifferencesTotals,
     /// Polling stations where results were investigated by the GSB
-    pub polling_station_investigations: PollingStationInvestigations,
+    pub polling_station_investigations: CSOInvestigations,
 }
 
-impl From<ElectionTotals> for ElectionTotalsWithoutVotes {
-    fn from(totals: ElectionTotals) -> Self {
-        ElectionTotalsWithoutVotes {
+impl TryFrom<ElectionTotals> for ElectionTotalsWithoutVotes {
+    type Error = APIError;
+
+    fn try_from(totals: ElectionTotals) -> Result<Self, Self::Error> {
+        let CommitteeSpecificTotals::GSB(GSBTotals::CSO(polling_station_investigations)) =
+            totals.committee_specific
+        else {
+            return Err(APIError::DataIntegrityError(
+                "Election totals without votes can only be created for CSO totals".to_string(),
+            ));
+        };
+
+        Ok(ElectionTotalsWithoutVotes {
             voters_counts: totals.voters_counts,
             votes_counts: totals.votes_counts,
             differences_counts: totals.differences_counts,
-            polling_station_investigations: totals.polling_station_investigations,
-        }
+            polling_station_investigations,
+        })
     }
 }
 
@@ -337,11 +474,18 @@ pub struct ElectionTotalsCSB {
 }
 
 impl ElectionTotalsCSB {
-    pub fn new(totals: &ElectionTotals, political_groups: &[PoliticalGroup]) -> Self {
-        ElectionTotalsCSB {
-            number_of_voters: totals
-                .number_of_voters
-                .expect("Number of voters needs to be filled in for CSB"),
+    pub fn new(
+        totals: &ElectionTotals,
+        political_groups: &[PoliticalGroup],
+    ) -> Result<Self, APIError> {
+        let CommitteeSpecificTotals::CSB { number_of_voters } = totals.committee_specific else {
+            return Err(APIError::DataIntegrityError(
+                "CSB election totals can only be created for CSB totals".to_string(),
+            ));
+        };
+
+        Ok(ElectionTotalsCSB {
+            number_of_voters,
             voters_counts: totals.voters_counts.clone(),
             votes_counts: EnrichedVotesCounts {
                 political_group_total_votes: totals
@@ -365,7 +509,7 @@ impl ElectionTotalsCSB {
                 total_votes_cast_count: totals.votes_counts.total_votes_cast_count,
             },
             differences_counts: totals.differences_counts.clone(),
-        }
+        })
     }
 }
 
@@ -386,8 +530,13 @@ mod tests {
             PollingStation, PollingStationFirstSession, test_helpers::polling_stations_fixture,
         },
         results::{
-            differences_counts::DifferencesCounts, extra_investigation::ExtraInvestigation,
-            gsb_differences_counts::GSBDifferencesCounts, gsb_results::GSBResults, yes_no::YesNo,
+            checks_and_corrections::{ChecksAndCorrections, ReasonInvestigationOwnInitiative},
+            differences_counts::DifferencesCounts,
+            extra_investigation::ExtraInvestigation,
+            gsb_differences_counts::GSBDifferencesCounts,
+            gsb_results::GSBResults,
+            next_session_results::NextSessionResults,
+            yes_no::YesNo,
         },
         sub_committee::{SubCommittee, SubCommitteeFirstSession, SubCommitteeId},
         valid_default::ValidDefault,
@@ -485,6 +634,30 @@ mod tests {
                 PoliticalGroupCandidateVotes::from_test_data_auto(PGNumber::from(1), &[17, 7]),
                 PoliticalGroupCandidateVotes::from_test_data_auto(PGNumber::from(2), &[12, 15, 5]),
             ],
+        })
+    }
+
+    /// Election fixture for a decentrally counted (DSO) election.
+    fn dso_election_fixture() -> ElectionWithPoliticalGroups {
+        let mut election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
+        election.counting_method = Some(VoteCountingMethod::DSO);
+        election
+    }
+
+    /// DSO first session results with the counts of [results_fixture_a]
+    /// and the given checks and corrections.
+    fn dso_results_fixture(checks_and_corrections: ChecksAndCorrections) -> Results {
+        let Results::CSOFirstSession(cso_results) = results_fixture_a() else {
+            unreachable!()
+        };
+
+        Results::DSOFirstSession(DSOFirstSessionResults {
+            about_report: Default::default(),
+            checks_and_corrections,
+            voters_counts: cso_results.voters_counts,
+            votes_counts: cso_results.votes_counts,
+            differences_counts: cso_results.differences_counts,
+            political_group_votes: cso_results.political_group_votes,
         })
     }
 
@@ -958,7 +1131,11 @@ mod tests {
             ],
         )
         .unwrap();
-        let investigations = totals.polling_station_investigations;
+        let CommitteeSpecificTotals::GSB(GSBTotals::CSO(investigations)) =
+            totals.committee_specific
+        else {
+            panic!("Expected CSO investigations in the totals");
+        };
         assert_eq!(investigations.admitted_voters_recounted, vec![32]);
         assert_eq!(investigations.investigated_other_reason, vec![32]);
         assert!(investigations.ballots_recounted.is_empty());
@@ -1003,6 +1180,183 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(totals.number_of_voters, Some(190));
+        assert_eq!(
+            totals.committee_specific,
+            CommitteeSpecificTotals::CSB {
+                number_of_voters: 190
+            }
+        );
+    }
+
+    #[test]
+    fn test_dso_investigations() {
+        let election = dso_election_fixture();
+        let ps = polling_stations_fixture(&[20, 20, 20]);
+        // first polling station: investigated because of an unaccounted-for difference,
+        // results corrected on the GSB's own initiative
+        let ps1_result = dso_results_fixture(ChecksAndCorrections {
+            reason_investigation_own_initiative: ReasonInvestigationOwnInitiative {
+                unaccounted_difference: true,
+                other_error: false,
+            },
+            corrected_results_own_initiative: YesNo::yes(),
+            corrected_results_csb_request: YesNo::no(),
+        });
+        // second polling station: investigated because of a (suspected) other error,
+        // results corrected at the request of the CSB
+        let ps2_result = dso_results_fixture(ChecksAndCorrections {
+            reason_investigation_own_initiative: ReasonInvestigationOwnInitiative {
+                unaccounted_difference: false,
+                other_error: true,
+            },
+            corrected_results_own_initiative: YesNo::no(),
+            corrected_results_csb_request: YesNo::yes(),
+        });
+        // third polling station: not investigated
+        let ps3_result = dso_results_fixture(ChecksAndCorrections::default());
+
+        let totals = ElectionTotals::tabulate(
+            &election,
+            &[
+                (test_ps_to_source(ps[0].clone()), ps1_result),
+                (test_ps_to_source(ps[1].clone()), ps2_result),
+                (test_ps_to_source(ps[2].clone()), ps3_result),
+            ],
+        )
+        .unwrap();
+
+        let CommitteeSpecificTotals::GSB(GSBTotals::DSO(investigations)) =
+            totals.committee_specific
+        else {
+            panic!("Expected DSO investigations in the totals");
+        };
+        assert_eq!(investigations.unaccounted_difference, vec![31]);
+        assert_eq!(investigations.other_error, vec![32]);
+        assert_eq!(investigations.corrected_results, vec![31, 32]);
+    }
+
+    #[test]
+    fn test_dso_corrected_results_merged() {
+        let election = dso_election_fixture();
+        let ps = polling_stations_fixture(&[20]);
+        // results corrected both on the GSB own initiative and at the
+        // request of the CSB: the station should be listed only once
+        let ps1_result = dso_results_fixture(ChecksAndCorrections {
+            reason_investigation_own_initiative: ReasonInvestigationOwnInitiative::default(),
+            corrected_results_own_initiative: YesNo::yes(),
+            corrected_results_csb_request: YesNo::yes(),
+        });
+
+        let totals =
+            ElectionTotals::tabulate(&election, &[(test_ps_to_source(ps[0].clone()), ps1_result)])
+                .unwrap();
+
+        let CommitteeSpecificTotals::GSB(GSBTotals::DSO(investigations)) =
+            totals.committee_specific
+        else {
+            panic!("Expected DSO investigations in the totals");
+        };
+        assert!(investigations.unaccounted_difference.is_empty());
+        assert!(investigations.other_error.is_empty());
+        assert_eq!(investigations.corrected_results, vec![31]);
+    }
+
+    #[test]
+    fn test_dso_next_session_results() {
+        let election = dso_election_fixture();
+        let ps = polling_stations_fixture(&[20, 20]);
+        let ps1_result = dso_results_fixture(ChecksAndCorrections {
+            reason_investigation_own_initiative: ReasonInvestigationOwnInitiative {
+                unaccounted_difference: true,
+                other_error: false,
+            },
+            corrected_results_own_initiative: YesNo::yes(),
+            corrected_results_csb_request: YesNo::no(),
+        });
+        // next session results with the counts of results_fixture_b
+        let Results::CSOFirstSession(cso_results) = results_fixture_b() else {
+            unreachable!()
+        };
+        let ps2_result = Results::DSONextSession(NextSessionResults {
+            voters_counts: cso_results.voters_counts,
+            votes_counts: cso_results.votes_counts,
+            differences_counts: cso_results.differences_counts,
+            political_group_votes: cso_results.political_group_votes,
+        });
+
+        let totals = ElectionTotals::tabulate(
+            &election,
+            &[
+                (test_ps_to_source(ps[0].clone()), ps1_result),
+                (test_ps_to_source(ps[1].clone()), ps2_result),
+            ],
+        )
+        .unwrap();
+
+        // the counts of both results are added to the totals
+        assert_eq!(totals.voters_counts.total_admitted_voters_count, 94);
+        assert_eq!(totals.votes_counts.total_votes_cast_count, 93);
+
+        // only the first session result contributes investigations
+        let CommitteeSpecificTotals::GSB(GSBTotals::DSO(investigations)) =
+            totals.committee_specific
+        else {
+            panic!("Expected DSO investigations in the totals");
+        };
+        assert_eq!(investigations.unaccounted_difference, vec![31]);
+        assert!(investigations.other_error.is_empty());
+        assert_eq!(investigations.corrected_results, vec![31]);
+    }
+
+    #[test]
+    fn test_result_model_must_match_election() {
+        let ps = polling_stations_fixture(&[20]);
+        let source = || test_ps_to_source(ps[0].clone());
+        let cso_election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
+        let dso_election = dso_election_fixture();
+        let csb_election = election_fixture(ElectionCategory::Municipal, CSB, &[2, 3]);
+        let dso_result = || dso_results_fixture(ChecksAndCorrections::default());
+
+        // a CSO result in a DSO election
+        let totals = ElectionTotals::tabulate(&dso_election, &[(source(), results_fixture_a())]);
+        assert!(totals.is_err());
+
+        // a DSO result in a CSO election
+        let totals = ElectionTotals::tabulate(&cso_election, &[(source(), dso_result())]);
+        assert!(totals.is_err());
+
+        // a GSB result in a GSB election
+        let totals =
+            ElectionTotals::tabulate(&cso_election, &[(source(), gsb_results_fixture_a())]);
+        assert!(totals.is_err());
+
+        // a CSO result in a CSB election
+        let totals = ElectionTotals::tabulate(&csb_election, &[(source(), results_fixture_a())]);
+        assert!(totals.is_err());
+
+        // a DSO result in a CSB election
+        let totals = ElectionTotals::tabulate(&csb_election, &[(source(), dso_result())]);
+        assert!(totals.is_err());
+    }
+
+    #[test]
+    fn test_election_totals_without_votes_requires_cso_totals() {
+        let cso_election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
+        let cso_totals = ElectionTotals::tabulate(&cso_election, &[]).unwrap();
+        assert!(ElectionTotalsWithoutVotes::try_from(cso_totals).is_ok());
+
+        let dso_totals = ElectionTotals::tabulate(&dso_election_fixture(), &[]).unwrap();
+        assert!(ElectionTotalsWithoutVotes::try_from(dso_totals).is_err());
+    }
+
+    #[test]
+    fn test_election_totals_csb_requires_csb_totals() {
+        let csb_election = election_fixture(ElectionCategory::Municipal, CSB, &[2, 3]);
+        let csb_totals = ElectionTotals::tabulate(&csb_election, &[]).unwrap();
+        assert!(ElectionTotalsCSB::new(&csb_totals, &csb_election.political_groups).is_ok());
+
+        let gsb_election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
+        let gsb_totals = ElectionTotals::tabulate(&gsb_election, &[]).unwrap();
+        assert!(ElectionTotalsCSB::new(&gsb_totals, &gsb_election.political_groups).is_err());
     }
 }

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -44,7 +44,7 @@ use crate::domain::{
         ElectionWithPoliticalGroups, NewElection, PGNumber, RegisteredPoliticalGroup,
     },
     results::political_group_candidate_votes::PoliticalGroupCandidateVotes,
-    tabulation::ElectionTotals,
+    tabulation::{CommitteeSpecificTotals, ElectionTotals},
 };
 
 fn max_votes(max_votes: &StringValue<NonZeroU64>) -> u32 {
@@ -661,10 +661,11 @@ impl ElectionWithPoliticalGroups {
     }
 
     /// Depending on the context of the totals coming from GSB or from CSB, the number of voters source is different.
-    /// In case of a GSB totals, the number of voters there should be the valid source.
-    /// Otherwise, it is the given number of voters.
     fn get_eligible_voter_count(&self, totals: &ElectionTotals) -> u32 {
-        totals.number_of_voters.unwrap_or(self.number_of_voters)
+        match totals.committee_specific {
+            CommitteeSpecificTotals::CSB { number_of_voters } => number_of_voters,
+            CommitteeSpecificTotals::GSB(_) => self.number_of_voters,
+        }
     }
 
     fn as_eml_count_selections(
@@ -1187,11 +1188,13 @@ mod tests {
 
     #[test]
     fn test_as_eml_count_contest() {
-        // Default number_of_voters=1000
-        let mut election =
-            election_fixture(ElectionCategory::Municipal, CommitteeCategory::CSB, &[2]);
+        // CSB elections take the eligible voter count from the totals
+        let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::CSB, &[2]);
         let committee_session = committee_session_fixture(election.id);
         let mut totals = ElectionTotals::tabulate(&election, &[]).unwrap();
+        totals.committee_specific = CommitteeSpecificTotals::CSB {
+            number_of_voters: 1001,
+        };
 
         let result_csb = election
             .as_eml_count_contest(&committee_session, &[], &totals)
@@ -1199,7 +1202,7 @@ mod tests {
         let total_votes_csb = result_csb.total_votes.unwrap();
         assert_eq!(
             total_votes_csb.eligible_voter_count,
-            StringValue::from_value(1000u64)
+            StringValue::from_value(1001u64)
         );
         assert!(
             !total_votes_csb
@@ -1208,8 +1211,10 @@ mod tests {
         );
         assert!(result_csb.reporting_unit_votes.is_empty());
 
-        election.committee_category = CommitteeCategory::GSB;
-        totals.number_of_voters = Some(1001);
+        // GSB elections take the eligible voter count from the election (default number_of_voters=1000)
+        let election = election_fixture(ElectionCategory::Municipal, CommitteeCategory::GSB, &[2]);
+        let committee_session = committee_session_fixture(election.id);
+        let totals = ElectionTotals::tabulate(&election, &[]).unwrap();
         let result_gsb = election
             .as_eml_count_contest(&committee_session, &[source_and_results_gsb(None)], &totals)
             .unwrap();
@@ -1217,7 +1222,7 @@ mod tests {
         let total_votes_gsb = result_gsb.total_votes.unwrap();
         assert_eq!(
             total_votes_gsb.eligible_voter_count,
-            StringValue::from_value(1001u64)
+            StringValue::from_value(1000u64)
         );
 
         assert_eq!(

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -55,8 +55,8 @@ use crate::{
             yes_no::YesNo,
         },
         tabulation::{
-            DifferencesTotals, ElectionTotals, ElectionTotalsCSB, PollingStationInvestigations,
-            SumCount,
+            CSOInvestigations, CommitteeSpecificTotals, DifferencesTotals, ElectionTotals,
+            ElectionTotalsCSB, GSBTotals, SumCount,
         },
     },
 };
@@ -430,7 +430,7 @@ fn random_election_totals(
             fewer_ballots_count: random_sum_count(rng, data_sources),
         },
         political_group_votes: result.political_group_votes,
-        polling_station_investigations: PollingStationInvestigations {
+        committee_specific: CommitteeSpecificTotals::GSB(GSBTotals::CSO(CSOInvestigations {
             admitted_voters_recounted: random_station_subset(rng, data_sources)
                 .into_iter()
                 .map(data_source_num)
@@ -443,8 +443,7 @@ fn random_election_totals(
                 .into_iter()
                 .map(data_source_num)
                 .collect(),
-        },
-        number_of_voters: Some(100),
+        })),
     }
 }
 
@@ -687,8 +686,8 @@ async fn test_na_14_2() {
             votes_tables: VotesTablesWithPreviousVotes::new(&election, &totals, &previous_totals)
                 .unwrap(),
             election: election.into(),
-            previous_summary: previous_totals.into(),
-            summary: totals.into(),
+            previous_summary: previous_totals.try_into().unwrap(),
+            summary: totals.try_into().unwrap(),
             committee_session,
             previous_committee_session,
             hash,
@@ -780,7 +779,7 @@ async fn test_na_31_2() {
             votes_tables: VotesTables::new(&election, &totals).unwrap(),
             committee_session,
             election: election.into(),
-            summary: totals.into(),
+            summary: totals.try_into().unwrap(),
             polling_stations,
             hash,
             creation_date_time,

--- a/backend/src/infra/pdf_gen/typst_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_tests.rs
@@ -38,7 +38,7 @@ async fn it_generates_a_pdf() {
     let totals = ElectionTotals::zero(&election);
     let content = generate_pdf(
         ModelNa31_2Input {
-            summary: totals.clone().into(),
+            summary: totals.clone().try_into().unwrap(),
             votes_tables: VotesTables::new(&election, &totals).unwrap(),
             committee_session: committee_session_fixture(ElectionId::from(1)),
             election: election.into(),
@@ -106,7 +106,7 @@ async fn it_generates_a_pdf_with_polling_stations() {
     let content = generate_pdf(
         ModelNa31_2Input {
             votes_tables: VotesTables::new(&election, &totals).unwrap(),
-            summary: totals.into(),
+            summary: totals.try_into().unwrap(),
             polling_stations: polling_stations_fixture(&[100, 200, 300]),
             committee_session,
             election: election.into(),

--- a/frontend/src/features/apportionment/components/ApportionmentPage.tsx
+++ b/frontend/src/features/apportionment/components/ApportionmentPage.tsx
@@ -307,7 +307,11 @@ function ElectionSummaryTableSection({
           votesCounts={electionSummary.votes_counts}
           seats={seatAssignment.seats}
           quota={seatAssignment.quota}
-          numberOfVoters={electionSummary.number_of_voters}
+          numberOfVoters={
+            electionSummary.committee_specific.committee === "CSB"
+              ? electionSummary.committee_specific.number_of_voters
+              : undefined
+          }
           preferenceThreshold={preferenceThreshold}
           deceasedCandidatesInfo={
             {

--- a/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
+++ b/frontend/src/features/apportionment/components/ElectionSummaryTable.stories.tsx
@@ -11,7 +11,11 @@ export const DefaultWithNumberOfVoters: StoryObj = {
         votesCounts={gte19Seats.election_totals.votes_counts}
         seats={gte19Seats.seat_assignment.seats}
         quota={gte19Seats.seat_assignment.quota}
-        numberOfVoters={gte19Seats.election_totals.number_of_voters}
+        numberOfVoters={
+          gte19Seats.election_totals.committee_specific.committee === "CSB"
+            ? gte19Seats.election_totals.committee_specific.number_of_voters
+            : undefined
+        }
         preferenceThreshold={gte19Seats.candidate_nomination.preference_threshold}
         deceasedCandidatesInfo={
           {
@@ -89,7 +93,11 @@ export const DefaultWithoutVotes: StoryObj = {
         }}
         seats={gte19Seats.seat_assignment.seats}
         quota={gte19Seats.seat_assignment.quota}
-        numberOfVoters={gte19Seats.election_totals.number_of_voters}
+        numberOfVoters={
+          gte19Seats.election_totals.committee_specific.committee === "CSB"
+            ? gte19Seats.election_totals.committee_specific.number_of_voters
+            : undefined
+        }
         preferenceThreshold={gte19Seats.candidate_nomination.preference_threshold}
         deceasedCandidatesInfo={
           {

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p10-full-seat-removal.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p10-full-seat-removal.ts
@@ -636,6 +636,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
+  committee_specific: { committee: "CSB", number_of_voters: 8634 },
   voters_counts: {
     poll_card_count: 8000,
     proxy_certificate_count: 0,
@@ -807,12 +808,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
-  number_of_voters: 8634,
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p7-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p7-drawing-lots.ts
@@ -1154,7 +1154,7 @@ export const seat_assignment_after_two_drawing_lots_seats_assigned: SeatAssignme
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 1329,
+  committee_specific: { committee: "CSB", number_of_voters: 1329 },
   voters_counts: {
     poll_card_count: 1200,
     proxy_certificate_count: 0,
@@ -2440,11 +2440,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9-drawing-lots-and-deceased-candidates.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9-drawing-lots-and-deceased-candidates.ts
@@ -1363,6 +1363,7 @@ export const seat_assignment_after_drawing_lots_seat_reassigned: SeatAssignment 
 };
 
 export const election_totals: ElectionTotals = {
+  committee_specific: { committee: "CSB", number_of_voters: 22273 },
   voters_counts: {
     poll_card_count: 15001,
     proxy_certificate_count: 0,
@@ -3068,12 +3069,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
-  number_of_voters: 22273,
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats-and-p9.ts
@@ -1837,7 +1837,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 20000,
+  committee_specific: { committee: "CSB", number_of_voters: 20000 },
   voters_counts: {
     poll_card_count: 15001,
     proxy_certificate_count: 1,
@@ -1868,11 +1868,6 @@ export const election_totals: ElectionTotals = {
       count: 0,
       data_entry_sources: [],
     },
-  },
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    ballots_recounted: [],
-    investigated_other_reason: [],
   },
   political_group_votes: [
     {

--- a/frontend/src/features/apportionment/testing/gte-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/gte-19-seats.ts
@@ -1174,7 +1174,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 2000,
+  committee_specific: { committee: "CSB", number_of_voters: 2000 },
   voters_counts: {
     poll_card_count: 1203,
     proxy_certificate_count: 2,
@@ -1202,11 +1202,6 @@ export const election_totals: ElectionTotals = {
       count: 0,
       data_entry_sources: [],
     },
-  },
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    ballots_recounted: [],
-    investigated_other_reason: [],
   },
   political_group_votes: [
     {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-not-all-seats-assigned.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-not-all-seats-assigned.ts
@@ -706,6 +706,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
+  committee_specific: { committee: "CSB", number_of_voters: 91 },
   voters_counts: {
     poll_card_count: 60,
     proxy_certificate_count: 0,
@@ -785,12 +786,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
-  number_of_voters: 91,
 };
 
 export const warnings: ApportionmentWarning[] = ["NotAllSeatsAssigned"];

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidate.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidate.ts
@@ -1427,6 +1427,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
+  committee_specific: { committee: "CSB", number_of_voters: 1166 },
   voters_counts: {
     poll_card_count: 995,
     proxy_certificate_count: 0,
@@ -1624,12 +1625,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
-  number_of_voters: 1166,
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidates.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10-and-deceased-candidates.ts
@@ -2036,7 +2036,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 2000,
+  committee_specific: { committee: "CSB", number_of_voters: 2000 },
   voters_counts: {
     poll_card_count: 1203,
     proxy_certificate_count: 2,
@@ -2067,11 +2067,6 @@ export const election_totals: ElectionTotals = {
       count: 0,
       data_entry_sources: [],
     },
-  },
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    ballots_recounted: [],
-    investigated_other_reason: [],
   },
   political_group_votes: [
     {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p10.ts
@@ -774,7 +774,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 100,
+  committee_specific: { committee: "CSB", number_of_voters: 100 },
   voters_counts: {
     poll_card_count: 60,
     proxy_certificate_count: 1,
@@ -800,11 +800,6 @@ export const election_totals: ElectionTotals = {
       count: 0,
       data_entry_sources: [],
     },
-  },
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    ballots_recounted: [],
-    investigated_other_reason: [],
   },
   political_group_votes: [
     {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p15-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p15-drawing-lots.ts
@@ -904,6 +904,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
+  committee_specific: { committee: "CSB", number_of_voters: 11158 },
   voters_counts: {
     poll_card_count: 8900,
     proxy_certificate_count: 0,
@@ -1099,12 +1100,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
-  number_of_voters: 11158,
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p7-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p7-drawing-lots.ts
@@ -370,7 +370,7 @@ export const seat_assignment: SeatAssignment = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 2272,
+  committee_specific: { committee: "CSB", number_of_voters: 2272 },
   voters_counts: {
     poll_card_count: 1200,
     proxy_certificate_count: 0,
@@ -2076,11 +2076,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-and-p10.ts
@@ -1429,7 +1429,7 @@ export const candidate_nomination: CandidateNomination = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 6000,
+  committee_specific: { committee: "CSB", number_of_voters: 6000 },
   voters_counts: {
     poll_card_count: 5104,
     proxy_certificate_count: 1,
@@ -1457,11 +1457,6 @@ export const election_totals: ElectionTotals = {
       count: 0,
       data_entry_sources: [],
     },
-  },
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    ballots_recounted: [],
-    investigated_other_reason: [],
   },
   political_group_votes: [
     {

--- a/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-drawing-lots.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats-and-p9-drawing-lots.ts
@@ -694,6 +694,7 @@ export const seat_assignment_after_drawing_lots_seat_reassigned: SeatAssignment 
 };
 
 export const election_totals: ElectionTotals = {
+  committee_specific: { committee: "CSB", number_of_voters: 9479 },
   voters_counts: {
     poll_card_count: 5103,
     proxy_certificate_count: 0,
@@ -1979,12 +1980,6 @@ export const election_totals: ElectionTotals = {
       ],
     },
   ],
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    investigated_other_reason: [],
-    ballots_recounted: [],
-  },
-  number_of_voters: 9479,
 };
 
 export const committee_session: CommitteeSession = {

--- a/frontend/src/features/apportionment/testing/lt-19-seats.ts
+++ b/frontend/src/features/apportionment/testing/lt-19-seats.ts
@@ -1364,7 +1364,7 @@ export const political_group_1_votes: PoliticalGroupCandidateVotes = {
 };
 
 export const election_totals: ElectionTotals = {
-  number_of_voters: 2000,
+  committee_specific: { committee: "CSB", number_of_voters: 2000 },
   voters_counts: {
     poll_card_count: 1203,
     proxy_certificate_count: 2,
@@ -1395,11 +1395,6 @@ export const election_totals: ElectionTotals = {
       count: 0,
       data_entry_sources: [],
     },
-  },
-  polling_station_investigations: {
-    admitted_voters_recounted: [],
-    ballots_recounted: [],
-    investigated_other_reason: [],
   },
   political_group_votes: [
     political_group_1_votes,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -600,6 +600,22 @@ export interface CSOFirstSessionResults {
 }
 
 /**
+ * Polling stations where results were investigated by the GSB,
+ * as vectors of polling station numbers
+ */
+export interface CSOInvestigations {
+  /** Admitted voters were recounted
+("Toegelaten kiezers opnieuw vastgesteld?") */
+  admitted_voters_recounted: number[];
+  /** Ballots were (partially) recounted
+("Stembiljetten (deels) herteld?") */
+  ballots_recounted: number[];
+  /** Investigated for other reasons than unexplained difference
+("Onderzocht vanwege andere reden dan onverklaard verschil?") */
+  investigated_other_reason: number[];
+}
+
+/**
  * Candidate
  */
 export interface Candidate {
@@ -753,6 +769,17 @@ export interface CommitteeSessionUpdateRequest {
 }
 
 /**
+ * Committee specific totals, i.e. specific for GSB or CSB.
+ */
+export type CommitteeSpecificTotals =
+  | (GSBTotals & { committee: "GSB" })
+  | {
+      committee: "CSB";
+      /** The number of voters ("Kiesgerechtigden") */
+      number_of_voters: number;
+    };
+
+/**
  * CommonPollingStationResults contains the common fields for polling station results,
  */
 export interface CommonPollingStationResults {
@@ -822,6 +849,22 @@ export interface DSOFirstSessionResults {
   voters_counts: VotersCounts;
   /** Votes counts ("2. Aantal getelde stembiljetten") */
   votes_counts: VotesCounts;
+}
+
+/**
+ * Polling stations where results were investigated by the GSB,
+ * as vectors of polling station numbers
+ */
+export interface DSOInvestigations {
+  /** Results were corrected
+("Uitslag gecorrigeerd?") */
+  corrected_results: number[];
+  /** Investigated because of a (suspected) other error
+("Onderzocht vanwege (het vermoeden van) een andere fout?") */
+  other_error: number[];
+  /** Investigated because of an unaccounted-for difference
+("Onderzocht vanwege een onverklaard verschil?") */
+  unaccounted_difference: number[];
 }
 
 /**
@@ -1052,14 +1095,12 @@ export type ElectionSubCategory = (typeof electionSubCategoryValues)[number];
  * Contains the totals of the election results, added up from the votes of all polling stations.
  */
 export interface ElectionTotals {
+  /** Totals specific to the committee (GSB or CSB) of the election */
+  committee_specific: CommitteeSpecificTotals;
   /** The differences between voters and votes */
   differences_counts: DifferencesTotals;
-  /** The number of voters (i.e. "Kiesgerechtigden") */
-  number_of_voters?: number;
   /** The total votes for each political group (and each candidate within) */
   political_group_votes: PoliticalGroupCandidateVotes[];
-  /** Polling stations where results were investigated by the GSB */
-  polling_station_investigations: PollingStationInvestigations;
   /** The total number of voters */
   voters_counts: VotersCounts;
   /** The total number of votes */
@@ -1220,6 +1261,13 @@ export interface GSBResults {
   /** Votes counts ("Aantal getelde stembiljetten") */
   votes_counts: VotesCounts;
 }
+
+/**
+ * GSB specific totals, depending on the vote counting method (CSO or DSO).
+ */
+export type GSBTotals =
+  | (CSOInvestigations & { counting_method: "CSO" })
+  | (DSOInvestigations & { counting_method: "DSO" });
 
 /**
  * Abacus API and asset server
@@ -1510,22 +1558,6 @@ export interface PollingStationInvestigationUpdateRequest {
   corrected_results?: boolean;
   findings?: string;
   reason: string;
-}
-
-/**
- * Polling stations where results were investigated by the GSB,
- * as vectors of polling station numbers
- */
-export interface PollingStationInvestigations {
-  /** Admitted voters were recounted
-("Toegelaten kiezers opnieuw vastgesteld?") */
-  admitted_voters_recounted: number[];
-  /** Ballots were (partially) recounted
-("Stembiljetten (deels) herteld?") */
-  ballots_recounted: number[];
-  /** Investigated for other reasons than unexplained difference
-("Onderzocht vanwege andere reden dan onverklaard verschil?") */
-  investigated_other_reason: number[];
 }
 
 /**


### PR DESCRIPTION
## What & why

Implement DSO tabulation with new data types (`ElectionTotals`, `CommitteeSpecificTotals`, `GSBTotals`, `DSOInvestigations`), see https://github.com/kiesraad/abacus/issues/3795#issuecomment-5217091735. This builds on top of the rename to 'tabulation' and 'totals' in #3817.

Some auxiliary types used for reporting (e.g. `ElectionTotalsWithoutVotes`) still need to be adjusted to support both CSO and DSO. This will be done in a followup PR, still in scope of #3795.

## How to test

CI passes, no functional changes expected.

## Reviewer notes

Please check if the DSO checkboxes are correctly mapped to the investigation checkboxes that are used in the DSO GSB model (Na 31-1).