### PR TITLE
Move reporting-only structs to models domain

### DIFF
--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -303,9 +303,11 @@ async fn export_election(
         let input = ModelNa31_2Input {
             votes_tables: VotesTables::new(election, &election_totals)
                 .expect("Votes tables should be created"),
-            summary: election_totals
-                .try_into()
-                .expect("Election totals should be converted to summary"),
+            summary: (&election_totals).into(),
+            polling_station_investigations: election_totals
+                .cso_investigations()
+                .expect("Election totals should be CSO totals")
+                .clone(),
             committee_session: committee_session.clone(),
             polling_stations: polling_stations.iter().map(Clone::clone).collect(),
             election: election.clone().into(),

--- a/backend/src/domain/models/election_totals.rs
+++ b/backend/src/domain/models/election_totals.rs
@@ -1,0 +1,113 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    APIError,
+    domain::{
+        election::PoliticalGroup,
+        results::{
+            political_group_total_votes::EnrichedPoliticalGroupTotalVotes,
+            voters_counts::VotersCounts,
+            votes_counts::{EnrichedVotesCounts, VotesCounts},
+        },
+        tabulation::{CommitteeSpecificTotals, DifferencesTotals, ElectionTotals},
+    },
+};
+
+/// A version of ElectionTotals without the political group votes and committee specific totals.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ElectionTotalsWithoutVotes {
+    /// The total number of voters
+    pub voters_counts: VotersCounts,
+    /// The total number of votes
+    pub votes_counts: VotesCounts,
+    /// The differences between voters and votes
+    pub differences_counts: DifferencesTotals,
+}
+
+impl From<&ElectionTotals> for ElectionTotalsWithoutVotes {
+    fn from(totals: &ElectionTotals) -> Self {
+        ElectionTotalsWithoutVotes {
+            voters_counts: totals.voters_counts.clone(),
+            votes_counts: totals.votes_counts.clone(),
+            differences_counts: totals.differences_counts.clone(),
+        }
+    }
+}
+
+/// A version of ElectionTotals without the political group votes and investigations
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ElectionTotalsCSB {
+    /// The number of voters (i.e. "Kiesgerechtigden")
+    pub number_of_voters: u32,
+    /// The total number of voters
+    pub voters_counts: VotersCounts,
+    /// The total number of votes
+    pub votes_counts: EnrichedVotesCounts,
+    /// The differences between voters and votes
+    pub differences_counts: DifferencesTotals,
+}
+
+impl ElectionTotalsCSB {
+    pub fn new(
+        totals: &ElectionTotals,
+        political_groups: &[PoliticalGroup],
+    ) -> Result<Self, APIError> {
+        let CommitteeSpecificTotals::CSB { number_of_voters } = totals.committee_specific else {
+            return Err(APIError::DataIntegrityError(
+                "CSB election totals can only be created for CSB totals".to_string(),
+            ));
+        };
+
+        Ok(ElectionTotalsCSB {
+            number_of_voters,
+            voters_counts: totals.voters_counts.clone(),
+            votes_counts: EnrichedVotesCounts {
+                political_group_total_votes: totals
+                    .votes_counts
+                    .political_group_total_votes
+                    .iter()
+                    .map(|pg_votes| EnrichedPoliticalGroupTotalVotes {
+                        number: pg_votes.number,
+                        name: political_groups
+                            .iter()
+                            .find(|pg| pg.number == pg_votes.number)
+                            .expect("Political group should exist")
+                            .name
+                            .clone(),
+                        total: pg_votes.total,
+                    })
+                    .collect(),
+                total_votes_candidates_count: totals.votes_counts.total_votes_candidates_count,
+                blank_votes_count: totals.votes_counts.blank_votes_count,
+                invalid_votes_count: totals.votes_counts.invalid_votes_count,
+                total_votes_cast_count: totals.votes_counts.total_votes_cast_count,
+            },
+            differences_counts: totals.differences_counts.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use super::*;
+    use crate::domain::election::{
+        CommitteeCategory::{CSB, GSB},
+        ElectionCategory,
+        tests::election_fixture,
+    };
+
+    #[test]
+    fn test_election_totals_csb_requires_csb_totals() {
+        let csb_election = election_fixture(ElectionCategory::Municipal, CSB, &[2, 3]);
+        let csb_totals = ElectionTotals::tabulate(&csb_election, &[]).unwrap();
+        assert!(ElectionTotalsCSB::new(&csb_totals, &csb_election.political_groups).is_ok());
+
+        let gsb_election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
+        let gsb_totals = ElectionTotals::tabulate(&gsb_election, &[]).unwrap();
+        assert!(ElectionTotalsCSB::new(&gsb_totals, &gsb_election.political_groups).is_err());
+    }
+}

--- a/backend/src/domain/models/enriched_seat_assignment.rs
+++ b/backend/src/domain/models/enriched_seat_assignment.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::domain::{
     apportionment::{DisplayFraction, ListSeatAssignment, SeatAssignment, SeatChangeStep},
     election::PGNumber,
-    models::error::ModelsError,
-    tabulation::ElectionTotalsCSB,
+    models::{election_totals::ElectionTotalsCSB, error::ModelsError},
 };
 
 struct InitialSteps<'a> {
@@ -265,16 +264,14 @@ mod tests {
                 CommitteeCategory, ElectionCategory, ElectionWithPoliticalGroups,
                 tests::election_fixture_with_given_number_of_seats,
             },
+            models::election_totals::ElectionTotalsCSB,
             models::enriched_seat_assignment::EnrichedSeatAssignment,
             results::{
                 political_group_candidate_votes::create_political_group_candidate_votes,
                 political_group_total_votes::PoliticalGroupTotalVotes, voters_counts::VotersCounts,
                 votes_counts::VotesCounts,
             },
-            tabulation::{
-                CommitteeSpecificTotals, DifferencesTotals, ElectionTotals, ElectionTotalsCSB,
-                SumCount,
-            },
+            tabulation::{CommitteeSpecificTotals, DifferencesTotals, ElectionTotals, SumCount},
         },
     };
 

--- a/backend/src/domain/models/mod.rs
+++ b/backend/src/domain/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod apportionment_footnotes;
+pub mod election_totals;
 pub mod enriched_candidate_nomination;
 pub mod enriched_seat_assignment;
 pub mod error;

--- a/backend/src/domain/models/model_na_14_2.rs
+++ b/backend/src/domain/models/model_na_14_2.rs
@@ -6,11 +6,11 @@ use crate::domain::{
     investigation::PollingStationInvestigation,
     models::{
         PdfFileModel, PdfModel, ToPdfFileModel,
+        election_totals::ElectionTotalsWithoutVotes,
         votes_table::{VotesTablesWithOnlyPreviousVotes, VotesTablesWithPreviousVotes},
     },
     polling_station::PollingStation,
     results::common_polling_station_results::CommonPollingStationResultsWithoutVotes,
-    tabulation::ElectionTotalsWithoutVotes,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/backend/src/domain/models/model_na_31_2.rs
+++ b/backend/src/domain/models/model_na_31_2.rs
@@ -5,10 +5,11 @@ use crate::domain::{
     election::Election,
     models::{
         PdfFileModel, PdfModel, ToPdfFileModel,
+        election_totals::ElectionTotalsWithoutVotes,
         votes_table::{CandidatesTables, VotesTables},
     },
     polling_station::PollingStation,
-    tabulation::ElectionTotalsWithoutVotes,
+    tabulation::CSOInvestigations,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -18,6 +19,7 @@ pub struct ModelNa31_2Input {
     pub election: Election,
     pub summary: ElectionTotalsWithoutVotes,
     pub polling_stations: Vec<PollingStation>,
+    pub polling_station_investigations: CSOInvestigations,
     pub hash: String,
     pub creation_date_time: String,
     pub votes_tables: VotesTables,

--- a/backend/src/domain/models/model_p_22_2.rs
+++ b/backend/src/domain/models/model_p_22_2.rs
@@ -5,10 +5,10 @@ use crate::domain::{
     election::Election,
     models::{
         PdfFileModel, PdfModel, ToPdfFileModel, apportionment_footnotes::ApportionmentFootnotes,
+        election_totals::ElectionTotalsCSB,
         enriched_candidate_nomination::EnrichedCandidateNomination,
         enriched_seat_assignment::EnrichedSeatAssignment, votes_table::VotesTables,
     },
-    tabulation::ElectionTotalsCSB,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -563,3 +563,42 @@ impl ResultsInputGSB {
         .to_pdf_file_model(overview_filename)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Local;
+    use sqlx::SqlitePool;
+    use test_log::test;
+
+    use super::*;
+
+    #[test(sqlx::test(fixtures(
+        path = "../../../fixtures",
+        scripts("election_12_dso_with_results")
+    )))]
+    async fn test_error_na14_2_dso(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let input = ResultsInputGSB::new(&mut conn, CommitteeSessionId::from(12), Local::now())
+            .await
+            .unwrap();
+
+        // Na 14-2 is only for CSO, DSO uses Na 14-1
+        let Err(error) = input.get_na14_2_pdf_file(
+            &input.data.totals,
+            &input.data.committee_session,
+            "hash".to_string(),
+            "creation_date_time".to_string(),
+            "Model_Na14-2.pdf".to_string(),
+        ) else {
+            panic!("generating a Na 14-2 report should fail for DSO elections");
+        };
+        assert!(
+            matches!(
+                &error,
+                APIError::DataIntegrityError(message)
+                    if message == "Na 14-2 report is only supported for CSO"
+            ),
+            "unexpected error: {error:?}"
+        );
+    }
+}

--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -11,13 +11,14 @@ use crate::{
     domain::{
         committee_session::{CommitteeSession, CommitteeSessionId},
         data_entry::DataEntrySource,
-        election::{CommitteeCategory, ElectionWithPoliticalGroups},
+        election::{CommitteeCategory, ElectionWithPoliticalGroups, VoteCountingMethod},
         file::{File, FileType},
         investigation::PollingStationInvestigation,
         models::{
             ModelNa14_2Input, ModelNa31_2Input, ModelP2aInput, ModelP22_2Bijlage1Input,
             ModelP22_2Input, PdfFileModel, ToPdfFileModel,
             apportionment_footnotes::ApportionmentFootnotes,
+            election_totals::ElectionTotalsCSB,
             enriched_candidate_nomination::EnrichedCandidateNomination,
             enriched_seat_assignment::EnrichedSeatAssignment,
             votes_table::{VotesTables, VotesTablesWithPreviousVotes},
@@ -25,7 +26,7 @@ use crate::{
         polling_station::PollingStation,
         report::DEFAULT_DATE_TIME_FORMAT,
         results::{Results, political_group_candidate_votes::PoliticalGroupCandidateVotes},
-        tabulation::{ElectionTotals, ElectionTotalsCSB},
+        tabulation::ElectionTotals,
     },
     eml::EmlHash,
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType},
@@ -492,6 +493,13 @@ impl ResultsInputGSB {
     ) -> Result<PdfFileModel, APIError> {
         let data = &self.data;
 
+        // Na 14-2 is only for CSO, DSO uses Na 14-1
+        if data.election.counting_method != Some(VoteCountingMethod::CSO) {
+            return Err(APIError::DataIntegrityError(
+                "Na 14-2 report is only supported for CSO".to_string(),
+            ));
+        }
+
         let pdf_file = ModelNa14_2Input {
             votes_tables: VotesTablesWithPreviousVotes::new(
                 &data.election,
@@ -500,8 +508,8 @@ impl ResultsInputGSB {
             )?,
             committee_session: data.committee_session.clone(),
             election: data.election.clone().into(),
-            summary: data.totals.clone().try_into()?,
-            previous_summary: previous_totals.clone().try_into()?,
+            summary: (&data.totals).into(),
+            previous_summary: previous_totals.into(),
             previous_committee_session: previous_committee_session.clone(),
             hash,
             creation_date_time,
@@ -522,7 +530,8 @@ impl ResultsInputGSB {
             votes_tables: VotesTables::new(&data.election, &data.totals)?,
             committee_session: data.committee_session.clone(),
             polling_stations: data.polling_stations.clone(),
-            summary: data.totals.clone().try_into()?,
+            summary: (&data.totals).into(),
+            polling_station_investigations: data.totals.cso_investigations()?.clone(),
             election: data.election.clone().into(),
             hash,
             creation_date_time,

--- a/backend/src/domain/tabulation.rs
+++ b/backend/src/domain/tabulation.rs
@@ -5,9 +5,7 @@ use crate::{
     APIError,
     domain::{
         data_entry::{DataEntrySource, DataEntrySourceNumber},
-        election::{
-            CommitteeCategory, ElectionWithPoliticalGroups, PoliticalGroup, VoteCountingMethod,
-        },
+        election::{CommitteeCategory, ElectionWithPoliticalGroups, VoteCountingMethod},
         polling_station::PollingStationForSession,
         results::{
             CommonDifferencesCounts, Results,
@@ -15,11 +13,9 @@ use crate::{
             cso_first_session_results::CSOFirstSessionResults,
             dso_first_session_results::DSOFirstSessionResults,
             political_group_candidate_votes::{CandidateVotes, PoliticalGroupCandidateVotes},
-            political_group_total_votes::{
-                EnrichedPoliticalGroupTotalVotes, PoliticalGroupTotalVotes,
-            },
+            political_group_total_votes::PoliticalGroupTotalVotes,
             voters_counts::VotersCounts,
-            votes_counts::{EnrichedVotesCounts, VotesCounts},
+            votes_counts::VotesCounts,
         },
         validate::Validate,
     },
@@ -165,6 +161,19 @@ impl ElectionTotals {
         totals = Self::process_results(election, results, &mut totals)?;
 
         Ok(totals)
+    }
+
+    /// The CSO polling station investigations of these totals,
+    /// or an error if these are not CSO totals.
+    pub fn cso_investigations(&self) -> Result<&CSOInvestigations, APIError> {
+        let CommitteeSpecificTotals::GSB(GSBTotals::CSO(investigations)) = &self.committee_specific
+        else {
+            return Err(APIError::DataIntegrityError(
+                "CSO investigations are only available for CSO totals".to_string(),
+            ));
+        };
+
+        Ok(investigations)
     }
 }
 
@@ -421,95 +430,6 @@ impl DSOInvestigations {
         {
             self.corrected_results.push(polling_station.number());
         }
-    }
-}
-
-/// A version of ElectionTotals without the political group votes.
-#[derive(Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ElectionTotalsWithoutVotes {
-    /// The total number of voters
-    pub voters_counts: VotersCounts,
-    /// The total number of votes
-    pub votes_counts: VotesCounts,
-    /// The differences between voters and votes
-    pub differences_counts: DifferencesTotals,
-    /// Polling stations where results were investigated by the GSB
-    pub polling_station_investigations: CSOInvestigations,
-}
-
-impl TryFrom<ElectionTotals> for ElectionTotalsWithoutVotes {
-    type Error = APIError;
-
-    fn try_from(totals: ElectionTotals) -> Result<Self, Self::Error> {
-        let CommitteeSpecificTotals::GSB(GSBTotals::CSO(polling_station_investigations)) =
-            totals.committee_specific
-        else {
-            return Err(APIError::DataIntegrityError(
-                "Election totals without votes can only be created for CSO totals".to_string(),
-            ));
-        };
-
-        Ok(ElectionTotalsWithoutVotes {
-            voters_counts: totals.voters_counts,
-            votes_counts: totals.votes_counts,
-            differences_counts: totals.differences_counts,
-            polling_station_investigations,
-        })
-    }
-}
-
-/// A version of ElectionTotals without the political group votes and investigations
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ElectionTotalsCSB {
-    /// The number of voters (i.e. "Kiesgerechtigden")
-    pub number_of_voters: u32,
-    /// The total number of voters
-    pub voters_counts: VotersCounts,
-    /// The total number of votes
-    pub votes_counts: EnrichedVotesCounts,
-    /// The differences between voters and votes
-    pub differences_counts: DifferencesTotals,
-}
-
-impl ElectionTotalsCSB {
-    pub fn new(
-        totals: &ElectionTotals,
-        political_groups: &[PoliticalGroup],
-    ) -> Result<Self, APIError> {
-        let CommitteeSpecificTotals::CSB { number_of_voters } = totals.committee_specific else {
-            return Err(APIError::DataIntegrityError(
-                "CSB election totals can only be created for CSB totals".to_string(),
-            ));
-        };
-
-        Ok(ElectionTotalsCSB {
-            number_of_voters,
-            voters_counts: totals.voters_counts.clone(),
-            votes_counts: EnrichedVotesCounts {
-                political_group_total_votes: totals
-                    .votes_counts
-                    .political_group_total_votes
-                    .iter()
-                    .map(|pg_votes| EnrichedPoliticalGroupTotalVotes {
-                        number: pg_votes.number,
-                        name: political_groups
-                            .iter()
-                            .find(|pg| pg.number == pg_votes.number)
-                            .expect("Political group should exist")
-                            .name
-                            .clone(),
-                        total: pg_votes.total,
-                    })
-                    .collect(),
-                total_votes_candidates_count: totals.votes_counts.total_votes_candidates_count,
-                blank_votes_count: totals.votes_counts.blank_votes_count,
-                invalid_votes_count: totals.votes_counts.invalid_votes_count,
-                total_votes_cast_count: totals.votes_counts.total_votes_cast_count,
-            },
-            differences_counts: totals.differences_counts.clone(),
-        })
     }
 }
 
@@ -1340,23 +1260,16 @@ mod tests {
     }
 
     #[test]
-    fn test_election_totals_without_votes_requires_cso_totals() {
+    fn test_cso_investigations_requires_cso_totals() {
         let cso_election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
         let cso_totals = ElectionTotals::tabulate(&cso_election, &[]).unwrap();
-        assert!(ElectionTotalsWithoutVotes::try_from(cso_totals).is_ok());
+        assert!(cso_totals.cso_investigations().is_ok());
 
         let dso_totals = ElectionTotals::tabulate(&dso_election_fixture(), &[]).unwrap();
-        assert!(ElectionTotalsWithoutVotes::try_from(dso_totals).is_err());
-    }
+        assert!(dso_totals.cso_investigations().is_err());
 
-    #[test]
-    fn test_election_totals_csb_requires_csb_totals() {
         let csb_election = election_fixture(ElectionCategory::Municipal, CSB, &[2, 3]);
         let csb_totals = ElectionTotals::tabulate(&csb_election, &[]).unwrap();
-        assert!(ElectionTotalsCSB::new(&csb_totals, &csb_election.political_groups).is_ok());
-
-        let gsb_election = election_fixture(ElectionCategory::Municipal, GSB, &[2, 3]);
-        let gsb_totals = ElectionTotals::tabulate(&gsb_election, &[]).unwrap();
-        assert!(ElectionTotalsCSB::new(&gsb_totals, &gsb_election.political_groups).is_err());
+        assert!(csb_totals.cso_investigations().is_err());
     }
 }

--- a/backend/src/infra/pdf_gen/typst_smoke_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_smoke_tests.rs
@@ -29,6 +29,7 @@ use crate::{
             ModelNa31_2Input, ModelP2aInput, ModelP22_2Bijlage1Input, ModelP22_2Input,
             PdfFileModel, PdfModel,
             apportionment_footnotes::ApportionmentFootnotes,
+            election_totals::ElectionTotalsCSB,
             enriched_candidate_nomination::EnrichedCandidateNomination,
             enriched_seat_assignment::EnrichedSeatAssignment,
             votes_table::{
@@ -56,7 +57,7 @@ use crate::{
         },
         tabulation::{
             CSOInvestigations, CommitteeSpecificTotals, DifferencesTotals, ElectionTotals,
-            ElectionTotalsCSB, GSBTotals, SumCount,
+            GSBTotals, SumCount,
         },
     },
 };
@@ -686,8 +687,8 @@ async fn test_na_14_2() {
             votes_tables: VotesTablesWithPreviousVotes::new(&election, &totals, &previous_totals)
                 .unwrap(),
             election: election.into(),
-            previous_summary: previous_totals.try_into().unwrap(),
-            summary: totals.try_into().unwrap(),
+            previous_summary: (&previous_totals).into(),
+            summary: (&totals).into(),
             committee_session,
             previous_committee_session,
             hash,
@@ -779,7 +780,8 @@ async fn test_na_31_2() {
             votes_tables: VotesTables::new(&election, &totals).unwrap(),
             committee_session,
             election: election.into(),
-            summary: totals.try_into().unwrap(),
+            summary: (&totals).into(),
+            polling_station_investigations: totals.cso_investigations().unwrap().clone(),
             polling_stations,
             hash,
             creation_date_time,

--- a/backend/src/infra/pdf_gen/typst_tests.rs
+++ b/backend/src/infra/pdf_gen/typst_tests.rs
@@ -38,7 +38,8 @@ async fn it_generates_a_pdf() {
     let totals = ElectionTotals::zero(&election);
     let content = generate_pdf(
         ModelNa31_2Input {
-            summary: totals.clone().try_into().unwrap(),
+            summary: (&totals).into(),
+            polling_station_investigations: totals.cso_investigations().unwrap().clone(),
             votes_tables: VotesTables::new(&election, &totals).unwrap(),
             committee_session: committee_session_fixture(ElectionId::from(1)),
             election: election.into(),
@@ -106,7 +107,8 @@ async fn it_generates_a_pdf_with_polling_stations() {
     let content = generate_pdf(
         ModelNa31_2Input {
             votes_tables: VotesTables::new(&election, &totals).unwrap(),
-            summary: totals.try_into().unwrap(),
+            summary: (&totals).into(),
+            polling_station_investigations: totals.cso_investigations().unwrap().clone(),
             polling_stations: polling_stations_fixture(&[100, 200, 300]),
             committee_session,
             election: election.into(),

--- a/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-GR.json
+++ b/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-GR.json
@@ -61,11 +61,6 @@
         "count": 0,
         "data_entry_sources": []
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [3, 7, 10, 16, 19, 20, 27, 28, 35, 41, 48, 49, 51, 52, 62, 64, 73, 82, 85, 89, 90],
-      "investigated_other_reason": [13, 19, 35, 51, 55, 75, 85],
-      "ballots_recounted": [13]
     }
   },
   "summary": {
@@ -99,11 +94,6 @@
         "count": 1,
         "data_entry_sources": [{"type": "PollingStation", "number": 1}]
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [3, 7, 10, 16, 19, 20, 27, 28, 35, 41, 48, 49, 51, 52, 62, 64, 73, 82, 85, 89, 90],
-      "investigated_other_reason": [13, 19, 35, 51, 55, 75, 85],
-      "ballots_recounted": [13]
     }
   },
   "hash": "9a41 7d73 0dd2 b6d2 d0a6 ebdd 5360 d2ed de0c 3cc4 22e1 0c13 863e 3241 040d bd14",

--- a/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-PS.json
+++ b/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-PS.json
@@ -62,11 +62,6 @@
         "count": 0,
         "data_entry_sources": []
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [3, 7, 10, 16, 19, 20, 27, 28, 35, 41, 48, 49, 51, 52, 62, 64, 73, 82, 85, 89, 90],
-      "investigated_other_reason": [13, 19, 35, 51, 55, 75, 85],
-      "ballots_recounted": [13]
     }
   },
   "summary": {
@@ -101,11 +96,6 @@
         "count": 1,
         "data_entry_sources": [{"type": "PollingStation", "number": 1}]
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [3, 7, 10, 16, 19, 20, 27, 28, 35, 41, 48, 49, 51, 52, 62, 64, 73, 82, 85, 89, 90],
-      "investigated_other_reason": [13, 19, 35, 51, 55, 75, 85],
-      "ballots_recounted": [13]
     }
   },
   "hash": "9a41 7d73 0dd2 b6d2 d0a6 ebdd 5360 d2ed de0c 3cc4 22e1 0c13 863e 3241 040d bd14",

--- a/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-WS.json
+++ b/backend/templates/inputs/model-na-14-2-variations/model-na-14-2-WS.json
@@ -62,11 +62,6 @@
         "count": 0,
         "data_entry_sources": []
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [3, 7, 10, 16, 19, 20, 27, 28, 35, 41, 48, 49, 51, 52, 62, 64, 73, 82, 85, 89, 90],
-      "investigated_other_reason": [13, 19, 35, 51, 55, 75, 85],
-      "ballots_recounted": [13]
     }
   },
   "summary": {
@@ -101,11 +96,6 @@
         "count": 1,
         "data_entry_sources": [{"type": "PollingStation", "number": 1}]
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [3, 7, 10, 16, 19, 20, 27, 28, 35, 41, 48, 49, 51, 52, 62, 64, 73, 82, 85, 89, 90],
-      "investigated_other_reason": [13, 19, 35, 51, 55, 75, 85],
-      "ballots_recounted": [13]
     }
   },
   "hash": "9a41 7d73 0dd2 b6d2 d0a6 ebdd 5360 d2ed de0c 3cc4 22e1 0c13 863e 3241 040d bd14",

--- a/backend/templates/inputs/model-na-31-2-variations/model-na-31-2-GR.json
+++ b/backend/templates/inputs/model-na-31-2-variations/model-na-31-2-GR.json
@@ -81,12 +81,12 @@
         "count": 2,
         "data_entry_sources": [{"type": "PollingStation", "number": 1}, {"type": "PollingStation", "number": 3}, {"type": "PollingStation", "number": 5}]
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [1, 5],
-      "investigated_other_reason": [3],
-      "ballots_recounted": [1]
     }
+  },
+  "polling_station_investigations": {
+    "admitted_voters_recounted": [1, 5],
+    "investigated_other_reason": [3],
+    "ballots_recounted": [1]
   },
   "polling_stations": [
     {

--- a/backend/templates/inputs/model-na-31-2-variations/model-na-31-2-PS.json
+++ b/backend/templates/inputs/model-na-31-2-variations/model-na-31-2-PS.json
@@ -82,12 +82,12 @@
         "count": 2,
         "data_entry_sources": [{"type": "PollingStation", "number": 1}, {"type": "PollingStation", "number": 3}, {"type": "PollingStation", "number": 5}]
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [1, 5],
-      "investigated_other_reason": [3],
-      "ballots_recounted": [1]
     }
+  },
+  "polling_station_investigations": {
+    "admitted_voters_recounted": [1, 5],
+    "investigated_other_reason": [3],
+    "ballots_recounted": [1]
   },
   "polling_stations": [
     {

--- a/backend/templates/inputs/model-na-31-2-variations/model-na-31-2-WS.json
+++ b/backend/templates/inputs/model-na-31-2-variations/model-na-31-2-WS.json
@@ -82,12 +82,12 @@
         "count": 2,
         "data_entry_sources": [{"type": "PollingStation", "number": 1}, {"type": "PollingStation", "number": 3}, {"type": "PollingStation", "number": 5}]
       }
-    },
-    "polling_station_investigations": {
-      "admitted_voters_recounted": [1, 5],
-      "investigated_other_reason": [3],
-      "ballots_recounted": [1]
     }
+  },
+  "polling_station_investigations": {
+    "admitted_voters_recounted": [1, 5],
+    "investigated_other_reason": [3],
+    "ballots_recounted": [1]
   },
   "polling_stations": [
     {

--- a/backend/templates/model-na-31-2.typ
+++ b/backend/templates/model-na-31-2.typ
@@ -109,9 +109,9 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter of lid
             #polling_station.postal_code #polling_station.locality
           ]
         ],
-        align(center, checkbox(checked: input.summary.polling_station_investigations.admitted_voters_recounted.contains(polling_station.number))[]),
-        align(center, checkbox(checked: input.summary.polling_station_investigations.investigated_other_reason.contains(polling_station.number))[]),
-        align(center, checkbox(checked: input.summary.polling_station_investigations.ballots_recounted.contains(polling_station.number))[]),
+        align(center, checkbox(checked: input.polling_station_investigations.admitted_voters_recounted.contains(polling_station.number))[]),
+        align(center, checkbox(checked: input.polling_station_investigations.investigated_other_reason.contains(polling_station.number))[]),
+        align(center, checkbox(checked: input.polling_station_investigations.ballots_recounted.contains(polling_station.number))[]),
       )
     })
     .flatten(),


### PR DESCRIPTION
## What & why

Move the reporting-only structs to the models domain, resolves #3795.

- Move reporting-only structs `ElectionTotalsWithoutVotes` and `ElectionTotalsCSB` to `domain/models`. 
- Move CSO investigations out of `ElectionTotalsWithoutVotes` and into `ModelNa31_2Input`
- New `ElectionTotals::cso_investigations()` accessor replaces the CSO-only `impl TryFrom<ElectionTotals> for ElectionTotalsWithoutVotes`

## How to test

- All tests (CI) passes
- PDF output is unchanged
- Optionally a full end-to-end test: generate a first session and next session GSB reports, DSO reports should return errors

## Reviewer notes

Suggested review order: `models/election_totals.rs` (new module for reporting-only structs), `tabulation.rs` (reporting-only structs removed, CSO investigation accessor added), `model_na_31_2.rs/model_na_14_2.rs`, `report/structs.rs`, and finally the template and fixture updates.
