### PR TITLE
Enforce Clippy `#[expect]` attributes instead of `#[allow]`

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -123,6 +123,7 @@ unsafe_code = "forbid"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [workspace.lints.clippy]
+allow_attributes = "warn"
 cast_possible_truncation = "deny"
 cloned_instead_of_copied = "warn"
 cognitive_complexity = "warn"

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -370,7 +370,7 @@ fn update_candidate_ranking<T: CandidateVotes>(
 }
 
 #[cfg(test)]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 mod tests {
     use std::{
         collections::{HashMap, HashSet},

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -345,7 +345,7 @@ mod tests {
     /// List 3: 80 -> 0 full seats, 1 residual (largest remainder = 80, threshold 72)
     /// Initial distribution: [3, 1, 1].
     #[test]
-    #[allow(clippy::too_many_lines, reason = "Written out cases take many lines")]
+    #[expect(clippy::too_many_lines, reason = "Written out cases take many lines")]
     fn test_apportionment_process_with_deceased_scenarios() {
         struct Case {
             name: &'static str,

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -33,7 +33,7 @@ type SeatAssignmentResult<T> =
     Result<SeatAssignment<ListNumber<<T as ApportionmentInput>::List>>, ApportionmentError>;
 
 /// Seat assignment
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub(crate) fn seat_assignment<T: ApportionmentInput>(input: &T) -> SeatAssignmentResult<T> {
     info!("Seat assignment");
     info!("Seats: {}", input.number_of_seats());

--- a/backend/apportionment/src/seat_assignment/structs.rs
+++ b/backend/apportionment/src/seat_assignment/structs.rs
@@ -413,7 +413,7 @@ pub(crate) mod tests {
     use crate::{Fraction, seat_assignment::ListStanding, test_helpers::ListVotesMock};
 
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn test_list_standing_functions() {
         let candidate_votes: Vec<u32> = vec![100, 100, 100];
         let votes_cast: u64 = candidate_votes.iter().sum::<u32>() as u64;

--- a/backend/pdf_gen/impl/src/lib.rs
+++ b/backend/pdf_gen/impl/src/lib.rs
@@ -48,7 +48,7 @@ fn convert_datetime<Tz: chrono::TimeZone>(date_time: &chrono::DateTime<Tz>) -> O
     )
 }
 
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::cognitive_complexity)]
 fn compile_pdf(world: &world::PdfWorld) -> Result<PdfGenResult, PdfGenError> {
     debug!(
         "Starting Typst compilation for {:?}",

--- a/backend/src/api/apportionment/handlers/process_apportionment.rs
+++ b/backend/src/api/apportionment/handlers/process_apportionment.rs
@@ -30,7 +30,6 @@ impl AsAuditEvent for ApportionmentProcessed {
 
 #[derive(Debug, PartialEq, Serialize, ToSchema)]
 #[serde(tag = "status")]
-#[allow(clippy::large_enum_variant)]
 pub enum ProcessApportionmentResponse {
     Finalised(ElectionApportionmentResponse),
     DrawingLotsRequired {

--- a/backend/src/api/middleware/airgap/detect.rs
+++ b/backend/src/api/middleware/airgap/detect.rs
@@ -89,7 +89,7 @@ impl AirgapDetection {
         airgap_detection
     }
 
-    #[allow(clippy::cognitive_complexity)]
+    #[expect(clippy::cognitive_complexity)]
     async fn log_status_change(&self) {
         let event_result = if self.violation_detected() {
             AirGapViolationDetectedAuditData.as_audit_event()
@@ -119,7 +119,7 @@ impl AirgapDetection {
         };
     }
 
-    #[allow(clippy::cognitive_complexity)]
+    #[expect(clippy::cognitive_complexity)]
     async fn perform_detection(&self) {
         let was_connected = self.violation_detected();
 

--- a/backend/src/api/middleware/airgap/middleware.rs
+++ b/backend/src/api/middleware/airgap/middleware.rs
@@ -15,7 +15,7 @@ const API_PREFIX: &str = "/api/";
 /// If `block_requests_on_violation` is true, it will return an error.
 /// If false, it will add a header to the response indicating the violation status.
 /// This middleware only operates on requests starting with `API_PREFIX`
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::cognitive_complexity)]
 pub async fn block_request_on_airgap_violation(
     State(airgap_detection): State<AirgapDetection>,
     request: Request,

--- a/backend/src/api/middleware/authentication/error.rs
+++ b/backend/src/api/middleware/authentication/error.rs
@@ -42,7 +42,7 @@ impl ApiErrorResponse for AuthenticationError {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn to_response_parts(&self) -> (StatusCode, ErrorResponse) {
         match self {
             AuthenticationError::InvalidUsernameOrPassword => (

--- a/backend/src/api/middleware/authentication/middleware.rs
+++ b/backend/src/api/middleware/authentication/middleware.rs
@@ -66,7 +66,7 @@ pub(crate) async fn inject_user(
 }
 
 /// Middleware to extend the session lifetime
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::cognitive_complexity)]
 pub(crate) async fn extend_session(
     State(pool): State<SqlitePool>,
     OriginalUri(uri): OriginalUri,

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -229,8 +229,8 @@ async fn main() -> Result<(), AppError> {
 }
 
 /// Export an election (in EML) to the specified directory
-#[allow(clippy::too_many_lines)]
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::too_many_lines)]
+#[expect(clippy::cognitive_complexity)]
 async fn export_election(
     export_dir: &Path,
     committee_session: &CommitteeSession,

--- a/backend/src/domain/data_entry.rs
+++ b/backend/src/domain/data_entry.rs
@@ -1694,7 +1694,7 @@ mod tests {
 
     /// SecondEntryInProgress --> is_equal: finalise
     /// is_equal --> EntriesDifferent: equal? no
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn second_entry_in_progress_finalise_not_equal() {
         let initial = DataEntryStatus::SecondEntryInProgress(SecondEntryInProgress {

--- a/backend/src/domain/models/model_p_22_2.rs
+++ b/backend/src/domain/models/model_p_22_2.rs
@@ -53,7 +53,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn test_main_json_variations_match_struct() {
         let mut reader = BufReader::new(
             File::open("templates/inputs/model-p-22-2-variations/gte-19-seats.json").unwrap(),

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -138,8 +138,8 @@ pub enum APIError {
 }
 
 impl APIError {
-    #[allow(clippy::too_many_lines)]
-    #[allow(clippy::cognitive_complexity)]
+    #[expect(clippy::too_many_lines)]
+    #[expect(clippy::cognitive_complexity)]
     fn into_response_parts(self) -> (StatusCode, ErrorResponse) {
         match self {
             APIError::Delegated(err) => {

--- a/backend/src/infra/audit_log/error_logging.rs
+++ b/backend/src/infra/audit_log/error_logging.rs
@@ -8,7 +8,7 @@ use tracing::error;
 use super::{AsAuditEvent, AuditService, ErrorDetails};
 use crate::ErrorResponse;
 
-#[allow(clippy::cognitive_complexity)]
+#[expect(clippy::cognitive_complexity)]
 pub async fn log_error(
     State(pool): State<SqlitePool>,
     audit_service: AuditService,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -120,7 +120,6 @@ pub async fn start_server(
 
 /// Start the API server over HTTPS using axum-server/rustls.
 #[cfg(feature = "tls")]
-#[allow(clippy::cognitive_complexity)]
 pub async fn start_server_tls(
     pool: SqlitePool,
     listener: TcpListener,

--- a/backend/src/service/apportionment.rs
+++ b/backend/src/service/apportionment.rs
@@ -122,7 +122,6 @@ pub async fn next_state(
 }
 
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum ApportionmentResult {
     Ok(ElectionApportionmentResponse),
     ListDrawingLotsRequired(ListDrawingLotsVariant, ElectionTotals, SeatAssignment),

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -278,7 +278,7 @@ fn format_election_name(
 }
 
 /// Generate a random election using the limits from args.
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity)]
 fn generate_election(
     rng: &mut impl rand::RngExt,
     args: &GenerateElectionArgs,
@@ -432,9 +432,9 @@ async fn generate_polling_stations(
             remaining_voters
         } else {
             let sample_voters = remaining_voters / remaining_ps;
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             let min_sample_voters = (sample_voters as f64 * 0.9) as u32;
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             let max_sample_voters = (sample_voters as f64 * 1.1) as u32;
             rng.random_range(min_sample_voters..=max_sample_voters)
         };
@@ -468,7 +468,7 @@ async fn generate_polling_stations(
 }
 
 /// Generate and store data entries for the given election based on arguments
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn generate_gsb_data_entry(
     election: &ElectionWithPoliticalGroups,
     polling_stations: &[(PollingStation, DataEntryId)],
@@ -567,7 +567,7 @@ async fn generate_gsb_data_entry(
 }
 
 /// Generate and store data entries for the given election based on arguments
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity)]
 async fn generate_csb_data_entry(
     election: &ElectionWithPoliticalGroups,
     sub_committee_first_session: SubCommitteeFirstSession,
@@ -674,7 +674,7 @@ async fn generate_csb_data_entry(
     (generated_first_entries, generated_second_entries)
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn generate_cso_first_session_results(
     rng: &mut impl rand::RngExt,
     election: &ElectionWithPoliticalGroups,
@@ -683,12 +683,12 @@ fn generate_cso_first_session_results(
     candidate_distribution_slope: f64,
 ) -> CSOFirstSessionResults {
     // generate a small percentage of blank votes
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let blank_votes = (number_of_votes as f64 * rng.random_range(0.0..0.02)) as u32;
     let remaining_votes = number_of_votes - blank_votes;
 
     // generate a small percentage of invalid votes
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let invalid_votes = (remaining_votes as f64 * rng.random_range(0.0..0.02)) as u32;
     let remaining_votes = remaining_votes - invalid_votes;
 
@@ -814,7 +814,7 @@ fn generate_cso_first_session_results(
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn generate_gsb_results(
     rng: &mut impl rand::RngExt,
     election: &ElectionWithPoliticalGroups,
@@ -824,12 +824,12 @@ fn generate_gsb_results(
     candidate_distribution_slope: f64,
 ) -> GSBResults {
     // generate a small percentage of blank votes
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let blank_votes = (number_of_votes as f64 * rng.random_range(0.0..0.02)) as u32;
     let remaining_votes = number_of_votes - blank_votes;
 
     // generate a small percentage of invalid votes
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let invalid_votes = (remaining_votes as f64 * rng.random_range(0.0..0.02)) as u32;
     let remaining_votes = remaining_votes - invalid_votes;
 
@@ -991,7 +991,7 @@ fn distribute_fill_weights(
     sorted: bool,
 ) -> Vec<u32> {
     // Convert weights to integer quantities
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let mut result: Vec<u32> = weights
         .iter()
         .map(|w| (w * votes as f64).floor() as u32)


### PR DESCRIPTION
## What & why

Enforce Clippy `#[expect]` attributes instead of `#[allow]`, because `#[expect]` emits a warning if the lint is not triggered (i.e. the attribute is no longer needed). This is enforced through the [`allow_attributes` Clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#allow_attributes). All existing `#[allow]` attributes are replaced by `#[expect]` or removed if no longer needed.

This was motivated by https://github.com/kiesraad/abacus/pull/3808#discussion_r3803840420, where unnecessary `#[allow]` attributes were left in the PR.

## How to test

Clippy passes (in CI).