### PR TITLE
Switch back order of candidate list import and committee category in election creation flow

### DIFF
--- a/frontend/e2e-tests/tests/election/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election/election-create.e2e.ts
@@ -37,13 +37,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // upload polling stations
       await uploadPollingStations(page);
@@ -112,13 +112,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // skip polling stations
       const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
@@ -194,15 +194,15 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.csb.check();
       await expect(committeeCategoryPage.csb).toBeChecked();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // Now we should be at the check and save page
       const checkAndSavePage = new CheckAndSavePgObj(page);
@@ -261,8 +261,8 @@ test.describe("Election creation", () => {
       await expect(checkDefinitionPage.hashInput1).toBeFocused();
       await checkDefinitionPage.inputHash("476B", "C0DE");
 
-      const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
-      await expect(uploadCandidateDefinitionPage.header).toBeVisible();
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
     });
 
     test("it fails on valid, but incorrect file", async ({ page }) => {
@@ -290,6 +290,11 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
+      // committee category
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
+
       // Candidate page
       const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
       await expect(uploadCandidateDefinitionPage.header).toBeVisible();
@@ -309,6 +314,11 @@ test.describe("Election creation", () => {
 
       // upload election and check hash
       await uploadElectionAndInputHash(page);
+
+      // committee category
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
 
       // Candidate page
       const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
@@ -353,8 +363,12 @@ test.describe("Election creation", () => {
       await overviewPage.create.click();
 
       // upload election and check hash
-      const uploadElectionDefinitionPage = new UploadElectionDefinitionPgObj(page);
       await uploadElectionAndInputHash(page);
+
+      // committee category
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
 
       // Candidate page
       const uploadCandidateDefinitionPage = new UploadCandidateDefinitionPgObj(page);
@@ -362,7 +376,7 @@ test.describe("Election creation", () => {
 
       // Back button
       await page.goBack();
-      await expect(uploadElectionDefinitionPage.header).toBeVisible();
+      await expect(committeeCategoryPage.header).toBeVisible();
     });
 
     test("after candidate upload, moving back to candidate page resets candidates", async ({ page }) => {
@@ -373,12 +387,17 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
+      // committee category
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
+
       // upload candidates list and check hash
       await uploadCandidatesAndInputHash(page, eml230b);
 
-      // Now we should be at the committee category page
-      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
-      await expect(committeeCategoryPage.header).toBeVisible();
+      // Now we should be at the polling station upload page
+      const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
+      await expect(uploadPollingStationsPage.header).toBeVisible();
 
       // Back button
       await page.goBack();
@@ -398,13 +417,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check hash
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check hash
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // Now we should be at the polling station upload page
       const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
@@ -431,13 +450,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check hash
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check hash
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // upload polling stations
       await uploadPollingStations(page);
@@ -478,11 +497,11 @@ test.describe("Election creation", () => {
 
       await uploadElectionAndInputHash(page);
 
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       await uploadPollingStations(page, eml110b_zero_voters);
 
@@ -514,13 +533,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check hash
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check hash
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // upload wrong file
       const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);

--- a/frontend/e2e-tests/tests/full-flow/full-flow-CSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-CSB.e2e.ts
@@ -90,13 +90,13 @@ test.describe("full flow CSB", () => {
 
     await uploadElectionAndInputHash(page);
 
-    await uploadCandidatesAndInputHash(page, eml230b_more_than_45_candidates);
-
     const committeeCategoryPage = new CommitteeCategoryPgObj(page);
     await expect(committeeCategoryPage.header).toBeVisible();
     await committeeCategoryPage.csb.click();
     await expect(committeeCategoryPage.csb).toBeChecked();
     await committeeCategoryPage.next.click();
+
+    await uploadCandidatesAndInputHash(page, eml230b_more_than_45_candidates);
 
     const checkAndSavePage = new CheckAndSavePgObj(page);
     await expect(checkAndSavePage.header).toBeVisible();

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB.e2e.ts
@@ -120,12 +120,12 @@ test.describe("full flow GSB", () => {
 
     await uploadElectionAndInputHash(page);
 
-    await uploadCandidatesAndInputHash(page, eml230b);
-
     const committeeCategoryPage = new CommitteeCategoryPgObj(page);
     await expect(committeeCategoryPage.header).toBeVisible();
     await expect(committeeCategoryPage.gsb).toBeChecked();
     await committeeCategoryPage.next.click();
+
+    await uploadCandidatesAndInputHash(page, eml230b);
 
     await uploadPollingStations(page, eml110b_single);
 

--- a/frontend/src/features/election_create/components/CommitteeCategory.test.tsx
+++ b/frontend/src/features/election_create/components/CommitteeCategory.test.tsx
@@ -23,7 +23,7 @@ describe("CommitteeCategory component", () => {
     expect(router.state.location.pathname).toEqual("/elections/create");
   });
 
-  test("GSB: Navigates to polling station upload page", async () => {
+  test("GSB: Navigates to candidate list upload page", async () => {
     const state = { election, committeeCategory: "GSB" as CommitteeCategoryType };
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
@@ -46,10 +46,10 @@ describe("CommitteeCategory component", () => {
       committeeCategory: "GSB",
     });
 
-    expect(router.state.location.pathname).toEqual("/elections/create/polling-stations");
+    expect(router.state.location.pathname).toEqual("/elections/create/list-of-candidates");
   });
 
-  test("CSB: Navigates to check and save page", async () => {
+  test("CSB: Navigates to candidate list upload page", async () => {
     const state = { election, committeeCategory: "CSB" as CommitteeCategoryType };
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
@@ -72,6 +72,6 @@ describe("CommitteeCategory component", () => {
       committeeCategory: "CSB",
     });
 
-    expect(router.state.location.pathname).toEqual("/elections/create/check-and-save");
+    expect(router.state.location.pathname).toEqual("/elections/create/list-of-candidates");
   });
 });

--- a/frontend/src/features/election_create/components/CommitteeCategory.tsx
+++ b/frontend/src/features/election_create/components/CommitteeCategory.tsx
@@ -31,11 +31,7 @@ export function CommitteeCategory() {
       type: "SET_COMMITTEE_CATEGORY",
       committeeCategory,
     });
-    if (committeeCategory === "CSB") {
-      await navigate("/elections/create/check-and-save");
-    } else {
-      await navigate("/elections/create/polling-stations");
-    }
+    await navigate("/elections/create/list-of-candidates");
   }
 
   return (

--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -232,6 +232,8 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      await setCommitteeCategory();
+
       // upload candidate file
       await uploadCandidateDefinition(file);
 
@@ -253,6 +255,8 @@ describe("Election create pages", () => {
       // update election and set hash, and continue
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
+
+      await setCommitteeCategory();
 
       // upload candidate file
       await uploadCandidateDefinition(file);
@@ -297,6 +301,8 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      await setCommitteeCategory();
+
       // upload candidate file
       await uploadCandidateDefinition(file);
 
@@ -325,6 +331,8 @@ describe("Election create pages", () => {
       // update election and set hash, and continue
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
+
+      await setCommitteeCategory();
 
       // upload candidate file
       await uploadCandidateDefinition(file);
@@ -356,6 +364,8 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      await setCommitteeCategory();
+
       // upload candidate file
       await uploadCandidateDefinition(file);
 
@@ -385,11 +395,11 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      await setCommitteeCategory();
+
       // upload candidate file, set hash and continue
       await uploadCandidateDefinition(file);
       await inputCandidateHash();
-
-      await setCommitteeCategory();
 
       // Make sure we are on the correct page
       expect(
@@ -411,11 +421,11 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      await setCommitteeCategory();
+
       // upload candidate file, set hash and continue
       await uploadCandidateDefinition(file);
       await inputCandidateHash();
-
-      await setCommitteeCategory();
 
       // upload polling station list file
       await uploadPollingStationList(file, false);
@@ -462,12 +472,12 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      // committee category
+      await setCommitteeCategory();
+
       // candidates lists
       await uploadCandidateDefinition(file);
       await inputCandidateHash();
-
-      // committee category
-      await setCommitteeCategory();
 
       // polling stations
       const eligibleVoters = 1234;
@@ -516,12 +526,12 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file);
       await inputElectionHash();
 
+      // committee category
+      await setCommitteeCategory();
+
       // candidates lists
       await uploadCandidateDefinition(file);
       await inputCandidateHash();
-
-      // committee category
-      await setCommitteeCategory();
 
       // polling stations
       const eligibleVoters = 1234;
@@ -583,12 +593,12 @@ describe("Election create pages", () => {
       await uploadElectionDefinition(router, file, "CSB");
       await inputElectionHash("CSB");
 
+      // committee category
+      await setCommitteeCategory("CSB");
+
       // candidates lists
       await uploadCandidateDefinition(file, "CSB");
       await inputCandidateHash("CSB");
-
-      // committee category
-      await setCommitteeCategory("CSB");
 
       // check and save
       await waitFor(async () => {

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -43,7 +43,7 @@ export function UploadCandidatesDefinition() {
       setFile(currentFile);
       const data = await currentFile.text();
       const response = await create({
-        committee_category: "GSB",
+        committee_category: state.committeeCategory,
         candidate_data: data,
         election_hash: state.electionDefinitionHash,
         election_data: state.electionDefinitionData,
@@ -83,7 +83,7 @@ export function UploadCandidatesDefinition() {
   ) {
     async function onSubmit(chunks: string[]) {
       const response = await create({
-        committee_category: "GSB",
+        committee_category: state.committeeCategory,
         candidate_data: state.candidateDefinitionData,
         election_hash: state.electionDefinitionHash,
         election_data: state.electionDefinitionData,
@@ -94,7 +94,11 @@ export function UploadCandidatesDefinition() {
           type: "SET_CANDIDATES_DEFINITION_HASH",
           candidateDefinitionHash: chunks,
         });
-        await navigate("/elections/create/committee-category");
+        if (state.committeeCategory && state.committeeCategory === "CSB") {
+          await navigate("/elections/create/check-and-save");
+        } else {
+          await navigate("/elections/create/polling-stations");
+        }
       } else if (isError(response) && response instanceof ApiError && response.reference === "InvalidHash") {
         setError(response.message);
       }

--- a/frontend/src/features/election_create/components/UploadElectionDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadElectionDefinition.test.tsx
@@ -93,7 +93,7 @@ describe("UploadElectionDefinition component", () => {
     overrideOnce("post", "/api/elections/import/validate", 200, electionValidateResponse(newElectionMockData));
     await user.click(screen.getByRole("button", { name: "Volgende" }));
 
-    expect(navigate).toHaveBeenCalledWith("/elections/create/list-of-candidates");
+    expect(navigate).toHaveBeenCalledWith("/elections/create/committee-category");
   });
 
   test("Shows an error when providing incorrect hash", async () => {

--- a/frontend/src/features/election_create/components/UploadElectionDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadElectionDefinition.tsx
@@ -82,7 +82,7 @@ export function UploadElectionDefinition() {
           type: "SET_ELECTION_DEFINITION_HASH",
           electionDefinitionHash: chunks,
         });
-        await navigate("/elections/create/list-of-candidates");
+        await navigate("/elections/create/committee-category");
       } else if (isError(response) && response instanceof ApiError && response.reference === "InvalidHash") {
         setError(response.message);
       }

--- a/frontend/src/features/election_create/routes.tsx
+++ b/frontend/src/features/election_create/routes.tsx
@@ -14,8 +14,8 @@ export const electionCreateRoutes: RouteObject[] = [
     Component: ElectionCreateLayout,
     children: [
       { index: true, Component: UploadElectionDefinition, handle: { roles: ["administrator"] } },
-      { path: "list-of-candidates", Component: UploadCandidatesDefinition, handle: { roles: ["administrator"] } },
       { path: "committee-category", Component: CommitteeCategory, handle: { roles: ["administrator"] } },
+      { path: "list-of-candidates", Component: UploadCandidatesDefinition, handle: { roles: ["administrator"] } },
       { path: "polling-stations", Component: UploadPollingStationDefinition, handle: { roles: ["administrator"] } },
       { path: "counting-method-type", Component: CountingMethodType, handle: { roles: ["administrator"] } },
       { path: "number-of-voters", Component: NumberOfVoters, handle: { roles: ["administrator"] } },


### PR DESCRIPTION
Closes #3858 

## What & why

Switch back order of candidate list import and committee category in election creation flow

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->