### PR TITLE
Add missing apportionment tests

### DIFF
--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -1919,6 +1919,150 @@ mod tests {
         );
     }
 
+    /// Candidate nomination where multiple groups of candidates with equal votes
+    /// require drawing of lots, on different lists
+    ///
+    /// Within a single list at most one group of candidates with equal votes can
+    /// require drawing of lots, so multiple groups can only occur across lists.
+    ///
+    /// List seats: [2, 3]
+    /// - List 1: Preferential candidate nomination of candidate 1
+    ///   - Drawing of lots is required for candidates: [2, 3] with 300 votes, only 1 seat available
+    ///   - Candidate 3 is drawn
+    /// - List 2: Preferential candidate nomination of candidate 1
+    ///   - Drawing of lots is required for candidates: [2, 3, 4] with 400 votes, only 2 seats available
+    ///   - Candidate 4 is drawn
+    ///   - Drawing of lots is required for candidates: [2, 3] with 400 votes, only 1 seat available
+    ///   - Candidate 2 is drawn
+    #[test]
+    fn test_with_drawing_of_lots_for_multiple_groups_of_candidates_with_equal_votes() {
+        let quota = Fraction::new(9600, 19);
+        let seat_assignment_input = seat_assignment_fixture_with_given_candidate_votes(
+            19,
+            vec![vec![500, 300, 300], vec![500, 400, 400, 400]],
+        );
+        let input = candidate_nomination_fixture_with_given_number_of_seats(
+            quota,
+            &seat_assignment_input,
+            vec![2, 3],
+        );
+
+        let Ok(CandidateNomination::DrawingLotsRequired(variant_one)) =
+            candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+        else {
+            panic!("should be DrawingLotsRequired");
+        };
+
+        assert_eq!(
+            variant_one,
+            CandidateDrawingLotsVariant {
+                list: 1,
+                total_seats: 2,
+                number_of_votes: 300,
+                seat_numbers: vec![2],
+                options: vec![2, 3]
+            }
+        );
+
+        // Candidate 3 of list 1 is drawn
+        let candidates_drawn = [CandidateDrawnMock {
+            variant: variant_one.clone(),
+            drawn: 3,
+        }];
+
+        let result = candidate_nomination(&input, &mut candidates_drawn.iter());
+        let Ok(CandidateNomination::DrawingLotsRequired(variant_two)) = result else {
+            panic!("should be DrawingLotsRequired, but was {:?}", result);
+        };
+
+        assert_eq!(
+            variant_two,
+            CandidateDrawingLotsVariant {
+                list: 2,
+                total_seats: 3,
+                number_of_votes: 400,
+                seat_numbers: vec![2, 3],
+                options: vec![2, 3, 4]
+            }
+        );
+
+        // Candidate 4 of list 2 is drawn
+        let candidates_drawn = [
+            CandidateDrawnMock {
+                variant: variant_one.clone(),
+                drawn: 3,
+            },
+            CandidateDrawnMock {
+                variant: variant_two.clone(),
+                drawn: 4,
+            },
+        ];
+
+        let result = candidate_nomination(&input, &mut candidates_drawn.iter());
+        let Ok(CandidateNomination::DrawingLotsRequired(variant_three)) = result else {
+            panic!("should be DrawingLotsRequired, but was {:?}", result);
+        };
+
+        assert_eq!(
+            variant_three,
+            CandidateDrawingLotsVariant {
+                list: 2,
+                total_seats: 3,
+                number_of_votes: 400,
+                seat_numbers: vec![3],
+                options: vec![2, 3]
+            }
+        );
+
+        // Candidate 2 of list 2 is drawn
+        let candidates_drawn = [
+            CandidateDrawnMock {
+                variant: variant_one,
+                drawn: 3,
+            },
+            CandidateDrawnMock {
+                variant: variant_two,
+                drawn: 4,
+            },
+            CandidateDrawnMock {
+                variant: variant_three,
+                drawn: 2,
+            },
+        ];
+
+        let result = candidate_nomination(&input, &mut candidates_drawn.iter());
+        let Ok(CandidateNomination::Completed(details)) = result else {
+            panic!("should be Completed, but was {:?}", result);
+        };
+
+        assert_eq!(
+            details.list_candidate_nomination,
+            vec![
+                ListCandidateNomination {
+                    list_number: 1,
+                    list_seats: 2,
+                    preferential_candidate_nomination: vec![
+                        &CandidateVotesMock(1, 500),
+                        &CandidateVotesMock(3, 300),
+                    ],
+                    other_candidate_nomination: Vec::new(),
+                    candidate_ranking: CandidateRanking::Updated(vec![1, 3, 2]),
+                },
+                ListCandidateNomination {
+                    list_number: 2,
+                    list_seats: 3,
+                    preferential_candidate_nomination: vec![
+                        &CandidateVotesMock(1, 500),
+                        &CandidateVotesMock(4, 400),
+                        &CandidateVotesMock(2, 400),
+                    ],
+                    other_candidate_nomination: Vec::new(),
+                    candidate_ranking: CandidateRanking::Updated(vec![1, 4, 2, 3]),
+                }
+            ]
+        );
+    }
+
     #[test]
     fn test_preferential_candidate_nomination_scenarios() {
         struct Case {
@@ -2001,6 +2145,24 @@ mod tests {
                 total_seats: 4,
                 candidates_drawn: vec![],
                 expected_nominations: vec![1, 3, 4, 5],
+            },
+            Case {
+                name: "multiple groups with equal votes, only the last group draws lots",
+                // The group with 900 votes fits within the remaining seats and is
+                // nominated without lots. Only the group with 600 votes draws lots.
+                candidates: vec![(1, 1000), (3, 900), (4, 900), (5, 600), (6, 600)],
+                total_seats: 4,
+                candidates_drawn: vec![CandidateDrawnMock {
+                    variant: CandidateDrawingLotsVariant {
+                        list: 1,
+                        total_seats: 4,
+                        number_of_votes: 600,
+                        seat_numbers: vec![4],
+                        options: vec![5, 6],
+                    },
+                    drawn: 6,
+                }],
+                expected_nominations: vec![1, 3, 4, 6],
             },
         ];
 

--- a/backend/apportionment/src/candidate_nomination/mod.rs
+++ b/backend/apportionment/src/candidate_nomination/mod.rs
@@ -759,10 +759,10 @@ mod tests {
                 input.list_votes[0].number,
                 &[
                     &input.list_votes[0].candidate_votes[..7],
-                    &input.list_votes[0].candidate_votes[10..],
+                    &input.list_votes[0].candidate_votes[9..],
                 ]
                 .concat(),
-                &input.list_votes[0].candidate_votes[8..9],
+                &input.list_votes[0].candidate_votes[7..9],
             );
             check_chosen_candidates(
                 &result.chosen_candidates,
@@ -1268,12 +1268,117 @@ mod tests {
             CandidateNomination, Fraction,
             candidate_nomination::candidate_nomination,
             test_helpers::{
-                CandidateDrawnMock, candidate_nomination_fixture_with_given_number_of_seats,
-                check_chosen_candidates, check_list_candidate_nomination,
-                get_chosen_and_not_chosen_candidates_for_a_list,
+                CandidateDrawnMock,
+                candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats,
+                candidate_nomination_fixture_with_given_number_of_seats, check_chosen_candidates,
+                check_list_candidate_nomination, get_chosen_and_not_chosen_candidates_for_a_list,
                 seat_assignment_fixture_with_given_candidate_votes,
+                seat_assignment_fixture_with_given_list_numbers_candidate_numbers_and_votes,
             },
         };
+
+        /// Candidate nomination with non-consecutive list and candidate numbers
+        ///
+        /// List seats: [(1, 10), (3, 6), (6, 3)]
+        /// - List 1: Preferential candidate nominations of candidates 2, 4 and 8 and
+        ///   other candidate nominations of candidates 6, 10, 12, 14, 16, 18 and 20
+        /// - List 3: Preferential candidate nominations of candidates 1, 3, 5, 7 and 9
+        ///   and other candidate nomination of candidate 11
+        /// - List 6: Preferential candidate nominations of candidates 2, 5 and 8 and
+        ///   no other candidate nominations
+        #[test]
+        fn test_with_gte_19_seats_and_non_consecutive_list_and_candidate_numbers() {
+            let quota = Fraction::new(1900, 19);
+            let seat_assignment_input =
+                seat_assignment_fixture_with_given_list_numbers_candidate_numbers_and_votes(
+                    19,
+                    vec![
+                        (
+                            1,
+                            vec![
+                                (2, 500),
+                                (4, 80),
+                                (6, 22),
+                                (8, 40),
+                                (10, 15),
+                                (12, 25),
+                                (14, 10),
+                                (16, 8),
+                                (18, 5),
+                                (20, 4),
+                                (22, 6),
+                            ],
+                        ),
+                        (
+                            3,
+                            vec![
+                                (1, 300),
+                                (3, 100),
+                                (5, 90),
+                                (7, 28),
+                                (9, 26),
+                                (11, 24),
+                                (13, 10),
+                            ],
+                        ),
+                        (6, vec![(2, 330), (5, 237), (8, 40)]),
+                    ],
+                );
+            let input = candidate_nomination_fixture_with_given_list_numbers_and_number_of_seats(
+                quota,
+                &seat_assignment_input,
+                [(1, 10), (3, 6), (6, 3)].into(),
+            );
+
+            let Ok(CandidateNomination::Completed(result)) =
+                candidate_nomination(&input, &mut iter::empty::<&CandidateDrawnMock>())
+            else {
+                panic!("should be completed");
+            };
+
+            assert_eq!(result.preference_threshold.percentage, 25);
+            assert_eq!(
+                result.preference_threshold.number_of_votes,
+                quota * Fraction::new(result.preference_threshold.percentage, 100)
+            );
+            check_list_candidate_nomination(
+                &result.list_candidate_nomination[0],
+                &[2, 4, 8],
+                &[6, 10, 12, 14, 16, 18, 20],
+                &[2, 4, 8, 6, 10, 12, 14, 16, 18, 20, 22],
+            );
+            check_list_candidate_nomination(
+                &result.list_candidate_nomination[1],
+                &[1, 3, 5, 7, 9],
+                &[11],
+                &[],
+            );
+            check_list_candidate_nomination(
+                &result.list_candidate_nomination[2],
+                &[2, 5, 8],
+                &[],
+                &[],
+            );
+
+            check_chosen_candidates(
+                &result.chosen_candidates,
+                input.list_votes[0].number,
+                &input.list_votes[0].candidate_votes[..10],
+                &input.list_votes[0].candidate_votes[10..],
+            );
+            check_chosen_candidates(
+                &result.chosen_candidates,
+                input.list_votes[1].number,
+                &input.list_votes[1].candidate_votes[..6],
+                &input.list_votes[1].candidate_votes[6..],
+            );
+            check_chosen_candidates(
+                &result.chosen_candidates,
+                input.list_votes[2].number,
+                &input.list_votes[2].candidate_votes[..],
+                &[],
+            );
+        }
 
         /// Candidate nomination with candidate votes meeting preference threshold but no seat
         ///

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -338,6 +338,53 @@ mod tests {
         );
     }
 
+    /// Same as `test_apportionment_process`, but on list 1 we mark candidate 3 as deceased:
+    /// a candidate with 0 votes who would have been elected purely because of their
+    /// position on the list (list 1 gets 7 seats, only candidate 1 is nominated
+    /// preferentially, candidates 2..=7 would be nominated based on list position).
+    ///
+    /// Seat assignment must be unchanged (list 1 still has enough alive candidates).
+    /// In the candidate nomination for list 1, candidate 3 is skipped and candidate 8
+    /// takes the last seat instead.
+    #[test]
+    fn test_apportionment_process_with_deceased_candidate_elected_by_list_position() {
+        let mut input = seat_assignment_fixture_with_default_50_candidates(
+            15,
+            vec![540, 160, 160, 80, 80, 80, 60, 40],
+        );
+        input.deceased_candidates = HashMap::from([(1, HashSet::from([3]))]);
+
+        let Ok(ApportionmentOutput::Completed(result)) = process(&input) else {
+            panic!("should be Completed")
+        };
+
+        // Seat assignment is identical to the `test_apportionment_process` test.
+        assert_eq!(result.seat_assignment.full_seats, 13);
+        assert_eq!(result.seat_assignment.residual_seats, 2);
+        let total_seats = get_total_seats_from_apportionment_result(&result.seat_assignment);
+        assert_eq!(total_seats, vec![7, 2, 2, 1, 1, 1, 1, 0]);
+
+        // List 1: candidate 1 still gets the preferential seat; the other 6 seats are
+        // assigned by list position, skipping deceased candidate 3.
+        let expected_ranking: Vec<u32> = [1, 2].into_iter().chain(4..=50).collect();
+        check_list_candidate_nomination(
+            &result.candidate_nomination.list_candidate_nomination[0],
+            &[1],
+            &[2, 4, 5, 6, 7, 8],
+            &expected_ranking,
+        );
+
+        // List 1 chosen: candidates 1, 2 (indices 0..2) and 4..=8 (indices 3..8)
+        // Not chosen: candidate 3 (deceased, index 2) and candidates 9..=50 (indices 8..)
+        let list1 = &input.list_votes[0];
+        check_chosen_candidates(
+            &result.candidate_nomination.chosen_candidates,
+            list1.number,
+            &[&list1.candidate_votes[..2], &list1.candidate_votes[3..8]].concat(),
+            &[&list1.candidate_votes[2..3], &list1.candidate_votes[8..]].concat(),
+        );
+    }
+
     /// Scenarios testing deceased candidates and seat assignment.
     ///
     /// All cases share the same small fixture:

--- a/backend/apportionment/src/lib.rs
+++ b/backend/apportionment/src/lib.rs
@@ -379,6 +379,16 @@ mod tests {
                 expects_exhaustion_step: true,
             },
             Case {
+                name: "deceased on multiple lists -> list 2 blocked, seat goes to list 3 via UHA",
+                // List 1, # alive = 2, list 1 seats = 3 -> exhausted by 1.
+                // List 2, # alive = 1, list 2 seats = 1 -> not retracted, but exhausted.
+                // Unlike the single-list case above, list 2 cannot absorb the retracted
+                // seat: it goes to list 3 through unique-highest-average instead.
+                deceased: HashMap::from([(1, HashSet::from([3])), (2, HashSet::from([2]))]),
+                expected_seats: vec![2, 1, 2],
+                expects_exhaustion_step: true,
+            },
+            Case {
                 name: "two-seat exhaustion on list 1 -> list 2 gets LR, list 3 gets UHA",
                 // List 1, # alive = 1, list 1 seats = 3 -> exhausted by 2.
                 // First retraction reassigns via largest remainder to list 2; after that

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -1200,6 +1200,88 @@ pub(crate) mod tests {
 
             /// Apportionment with residual seats assigned with largest remainders method
             ///
+            /// This test triggers Kieswet Article P 9, where the last residual seat (a single
+            /// seat) was assigned by drawing of lots. The retraction itself requires no
+            /// drawing of lots, since only one list holds the last residual seat.
+            ///
+            /// Full seats: [7, 1, 2, 1, 1] - Remainder seats: 3
+            /// Remainders: [151, 210, 199, 170, 170]
+            /// 1 - largest remainder: seat assigned to list 2
+            /// 2 - largest remainder: seat assigned to list 3
+            /// 3 - Drawing of lots is required for lists: [4, 5], only 1 seat available
+            ///     Option 4 is picked
+            /// 4 - Seat first assigned to list 4 has been re-assigned to list 1 in
+            ///     accordance with Article P 9 Kieswet, without drawing of lots
+            #[test]
+            fn test_with_absolute_majority_of_votes_but_not_seats_and_single_last_residual_seat_assigned_by_drawing_of_lots()
+             {
+                let mut input = seat_assignment_fixture_with_default_50_candidates(
+                    15,
+                    vec![2251, 510, 799, 470, 470],
+                );
+
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(170, 1),
+                            residual_seat_numbers: vec![3],
+                            options: vec![4, 5],
+                            list_remainders: vec![
+                                (1, Fraction::new(151, 1)),
+                                (2, Fraction::new(210, 1)),
+                                (3, Fraction::new(199, 1)),
+                                (4, Fraction::new(170, 1)),
+                                (5, Fraction::new(170, 1)),
+                            ],
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.seats, 15);
+                assert_eq!(preliminary_result.full_seats, 12);
+                assert_eq!(preliminary_result.residual_seats, 3);
+                assert_eq!(preliminary_result.quota, Fraction::new(4500, 15));
+                assert_eq!(preliminary_result.steps.len(), 2);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 1, 0, 0]
+                );
+
+                // Drawing lots results in list 4, which gets the last residual seat.
+                // The Article P 9 retraction then needs no drawing of lots, since
+                // list 4 is the only list holding the last residual seat.
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.full_seats, 12);
+                assert_eq!(result.residual_seats, 3);
+                assert_eq!(result.steps.len(), 4);
+                assert_eq!(result.steps[0].change.list_number_assigned(), 2);
+                assert_eq!(result.steps[1].change.list_number_assigned(), 3);
+                assert_eq!(result.steps[2].change.list_number_assigned(), 4);
+                assert_eq!(
+                    result.steps[3].change,
+                    SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                        list_retracted_seat: 4,
+                        list_assigned_seat: 1,
+                        drawing_lots: None,
+                    })
+                );
+                assert_eq!(get_standings_residual_seats(&result), vec![1, 1, 1, 0, 0]);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, vec![8, 2, 3, 1, 1]);
+                assert!(result.warnings().is_empty());
+            }
+
+            /// Apportionment with residual seats assigned with largest remainders method
+            ///
             /// Full seats: [6, 2, 2, 1, 1, 1, 0, 0] - Remainder seats: 2  
             /// Remainders: [60, 0/15, 0/15, 0/15, 0/15, 0/15, 55, 45]  
             /// 1 - largest remainder: seat assigned to list 1  
@@ -2768,6 +2850,91 @@ pub(crate) mod tests {
                 );
             }
 
+            /// Apportionment with residual seats assigned with highest averages method
+            ///
+            /// This test triggers Kieswet Article P 9, where the last residual seat (a single
+            /// seat) was assigned by drawing of lots. The retraction itself requires no
+            /// drawing of lots, since only one list holds the last residual seat.
+            ///
+            /// With 19 or more seats this is only possible when the majority list itself is
+            /// among the tied lists and loses the draw. Any other list winning a residual
+            /// seat must have an average at least equal to the majority list's.
+            ///
+            /// Full seats: [10, 9] - Remainder seats: 1
+            /// 1 - Drawing of lots is required for lists: [1, 2], tied averages [20, 20],
+            ///     only 1 seat available. Option 2 is picked
+            /// 2 - Seat first assigned to list 2 has been re-assigned to list 1 in
+            ///     accordance with Article P 9 Kieswet, without drawing of lots
+            #[test]
+            fn test_with_absolute_majority_of_votes_but_not_seats_and_single_last_residual_seat_assigned_by_drawing_of_lots()
+             {
+                let mut input =
+                    seat_assignment_fixture_with_default_50_candidates(20, vec![220, 200]);
+
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            max_average: Fraction::new(20, 1),
+                            residual_seat_numbers: vec![1],
+                            options: vec![1, 2],
+                            list_averages: vec![
+                                (1, Fraction::new(20, 1)),
+                                (2, Fraction::new(20, 1)),
+                            ],
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.seats, 20);
+                assert_eq!(preliminary_result.full_seats, 19);
+                assert_eq!(preliminary_result.residual_seats, 1);
+                assert_eq!(preliminary_result.quota, Fraction::new(420, 20));
+                assert_eq!(preliminary_result.steps.len(), 0);
+
+                // Drawing lots results in list 2, so the majority list loses the draw and
+                // stays at exactly half of the seats. The Article P 9 retraction then needs
+                // no drawing of lots, since list 2 is the only list holding the last
+                // residual seat.
+                input.lists_drawn.push(ListDrawnMock {
+                    variant: variant.clone(),
+                    drawn: 2,
+                });
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.full_seats, 19);
+                assert_eq!(result.residual_seats, 1);
+                assert_eq!(result.steps.len(), 2);
+                assert_eq!(
+                    result.steps[0].change,
+                    SeatChange::HighestAverageAssignment(HighestAverageAssignedSeat {
+                        selected_list_number: 2,
+                        list_options: vec![1, 2],
+                        list_assigned: vec![2],
+                        list_exhausted: vec![],
+                        votes_per_seat: Fraction::new(20, 1),
+                        drawing_lots: Some(variant),
+                    })
+                );
+                assert_eq!(
+                    result.steps[1].change,
+                    SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                        list_retracted_seat: 2,
+                        list_assigned_seat: 1,
+                        drawing_lots: None,
+                    })
+                );
+                assert_eq!(get_standings_residual_seats(&result), vec![1, 0]);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, vec![11, 9]);
+                assert!(result.warnings().is_empty());
+            }
             /// Apportionment with residual seats assigned with highest averages method
             ///
             /// This test triggers Kieswet Article P 9, where the last residual seats were

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -1850,6 +1850,77 @@ pub(crate) mod tests {
                 assert_eq!(total_seats, [2, 2, 2]);
             }
 
+            /// Apportionment with residual seats assigned with largest remainders and highest averages methods,
+            /// where the seat freed by list exhaustion starts the 2nd round of the highest averages method
+            /// (assignment to any list) directly
+            ///
+            /// All candidates of list 4 are deceased, so list 4 is exhausted without holding any seats.
+            /// This is the only way the reassignment can start with the 2nd round: every other
+            /// non-exhausted list must already hold a unique highest average seat, and a list
+            /// without any seats only counts as exhausted when it has no candidates left.
+            ///
+            /// Full seats: [1, 2, 0, 0] - Remainder seats: 3
+            /// Remainders: [99, 60, 74, 67], only votes of lists [1, 2] meet the threshold of 75% of the quota
+            /// 1 - largest remainder: seat assigned to list 1
+            /// 2 - largest remainder: seat assigned to list 2
+            /// 1st round of highest averages method (assignment to unique lists):
+            /// 3 - highest average: [66 1/3, 65, 74, 67] seat assigned to list 3
+            /// 4 - Seat first assigned to list 1 has been removed and
+            ///     will be assigned to another list in accordance with Article P 10 Kieswet
+            /// 2nd round of highest averages method (assignment to any list), since list 3 is the
+            /// only list that is not exhausted and it already received a unique highest average seat:
+            /// 5 - highest average: [99 1/2, 65, 37, 67] seat assigned to list 3
+            #[test]
+            fn test_with_list_exhaustion_where_reassignment_starts_with_2nd_round_highest_average_assignment()
+             {
+                let mut input = seat_assignment_fixture_with_given_candidate_votes(
+                    6,
+                    vec![vec![199], vec![100, 90, 70], vec![40, 34], vec![35, 32]],
+                );
+                input.deceased_candidates = HashMap::from([(4, HashSet::from([1, 2]))]);
+
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.full_seats, 3);
+                assert_eq!(result.residual_seats, 3);
+                assert_eq!(result.steps.len(), 5);
+                assert!(
+                    result.steps[0]
+                        .change
+                        .is_changed_by_largest_remainder_assignment()
+                );
+                assert_eq!(result.steps[0].change.list_number_assigned(), 1);
+                assert!(
+                    result.steps[1]
+                        .change
+                        .is_changed_by_largest_remainder_assignment()
+                );
+                assert_eq!(result.steps[1].change.list_number_assigned(), 2);
+                assert!(
+                    result.steps[2]
+                        .change
+                        .is_changed_by_unique_highest_average_assignment()
+                );
+                assert_eq!(result.steps[2].change.list_number_assigned(), 3);
+                assert!(
+                    result.steps[3]
+                        .change
+                        .is_changed_by_list_exhaustion_removal()
+                );
+                assert_eq!(result.steps[3].change.list_number_retracted(), 1);
+                assert!(
+                    result.steps[4]
+                        .change
+                        .is_changed_by_highest_average_assignment()
+                );
+                assert_eq!(result.steps[4].change.list_number_assigned(), 3);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, [1, 3, 2, 0]);
+                assert!(result.warnings().is_empty());
+            }
+
             /// Apportionment with residual seats assigned with largest remainders method  
             /// This test triggers Kieswet Article P 9 and P 10
             ///

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -1046,6 +1046,160 @@ pub(crate) mod tests {
 
             /// Apportionment with residual seats assigned with largest remainders method
             ///
+            /// This test triggers Kieswet Article P 9, where the last residual seats were
+            /// themselves assigned by drawing of lots (more tied lists than available seats)
+            ///
+            /// Full seats: [7, 1, 1, 1, 1, 1] - Remainder seats: 3
+            /// Remainders: [160, 170, 170, 170, 170, 60]
+            /// 1 - Drawing of lots is required for lists: [2, 3, 4, 5], only 3 seats available
+            ///     Option 2 is picked
+            /// 2 - Drawing of lots is required for lists: [3, 4, 5], only 2 seats available
+            ///     Option 3 is picked
+            /// 3 - Drawing of lots is required for lists: [4, 5], only 1 seat available
+            ///     Option 4 is picked
+            /// 4 - Drawing of lots is required for lists: [2, 3, 4] to pick a list which the
+            ///     residual seat gets retracted from
+            ///     Option 3 is picked, completing the apportionment
+            #[test]
+            fn test_with_absolute_majority_of_votes_but_not_seats_and_last_residual_seats_assigned_by_drawing_of_lots()
+             {
+                let mut input = seat_assignment_fixture_with_default_50_candidates(
+                    15,
+                    vec![2260, 470, 470, 470, 470, 360],
+                );
+                let list_remainders: Vec<(u32, Fraction)> = vec![
+                    (1, Fraction::new(160, 1)),
+                    (2, Fraction::new(170, 1)),
+                    (3, Fraction::new(170, 1)),
+                    (4, Fraction::new(170, 1)),
+                    (5, Fraction::new(170, 1)),
+                    (6, Fraction::new(60, 1)),
+                ];
+
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(170, 1),
+                            residual_seat_numbers: vec![1, 2, 3],
+                            options: vec![2, 3, 4, 5],
+                            list_remainders: list_remainders.clone(),
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.seats, 15);
+                assert_eq!(preliminary_result.full_seats, 12);
+                assert_eq!(preliminary_result.residual_seats, 3);
+                assert_eq!(preliminary_result.quota, Fraction::new(4500, 15));
+                assert_eq!(preliminary_result.steps.len(), 0);
+
+                // Drawing lots results in list 2
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 2 });
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(170, 1),
+                            residual_seat_numbers: vec![2, 3],
+                            options: vec![3, 4, 5],
+                            list_remainders: list_remainders.clone(),
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.steps.len(), 1);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 0, 0, 0, 0]
+                );
+
+                // Drawing lots results in list 3
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::LargestRemainderResidualSeat(
+                        LargestRemainderResidualSeatDrawingLots {
+                            max_remainder: Fraction::new(170, 1),
+                            residual_seat_numbers: vec![3],
+                            options: vec![4, 5],
+                            list_remainders: list_remainders.clone(),
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.steps.len(), 2);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 1, 0, 0, 0]
+                );
+
+                // Drawing lots results in list 4, then Article P 9 requires drawing of lots
+                // among the lists that were assigned the last residual seats
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 4 });
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::AbsoluteMajorityLargestRemainder(
+                        AbsoluteMajorityDrawingLots {
+                            assign_to: 1,
+                            options: vec![2, 3, 4],
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.steps.len(), 3);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 1, 1, 0, 0]
+                );
+
+                // Drawing lots results in list 3, which gets its seat retracted
+                input.lists_drawn.push(ListDrawnMock {
+                    variant: variant.clone(),
+                    drawn: 3,
+                });
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.full_seats, 12);
+                assert_eq!(result.residual_seats, 3);
+                assert_eq!(result.steps.len(), 4);
+                assert_eq!(
+                    result.steps[3].change,
+                    SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                        list_retracted_seat: 3,
+                        list_assigned_seat: 1,
+                        drawing_lots: Some(variant),
+                    })
+                );
+                assert_eq!(
+                    get_standings_residual_seats(&result),
+                    vec![1, 1, 0, 1, 0, 0]
+                );
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, vec![8, 2, 1, 2, 1, 1]);
+                assert!(result.warnings().is_empty());
+            }
+
+            /// Apportionment with residual seats assigned with largest remainders method
+            ///
             /// Full seats: [6, 2, 2, 1, 1, 1, 0, 0] - Remainder seats: 2  
             /// Remainders: [60, 0/15, 0/15, 0/15, 0/15, 0/15, 55, 45]  
             /// 1 - largest remainder: seat assigned to list 1  

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -1663,6 +1663,61 @@ pub(crate) mod tests {
                 assert_eq!(total_seats, [0, 0, 0, 1, 1, 8]);
             }
 
+            /// Apportionment with residual seats assigned with largest remainders method,
+            /// where the seat freed by list exhaustion starts the 1st round of the highest averages method
+            ///
+            /// 8 seats, quota = 80 votes / 8 = 10
+            /// Full seats: [4, 2, 0, 0] - Remainder seats: 2
+            /// Remainders: [4, 3, 7, 6], only votes of lists [1, 2] meet the threshold of 75% of the quota
+            /// 1 - largest remainder: seat assigned to list 1
+            /// 2 - largest remainder: seat assigned to list 2
+            /// 3 - Seat first assigned to list 1 has been removed and
+            ///     will be assigned to another list in accordance with Article P 10 Kieswet
+            /// 1st round of highest averages method (assignment to unique lists):
+            /// 4 - highest average: [8 4/5, 5 3/4, 7, 6] seat assigned to list 3
+            ///     (list 1 is exhausted, list 2 already received a residual seat)
+            #[test]
+            fn test_with_list_exhaustion_triggering_1st_round_highest_average_assignment() {
+                let input = seat_assignment_fixture_with_given_candidate_votes(
+                    8,
+                    vec![vec![11, 11, 11, 11], vec![10, 8, 5], vec![7], vec![6]],
+                );
+                let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.full_seats, 6);
+                assert_eq!(result.residual_seats, 2);
+                assert_eq!(result.steps.len(), 4);
+                assert!(
+                    result.steps[0]
+                        .change
+                        .is_changed_by_largest_remainder_assignment()
+                );
+                assert_eq!(result.steps[0].change.list_number_assigned(), 1);
+                assert!(
+                    result.steps[1]
+                        .change
+                        .is_changed_by_largest_remainder_assignment()
+                );
+                assert_eq!(result.steps[1].change.list_number_assigned(), 2);
+                assert!(
+                    result.steps[2]
+                        .change
+                        .is_changed_by_list_exhaustion_removal()
+                );
+                assert_eq!(result.steps[2].change.list_number_retracted(), 1);
+                assert!(
+                    result.steps[3]
+                        .change
+                        .is_changed_by_unique_highest_average_assignment()
+                );
+                assert_eq!(result.steps[3].change.list_number_assigned(), 3);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, [4, 3, 1, 0]);
+                assert!(result.warnings().is_empty());
+            }
+
             /// Apportionment with residual seats assigned with largest remainders and highest averages methods
             ///
             /// Full seats: [0, 0, 5] - Remainder seats: 1  

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -2935,6 +2935,7 @@ pub(crate) mod tests {
                 assert_eq!(total_seats, vec![11, 9]);
                 assert!(result.warnings().is_empty());
             }
+
             /// Apportionment with residual seats assigned with highest averages method
             ///
             /// This test triggers Kieswet Article P 9, where the last residual seats were

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -886,6 +886,42 @@ pub(crate) mod tests {
             assert!(result.warnings().is_empty());
         }
 
+        /// Apportionment with residual seats assigned with largest remainders method
+        /// This test does not trigger a reassignment under Kieswet Article P 9, since the
+        /// list with an absolute majority of votes also has an absolute majority of seats.
+        ///
+        /// Full seats: [6, 2, 1] - Remainder seats: 1
+        /// Remainders: [0/10, 4, 6]
+        /// 1 - largest remainder: seat assigned to list 3
+        /// List 1 has an absolute majority of votes (60 of 100) and of seats (6 of 10),
+        /// so no reassignment takes place
+        #[test]
+        fn test_with_absolute_majority_of_votes_and_seats() {
+            let input = seat_assignment_fixture_with_default_50_candidates(10, vec![60, 24, 16]);
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
+            assert_eq!(result.full_seats, 9);
+            assert_eq!(result.residual_seats, 1);
+            assert_eq!(result.steps.len(), 1);
+            assert!(
+                result.steps[0]
+                    .change
+                    .is_changed_by_largest_remainder_assignment()
+            );
+            assert_eq!(result.steps[0].change.list_number_assigned(), 3);
+            assert!(
+                result
+                    .steps
+                    .iter()
+                    .all(|step| !step.change.is_changed_by_absolute_majority_reassignment())
+            );
+            let total_seats = get_total_seats_from_apportionment_result(&result);
+            assert_eq!(total_seats, vec![6, 2, 2]);
+            assert!(result.warnings().is_empty());
+        }
+
         /// Apportionment with residual seats assigned with largest remainders method  
         /// This test does not trigger Kieswet Article P 9, since this requires a
         /// strict majority of votes (> 50%), so exactly 50% does not trigger it.
@@ -2446,6 +2482,42 @@ pub(crate) mod tests {
             assert_eq!(result.steps[6].change.list_number_assigned(), 1);
             let total_seats = get_total_seats_from_apportionment_result(&result);
             assert_eq!(total_seats, vec![13, 2, 2, 2, 2, 2, 1, 0]);
+            assert!(result.warnings().is_empty());
+        }
+
+        /// Apportionment with residual seats assigned with highest averages method
+        /// This test does not trigger a reassignment under Kieswet Article P 9, since the
+        /// list with an absolute majority of votes also has an absolute majority of seats.
+        ///
+        /// Full seats: [11, 4, 3] - Remainder seats: 1
+        /// 1 - highest average: [95, 92, 75] seat assigned to list 1
+        /// List 1 has an absolute majority of votes (1140 of 1900) and of seats (12 of 19),
+        /// so no reassignment takes place
+        #[test]
+        fn test_with_absolute_majority_of_votes_and_seats() {
+            let input =
+                seat_assignment_fixture_with_default_50_candidates(19, vec![1140, 460, 300]);
+            let SeatAssignment::Completed(result) = seat_assignment(&input).unwrap() else {
+                panic!("should be Completed");
+            };
+
+            assert_eq!(result.full_seats, 18);
+            assert_eq!(result.residual_seats, 1);
+            assert_eq!(result.steps.len(), 1);
+            assert!(
+                result.steps[0]
+                    .change
+                    .is_changed_by_highest_average_assignment()
+            );
+            assert_eq!(result.steps[0].change.list_number_assigned(), 1);
+            assert!(
+                result
+                    .steps
+                    .iter()
+                    .all(|step| !step.change.is_changed_by_absolute_majority_reassignment())
+            );
+            let total_seats = get_total_seats_from_apportionment_result(&result);
+            assert_eq!(total_seats, vec![12, 4, 3]);
             assert!(result.warnings().is_empty());
         }
 

--- a/backend/apportionment/src/seat_assignment/mod.rs
+++ b/backend/apportionment/src/seat_assignment/mod.rs
@@ -2770,6 +2770,134 @@ pub(crate) mod tests {
 
             /// Apportionment with residual seats assigned with highest averages method
             ///
+            /// This test triggers Kieswet Article P 9, where the last residual seats were
+            /// themselves assigned by drawing of lots (more tied lists than available seats)
+            ///
+            /// With 19 or more seats this is only possible when the majority list itself is
+            /// among the tied lists and loses every draw.
+            ///
+            /// Full seats: [10, 5, 3] - Remainder seats: 2
+            /// 1 - Drawing of lots is required for lists: [1, 2, 3], tied averages
+            ///     [20, 20, 20], only 2 seats available. Option 2 is picked
+            /// 2 - Drawing of lots is required for lists: [1, 3], only 1 seat available.
+            ///     Option 3 is picked
+            /// 3 - Drawing of lots is required for lists: [2, 3] to pick a list which the
+            ///     residual seat gets retracted from. Option 2 is picked,
+            ///     completing the apportionment
+            #[test]
+            fn test_with_absolute_majority_of_votes_but_not_seats_and_last_residual_seats_assigned_by_drawing_of_lots()
+             {
+                let mut input =
+                    seat_assignment_fixture_with_default_50_candidates(20, vec![220, 120, 80]);
+
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            max_average: Fraction::new(20, 1),
+                            residual_seat_numbers: vec![1, 2],
+                            options: vec![1, 2, 3],
+                            list_averages: vec![
+                                (1, Fraction::new(20, 1)),
+                                (2, Fraction::new(20, 1)),
+                                (3, Fraction::new(20, 1)),
+                            ],
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.seats, 20);
+                assert_eq!(preliminary_result.full_seats, 18);
+                assert_eq!(preliminary_result.residual_seats, 2);
+                assert_eq!(preliminary_result.quota, Fraction::new(420, 20));
+                assert_eq!(preliminary_result.steps.len(), 0);
+
+                // Drawing lots results in list 2
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 2 });
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::HighestAverageResidualSeat(
+                        HighestAverageResidualSeatDrawingLots {
+                            max_average: Fraction::new(20, 1),
+                            residual_seat_numbers: vec![2],
+                            options: vec![1, 3],
+                            list_averages: vec![
+                                (1, Fraction::new(20, 1)),
+                                (2, Fraction::new(120, 7)),
+                                (3, Fraction::new(20, 1)),
+                            ],
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.steps.len(), 1);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 0]
+                );
+
+                // Drawing lots results in list 3, so the majority list loses both draws and
+                // stays at exactly half of the seats. Article P 9 then requires drawing of
+                // lots among the lists that were assigned the last residual seats
+                input.lists_drawn.push(ListDrawnMock { variant, drawn: 3 });
+                let Ok(SeatAssignment::DrawingLotsRequired(variant, preliminary_result)) =
+                    seat_assignment(&input)
+                else {
+                    panic!("should be DrawingLotsRequired");
+                };
+                assert_eq!(
+                    variant,
+                    ListDrawingLotsVariant::AbsoluteMajorityHighestAverage(
+                        AbsoluteMajorityDrawingLots {
+                            assign_to: 1,
+                            options: vec![2, 3],
+                        }
+                    )
+                );
+                assert_eq!(preliminary_result.steps.len(), 2);
+                assert_eq!(
+                    get_standings_residual_seats(&preliminary_result),
+                    vec![0, 1, 1]
+                );
+
+                // Drawing lots results in list 2, which gets its seat retracted
+                input.lists_drawn.push(ListDrawnMock {
+                    variant: variant.clone(),
+                    drawn: 2,
+                });
+                let Ok(SeatAssignment::Completed(result)) = seat_assignment(&input) else {
+                    panic!("should be Completed");
+                };
+
+                assert_eq!(result.full_seats, 18);
+                assert_eq!(result.residual_seats, 2);
+                assert_eq!(result.steps.len(), 3);
+                assert_eq!(result.steps[0].change.list_number_assigned(), 2);
+                assert_eq!(result.steps[1].change.list_number_assigned(), 3);
+                assert_eq!(
+                    result.steps[2].change,
+                    SeatChange::AbsoluteMajorityReassignment(AbsoluteMajorityReassignedSeat {
+                        list_retracted_seat: 2,
+                        list_assigned_seat: 1,
+                        drawing_lots: Some(variant),
+                    })
+                );
+                assert_eq!(get_standings_residual_seats(&result), vec![1, 0, 1]);
+                let total_seats = get_total_seats_from_apportionment_result(&result);
+                assert_eq!(total_seats, vec![11, 5, 4]);
+                assert!(result.warnings().is_empty());
+            }
+
+            /// Apportionment with residual seats assigned with highest averages method
+            ///
             /// Full seats: [9, 2, 2, 2, 2, 2] - Remainder seats: 4  
             /// 1 - highest average: [50, 46 2/3, 46 2/3, 46 2/3, 46 2/3, 46 2/3] seat assigned to list 1  
             /// 2 - Drawing of lots is required for lists: [2, 3, 4, 5, 6], only 3 seats available  

--- a/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
+++ b/backend/apportionment/src/seat_assignment/residual_seat_assignment.rs
@@ -1261,7 +1261,7 @@ mod tests {
         }
 
         #[test]
-        fn test_unioque_highest_average_qualify_when_retracted_with_one_largest_remainder() {
+        fn test_unique_highest_average_qualify_when_retracted_with_one_largest_remainder() {
             let previous_steps = vec![
                 largest_remainder_step(LIST),
                 unique_highest_average_step(LIST),


### PR DESCRIPTION
## What & why

Relates to #3268 

@jschuurk-kr has gone through the [apportionment flowchart](https://github.com/kiesraad/abacus-documentatie/blob/main/verkiezingsproces/zetelverdeling-GR-flowchart.md), written down every path and looked for relevant test cases. Some were missing, this PR adds those tests.

**testgevallen voor de volledige flow van zetelverdeling**
- volle zetels en restzetels en lijstuitputting, dan verder met restzetels
  - minder dan 19 zetels, varianten voor "verder met restzetels":
    - start met grootste gemiddelden (max 1 zetel per lijst): [`test_with_list_exhaustion_triggering_1st_round_highest_average_assignment`](https://github.com/kiesraad/abacus/commit/04f7d8994bbbebf2a50a877efbc95ede65ec08d3)
    - start met grootste gemiddelden (geen beperking): lt_19_seats: [`test_with_list_exhaustion_where_reassignment_starts_with_2nd_round_highest_average_assignment`](https://github.com/kiesraad/abacus/commit/5c3c872e2c89b0fdb7995e19875c5e955f45af99)

**volstrekte meerderheid** 
- drie opties
  - meerderheid aan stemmen en zetels: [`test_with_absolute_majority_of_votes_and_seats`](https://github.com/kiesraad/abacus/commit/256b9f6b3938fe7a401ed57a93b8b4f89b690ba6) (for lt_19 + gte_19)

**loting voor afnemen restzetel want P 9**
- alleen als laatste restzetels (meervoud) met gelijke overschotten/gemiddelden zijn toegewezen
  - laatste restzetels zijn met loting toegewezen (onvoldoende beschikbare zetels): `test_with_absolute_majority_of_votes_but_not_seats_and_last_residual_seats_assigned_by_drawing_of_lots` for [`lt_19`](https://github.com/kiesraad/abacus/commit/5cb7413589df203e10d3100859e839c61fb7b330) + [`gte_19`](https://github.com/kiesraad/abacus/commit/5df046a2ddf698425c0be52be2d9edeec4569f4c)
- geen loting als laatste restzetel (enkelvoud) met loting is toegewezen, want dan is er al een laatste restzetel: [`test_with_absolute_majority_of_votes_but_not_seats_and_single_last_residual_seat_assigned_by_drawing_of_lots`](https://github.com/kiesraad/abacus/commit/86d7b52bb65a168bba6d9233ebbc42746e09e6aa)

**overleden kandidaten**
- één of meerdere overleden kandidaten voor één of meerdere lijsten
  - meerdere kandidaten van meerdere lijsten: [`test_apportionment_process_with_deceased_scenarios` extended with case](https://github.com/kiesraad/abacus/commit/71f286e01bb14309b2b8da5b00fd1d7394e2baed)
- overleden kandidaat die
  - verkozen zou zijn geworden vanwege positie op lijst: [`test_apportionment_process_with_deceased_candidate_elected_by_list_position`](https://github.com/kiesraad/abacus/commit/a5dccd8582757e5fffb2602bfc3e83d0a9411cdd)

**aanwijzing van kandidaten**
- loting voor gelijk aantal voorkeurstemmen maar niet genoeg zetels
  - meerdere groepen kandidaten met gelijk aantal voorkeurstemmen: [`test_with_drawing_of_lots_for_multiple_groups_of_candidates_with_equal_votes`](https://github.com/kiesraad/abacus/commit/7f736fafefbc7cb03f686dc58ed1d060d4af0a56) + scenario added for `test_preferential_candidate_nomination_scenarios` in same commit

**de bijzondere gevallen**
  - kandidaatnummers niet opeenvolgend gte_19_seats: [`test_with_gte_19_seats_and_non_consecutive_list_and_candidate_numbers`](https://github.com/kiesraad/abacus/commit/9ee2974d67475fe43fdb092a6559b33eefc6ed62)

## How to test

- Compare the path to the linked test
- Check if the test actually covers the case
- Check if all relevant parts are asserted

## Reviewer notes

This is quite a lot to review. I've had a session with @jschuurk-kr today to go through all tests (except the last one). Also had a short session with @oliver3 for the first ones, so they would be the perfect candidates to review. I can walk you through the cases if you like. 