### PR TITLE
Fix N 10-1 1.1 Presentielijst en 1.2.1 Bezwaren should not overflow to the next page

### DIFF
--- a/backend/templates/model-n-10-1.typ
+++ b/backend/templates/model-n-10-1.typ
@@ -16,7 +16,7 @@
 
 #show: doc => conf(
   doc,
-  header-right: header-right, 
+  header-right: header-right,
   footer: [
     Proces-verbaal van een stembureau \
     Model N 10-1 decentrale stemopneming (versie 2027)
@@ -81,7 +81,7 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter, lid o
   columns: (8em, 1fr, 1fr, 1fr, 7em, 7em),
   headers: ("Voorletters", "Achternaam", "Rol", "Aanwezig van - tot", "Aanwezig bij stemmen", "Aanwezig bij tellen"),
   values: ("", "", "", "-", checkbox(small: true)[], checkbox(small: true)[]),
-  rows: 22,
+  rows: 21,
 )
 
 == Tijdens het stemmen

--- a/backend/templates/model-n-10-2.typ
+++ b/backend/templates/model-n-10-2.typ
@@ -67,7 +67,7 @@ Elk stembureau maakt bij een verkiezing een verslag: het proces-verbaal. Hierin 
 
 == Presentielijst
 
-=== Aanwezige leden van het stembureau
+#emph_block[Aanwezige leden van het stembureau]
 
 De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter, lid of teller. Vink aan of iemand bij het stemmen en/of tellen aanwezig was.
 
@@ -75,12 +75,12 @@ De volgende rollen zijn mogelijk: voorzitter, plaatsvervangend voorzitter, lid o
   columns: (8em, 1fr, 1fr, 1fr, 7em, 7em),
   headers: ("Voorletters", "Achternaam", "Rol", "Aanwezig van - tot", "Aanwezig bij stemmen", "Aanwezig bij tellen"),
   values: ("", "", "", "-", checkbox(small: true)[], checkbox(small: true)[]),
-  rows: 22,
+  rows: 21,
 )
 
 == Tijdens het stemmen
 
-=== Schrijf *alle bezwaren van aanwezigen tijdens het stemmen* op.
+=== Schrijf alle *bezwaren van aanwezigen tijdens het stemmen* op.
 
 Bijvoorbeeld over toegankelijkheid, niet toegelaten worden of het stemgeheim.
 
@@ -90,7 +90,7 @@ Schrijf geen namen of andere persoonsgegevens op. Schrijf alle bezwaren op, ook 
   columns: (7em, 1fr, 1fr),
   headers: ("Tijdstip", "Bezwaar", "Reactie stembureau"),
   values: ("", "", ""),
-  rows: 24,
+  rows: 27,
 )
 
 #pagebreak(weak: true)


### PR DESCRIPTION
## What & why

Reported by @jorisleker in comment https://github.com/kiesraad/abacus/pull/3837#pullrequestreview-4969770064

Result:

<kbd>
<img width="397" height="920" alt="image" src="https://github.com/user-attachments/assets/0ed94825-eb38-4517-8ecb-4db6e312c160" />
</kbd>

Plus two small findings reported by @Lionqueen94:
- 'alle' should not be bold in 'Schrijf alle *bezwaren van aanwezigen tijdens het stemmen* op.'
- change heading to `emph_block` for `Aanwezige leden van het stembureau`


## How to test

Check the PDF diff.

## Reviewer notes

None.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->