### PR TITLE
Update Vite config for `configLoader: 'native'`

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -94,6 +94,13 @@ export default defineConfig(
       },
     },
   },
+  // Vite's future `configLoader: 'native'` requires file extensions on relative imports in its config files
+  {
+    files: ["*.config.ts"],
+    rules: {
+      "import-x/extensions": "off",
+    },
+  },
   // Enforce Rules of React for frontend code
   {
     files: ["src/**/*.ts{,x}"],

--- a/frontend/vite-prod.config.ts
+++ b/frontend/vite-prod.config.ts
@@ -5,7 +5,7 @@ import browserslist from "browserslist";
 import { browserslistToTargets } from "lightningcss";
 import { defineConfig, type UserConfig } from "vite";
 
-import pkgjson from "./package.json";
+import pkgjson from "./package.json" with { type: "json" };
 
 // https://vitejs.dev/config/
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
@@ -84,7 +84,7 @@ export default defineConfig(({ command }) => {
   return {
     plugins: [react()],
     build: {
-      outDir: path.resolve(__dirname, "dist"),
+      outDir: path.resolve(import.meta.dirname, "dist"),
       emptyOutDir: true,
       sourcemap: true,
       minify: false,
@@ -103,7 +103,7 @@ export default defineConfig(({ command }) => {
     define,
     optimizeDeps: { exclude: ["msw"] },
     resolve: {
-      alias: [{ find: "@", replacement: path.resolve(__dirname, "./src") }],
+      alias: [{ find: "@", replacement: path.resolve(import.meta.dirname, "./src") }],
     },
   } satisfies UserConfig;
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,7 @@
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { defineConfig, mergeConfig } from "vite";
 
-import viteConfig from "./vite-prod.config";
+import viteConfig from "./vite-prod.config.ts";
 
 export default defineConfig((configEnv) =>
   mergeConfig(


### PR DESCRIPTION
## What & why

Update Vite config for `configLoader: 'native'` compatibility, resolves #3841.

## How to test

`pnpm dev` in the frontend folder should still work and return no warnings.
