### PR TITLE
Add DSO end to end tests

### DIFF
--- a/backend/src/domain/report/structs.rs
+++ b/backend/src/domain/report/structs.rs
@@ -498,13 +498,6 @@ impl ResultsInputGSB {
     ) -> Result<PdfFileModel, APIError> {
         let data = &self.data;
 
-        // Na 14-2 is only for CSO, DSO uses Na 14-1
-        if data.election.counting_method != Some(VoteCountingMethod::CSO) {
-            return Err(APIError::DataIntegrityError(
-                "Na 14-2 report is only supported for CSO".to_string(),
-            ));
-        }
-
         let pdf_file = ModelNa14_2Input {
             votes_tables: VotesTablesWithPreviousVotes::new(
                 &data.election,
@@ -588,44 +581,5 @@ impl ResultsInputGSB {
                 .collect(),
         }
         .to_pdf_file_model(overview_filename)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use chrono::Local;
-    use sqlx::SqlitePool;
-    use test_log::test;
-
-    use super::*;
-
-    #[test(sqlx::test(fixtures(
-        path = "../../../fixtures",
-        scripts("election_12_dso_with_results")
-    )))]
-    async fn test_error_na14_2_dso(pool: SqlitePool) {
-        let mut conn = pool.acquire().await.unwrap();
-        let input = ResultsInputGSB::new(&mut conn, CommitteeSessionId::from(12), Local::now())
-            .await
-            .unwrap();
-
-        // Na 14-2 is only for CSO, DSO uses Na 14-1
-        let Err(error) = input.get_na14_2_pdf_file(
-            &input.data.totals,
-            &input.data.committee_session,
-            "hash".to_string(),
-            "creation_date_time".to_string(),
-            "Model_Na14-2.pdf".to_string(),
-        ) else {
-            panic!("generating a Na 14-2 report should fail for DSO elections");
-        };
-        assert!(
-            matches!(
-                &error,
-                APIError::DataIntegrityError(message)
-                    if message == "Na 14-2 report is only supported for CSO"
-            ),
-            "unexpected error: {error:?}"
-        );
     }
 }

--- a/frontend/e2e-tests/fixtures.ts
+++ b/frontend/e2e-tests/fixtures.ts
@@ -69,41 +69,47 @@ type Fixtures = {
   typistTwoCSB: { page: Page; request: APIRequestContext };
   eml230b: Eml230b;
   eml230b_more_than_45_candidates: Eml230b;
-  // GSB election without polling stations
+  // GSB CSO election without polling stations
   emptyElectionGSB: Election;
+  // GSB DSO election without polling stations
+  emptyElectionGSBDSO: Election;
   // CSB election with >= 19 seats
   emptyElectionCSBLargeCouncil: Election;
   // CSB election with < 19 seats
   emptyElectionCSBSmallCouncil: Election;
-  // GSB election with two polling stations
+  // GSB CSO election with two polling stations
   electionGSB: ElectionDetailsResponse;
+  // GSB DSO election with two polling stations
+  electionGSBDSO: ElectionDetailsResponse;
   // CSB election with >= 19 seats and one subcommittee
   electionCSBLargeCouncil: ElectionDetailsResponse;
   // CSB election with < 19 seats and one subcommittee
   electionCSBSmallCouncil: ElectionDetailsResponse;
-  // First data entry of the GSB election
+  // First data entry of the GSB CSO election
   dataEntryGSB: DataEntry;
-  // GSB election with one investigation in the second committee session
+  // First data entry of the GSB DSO election
+  dataEntryGSBDSO: DataEntry;
+  // GSB CSO election with one investigation in the second committee session
   dataEntryNextSession: DataEntry;
-  // First data entry of the GSB election with entry claimed by typist one
+  // First data entry of the GSB CSO election with entry claimed by typist one
   dataEntryGSBFirstEntryClaimed: DataEntry;
-  // First data entry of the GSB election with first data entry done
+  // First data entry of the GSB CSO election with first data entry done
   dataEntryGSBFirstEntryDone: DataEntry;
-  // First data entry correction of the GSB election after resolve differences
+  // First data entry correction of the GSB CSO election after resolve differences
   dataEntryGSBFirstEntryCorrection: DataEntry;
-  // First data entry correction of the next session of a GSB election after resolve differences
+  // First data entry correction of the next session of a GSB CSO election after resolve differences
   dataEntryNextSessionFirstEntryCorrection: DataEntry;
-  // Second data entry correction of the GSB election after resolve differences
+  // Second data entry correction of the GSB CSO election after resolve differences
   dataEntryGSBSecondEntryCorrection: DataEntry;
-  // First data entry of the GSB election with first data entry with errors
+  // First data entry of the GSB CSO election with first data entry with errors
   dataEntryGSBFirstEntryHasErrors: DataEntry;
-  // First data entry of the GSB election with first and second data entries done
+  // First data entry of the GSB CSO election with first and second data entries done
   dataEntryGSBDefinitive: DataEntry;
-  // First data entry of the GSB election with differences between the first and second data entry
+  // First data entry of the GSB CSO election with differences between the first and second data entry
   dataEntryGSBEntriesDifferent: DataEntry;
-  // First data entry of the GSB election with second data entry that has errors and is therefore different
+  // First data entry of the GSB CSO election with second data entry that has errors and is therefore different
   dataEntryGSBEntriesDifferentWithErrors: DataEntry;
-  // GSB election with polling stations and two completed data entries for each
+  // GSB CSO election with polling stations and two completed data entries for each
   completedElectionGSB: Election;
   // CSB election with >= 19 seats, one subcommittee and two completed data entries
   completedElectionCSB: Election;
@@ -111,7 +117,7 @@ type Fixtures = {
   completedElectionCSBWithDrawingLotsForListAndCandidate: Election;
   // CSB election with < 19 seats, one subcommittee and two completed data entries that triggers drawing lots for P 9
   completedElectionCSBWithDrawingLotsForP9: Election;
-  // The current committee session for the GSB election
+  // The current committee session for the GSB CSO election
   currentCommitteeSessionElectionGSB: CommitteeSession;
   // Newly created GSB User
   newTypistGSB: User;
@@ -183,6 +189,27 @@ export const test = base.extend<Fixtures>({
 
     await use(election);
   },
+  emptyElectionGSBDSO: async ({ adminOne, eml230b }, use) => {
+    const { request } = adminOne;
+    const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
+    const election_data = await readFile(eml110a.path, "utf8");
+    const candidate_data = await readFile(eml230b.path, "utf8");
+    const electionResponse = await request.post(url, {
+      data: {
+        committee_category: "GSB",
+        election_data,
+        election_hash: eml110a.fullHash,
+        candidate_data,
+        candidate_hash: eml230b.fullHash,
+        number_of_voters: 1234,
+        counting_method: "DSO",
+      },
+    });
+    expect(electionResponse.ok()).toBeTruthy();
+    const election = (await electionResponse.json()) as Election;
+
+    await use(election);
+  },
   emptyElectionCSBLargeCouncil: async ({ adminOne, eml230b_more_than_45_candidates }, use) => {
     const { request } = adminOne;
     const url: ELECTION_IMPORT_REQUEST_PATH = `/api/elections/import`;
@@ -244,6 +271,29 @@ export const test = base.extend<Fixtures>({
 
     await use(electionDetails);
   },
+  electionGSBDSO: async ({ adminOne, coordinatorOneGSB, emptyElectionGSBDSO }, use) => {
+    // create polling stations in the existing emptyElection
+    const url: POLLING_STATION_CREATE_REQUEST_PATH = `/api/elections/${emptyElectionGSBDSO.id}/polling_stations`;
+    for (const pollingStationRequest of pollingStationRequests) {
+      const pollingStationResponse = await adminOne.request.post(url, { data: pollingStationRequest });
+      expect(pollingStationResponse.ok()).toBeTruthy();
+    }
+
+    // Set committee session status to DataEntry
+    const electionDetails = await changeCommitteeSessionStatus(coordinatorOneGSB, emptyElectionGSBDSO.id, "data_entry");
+
+    // Fill in committee session details
+    const detailsUpdateUrl: COMMITTEE_SESSION_UPDATE_REQUEST_PATH = `/api/elections/${emptyElectionGSBDSO.id}/committee_sessions/${electionDetails.current_committee_session.id}`;
+    const detailsUpdateData: COMMITTEE_SESSION_UPDATE_REQUEST_BODY = {
+      location: "Den Haag",
+      start_date: "2026-03-18",
+      start_time: "21:45",
+    };
+    const detailsUpdateResponse = await coordinatorOneGSB.request.put(detailsUpdateUrl, { data: detailsUpdateData });
+    expect(detailsUpdateResponse.ok()).toBeTruthy();
+
+    await use(electionDetails);
+  },
   electionCSBLargeCouncil: async ({ coordinatorOneCSB, emptyElectionCSBLargeCouncil }, use) => {
     const electionId = emptyElectionCSBLargeCouncil.id;
 
@@ -291,6 +341,22 @@ export const test = base.extend<Fixtures>({
 
     await use({
       election_id: electionGSB.election.id,
+      id: electionStatus.data_entry_id,
+      name: electionStatus.source.name,
+      number: electionStatus.source.number.toString(),
+    });
+  },
+  dataEntryGSBDSO: async ({ adminOne, electionGSBDSO }, use) => {
+    const { request } = adminOne;
+    // get the first polling station of the existing election
+    const url: ELECTION_STATUS_REQUEST_PATH = `/api/elections/${electionGSBDSO.election.id}/status`;
+    const response = await request.get(url);
+    expect(response.ok()).toBeTruthy();
+    const electionStatuses = (await response.json()) as ElectionStatusResponse;
+    const electionStatus = electionStatuses.statuses[0]!;
+
+    await use({
+      election_id: electionGSBDSO.election.id,
       id: electionStatus.data_entry_id,
       name: electionStatus.source.name,
       number: electionStatus.source.number.toString(),

--- a/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
@@ -22,7 +22,7 @@ import { InvestigationOverviewPgObj } from "e2e-tests/page-objects/investigation
 import { InvestigationPrintCorrigendumPgObj } from "e2e-tests/page-objects/investigations/InvestigationPrintCorrigendumPgObj";
 import { InvestigationReasonPgObj } from "e2e-tests/page-objects/investigations/InvestigationReasonPgObj";
 import { UserInfoTopBar } from "e2e-tests/page-objects/nav_bar/UserInfoTopBarPgObj";
-import type { Results } from "@/types/generated/openapi";
+import type { Results, VoteCountingMethod } from "@/types/generated/openapi";
 import { type Eml230b, eml110a, eml110b } from "../test-data/eml-files";
 
 export async function fillDataEntryPages(page: Page, results: Results) {
@@ -52,32 +52,20 @@ export async function fillDataEntryPages(page: Page, results: Results) {
 
   switch (results.model) {
     case "DSOFirstSession":
-    case "DSONextSession": {
-      {
-        const differencesPage = new DifferencesPage(page);
-        await expect(differencesPage.fieldset).toBeVisible();
-        await differencesPage.fillInPageAndClickNext(results.differences_counts);
-      }
+    case "DSONextSession":
+    case "CSOFirstSession":
+    case "CSONextSession": {
+      const differencesPage = new DifferencesPage(page);
+      await expect(differencesPage.fieldset).toBeVisible();
+      await differencesPage.fillInPageAndClickNext(results.differences_counts);
       break;
     }
-
-    case "CSOFirstSession":
-    case "CSONextSession":
-      {
-        const differencesPage = new DifferencesPage(page);
-        await expect(differencesPage.fieldset).toBeVisible();
-        await differencesPage.fillInPageAndClickNext(results.differences_counts);
-      }
+    case "GSB": {
+      const gsbDifferencesPage = new GSBDifferencesPage(page);
+      await expect(gsbDifferencesPage.fieldset).toBeVisible();
+      await gsbDifferencesPage.fillInPageAndClickNext(results.differences_counts);
       break;
-
-    case "GSB":
-      {
-        const gsbDifferencesPage = new GSBDifferencesPage(page);
-        await expect(gsbDifferencesPage.fieldset).toBeVisible();
-        await gsbDifferencesPage.fillInPageAndClickNext(results.differences_counts);
-      }
-      break;
-
+    }
     default:
       // Exhaustive check
       results satisfies never;
@@ -156,31 +144,21 @@ export async function uploadPollingStations(page: Page, eml = eml110b) {
   await checkDefinitionPage.next.click();
 }
 
-export async function createCSOInvestigation(page: Page, pollingStation: string, reason: string) {
-  const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
-  await investigationsOverviewPage.addInvestigationButton.click();
-
-  const addInvestigationPage = new AddInvestigationPgObj(page);
-  await expect(addInvestigationPage.header).toBeVisible();
-  await addInvestigationPage.selectPollingStation(pollingStation);
-
-  const investigationReasonPage = new InvestigationReasonPgObj(page);
-  await expect(investigationReasonPage.header).toBeVisible();
-  await investigationReasonPage.reasonField.fill(reason);
-  await investigationReasonPage.nextButton.click();
-
-  const investigationPrintCorrigendumPage = new InvestigationPrintCorrigendumPgObj(page);
-  await expect(investigationPrintCorrigendumPage.header).toBeVisible();
-  const downloadPromise = page.waitForEvent("download");
-  await investigationPrintCorrigendumPage.downloadLink.click();
-  const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/Model_Na14-2_GR2022_Stembureau_\d+_Bijlage_1.pdf/);
-  expect((await stat(await download.path())).size).toBeGreaterThan(1024);
-
-  await investigationPrintCorrigendumPage.backToInvestigationsButton.click();
+function getCorrigendumFilename(countingMethod: VoteCountingMethod): RegExp {
+  switch (countingMethod) {
+    case "CSO":
+      return /Model_Na14-2_GR2022_Stembureau_\d+_Bijlage_1.pdf/;
+    case "DSO":
+      return /Model_Na14-1_versie_2_GR2022_Stembureau_\d+.pdf/;
+  }
 }
 
-export async function createDSOInvestigation(page: Page, pollingStation: string, reason: string) {
+export async function createInvestigation(
+  page: Page,
+  pollingStation: string,
+  reason: string,
+  countingMethod: VoteCountingMethod,
+) {
   const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
   await investigationsOverviewPage.addInvestigationButton.click();
 
@@ -198,7 +176,7 @@ export async function createDSOInvestigation(page: Page, pollingStation: string,
   const downloadPromise = page.waitForEvent("download");
   await investigationPrintCorrigendumPage.downloadLink.click();
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/Model_Na14-1_versie_2_GR2022_Stembureau_\d+.pdf/);
+  expect(download.suggestedFilename()).toMatch(getCorrigendumFilename(countingMethod));
   expect((await stat(await download.path())).size).toBeGreaterThan(1024);
 
   await investigationPrintCorrigendumPage.backToInvestigationsButton.click();

--- a/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
@@ -156,7 +156,7 @@ export async function uploadPollingStations(page: Page, eml = eml110b) {
   await checkDefinitionPage.next.click();
 }
 
-export async function createInvestigation(page: Page, pollingStation: string, reason: string) {
+export async function createCSOInvestigation(page: Page, pollingStation: string, reason: string) {
   const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
   await investigationsOverviewPage.addInvestigationButton.click();
 
@@ -175,6 +175,30 @@ export async function createInvestigation(page: Page, pollingStation: string, re
   await investigationPrintCorrigendumPage.downloadLink.click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toMatch(/Model_Na14-2_GR2022_Stembureau_\d+_Bijlage_1.pdf/);
+  expect((await stat(await download.path())).size).toBeGreaterThan(1024);
+
+  await investigationPrintCorrigendumPage.backToInvestigationsButton.click();
+}
+
+export async function createDSOInvestigation(page: Page, pollingStation: string, reason: string) {
+  const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
+  await investigationsOverviewPage.addInvestigationButton.click();
+
+  const addInvestigationPage = new AddInvestigationPgObj(page);
+  await expect(addInvestigationPage.header).toBeVisible();
+  await addInvestigationPage.selectPollingStation(pollingStation);
+
+  const investigationReasonPage = new InvestigationReasonPgObj(page);
+  await expect(investigationReasonPage.header).toBeVisible();
+  await investigationReasonPage.reasonField.fill(reason);
+  await investigationReasonPage.nextButton.click();
+
+  const investigationPrintCorrigendumPage = new InvestigationPrintCorrigendumPgObj(page);
+  await expect(investigationPrintCorrigendumPage.header).toBeVisible();
+  const downloadPromise = page.waitForEvent("download");
+  await investigationPrintCorrigendumPage.downloadLink.click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/Model_Na14-1_versie_2_GR2022_Stembureau_\d+.pdf/);
   expect((await stat(await download.path())).size).toBeGreaterThan(1024);
 
   await investigationPrintCorrigendumPage.backToInvestigationsButton.click();

--- a/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
+++ b/frontend/e2e-tests/helpers-utils/e2e-test-browser-helpers.ts
@@ -1,7 +1,9 @@
 import { stat } from "node:fs/promises";
 import { expect, type Page } from "@playwright/test";
+import { AboutReportPage } from "e2e-tests/page-objects/data_entry/AboutReportPgObj";
 import { CandidatesListPage } from "e2e-tests/page-objects/data_entry/CandidatesListPgObj";
 import { CheckAndSavePage } from "e2e-tests/page-objects/data_entry/CheckAndSavePgObj";
+import { ChecksAndCorrectionsPage } from "e2e-tests/page-objects/data_entry/ChecksAndCorrectionsPgObj";
 import { CountingDifferencesPollingStationPage } from "e2e-tests/page-objects/data_entry/CountingDifferencesPollingStationPgObj";
 import { DataEntryHomePage } from "e2e-tests/page-objects/data_entry/DataEntryHomePgObj";
 import { DifferencesPage } from "e2e-tests/page-objects/data_entry/DifferencesPgObj";
@@ -32,6 +34,14 @@ export async function fillDataEntryPages(page: Page, results: Results) {
     await countingDifferencesPollingStationPage.fillAndClickNext(results.counting_differences_polling_station);
   }
 
+  if (results.model === "DSOFirstSession") {
+    const aboutReportPage = new AboutReportPage(page);
+    await aboutReportPage.fillAndClickNext(results.about_report);
+
+    const checksAndCorrectionsPage = new ChecksAndCorrectionsPage(page);
+    await checksAndCorrectionsPage.fillAndClickNext(results.checks_and_corrections);
+  }
+
   const votersAndVotesPage = new VotersAndVotesPage(page);
   await expect(votersAndVotesPage.fieldset).toBeVisible();
   if (results.model === "GSB") {
@@ -43,8 +53,14 @@ export async function fillDataEntryPages(page: Page, results: Results) {
   switch (results.model) {
     case "DSOFirstSession":
     case "DSONextSession": {
-      /* TODO: https://github.com/kiesraad/abacus/issues/3691 */ break;
+      {
+        const differencesPage = new DifferencesPage(page);
+        await expect(differencesPage.fieldset).toBeVisible();
+        await differencesPage.fillInPageAndClickNext(results.differences_counts);
+      }
+      break;
     }
+
     case "CSOFirstSession":
     case "CSONextSession":
       {

--- a/frontend/e2e-tests/page-objects/data_entry/AboutReportPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/AboutReportPgObj.ts
@@ -1,0 +1,65 @@
+import type { Locator, Page } from "@playwright/test";
+
+import type { AboutReport } from "@/types/generated/openapi";
+
+import { DataEntryBasePage } from "./DataEntryBasePgObj";
+
+export const twoDocumentsPagePresent: AboutReport = {
+  corrigendum_present: "TwoDocuments",
+  checks_and_corrections_present: "PagePresent",
+};
+
+export class AboutReportPage extends DataEntryBasePage {
+  readonly fieldset: Locator;
+  readonly corrigendumPresent: Locator;
+  readonly twoDocuments: Locator;
+  readonly oneDocument: Locator;
+  readonly checksAndCorrectionsPresent: Locator;
+  readonly pagePresent: Locator;
+  readonly pageMissing: Locator;
+  readonly next: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.fieldset = page.getByRole("group", {
+      name: "Over het proces-verbaal",
+    });
+
+    this.corrigendumPresent = this.fieldset.getByRole("group").filter({
+      hasText: /^Is er een corrigendum bij het papieren proces-verbaal aanwezig\?/,
+    });
+    this.twoDocuments = this.corrigendumPresent.getByRole("radio", {
+      name: /^Ja, ik heb twee documenten \(een proces-verbaal en een corrigendum\)/,
+    });
+    this.oneDocument = this.corrigendumPresent.getByRole("radio", {
+      name: /^Nee, ik heb één document \(alleen een proces-verbaal\)/,
+    });
+
+    this.checksAndCorrectionsPresent = this.fieldset.getByRole("group").filter({
+      hasText: /^Is voorin het proces-verbaal de extra pagina controles en correcties ingevoegd\?/,
+    });
+    this.pagePresent = this.checksAndCorrectionsPresent.getByRole("radio", {
+      name: "Ja, de pagina ‘controles en correcties’ is aanwezig",
+    });
+    this.pageMissing = this.checksAndCorrectionsPresent.getByRole("radio", { name: "Nee, de pagina ontbreekt" });
+
+    this.next = page.getByRole("button", { name: "Volgende" });
+  }
+
+  async fillAndClickNext(aboutReport: AboutReport) {
+    if (aboutReport.corrigendum_present === "TwoDocuments") {
+      await this.twoDocuments.check();
+    } else if (aboutReport.corrigendum_present === "OneDocument") {
+      await this.oneDocument.check();
+    }
+
+    if (aboutReport.checks_and_corrections_present === "PagePresent") {
+      await this.pagePresent.check();
+    } else if (aboutReport.checks_and_corrections_present === "PageMissing") {
+      await this.pageMissing.check();
+    }
+
+    await this.next.click();
+  }
+}

--- a/frontend/e2e-tests/page-objects/data_entry/AboutReportPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/AboutReportPgObj.ts
@@ -9,6 +9,11 @@ export const twoDocumentsPagePresent: AboutReport = {
   checks_and_corrections_present: "PagePresent",
 };
 
+export const oneDocumentPageMissing: AboutReport = {
+  corrigendum_present: "OneDocument",
+  checks_and_corrections_present: "PageMissing",
+};
+
 export class AboutReportPage extends DataEntryBasePage {
   readonly fieldset: Locator;
   readonly corrigendumPresent: Locator;

--- a/frontend/e2e-tests/page-objects/data_entry/ChecksAndCorrectionsPgObj.ts
+++ b/frontend/e2e-tests/page-objects/data_entry/ChecksAndCorrectionsPgObj.ts
@@ -1,0 +1,103 @@
+import type { Locator, Page } from "@playwright/test";
+
+import type { ChecksAndCorrections } from "@/types/generated/openapi";
+
+import { DataEntryBasePage } from "./DataEntryBasePgObj";
+
+export const bothReasonsAndCorrectedResultsOwnInitiative: ChecksAndCorrections = {
+  reason_investigation_own_initiative: { unaccounted_difference: true, other_error: true },
+  corrected_results_own_initiative: { yes: true, no: false },
+  corrected_results_csb_request: { yes: false, no: false },
+};
+
+export class ChecksAndCorrectionsPage extends DataEntryBasePage {
+  readonly fieldset: Locator;
+  readonly reasonInvestigationOwnInitiative: Locator;
+  readonly unaccountedDifference: Locator;
+  readonly otherError: Locator;
+  readonly correctedResultsOwnInitiative: Locator;
+  readonly correctedResultsOwnInitiativeYes: Locator;
+  readonly correctedResultsOwnInitiativeNo: Locator;
+  readonly correctedResultsCsbRequest: Locator;
+  readonly correctedResultsCsbRequestYes: Locator;
+  readonly correctedResultsCsbRequestNo: Locator;
+  readonly next: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.fieldset = page.getByRole("group", {
+      name: "Controles en correcties",
+    });
+
+    this.reasonInvestigationOwnInitiative = this.fieldset.getByRole("group").filter({
+      hasText: "Waarom heeft het gemeentelijk stembureau de telresultaten onderzocht?",
+    });
+    this.unaccountedDifference = this.reasonInvestigationOwnInitiative.getByRole("checkbox", {
+      name: "Vanwege een onverklaard verschil",
+    });
+    this.otherError = this.reasonInvestigationOwnInitiative.getByRole("checkbox", {
+      name: "Vanwege (het vermoeden van) een andere fout",
+    });
+
+    this.correctedResultsOwnInitiative = this.fieldset
+      .getByRole("group")
+      .filter({
+        hasText: "Zijn er gecorrigeerde telresultaten?",
+      })
+      .first();
+    this.correctedResultsOwnInitiativeYes = this.correctedResultsOwnInitiative.getByRole("checkbox", { name: "Ja" });
+    this.correctedResultsOwnInitiativeNo = this.correctedResultsOwnInitiative.getByRole("checkbox", { name: "Nee" });
+
+    this.correctedResultsCsbRequest = this.fieldset
+      .getByRole("group")
+      .filter({
+        hasText: "Zijn er gecorrigeerde telresultaten?",
+      })
+      .last();
+    this.correctedResultsCsbRequestYes = this.correctedResultsCsbRequest.getByRole("checkbox", { name: "Ja" });
+    this.correctedResultsCsbRequestNo = this.correctedResultsCsbRequest.getByRole("checkbox", { name: "Nee" });
+
+    this.next = page.getByRole("button", { name: "Volgende" });
+  }
+
+  async fillAndClickNext(checksAndCorrections: ChecksAndCorrections) {
+    if (checksAndCorrections.reason_investigation_own_initiative.unaccounted_difference) {
+      await this.unaccountedDifference.check();
+    } else {
+      await this.unaccountedDifference.uncheck();
+    }
+
+    if (checksAndCorrections.reason_investigation_own_initiative.other_error) {
+      await this.otherError.check();
+    } else {
+      await this.otherError.uncheck();
+    }
+
+    if (checksAndCorrections.corrected_results_own_initiative.yes) {
+      await this.correctedResultsOwnInitiativeYes.check();
+    } else {
+      await this.correctedResultsOwnInitiativeYes.uncheck();
+    }
+
+    if (checksAndCorrections.corrected_results_own_initiative.no) {
+      await this.correctedResultsOwnInitiativeNo.check();
+    } else {
+      await this.correctedResultsOwnInitiativeNo.uncheck();
+    }
+
+    if (checksAndCorrections.corrected_results_csb_request.yes) {
+      await this.correctedResultsCsbRequestYes.check();
+    } else {
+      await this.correctedResultsCsbRequestYes.uncheck();
+    }
+
+    if (checksAndCorrections.corrected_results_csb_request.no) {
+      await this.correctedResultsCsbRequestNo.check();
+    } else {
+      await this.correctedResultsCsbRequestNo.uncheck();
+    }
+
+    await this.next.click();
+  }
+}

--- a/frontend/e2e-tests/page-objects/election/ElectionHomePgObj.ts
+++ b/frontend/e2e-tests/page-objects/election/ElectionHomePgObj.ts
@@ -14,7 +14,8 @@ export class ElectionHome {
   readonly pollingStationsRow: Locator;
   readonly downloadNa31_2Bijlage1: Locator;
   readonly downloadN10_2: Locator;
-  readonly downloadInlegvel: Locator;
+  readonly downloadNa31_2Inlegvel: Locator;
+  readonly downloadNa31_1Inlegvel: Locator;
 
   constructor(protected readonly page: Page) {
     this.header = page.getByRole("heading", { level: 1 });
@@ -30,7 +31,8 @@ export class ElectionHome {
     this.pollingStationsRow = page.getByRole("rowheader", { name: "Stembureaus" });
     this.downloadNa31_2Bijlage1 = page.getByRole("cell", { name: "Na 31-2 Bijlage 1" });
     this.downloadN10_2 = page.getByRole("cell", { name: "N 10-2" });
-    this.downloadInlegvel = page.getByRole("cell", { name: "Na 31-2 Inlegvel" });
+    this.downloadNa31_2Inlegvel = page.getByRole("cell", { name: "Na 31-2 Inlegvel" });
+    this.downloadNa31_1Inlegvel = page.getByRole("cell", { name: "Na 31-1 Inlegvel" });
   }
 
   getCommitteeSessionCard(number: number) {

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -1,4 +1,5 @@
 import type {
+  CommonPollingStationResults,
   CSOFirstSessionResults,
   DataEntry,
   DSOFirstSessionResults,
@@ -160,16 +161,7 @@ export function emptyCSOFirstSessionResults(): CSOFirstSessionResults {
   };
 }
 
-export const noRecountNoDifferencesDataEntry: CSOFirstSessionResults & { model: "CSOFirstSession" } = {
-  model: "CSOFirstSession",
-  extra_investigation: {
-    extra_investigation_other_reason: { yes: false, no: true },
-    ballots_recounted_extra_investigation: { yes: false, no: true },
-  },
-  counting_differences_polling_station: {
-    difference_ballots_voters_completely_accounted_for: { yes: true, no: false },
-    difference_ballots_per_list: { yes: false, no: true },
-  },
+const commonDataEntry: CommonPollingStationResults = {
   voters_counts: {
     poll_card_count: 3450,
     proxy_certificate_count: 157,
@@ -290,7 +282,20 @@ export const noRecountNoDifferencesDataEntry: CSOFirstSessionResults & { model: 
   ],
 };
 
-export const noRecountNoDifferencesDataEntryDSOChecksAndCorrections: DSOFirstSessionResults & {
+export const noRecountNoDifferencesDataEntry: CSOFirstSessionResults & { model: "CSOFirstSession" } = {
+  model: "CSOFirstSession",
+  extra_investigation: {
+    extra_investigation_other_reason: { yes: false, no: true },
+    ballots_recounted_extra_investigation: { yes: false, no: true },
+  },
+  counting_differences_polling_station: {
+    difference_ballots_voters_completely_accounted_for: { yes: true, no: false },
+    difference_ballots_per_list: { yes: false, no: true },
+  },
+  ...structuredClone(commonDataEntry),
+};
+
+export const checksAndCorrectionsDataEntryDSO: DSOFirstSessionResults & {
   model: "DSOFirstSession";
 } = {
   model: "DSOFirstSession",
@@ -303,127 +308,10 @@ export const noRecountNoDifferencesDataEntryDSOChecksAndCorrections: DSOFirstSes
     corrected_results_own_initiative: { yes: true, no: false },
     corrected_results_csb_request: { yes: false, no: false },
   },
-  voters_counts: {
-    poll_card_count: 3450,
-    proxy_certificate_count: 157,
-    total_admitted_voters_count: 3607,
-  },
-  votes_counts: {
-    political_group_total_votes: [
-      { number: 1, total: 3536 },
-      { number: 2, total: 36 },
-      { number: 3, total: 0 },
-    ],
-    total_votes_candidates_count: 3572,
-    blank_votes_count: 20,
-    invalid_votes_count: 15,
-    total_votes_cast_count: 3607,
-  },
-  differences_counts: {
-    more_ballots_count: 0,
-    fewer_ballots_count: 0,
-    compare_votes_cast_admitted_voters: {
-      admitted_voters_equal_votes_cast: true,
-      votes_cast_greater_than_admitted_voters: false,
-      votes_cast_smaller_than_admitted_voters: false,
-    },
-    difference_completely_accounted_for: { yes: true, no: false },
-  },
-  political_group_votes: [
-    {
-      number: 1,
-      total: 3536,
-      candidate_votes: [
-        {
-          number: 1,
-          votes: 1337,
-        },
-        {
-          number: 2,
-          votes: 423,
-        },
-        {
-          number: 3,
-          votes: 300,
-        },
-        {
-          number: 4,
-          votes: 236,
-        },
-        {
-          number: 5,
-          votes: 533,
-        },
-        {
-          number: 6,
-          votes: 205,
-        },
-        {
-          number: 7,
-          votes: 103,
-        },
-        {
-          number: 8,
-          votes: 286,
-        },
-        {
-          number: 9,
-          votes: 0,
-        },
-        {
-          number: 10,
-          votes: 0,
-        },
-        {
-          number: 11,
-          votes: 113,
-        },
-        {
-          number: 12,
-          votes: 0,
-        },
-      ],
-    },
-    {
-      number: 2,
-      total: 36,
-      candidate_votes: [
-        {
-          number: 1,
-          votes: 28,
-        },
-        {
-          number: 2,
-          votes: 4,
-        },
-        {
-          number: 3,
-          votes: 2,
-        },
-        {
-          number: 4,
-          votes: 2,
-        },
-      ],
-    },
-    {
-      number: 3,
-      total: 0,
-      candidate_votes: [
-        {
-          number: 1,
-          votes: 0,
-        },
-        {
-          number: 2,
-          votes: 0,
-        },
-      ],
-    },
-  ],
+  ...structuredClone(commonDataEntry),
 };
 
-export const noRecountNoDifferencesDataEntryDSO: DSOFirstSessionResults & { model: "DSOFirstSession" } = {
+export const noChecksAndCorrectionsDataEntryDSO: DSOFirstSessionResults & { model: "DSOFirstSession" } = {
   model: "DSOFirstSession",
   about_report: {
     corrigendum_present: "OneDocument",
@@ -434,124 +322,7 @@ export const noRecountNoDifferencesDataEntryDSO: DSOFirstSessionResults & { mode
     corrected_results_own_initiative: { yes: false, no: false },
     corrected_results_csb_request: { yes: false, no: false },
   },
-  voters_counts: {
-    poll_card_count: 3450,
-    proxy_certificate_count: 157,
-    total_admitted_voters_count: 3607,
-  },
-  votes_counts: {
-    political_group_total_votes: [
-      { number: 1, total: 3536 },
-      { number: 2, total: 36 },
-      { number: 3, total: 0 },
-    ],
-    total_votes_candidates_count: 3572,
-    blank_votes_count: 20,
-    invalid_votes_count: 15,
-    total_votes_cast_count: 3607,
-  },
-  differences_counts: {
-    more_ballots_count: 0,
-    fewer_ballots_count: 0,
-    compare_votes_cast_admitted_voters: {
-      admitted_voters_equal_votes_cast: true,
-      votes_cast_greater_than_admitted_voters: false,
-      votes_cast_smaller_than_admitted_voters: false,
-    },
-    difference_completely_accounted_for: { yes: true, no: false },
-  },
-  political_group_votes: [
-    {
-      number: 1,
-      total: 3536,
-      candidate_votes: [
-        {
-          number: 1,
-          votes: 1337,
-        },
-        {
-          number: 2,
-          votes: 423,
-        },
-        {
-          number: 3,
-          votes: 300,
-        },
-        {
-          number: 4,
-          votes: 236,
-        },
-        {
-          number: 5,
-          votes: 533,
-        },
-        {
-          number: 6,
-          votes: 205,
-        },
-        {
-          number: 7,
-          votes: 103,
-        },
-        {
-          number: 8,
-          votes: 286,
-        },
-        {
-          number: 9,
-          votes: 0,
-        },
-        {
-          number: 10,
-          votes: 0,
-        },
-        {
-          number: 11,
-          votes: 113,
-        },
-        {
-          number: 12,
-          votes: 0,
-        },
-      ],
-    },
-    {
-      number: 2,
-      total: 36,
-      candidate_votes: [
-        {
-          number: 1,
-          votes: 28,
-        },
-        {
-          number: 2,
-          votes: 4,
-        },
-        {
-          number: 3,
-          votes: 2,
-        },
-        {
-          number: 4,
-          votes: 2,
-        },
-      ],
-    },
-    {
-      number: 3,
-      total: 0,
-      candidate_votes: [
-        {
-          number: 1,
-          votes: 0,
-        },
-        {
-          number: 2,
-          votes: 0,
-        },
-      ],
-    },
-  ],
+  ...structuredClone(commonDataEntry),
 };
 
 export const noRecountNoDifferencesDataEntryGSB: GSBResults & { model: "GSB" } = {
@@ -1506,7 +1277,7 @@ export const dataEntryRequest: DataEntry = {
 
 export const dataEntryRequestDSOChecksAndCorrections: DataEntry = {
   progress: 87,
-  data: noRecountNoDifferencesDataEntryDSOChecksAndCorrections,
+  data: checksAndCorrectionsDataEntryDSO,
   client_state: {
     furthest: "political_group_votes_3",
     current: "political_group_votes_3",
@@ -1517,7 +1288,7 @@ export const dataEntryRequestDSOChecksAndCorrections: DataEntry = {
 
 export const dataEntryRequestDSO: DataEntry = {
   progress: 87,
-  data: noRecountNoDifferencesDataEntryDSO,
+  data: noChecksAndCorrectionsDataEntryDSO,
   client_state: {
     furthest: "political_group_votes_3",
     current: "political_group_votes_3",

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -290,7 +290,9 @@ export const noRecountNoDifferencesDataEntry: CSOFirstSessionResults & { model: 
   ],
 };
 
-export const noRecountNoDifferencesDataEntryDSO: DSOFirstSessionResults & { model: "DSOFirstSession" } = {
+export const noRecountNoDifferencesDataEntryDSOChecksAndCorrections: DSOFirstSessionResults & {
+  model: "DSOFirstSession";
+} = {
   model: "DSOFirstSession",
   about_report: {
     corrigendum_present: "TwoDocuments",
@@ -299,6 +301,137 @@ export const noRecountNoDifferencesDataEntryDSO: DSOFirstSessionResults & { mode
   checks_and_corrections: {
     reason_investigation_own_initiative: { unaccounted_difference: true, other_error: true },
     corrected_results_own_initiative: { yes: true, no: false },
+    corrected_results_csb_request: { yes: false, no: false },
+  },
+  voters_counts: {
+    poll_card_count: 3450,
+    proxy_certificate_count: 157,
+    total_admitted_voters_count: 3607,
+  },
+  votes_counts: {
+    political_group_total_votes: [
+      { number: 1, total: 3536 },
+      { number: 2, total: 36 },
+      { number: 3, total: 0 },
+    ],
+    total_votes_candidates_count: 3572,
+    blank_votes_count: 20,
+    invalid_votes_count: 15,
+    total_votes_cast_count: 3607,
+  },
+  differences_counts: {
+    more_ballots_count: 0,
+    fewer_ballots_count: 0,
+    compare_votes_cast_admitted_voters: {
+      admitted_voters_equal_votes_cast: true,
+      votes_cast_greater_than_admitted_voters: false,
+      votes_cast_smaller_than_admitted_voters: false,
+    },
+    difference_completely_accounted_for: { yes: true, no: false },
+  },
+  political_group_votes: [
+    {
+      number: 1,
+      total: 3536,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 1337,
+        },
+        {
+          number: 2,
+          votes: 423,
+        },
+        {
+          number: 3,
+          votes: 300,
+        },
+        {
+          number: 4,
+          votes: 236,
+        },
+        {
+          number: 5,
+          votes: 533,
+        },
+        {
+          number: 6,
+          votes: 205,
+        },
+        {
+          number: 7,
+          votes: 103,
+        },
+        {
+          number: 8,
+          votes: 286,
+        },
+        {
+          number: 9,
+          votes: 0,
+        },
+        {
+          number: 10,
+          votes: 0,
+        },
+        {
+          number: 11,
+          votes: 113,
+        },
+        {
+          number: 12,
+          votes: 0,
+        },
+      ],
+    },
+    {
+      number: 2,
+      total: 36,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 28,
+        },
+        {
+          number: 2,
+          votes: 4,
+        },
+        {
+          number: 3,
+          votes: 2,
+        },
+        {
+          number: 4,
+          votes: 2,
+        },
+      ],
+    },
+    {
+      number: 3,
+      total: 0,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 0,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+      ],
+    },
+  ],
+};
+
+export const noRecountNoDifferencesDataEntryDSO: DSOFirstSessionResults & { model: "DSOFirstSession" } = {
+  model: "DSOFirstSession",
+  about_report: {
+    corrigendum_present: "OneDocument",
+    checks_and_corrections_present: "PageMissing",
+  },
+  checks_and_corrections: {
+    reason_investigation_own_initiative: { unaccounted_difference: false, other_error: false },
+    corrected_results_own_initiative: { yes: false, no: false },
     corrected_results_csb_request: { yes: false, no: false },
   },
   voters_counts: {
@@ -1363,6 +1496,28 @@ export const nextSessionResultsWithDifferences: NextSessionResults & { model: "C
 export const dataEntryRequest: DataEntry = {
   progress: 87,
   data: noRecountNoDifferencesDataEntry,
+  client_state: {
+    furthest: "political_group_votes_3",
+    current: "political_group_votes_3",
+    acceptedErrorsAndWarnings: [],
+    continue: true,
+  },
+};
+
+export const dataEntryRequestDSOChecksAndCorrections: DataEntry = {
+  progress: 87,
+  data: noRecountNoDifferencesDataEntryDSOChecksAndCorrections,
+  client_state: {
+    furthest: "political_group_votes_3",
+    current: "political_group_votes_3",
+    acceptedErrorsAndWarnings: [],
+    continue: true,
+  },
+};
+
+export const dataEntryRequestDSO: DataEntry = {
+  progress: 87,
+  data: noRecountNoDifferencesDataEntryDSO,
   client_state: {
     furthest: "political_group_votes_3",
     current: "political_group_votes_3",

--- a/frontend/e2e-tests/test-data/request-response-templates.ts
+++ b/frontend/e2e-tests/test-data/request-response-templates.ts
@@ -1,6 +1,7 @@
 import type {
   CSOFirstSessionResults,
   DataEntry,
+  DSOFirstSessionResults,
   GSBResults,
   NextSessionResults,
   PollingStationRequest,
@@ -168,6 +169,137 @@ export const noRecountNoDifferencesDataEntry: CSOFirstSessionResults & { model: 
   counting_differences_polling_station: {
     difference_ballots_voters_completely_accounted_for: { yes: true, no: false },
     difference_ballots_per_list: { yes: false, no: true },
+  },
+  voters_counts: {
+    poll_card_count: 3450,
+    proxy_certificate_count: 157,
+    total_admitted_voters_count: 3607,
+  },
+  votes_counts: {
+    political_group_total_votes: [
+      { number: 1, total: 3536 },
+      { number: 2, total: 36 },
+      { number: 3, total: 0 },
+    ],
+    total_votes_candidates_count: 3572,
+    blank_votes_count: 20,
+    invalid_votes_count: 15,
+    total_votes_cast_count: 3607,
+  },
+  differences_counts: {
+    more_ballots_count: 0,
+    fewer_ballots_count: 0,
+    compare_votes_cast_admitted_voters: {
+      admitted_voters_equal_votes_cast: true,
+      votes_cast_greater_than_admitted_voters: false,
+      votes_cast_smaller_than_admitted_voters: false,
+    },
+    difference_completely_accounted_for: { yes: true, no: false },
+  },
+  political_group_votes: [
+    {
+      number: 1,
+      total: 3536,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 1337,
+        },
+        {
+          number: 2,
+          votes: 423,
+        },
+        {
+          number: 3,
+          votes: 300,
+        },
+        {
+          number: 4,
+          votes: 236,
+        },
+        {
+          number: 5,
+          votes: 533,
+        },
+        {
+          number: 6,
+          votes: 205,
+        },
+        {
+          number: 7,
+          votes: 103,
+        },
+        {
+          number: 8,
+          votes: 286,
+        },
+        {
+          number: 9,
+          votes: 0,
+        },
+        {
+          number: 10,
+          votes: 0,
+        },
+        {
+          number: 11,
+          votes: 113,
+        },
+        {
+          number: 12,
+          votes: 0,
+        },
+      ],
+    },
+    {
+      number: 2,
+      total: 36,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 28,
+        },
+        {
+          number: 2,
+          votes: 4,
+        },
+        {
+          number: 3,
+          votes: 2,
+        },
+        {
+          number: 4,
+          votes: 2,
+        },
+      ],
+    },
+    {
+      number: 3,
+      total: 0,
+      candidate_votes: [
+        {
+          number: 1,
+          votes: 0,
+        },
+        {
+          number: 2,
+          votes: 0,
+        },
+      ],
+    },
+  ],
+};
+
+export const noRecountNoDifferencesDataEntryDSO: DSOFirstSessionResults & { model: "DSOFirstSession" } = {
+  model: "DSOFirstSession",
+  about_report: {
+    corrigendum_present: "TwoDocuments",
+    checks_and_corrections_present: "PagePresent",
+  },
+  checks_and_corrections: {
+    reason_investigation_own_initiative: { unaccounted_difference: true, other_error: true },
+    corrected_results_own_initiative: { yes: true, no: false },
+    corrected_results_csb_request: { yes: false, no: false },
   },
   voters_counts: {
     poll_card_count: 3450,

--- a/frontend/e2e-tests/tests/data-entry-GSB/data-entry-DSO.e2e.ts
+++ b/frontend/e2e-tests/tests/data-entry-GSB/data-entry-DSO.e2e.ts
@@ -1,0 +1,231 @@
+import { expect } from "@playwright/test";
+import {
+  AboutReportPage,
+  oneDocumentPageMissing,
+  twoDocumentsPagePresent,
+} from "e2e-tests/page-objects/data_entry/AboutReportPgObj";
+import { CandidatesListPage } from "e2e-tests/page-objects/data_entry/CandidatesListPgObj";
+import { CheckAndSavePage } from "e2e-tests/page-objects/data_entry/CheckAndSavePgObj";
+import {
+  bothReasonsAndCorrectedResultsOwnInitiative,
+  ChecksAndCorrectionsPage,
+} from "e2e-tests/page-objects/data_entry/ChecksAndCorrectionsPgObj";
+import { DataEntryHomePage } from "e2e-tests/page-objects/data_entry/DataEntryHomePgObj";
+import { DifferencesPage } from "e2e-tests/page-objects/data_entry/DifferencesPgObj";
+import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
+import {
+  dataEntryRequestDSO,
+  dataEntryRequestDSOChecksAndCorrections,
+  noErrorsWarningsResponse,
+} from "e2e-tests/test-data/request-response-templates";
+import type { VotersCounts, VotesCounts } from "@/types/generated/openapi";
+import { test } from "../../fixtures";
+
+test.use({
+  storageState: "e2e-tests/state/typist1-GSB.json",
+});
+
+test.describe("full DSO data entry flow", () => {
+  test("two documents, checks and corrections, no differences", async ({ page, dataEntryGSBDSO }) => {
+    await page.goto(`/elections/${dataEntryGSBDSO.election_id}/data-entry`);
+
+    const dataEntryHomePage = new DataEntryHomePage(page);
+    await expect(dataEntryHomePage.fieldset).toBeVisible();
+    await dataEntryHomePage.number.fill(dataEntryGSBDSO.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSBDSO.name);
+    await dataEntryHomePage.start.click();
+
+    const aboutReportPage = new AboutReportPage(page);
+    await aboutReportPage.fillAndClickNext(twoDocumentsPagePresent);
+
+    const checksAndCorrectionsPage = new ChecksAndCorrectionsPage(page);
+    await checksAndCorrectionsPage.fillAndClickNext(bothReasonsAndCorrectedResultsOwnInitiative);
+
+    const votersAndVotesPage = new VotersAndVotesPage(page);
+    await expect(votersAndVotesPage.pollCardCount).toBeFocused();
+    const voters: VotersCounts = {
+      poll_card_count: 3450,
+      proxy_certificate_count: 157,
+      total_admitted_voters_count: 3607,
+    };
+    const votes: VotesCounts = {
+      political_group_total_votes: [
+        { number: 1, total: 3536 },
+        { number: 2, total: 36 },
+        { number: 3, total: 0 },
+      ],
+      total_votes_candidates_count: 3572,
+      blank_votes_count: 20,
+      invalid_votes_count: 15,
+      total_votes_cast_count: 3607,
+    };
+    await votersAndVotesPage.inputVotersCounts(voters);
+    await votersAndVotesPage.inputVotesCounts(votes);
+    await expect(votersAndVotesPage.pollCardCount).toHaveValue(voters.poll_card_count.toString());
+    await votersAndVotesPage.next.click();
+
+    const differencesPage = new DifferencesPage(page);
+    await differencesPage.admittedVotersEqualsVotesCastCheckbox.check();
+    await differencesPage.differenceCompletelyAccountedForYes.check();
+    await differencesPage.next.click();
+
+    const candidatesListPage_1 = new CandidatesListPage(page, 0, "Partijdige Partij");
+    await expect(candidatesListPage_1.getCandidate(0)).toBeFocused();
+
+    await candidatesListPage_1.fillCandidatesAndTotal([1337, 423, 300, 236, 533, 205, 103, 286, 0, 0, 113, 0], 3536);
+    await candidatesListPage_1.next.click();
+
+    const candidatesListPage_2 = new CandidatesListPage(page, 1, "Lijst van de Kandidaten");
+    await expect(candidatesListPage_2.getCandidate(0)).toBeFocused();
+
+    await candidatesListPage_2.fillCandidatesAndTotal([28, 4, 2, 2], 36);
+    await candidatesListPage_2.next.click();
+
+    const candidatesListPage_3 = new CandidatesListPage(page, 2, "Partij voor de Stemmer");
+    await expect(candidatesListPage_3.getCandidate(0)).toBeFocused();
+
+    await candidatesListPage_3.fillCandidatesAndTotal([0, 0], 0);
+    const responsePromise = page.waitForResponse(/\/api\/data_entries\/(\d+)\/([12])/);
+    await candidatesListPage_3.next.click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+    expect(response.request().postDataJSON()).toStrictEqual(dataEntryRequestDSOChecksAndCorrections);
+    expect(await response.json()).toStrictEqual(noErrorsWarningsResponse);
+
+    const checkAndSavePage = new CheckAndSavePage(page);
+    await expect(checkAndSavePage.fieldset).toBeVisible();
+
+    await expect(checkAndSavePage.summaryText).toContainText(
+      "De aantallen die je hebt ingevoerd in de verschillende stappen spreken elkaar niet tegen. Er zijn geen blokkerende fouten of waarschuwingen.",
+    );
+
+    const expectedSummaryItems = [
+      { text: "Alle optellingen kloppen", iconLabel: "opgeslagen" },
+      { text: "Er zijn geen blokkerende fouten of waarschuwingen", iconLabel: "opgeslagen" },
+      { text: "Je kan de resultaten van dit stembureau opslaan", iconLabel: "opgeslagen" },
+    ];
+    const listItems = checkAndSavePage.allSummaryListItems();
+    const expectedTexts = Array.from(expectedSummaryItems, (item) => item.text);
+    await expect(listItems).toHaveText(expectedTexts);
+
+    for (const expectedItem of expectedSummaryItems) {
+      await expect(checkAndSavePage.summaryListItemIcon(expectedItem.text)).toHaveAccessibleName(
+        expectedItem.iconLabel,
+      );
+    }
+
+    await checkAndSavePage.save.click();
+
+    await expect(dataEntryHomePage.fieldsetContinueNext).toBeVisible();
+    await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
+
+    await expect(dataEntryHomePage.alertDataEntrySaved).toHaveText(
+      [
+        "Eerste invoer is opgeslagen",
+        "Geef het papieren proces-verbaal terug aan de coördinator.",
+        "Een andere invoerder doet straks de tweede invoer.",
+      ].join(""),
+    );
+  });
+
+  test("one document, no differences", async ({ page, dataEntryGSBDSO }) => {
+    await page.goto(`/elections/${dataEntryGSBDSO.election_id}/data-entry`);
+
+    const dataEntryHomePage = new DataEntryHomePage(page);
+    await expect(dataEntryHomePage.fieldset).toBeVisible();
+    await dataEntryHomePage.number.fill(dataEntryGSBDSO.number);
+    await expect(dataEntryHomePage.feedback).toContainText(dataEntryGSBDSO.name);
+    await dataEntryHomePage.start.click();
+
+    const aboutReportPage = new AboutReportPage(page);
+    await aboutReportPage.fillAndClickNext(oneDocumentPageMissing);
+
+    const votersAndVotesPage = new VotersAndVotesPage(page);
+    await expect(votersAndVotesPage.pollCardCount).toBeFocused();
+    const voters: VotersCounts = {
+      poll_card_count: 3450,
+      proxy_certificate_count: 157,
+      total_admitted_voters_count: 3607,
+    };
+    const votes: VotesCounts = {
+      political_group_total_votes: [
+        { number: 1, total: 3536 },
+        { number: 2, total: 36 },
+        { number: 3, total: 0 },
+      ],
+      total_votes_candidates_count: 3572,
+      blank_votes_count: 20,
+      invalid_votes_count: 15,
+      total_votes_cast_count: 3607,
+    };
+    await votersAndVotesPage.inputVotersCounts(voters);
+    await votersAndVotesPage.inputVotesCounts(votes);
+    await expect(votersAndVotesPage.pollCardCount).toHaveValue(voters.poll_card_count.toString());
+    await votersAndVotesPage.next.click();
+
+    const differencesPage = new DifferencesPage(page);
+    await differencesPage.admittedVotersEqualsVotesCastCheckbox.check();
+    await differencesPage.differenceCompletelyAccountedForYes.check();
+    await differencesPage.next.click();
+
+    const candidatesListPage_1 = new CandidatesListPage(page, 0, "Partijdige Partij");
+    await expect(candidatesListPage_1.getCandidate(0)).toBeFocused();
+
+    await candidatesListPage_1.fillCandidatesAndTotal([1337, 423, 300, 236, 533, 205, 103, 286, 0, 0, 113, 0], 3536);
+    await candidatesListPage_1.next.click();
+
+    const candidatesListPage_2 = new CandidatesListPage(page, 1, "Lijst van de Kandidaten");
+    await expect(candidatesListPage_2.getCandidate(0)).toBeFocused();
+
+    await candidatesListPage_2.fillCandidatesAndTotal([28, 4, 2, 2], 36);
+    await candidatesListPage_2.next.click();
+
+    const candidatesListPage_3 = new CandidatesListPage(page, 2, "Partij voor de Stemmer");
+    await expect(candidatesListPage_3.getCandidate(0)).toBeFocused();
+
+    await candidatesListPage_3.fillCandidatesAndTotal([0, 0], 0);
+    const responsePromise = page.waitForResponse(/\/api\/data_entries\/(\d+)\/([12])/);
+    await candidatesListPage_3.next.click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+    expect(response.request().postDataJSON()).toStrictEqual(dataEntryRequestDSO);
+    expect(await response.json()).toStrictEqual(noErrorsWarningsResponse);
+
+    const checkAndSavePage = new CheckAndSavePage(page);
+    await expect(checkAndSavePage.fieldset).toBeVisible();
+
+    await expect(checkAndSavePage.summaryText).toContainText(
+      "De aantallen die je hebt ingevoerd in de verschillende stappen spreken elkaar niet tegen. Er zijn geen blokkerende fouten of waarschuwingen.",
+    );
+
+    const expectedSummaryItems = [
+      { text: "Alle optellingen kloppen", iconLabel: "opgeslagen" },
+      { text: "Er zijn geen blokkerende fouten of waarschuwingen", iconLabel: "opgeslagen" },
+      { text: "Je kan de resultaten van dit stembureau opslaan", iconLabel: "opgeslagen" },
+    ];
+    const listItems = checkAndSavePage.allSummaryListItems();
+    const expectedTexts = Array.from(expectedSummaryItems, (item) => item.text);
+    await expect(listItems).toHaveText(expectedTexts);
+
+    for (const expectedItem of expectedSummaryItems) {
+      await expect(checkAndSavePage.summaryListItemIcon(expectedItem.text)).toHaveAccessibleName(
+        expectedItem.iconLabel,
+      );
+    }
+
+    await checkAndSavePage.save.click();
+
+    await expect(dataEntryHomePage.fieldsetContinueNext).toBeVisible();
+    await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
+
+    await expect(dataEntryHomePage.alertDataEntrySaved).toHaveText(
+      [
+        "Eerste invoer is opgeslagen",
+        "Geef het papieren proces-verbaal terug aan de coördinator.",
+        "Een andere invoerder doet straks de tweede invoer.",
+      ].join(""),
+    );
+  });
+});

--- a/frontend/e2e-tests/tests/election/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election/election-create.e2e.ts
@@ -28,7 +28,7 @@ test.use({
 });
 
 test.describe("Election creation", () => {
-  test.describe("GSB election creation", () => {
+  test.describe("GSB CSO election creation", () => {
     test("it uploads an election file, candidate list and polling stations", async ({ page }) => {
       await page.goto("/elections");
       const overviewPage = new ElectionsOverviewPgObj(page);
@@ -151,6 +151,163 @@ test.describe("Election creation", () => {
       await expect(checkAndSavePage.numberOfListsAndCandidates).toContainText("3 lijsten en 18 kandidaten");
       await expect(checkAndSavePage.numberOfPollingStations).toBeHidden();
       await expect(checkAndSavePage.countingMethod).toContainText("Centrale stemopneming");
+      await expect(checkAndSavePage.numberOfVoters).toContainText("1.234 kiesgerechtigden");
+
+      const election = await checkAndSavePage.saveElection();
+      await expect(overviewPage.adminHeader).toBeVisible();
+
+      const electionRow = overviewPage.findElectionRowById(election.id);
+      await expect(electionRow).toBeVisible();
+      await expect(electionRow).toContainText("Gemeenteraad Test 2022");
+      await expect(electionRow).toContainText("Zitting voorbereiden");
+      await electionRow.click();
+
+      const electionHomePage = new ElectionHome(page);
+      await expect(electionHomePage.header).toHaveText("Gemeenteraad Test 2022");
+      await electionHomePage.alertLinkToPollingStations.click();
+
+      const pollingStationsPage = new PollingStationListEmptyPgObj(page);
+      await pollingStationsPage.importButton.click();
+      const importPage = new PollingStationImportPgObj(page);
+      await importPage.uploadFile(eml110b.path);
+      await importPage.importButton.click();
+
+      const listPage = new PollingStationListPgObj(page);
+      await expect(listPage.header).toBeVisible();
+      await expect(listPage.alert).toContainText(/Er zijn \d+ stembureaus geïmporteerd/);
+
+      const navBar = new AdminNavBar(page);
+      await navBar.getElectionBreadcrumb(eml110a.electionName).click();
+
+      await expect(electionHomePage.header).toBeVisible();
+      const session = electionHomePage.getCommitteeSessionCard(1);
+      await expect(session).toContainText("Klaar voor invoer");
+    });
+  });
+
+  test.describe("GSB DSO election creation", () => {
+    test("it uploads an election file, candidate list and polling stations", async ({ page }) => {
+      await page.goto("/elections");
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await overviewPage.create.click();
+
+      // upload election and check hash
+      await uploadElectionAndInputHash(page);
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
+
+      // committee category
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
+
+      // upload polling stations
+      await uploadPollingStations(page);
+
+      // Counting method page
+      const countingMethodPage = new CountingMethodTypePgObj(page);
+      await expect(countingMethodPage.header).toBeVisible();
+      await expect(countingMethodPage.cso).not.toBeChecked();
+      await expect(countingMethodPage.dso).not.toBeChecked();
+      await countingMethodPage.dso.check();
+      await countingMethodPage.next.click();
+
+      // Number of voters page
+      const numberOfVotersPage = new NumberOfVotersPgObj(page);
+      await expect(numberOfVotersPage.header).toBeVisible();
+      await expect(numberOfVotersPage.hint).toBeVisible();
+      await numberOfVotersPage.next.click();
+
+      // Now we should be at the check and save page
+      const checkAndSavePage = new CheckAndSavePgObj(page);
+      await expect(checkAndSavePage.header).toBeVisible();
+
+      await expect(checkAndSavePage.electionName).toContainText("verkiezing: Gemeenteraad Test 2022");
+      await expect(checkAndSavePage.committeeCategory).toContainText("type stembureau: Gemeentelijk stembureau");
+      await expect(checkAndSavePage.electionLocation).toContainText("gebiedsaanduiding: Test");
+      await expect(checkAndSavePage.numberOfListsAndCandidates).toContainText("3 lijsten en 18 kandidaten");
+      await expect(checkAndSavePage.numberOfPollingStations).toContainText("420 stembureaus");
+      await expect(checkAndSavePage.countingMethod).toContainText("Decentrale stemopneming");
+      await expect(checkAndSavePage.numberOfVoters).toContainText("612.694 kiesgerechtigden");
+
+      // Now go back and fill the number of voters with a custom value
+      await page.goBack();
+      await expect(numberOfVotersPage.header).toBeVisible();
+      await expect(numberOfVotersPage.hint).toBeVisible();
+      await numberOfVotersPage.input.fill("1234");
+      await numberOfVotersPage.next.click();
+
+      // Check that the value is updated
+      await expect(checkAndSavePage.header).toBeVisible();
+      await expect(checkAndSavePage.numberOfVoters).toContainText("1.234 kiesgerechtigden");
+
+      // Go back another time to check that the hint is gone (since now it's not an imported value anymore)
+      // It should also still show the updated value
+      await page.goBack();
+      await expect(numberOfVotersPage.input).toHaveValue("1234");
+      await expect(numberOfVotersPage.hint).toBeHidden();
+      await numberOfVotersPage.next.click();
+
+      // Back to the check and save page to test saving the election
+      const election = await checkAndSavePage.saveElection();
+      await expect(overviewPage.adminHeader).toBeVisible();
+      await expect(overviewPage.alertGSBElectionCreated).toBeVisible();
+
+      const electionRow = overviewPage.findElectionRowById(election.id);
+      await expect(electionRow).toBeVisible();
+      await expect(electionRow).toContainText("Gemeenteraad Test 2022");
+      await expect(electionRow).toContainText("GSB - Test (0000)");
+      await expect(electionRow).toContainText("Klaar voor invoer");
+    });
+
+    test("it uploads an election file, candidate list but adds polling stations afterwards", async ({ page }) => {
+      await page.goto("/elections");
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await overviewPage.create.click();
+
+      // upload election and check hash
+      await uploadElectionAndInputHash(page);
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
+
+      // committee category
+      const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+      await expect(committeeCategoryPage.header).toBeVisible();
+      await committeeCategoryPage.next.click();
+
+      // skip polling stations
+      const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);
+      await expect(uploadPollingStationsPage.header).toBeVisible();
+      await uploadPollingStationsPage.skipButton.click();
+
+      // Counting method page
+      const countingMethodPage = new CountingMethodTypePgObj(page);
+      await expect(countingMethodPage.header).toBeVisible();
+      await countingMethodPage.dso.check();
+      await countingMethodPage.next.click();
+
+      // Number of voters page
+      const numberOfVotersPage = new NumberOfVotersPgObj(page);
+      await expect(numberOfVotersPage.header).toBeVisible();
+      await expect(numberOfVotersPage.hint).toBeHidden();
+      await numberOfVotersPage.next.click();
+
+      // Expect error, input a value and try clicking Next again
+      await expect(numberOfVotersPage.error).toBeVisible();
+      await numberOfVotersPage.input.fill("1234");
+      await numberOfVotersPage.next.click();
+
+      // Now we should be at the check and save page
+      const checkAndSavePage = new CheckAndSavePgObj(page);
+      await expect(checkAndSavePage.header).toBeVisible();
+      await expect(checkAndSavePage.electionName).toContainText("verkiezing: Gemeenteraad Test 2022");
+      await expect(checkAndSavePage.committeeCategory).toHaveText("type stembureau: Gemeentelijk stembureau");
+      await expect(checkAndSavePage.electionLocation).toContainText("gebiedsaanduiding: Test");
+      await expect(checkAndSavePage.numberOfListsAndCandidates).toContainText("3 lijsten en 18 kandidaten");
+      await expect(checkAndSavePage.numberOfPollingStations).toBeHidden();
+      await expect(checkAndSavePage.countingMethod).toContainText("Decentrale stemopneming");
       await expect(checkAndSavePage.numberOfVoters).toContainText("1.234 kiesgerechtigden");
 
       const election = await checkAndSavePage.saveElection();

--- a/frontend/e2e-tests/tests/election/election-create.e2e.ts
+++ b/frontend/e2e-tests/tests/election/election-create.e2e.ts
@@ -194,13 +194,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // upload polling stations
       await uploadPollingStations(page);
@@ -269,13 +269,13 @@ test.describe("Election creation", () => {
       // upload election and check hash
       await uploadElectionAndInputHash(page);
 
-      // upload candidates list and check
-      await uploadCandidatesAndInputHash(page, eml230b);
-
       // committee category
       const committeeCategoryPage = new CommitteeCategoryPgObj(page);
       await expect(committeeCategoryPage.header).toBeVisible();
       await committeeCategoryPage.next.click();
+
+      // upload candidates list and check
+      await uploadCandidatesAndInputHash(page, eml230b);
 
       // skip polling stations
       const uploadPollingStationsPage = new UploadPollingStationsFilePgObj(page);

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-CSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-CSO.e2e.ts
@@ -95,7 +95,7 @@ const typistUsers: TestUser[] = [
 
 test.describe.configure({ mode: "serial" });
 
-test.describe("full flow GSB", () => {
+test.describe("full flow GSB CSO", () => {
   let electionId: number | null = null;
 
   test("create and complete admin user account", async ({ adminOne }) => {

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-CSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-CSO.e2e.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { expect, request } from "@playwright/test";
 import { apiLogout, createUser, firstLogin, getTestPassword } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import {
-  createCSOInvestigation,
+  createInvestigation,
   fillCandidatesListPages,
   fillDataEntryPagesAndSave,
   logout,
@@ -481,7 +481,7 @@ test.describe("full flow GSB CSO", () => {
       const electionHome = new ElectionHome(page);
       await electionHome.investigationsOverviewButton.click();
 
-      await createCSOInvestigation(page, station.name, station.reason);
+      await createInvestigation(page, station.name, station.reason, "CSO");
       const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
       await expect(investigationsOverviewPage.alert).toHaveText(
         `Onderzoek voor stembureau ${station.number} (${station.name}) toegevoegd`,

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-CSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-CSO.e2e.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { expect, request } from "@playwright/test";
 import { apiLogout, createUser, firstLogin, getTestPassword } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import {
-  createInvestigation,
+  createCSOInvestigation,
   fillCandidatesListPages,
   fillDataEntryPagesAndSave,
   logout,
@@ -423,7 +423,7 @@ test.describe("full flow GSB CSO", () => {
     await expect(electionHomePage.header).toHaveText("Gemeenteraad Test 2022");
 
     const downloadPromise = page.waitForEvent("download");
-    await electionHomePage.downloadInlegvel.click();
+    await electionHomePage.downloadNa31_2Inlegvel.click();
     const download = await downloadPromise;
 
     expect(download.suggestedFilename()).toBe("Model_Na_31_2_Inlegvel.pdf");
@@ -481,7 +481,7 @@ test.describe("full flow GSB CSO", () => {
       const electionHome = new ElectionHome(page);
       await electionHome.investigationsOverviewButton.click();
 
-      await createInvestigation(page, station.name, station.reason);
+      await createCSOInvestigation(page, station.name, station.reason);
       const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
       await expect(investigationsOverviewPage.alert).toHaveText(
         `Onderzoek voor stembureau ${station.number} (${station.name}) toegevoegd`,

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
@@ -44,7 +44,7 @@ import { UserListPgObj } from "e2e-tests/page-objects/users/UserListPgObj";
 import { eml110b_single, eml230b } from "e2e-tests/test-data/eml-files";
 import {
   noRecountNoDifferencesDataEntry,
-  noRecountNoDifferencesDataEntryDSO,
+  noRecountNoDifferencesDataEntryDSOChecksAndCorrections,
 } from "e2e-tests/test-data/request-response-templates";
 import type { TestUser } from "e2e-tests/test-data/users";
 import { test } from "../../fixtures";
@@ -331,7 +331,7 @@ test.describe("full flow GSB DSO", () => {
       await expect(dataEntryHomePage.feedback).toContainText(station.name);
       await dataEntryHomePage.start.click();
 
-      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSO);
+      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSOChecksAndCorrections);
       await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
 
       await logout(page);
@@ -354,7 +354,7 @@ test.describe("full flow GSB DSO", () => {
       await expect(dataEntryHomePage.feedback).toContainText(station.name);
       await dataEntryHomePage.start.click();
 
-      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSO);
+      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSOChecksAndCorrections);
       await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
 
       await logout(page);

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { expect, request } from "@playwright/test";
 import { apiLogout, createUser, firstLogin, getTestPassword } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import {
-  createInvestigation,
+  createDSOInvestigation,
   fillCandidatesListPages,
   fillDataEntryPagesAndSave,
   logout,
@@ -412,7 +412,7 @@ test.describe("full flow GSB DSO", () => {
     await logout(page);
   });
 
-  test("download Na 31-2 inlegvel", async ({ page }) => {
+  test("download Na 31-1 inlegvel", async ({ page }) => {
     await page.goto("/account/login");
 
     const loginPage = new LoginPgObj(page);
@@ -426,10 +426,10 @@ test.describe("full flow GSB DSO", () => {
     await expect(electionHomePage.header).toHaveText("Gemeenteraad Test 2022");
 
     const downloadPromise = page.waitForEvent("download");
-    await electionHomePage.downloadInlegvel.click();
+    await electionHomePage.downloadNa31_1Inlegvel.click();
     const download = await downloadPromise;
 
-    expect(download.suggestedFilename()).toBe("Model_Na_31_2_Inlegvel.pdf");
+    expect(download.suggestedFilename()).toBe("Model_Na_31_1_Inlegvel.pdf");
     expect((await stat(await download.path())).size).toBeGreaterThan(1024);
 
     await logout(page);
@@ -482,9 +482,17 @@ test.describe("full flow GSB DSO", () => {
       await overviewPage.findElectionRowById(electionId!).click();
 
       const electionHome = new ElectionHome(page);
+      await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+      await expect(electionHome.getCommitteeSessionCard(2)).toContainText("Tweede zitting");
+      await electionHome.detailsButton.click();
+
+      const electionDetails = new ElectionDetailsPgObj(page);
+      await expect(electionDetails.header).toHaveText("Gemeentelijk stembureau Test");
+      await electionDetails.fillForm("Pannerdam", "18-03-2026", "21:34");
+
       await electionHome.investigationsOverviewButton.click();
 
-      await createInvestigation(page, station.name, station.reason);
+      await createDSOInvestigation(page, station.name, station.reason);
       const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
       await expect(investigationsOverviewPage.alert).toHaveText(
         `Onderzoek voor stembureau ${station.number} (${station.name}) toegevoegd`,
@@ -657,13 +665,6 @@ test.describe("full flow GSB DSO", () => {
 
     const finishDataEntryPage = new FinishDataEntry(page);
     await finishDataEntryPage.finishDataEntry.click();
-
-    const electionDetails = new ElectionDetailsPgObj(page);
-    await expect(electionDetails.header).toHaveText("Gemeentelijk stembureau Test");
-    await electionDetails.locationInput.fill("Pannerdam");
-    await electionDetails.dateInput.fill("18-03-2026");
-    await electionDetails.timeInput.fill("21:34");
-    await electionDetails.toCertifiedResults.click();
 
     const electionHomePage = new ElectionReport(page);
     await expect(electionHomePage.header).toContainText("Tweede zitting gemeentelijk stembureau");

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { expect, request } from "@playwright/test";
 import { apiLogout, createUser, firstLogin, getTestPassword } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
 import {
-  createDSOInvestigation,
+  createInvestigation,
   fillCandidatesListPages,
   fillDataEntryPagesAndSave,
   logout,
@@ -43,8 +43,8 @@ import { UserCreateTypePgObj } from "e2e-tests/page-objects/users/UserCreateType
 import { UserListPgObj } from "e2e-tests/page-objects/users/UserListPgObj";
 import { eml110b_single, eml230b } from "e2e-tests/test-data/eml-files";
 import {
+  checksAndCorrectionsDataEntryDSO,
   noRecountNoDifferencesDataEntry,
-  noRecountNoDifferencesDataEntryDSOChecksAndCorrections,
 } from "e2e-tests/test-data/request-response-templates";
 import type { TestUser } from "e2e-tests/test-data/users";
 import { test } from "../../fixtures";
@@ -331,7 +331,7 @@ test.describe("full flow GSB DSO", () => {
       await expect(dataEntryHomePage.feedback).toContainText(station.name);
       await dataEntryHomePage.start.click();
 
-      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSOChecksAndCorrections);
+      await fillDataEntryPagesAndSave(page, checksAndCorrectionsDataEntryDSO);
       await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
 
       await logout(page);
@@ -354,7 +354,7 @@ test.describe("full flow GSB DSO", () => {
       await expect(dataEntryHomePage.feedback).toContainText(station.name);
       await dataEntryHomePage.start.click();
 
-      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSOChecksAndCorrections);
+      await fillDataEntryPagesAndSave(page, checksAndCorrectionsDataEntryDSO);
       await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
 
       await logout(page);
@@ -492,7 +492,7 @@ test.describe("full flow GSB DSO", () => {
 
       await electionHome.investigationsOverviewButton.click();
 
-      await createDSOInvestigation(page, station.name, station.reason);
+      await createInvestigation(page, station.name, station.reason, "DSO");
       const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
       await expect(investigationsOverviewPage.alert).toHaveText(
         `Onderzoek voor stembureau ${station.number} (${station.name}) toegevoegd`,

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
@@ -1,0 +1,679 @@
+import { stat } from "node:fs/promises";
+import { expect, request } from "@playwright/test";
+import { apiLogout, createUser, firstLogin, getTestPassword } from "e2e-tests/helpers-utils/e2e-test-api-helpers";
+import {
+  createInvestigation,
+  fillCandidatesListPages,
+  fillDataEntryPagesAndSave,
+  logout,
+  uploadCandidatesAndInputHash,
+  uploadElectionAndInputHash,
+  uploadPollingStations,
+} from "e2e-tests/helpers-utils/e2e-test-browser-helpers";
+import { AccountSetupPgObj } from "e2e-tests/page-objects/authentication/AccountSetupPgObj";
+import { LoginPgObj } from "e2e-tests/page-objects/authentication/LoginPgObj";
+import { CandidatesListPage } from "e2e-tests/page-objects/data_entry/CandidatesListPgObj";
+import { CheckAndSavePage } from "e2e-tests/page-objects/data_entry/CheckAndSavePgObj";
+import { DataEntryHomePage } from "e2e-tests/page-objects/data_entry/DataEntryHomePgObj";
+import { DifferencesPage } from "e2e-tests/page-objects/data_entry/DifferencesPgObj";
+import { ExtraInvestigationPage } from "e2e-tests/page-objects/data_entry/ExtraInvestigationPgObj";
+import { ProgressList } from "e2e-tests/page-objects/data_entry/ProgressListPgObj";
+import { VotersAndVotesPage } from "e2e-tests/page-objects/data_entry/VotersAndVotesPgObj";
+import { CheckAndSavePgObj } from "e2e-tests/page-objects/election/create/CheckAndSavePgObj";
+import { CommitteeCategoryPgObj } from "e2e-tests/page-objects/election/create/CommitteeCategoryPgObj";
+import { CountingMethodTypePgObj } from "e2e-tests/page-objects/election/create/CountingMethodTypePgObj";
+import { NumberOfVotersPgObj } from "e2e-tests/page-objects/election/create/NumberOfVotersPgObj";
+import { ElectionDetailsPgObj } from "e2e-tests/page-objects/election/ElectionDetailsPgObj";
+import { ElectionHome } from "e2e-tests/page-objects/election/ElectionHomePgObj";
+import { ElectionReport } from "e2e-tests/page-objects/election/ElectionReportPgObj";
+import { ElectionStatus } from "e2e-tests/page-objects/election/ElectionStatusPgObj";
+import { ElectionsOverviewPgObj } from "e2e-tests/page-objects/election/ElectionsOverviewPgObj";
+import { FinishDataEntry } from "e2e-tests/page-objects/election/FinishDataEntryPgObj";
+import { AddInvestigationPgObj } from "e2e-tests/page-objects/investigations/AddInvestigationPgObj";
+import { InvestigationFindingsPgObj } from "e2e-tests/page-objects/investigations/InvestigationFindingsPgObj";
+import { InvestigationOverviewPgObj } from "e2e-tests/page-objects/investigations/InvestigationOverviewPgObj";
+import { AdminNavBar } from "e2e-tests/page-objects/nav_bar/AdminNavBarPgObj";
+import { UserInfoTopBar } from "e2e-tests/page-objects/nav_bar/UserInfoTopBarPgObj";
+import { PollingStationFormPgObj } from "e2e-tests/page-objects/polling_station/PollingStationFormPgObj";
+import { PollingStationListPgObj } from "e2e-tests/page-objects/polling_station/PollingStationListPgObj";
+import { UserCreateDetailsPgObj } from "e2e-tests/page-objects/users/UserCreateDetailsPgObj";
+import { UserCreateElectionPgObj } from "e2e-tests/page-objects/users/UserCreateElectionPgObj";
+import { UserCreateRolePgObj } from "e2e-tests/page-objects/users/UserCreateRolePgObj";
+import { UserCreateTypePgObj } from "e2e-tests/page-objects/users/UserCreateTypePgObj";
+import { UserListPgObj } from "e2e-tests/page-objects/users/UserListPgObj";
+import { eml110b_single, eml230b } from "e2e-tests/test-data/eml-files";
+import {
+  noRecountNoDifferencesDataEntry,
+  noRecountNoDifferencesDataEntryDSO,
+} from "e2e-tests/test-data/request-response-templates";
+import type { TestUser } from "e2e-tests/test-data/users";
+import { test } from "../../fixtures";
+
+const investigations = [
+  { number: "1", name: "Stadhuis", reason: "Reden", findings: "Probleem", correctedResults: true },
+  {
+    number: "2",
+    name: "Basisschool de Regenboog",
+    reason: "Reden",
+    findings: "Geen probleem",
+    correctedResults: false,
+  },
+  {
+    number: "5",
+    name: "Sportfondsenbad",
+    reason: "Stembureau vergeten te importeren",
+    findings: "Stembureau toegevoegd en ingevoerd",
+    correctedResults: true,
+  },
+];
+
+// Note: Do not use the randomSuffix in test titles. You cannot interpolate a non-static value.
+// Using the randomSuffix in test titles will result in those tests being executed last.
+const randomSuffix = Date.now();
+
+const adminUser: TestUser = {
+  username: `admin1-GSB-${randomSuffix}`,
+  fullname: `full flow admin1 GSB`,
+  role: "administrator",
+};
+
+const coordinatorUser: TestUser = {
+  username: `coordinator1-GSB-${randomSuffix}`,
+  fullname: `full flow coordinator1 GSB`,
+  role: "coordinator_gsb",
+};
+
+const typistUsers: TestUser[] = [
+  {
+    username: `typist1-GSB-${randomSuffix}`,
+    fullname: `full flow typist1 GSB`,
+    role: "typist_gsb",
+  },
+  {
+    username: `typist2-GSB-${randomSuffix}`,
+    fullname: `full flow typist2 GSB`,
+    role: "typist_gsb",
+  },
+];
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("full flow GSB DSO", () => {
+  let electionId: number | null = null;
+
+  test("create and complete admin user account", async ({ adminOne }) => {
+    const { request: adminOneContext } = adminOne;
+
+    await createUser(adminOneContext, adminUser);
+
+    const newAdminContext = await request.newContext();
+    await firstLogin(newAdminContext, adminUser);
+    const logoutResponse = await apiLogout(newAdminContext);
+    expect(logoutResponse.status()).toBe(204);
+  });
+
+  test("create GSB election and a new polling station", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(adminUser.username, getTestPassword(adminUser.username));
+
+    const electionsOverviewPage = new ElectionsOverviewPgObj(page);
+    await electionsOverviewPage.create.click();
+
+    await uploadElectionAndInputHash(page);
+
+    await uploadCandidatesAndInputHash(page, eml230b);
+
+    const committeeCategoryPage = new CommitteeCategoryPgObj(page);
+    await expect(committeeCategoryPage.header).toBeVisible();
+    await expect(committeeCategoryPage.gsb).toBeChecked();
+    await committeeCategoryPage.next.click();
+
+    await uploadPollingStations(page, eml110b_single);
+
+    const countingMethodPage = new CountingMethodTypePgObj(page);
+    await expect(countingMethodPage.header).toBeVisible();
+    await expect(countingMethodPage.cso).not.toBeChecked();
+    await expect(countingMethodPage.dso).not.toBeChecked();
+    await countingMethodPage.dso.check();
+    await countingMethodPage.next.click();
+
+    const numberOfVotersPage = new NumberOfVotersPgObj(page);
+    await expect(numberOfVotersPage.header).toBeVisible();
+    await expect(numberOfVotersPage.input).toHaveValue("612694"); // value comes from eml110b
+    await numberOfVotersPage.input.fill("61269");
+    await numberOfVotersPage.next.click();
+
+    const checkAndSavePage = new CheckAndSavePgObj(page);
+    await expect(checkAndSavePage.header).toBeVisible();
+    await expect(checkAndSavePage.committeeCategory).toHaveText("type stembureau: Gemeentelijk stembureau");
+    await expect(checkAndSavePage.numberOfVoters).toHaveText("61.269 kiesgerechtigden");
+    const election = await checkAndSavePage.saveElection();
+
+    electionId = election.id;
+
+    await expect(electionsOverviewPage.adminHeader).toBeVisible();
+    await expect(electionsOverviewPage.alertGSBElectionCreated).toBeVisible();
+    await electionsOverviewPage.findElectionRowById(electionId).click();
+
+    const electionHomePage = new ElectionHome(page);
+    await expect(electionHomePage.header).toHaveText("Gemeenteraad Test 2022");
+    const sessionCard = electionHomePage.getCommitteeSessionCard(1);
+    await expect(sessionCard).toContainText("Eerste zitting — Klaar voor invoer");
+
+    await electionHomePage.pollingStationsRow.click();
+    const pollingStationListPage = new PollingStationListPgObj(page);
+    await expect(pollingStationListPage.header).toBeVisible();
+    await pollingStationListPage.createPollingStation.click();
+
+    const form = new PollingStationFormPgObj(page);
+    await form.fillIn({ number: 2, name: "Basisschool de Regenboog" });
+    await form.create.click();
+    await expect(pollingStationListPage.alert).toHaveText("Stembureau 2 (Basisschool de Regenboog) toegevoegd");
+
+    await logout(page);
+  });
+
+  test(`create coordinator user account`, async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(adminUser.username, getTestPassword(adminUser.username));
+
+    const userInfoTopBar = new UserInfoTopBar(page);
+    await expect(userInfoTopBar.username).toHaveText(adminUser.fullname);
+
+    const adminNavBar = new AdminNavBar(page);
+    await adminNavBar.users.click();
+
+    const userListPgObj = new UserListPgObj(page);
+    await userListPgObj.create.click();
+
+    const userCreateRolePgObj = new UserCreateRolePgObj(page);
+    await userCreateRolePgObj.coordinator.click();
+    await userCreateRolePgObj.continue.click();
+
+    const userCreateElectionPgObj = new UserCreateElectionPgObj(page);
+    await userCreateElectionPgObj.gsb.click();
+    await userCreateElectionPgObj.continue.click();
+
+    const userCreateDetailsPgObj = new UserCreateDetailsPgObj(page);
+    await userCreateDetailsPgObj.createNamedUser(
+      coordinatorUser.username,
+      coordinatorUser.fullname,
+      getTestPassword(coordinatorUser.username, "Temp"),
+    );
+
+    await expect(userListPgObj.alert).toContainText(`${coordinatorUser.username} is toegevoegd met de rol Coördinator`);
+
+    await logout(page);
+  });
+
+  test(`complete coordinator user account`, async ({ page }) => {
+    await page.goto("/account/login");
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username, "Temp"));
+
+    const password = getTestPassword(coordinatorUser.username);
+    const accountSetupPage = new AccountSetupPgObj(page);
+    await accountSetupPage.password.fill(password);
+    await accountSetupPage.passwordRepeat.fill(password);
+    await accountSetupPage.saveBtn.click();
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.alertAccountSetup).toBeVisible();
+
+    await logout(page);
+  });
+
+  test(`create typist user accounts`, async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(adminUser.username, getTestPassword(adminUser.username));
+
+    const userInfoTopBar = new UserInfoTopBar(page);
+    await expect(userInfoTopBar.username).toHaveText(adminUser.fullname);
+
+    for (const typist of typistUsers) {
+      const adminNavBar = new AdminNavBar(page);
+      await adminNavBar.users.click();
+
+      const userListPgObj = new UserListPgObj(page);
+      await userListPgObj.create.click();
+
+      const userCreateRolePgObj = new UserCreateRolePgObj(page);
+      await userCreateRolePgObj.typist.click();
+      await userCreateRolePgObj.continue.click();
+
+      const userCreateElectionPgObj = new UserCreateElectionPgObj(page);
+      await userCreateElectionPgObj.gsb.click();
+      await userCreateElectionPgObj.continue.click();
+
+      const userCreateTypePgObj = new UserCreateTypePgObj(page);
+      await userCreateTypePgObj.continue.click();
+
+      const userCreateDetailsPgObj = new UserCreateDetailsPgObj(page);
+      await userCreateDetailsPgObj.createNamedUser(typist.username, typist.fullname, typist.username.repeat(3));
+      await expect(userListPgObj.alert).toContainText(`${typist.username} is toegevoegd met de rol Invoerder`);
+    }
+    await logout(page);
+  });
+
+  test("start data entry", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHome = new ElectionHome(page);
+    await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+    await expect(electionHome.getCommitteeSessionCard(1)).toContainText("Eerste zitting");
+    await electionHome.detailsButton.click();
+
+    const electionDetails = new ElectionDetailsPgObj(page);
+    await expect(electionDetails.header).toHaveText("Gemeentelijk stembureau Test");
+    await electionDetails.fillForm("Pannerdam", "18-03-2026", "21:34");
+
+    await expect(electionHome.header).toContainText("Gemeenteraad Test 2022");
+    await expect(page.getByText("Begon op 18 maart 2026 om 21:34")).toBeVisible();
+    await electionHome.startButton.click();
+
+    const electionStatus = new ElectionStatus(page);
+    await expect(electionStatus.header).toContainText("Eerste zitting");
+
+    await logout(page);
+  });
+
+  for (const typist of typistUsers) {
+    test(`complete user account for ${typist.fullname}`, async ({ page }) => {
+      await page.goto("/account/login");
+      const loginPage = new LoginPgObj(page);
+      await loginPage.login(typist.username, typist.username.repeat(3));
+
+      const password = getTestPassword(typist.username);
+      const accountSetupPage = new AccountSetupPgObj(page);
+      await accountSetupPage.password.fill(password);
+      await accountSetupPage.passwordRepeat.fill(password);
+      await accountSetupPage.saveBtn.click();
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.alertAccountSetup).toBeVisible();
+
+      await logout(page);
+    });
+  }
+
+  for (const station of [
+    { number: "1", name: "Stadhuis" },
+    { number: "2", name: "Basisschool de Regenboog" },
+  ]) {
+    test(`first data entry ${station.name}`, async ({ page }) => {
+      await page.goto("/account/login");
+
+      const firstTypist = typistUsers[0]!;
+      const loginPage = new LoginPgObj(page);
+      const password = getTestPassword(firstTypist.username);
+      await loginPage.login(firstTypist.username, password);
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.header).toBeVisible();
+      await overviewPage.findElectionRowById(electionId!).click();
+
+      const dataEntryHomePage = new DataEntryHomePage(page);
+      await expect(dataEntryHomePage.fieldset).toBeVisible();
+      await dataEntryHomePage.number.fill(station.number);
+      await expect(dataEntryHomePage.feedback).toContainText(station.name);
+      await dataEntryHomePage.start.click();
+
+      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSO);
+      await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
+
+      await logout(page);
+    });
+
+    test(`second data entry ${station.name}`, async ({ page }) => {
+      await page.goto("/account/login");
+
+      const secondTypist = typistUsers[1]!;
+      const loginPage = new LoginPgObj(page);
+      await loginPage.login(secondTypist.username, getTestPassword(secondTypist.username));
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.header).toBeVisible();
+      await overviewPage.findElectionRowById(electionId!).click();
+
+      const dataEntryHomePage = new DataEntryHomePage(page);
+      await expect(dataEntryHomePage.fieldset).toBeVisible();
+      await dataEntryHomePage.number.fill(station.number);
+      await expect(dataEntryHomePage.feedback).toContainText(station.name);
+      await dataEntryHomePage.start.click();
+
+      await fillDataEntryPagesAndSave(page, noRecountNoDifferencesDataEntryDSO);
+      await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
+
+      await logout(page);
+    });
+  }
+
+  test("finish first session and download results", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHomePage = new ElectionHome(page);
+    await expect(electionHomePage.header).toHaveText("Gemeenteraad Test 2022");
+    await electionHomePage.statusButton.click();
+
+    const electionStatusPage = new ElectionStatus(page);
+    await electionStatusPage.finish.click();
+
+    const finishDataEntryPage = new FinishDataEntry(page);
+    await finishDataEntryPage.finishDataEntry.click();
+
+    const electionReportPage = new ElectionReport(page);
+    const downloadPromise = page.waitForEvent("download");
+    await electionReportPage.downloadFirstSessionZip.click();
+
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/definitieve-documenten_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/);
+    expect((await stat(await download.path())).size).toBeGreaterThan(1024);
+
+    await logout(page);
+  });
+
+  test("create new committee session", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHome = new ElectionHome(page);
+    await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+    await electionHome.newSessionButton.click();
+    await electionHome.newSessionModalConfirmButton.click();
+    await expect(electionHome.getCommitteeSessionCard(2)).toContainText("Tweede zitting");
+
+    await logout(page);
+  });
+
+  test("download Na 31-2 inlegvel", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHomePage = new ElectionHome(page);
+    await expect(electionHomePage.header).toHaveText("Gemeenteraad Test 2022");
+
+    const downloadPromise = page.waitForEvent("download");
+    await electionHomePage.downloadInlegvel.click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe("Model_Na_31_2_Inlegvel.pdf");
+    expect((await stat(await download.path())).size).toBeGreaterThan(1024);
+
+    await logout(page);
+  });
+
+  test("add missing polling station", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHome = new ElectionHome(page);
+    await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+    await electionHome.investigationsOverviewButton.click();
+
+    const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
+    await expect(investigationsOverviewPage.header).toHaveText("Onderzoeken in tweede zitting");
+    await investigationsOverviewPage.addInvestigationButton.click();
+
+    const addInvestigationPage = new AddInvestigationPgObj(page);
+    await expect(addInvestigationPage.header).toBeVisible();
+    await addInvestigationPage.addPollingStation.click();
+
+    const form = new PollingStationFormPgObj(page);
+    await form.fillIn({
+      number: 5,
+      name: "Sportfondsenbad",
+    });
+    await form.create.click();
+
+    const pollingStationListPage = new PollingStationListPgObj(page);
+    await expect(pollingStationListPage.alert).toHaveText("Stembureau 5 (Sportfondsenbad) toegevoegd");
+
+    await logout(page);
+  });
+
+  for (const station of investigations) {
+    test(`create investigation for ${station.name}`, async ({ page }) => {
+      await page.goto("/account/login");
+
+      const loginPage = new LoginPgObj(page);
+      await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.header).toBeVisible();
+      await overviewPage.findElectionRowById(electionId!).click();
+
+      const electionHome = new ElectionHome(page);
+      await electionHome.investigationsOverviewButton.click();
+
+      await createInvestigation(page, station.name, station.reason);
+      const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
+      await expect(investigationsOverviewPage.alert).toHaveText(
+        `Onderzoek voor stembureau ${station.number} (${station.name}) toegevoegd`,
+      );
+
+      await logout(page);
+    });
+  }
+
+  test("start data entry of corrected results", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHome = new ElectionHome(page);
+    await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+    await electionHome.startDataEntryButton.click();
+
+    const electionStatus = new ElectionStatus(page);
+    await expect(electionStatus.header).toContainText("Tweede zitting");
+
+    await logout(page);
+  });
+
+  for (const station of investigations) {
+    test(`finish investigation for ${station.name}`, async ({ page }) => {
+      await page.goto("/account/login");
+
+      const loginPage = new LoginPgObj(page);
+      await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.header).toBeVisible();
+      await overviewPage.findElectionRowById(electionId!).click();
+
+      const electionHome = new ElectionHome(page);
+      await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+      await electionHome.investigationsOverviewButton.click();
+
+      const investigationsOverviewPage = new InvestigationOverviewPgObj(page);
+      await expect(investigationsOverviewPage.header).toHaveText("Onderzoeken in tweede zitting");
+      await investigationsOverviewPage.getInvestigationEditButtonByPollingStationId(station.number).click();
+
+      const investigationsFindingsPage = new InvestigationFindingsPgObj(page);
+      await expect(investigationsFindingsPage.header).toBeVisible();
+      await investigationsFindingsPage.findingsField.fill(station.findings);
+      await investigationsFindingsPage.setCorrectedResults(station.correctedResults);
+      await investigationsFindingsPage.save.click();
+
+      await expect(investigationsOverviewPage.alert).toHaveText(
+        `Onderzoek voor stembureau ${station.number} (${station.name}) aangepast`,
+      );
+
+      await logout(page);
+    });
+  }
+
+  for (const user of typistUsers) {
+    test(`corrected data entry with ${user.fullname}`, async ({ page }) => {
+      await page.goto("/account/login");
+
+      const loginPage = new LoginPgObj(page);
+      await loginPage.login(user.username, getTestPassword(user.username));
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.header).toBeVisible();
+      await overviewPage.findElectionRowById(electionId!).click();
+
+      const dataEntryHomePage = new DataEntryHomePage(page);
+      await expect(dataEntryHomePage.fieldset).toBeVisible();
+      await dataEntryHomePage.number.fill("1");
+      await expect(dataEntryHomePage.feedback).toContainText("Stadhuis");
+      await dataEntryHomePage.start.click();
+
+      const extraInvestigationPage = new ExtraInvestigationPage(page);
+      await extraInvestigationPage.next.click();
+
+      const differencesPage = new DifferencesPage(page);
+      await differencesPage.admittedVotersEqualsVotesCastCheckbox.check();
+      await differencesPage.differenceCompletelyAccountedForNo.check();
+      await differencesPage.next.click();
+
+      const progressList = new ProgressList(page);
+      const [firstListName, secondListName, thirdListName] = await progressList.allListNames();
+
+      const firstCandidatesPage = new CandidatesListPage(page, 0, firstListName!);
+      await firstCandidatesPage.fillCandidate(0, 1336);
+      await firstCandidatesPage.fillCandidate(1, 424);
+      await firstCandidatesPage.next.click();
+
+      const secondCandidatesPage = new CandidatesListPage(page, 1, secondListName!);
+      await expect(secondCandidatesPage.fieldset).toBeVisible();
+      await secondCandidatesPage.next.click();
+
+      const thirdCandidatesPage = new CandidatesListPage(page, 2, thirdListName!);
+      await expect(thirdCandidatesPage.fieldset).toBeVisible();
+      await thirdCandidatesPage.next.click();
+
+      const checkAndSavePage = new CheckAndSavePage(page);
+      await checkAndSavePage.save.click();
+
+      await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
+
+      await logout(page);
+    });
+  }
+
+  for (const typist of typistUsers) {
+    test(`data entry for new polling station with ${typist.fullname}`, async ({ page }) => {
+      await page.goto("/account/login");
+
+      const loginPage = new LoginPgObj(page);
+      await loginPage.login(typist.username, getTestPassword(typist.username));
+
+      const overviewPage = new ElectionsOverviewPgObj(page);
+      await expect(overviewPage.header).toBeVisible();
+      await overviewPage.findElectionRowById(electionId!).click();
+
+      const dataEntryHomePage = new DataEntryHomePage(page);
+      await expect(dataEntryHomePage.fieldset).toBeVisible();
+      await dataEntryHomePage.number.fill("5");
+      await expect(dataEntryHomePage.feedback).toContainText("Sportfondsenbad");
+      await dataEntryHomePage.start.click();
+
+      const votersAndVotesPage = new VotersAndVotesPage(page);
+      await expect(votersAndVotesPage.fieldset).toBeVisible();
+      await votersAndVotesPage.fillInPageAndClickNext(
+        noRecountNoDifferencesDataEntry.voters_counts,
+        noRecountNoDifferencesDataEntry.votes_counts,
+      );
+
+      const differencesPage = new DifferencesPage(page);
+      await expect(differencesPage.fieldset).toBeVisible();
+      await differencesPage.fillInPageAndClickNext(noRecountNoDifferencesDataEntry.differences_counts);
+
+      await fillCandidatesListPages(page, noRecountNoDifferencesDataEntry);
+
+      const checkAndSavePage = new CheckAndSavePage(page);
+      await checkAndSavePage.save.click();
+
+      await expect(dataEntryHomePage.alertDataEntrySaved).toBeVisible();
+
+      await logout(page);
+    });
+  }
+
+  test("finish second session and download results", async ({ page }) => {
+    await page.goto("/account/login");
+
+    const loginPage = new LoginPgObj(page);
+    await loginPage.login(coordinatorUser.username, getTestPassword(coordinatorUser.username));
+
+    const overviewPage = new ElectionsOverviewPgObj(page);
+    await expect(overviewPage.header).toBeVisible();
+    await overviewPage.findElectionRowById(electionId!).click();
+
+    const electionHome = new ElectionHome(page);
+    await expect(electionHome.header).toHaveText("Gemeenteraad Test 2022");
+    await expect(electionHome.header).toBeVisible();
+    await electionHome.statusButton.click();
+
+    const statusPage = new ElectionStatus(page);
+    await expect(statusPage.definitive).toBeVisible();
+    await statusPage.finish.click();
+
+    const finishDataEntryPage = new FinishDataEntry(page);
+    await finishDataEntryPage.finishDataEntry.click();
+
+    const electionDetails = new ElectionDetailsPgObj(page);
+    await expect(electionDetails.header).toHaveText("Gemeentelijk stembureau Test");
+    await electionDetails.locationInput.fill("Pannerdam");
+    await electionDetails.dateInput.fill("18-03-2026");
+    await electionDetails.timeInput.fill("21:34");
+    await electionDetails.toCertifiedResults.click();
+
+    const electionHomePage = new ElectionReport(page);
+    await expect(electionHomePage.header).toContainText("Tweede zitting gemeentelijk stembureau");
+    const downloadPromise = page.waitForEvent("download");
+    await electionHomePage.downloadSecondSessionZip.click();
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/correctie_gr2022_test_gemeente_test-\d{8}-\d{6}.zip/);
+    expect((await stat(await download.path())).size).toBeGreaterThan(1024);
+
+    await logout(page);
+  });
+});

--- a/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
+++ b/frontend/e2e-tests/tests/full-flow/full-flow-GSB-DSO.e2e.ts
@@ -123,12 +123,12 @@ test.describe("full flow GSB DSO", () => {
 
     await uploadElectionAndInputHash(page);
 
-    await uploadCandidatesAndInputHash(page, eml230b);
-
     const committeeCategoryPage = new CommitteeCategoryPgObj(page);
     await expect(committeeCategoryPage.header).toBeVisible();
     await expect(committeeCategoryPage.gsb).toBeChecked();
     await committeeCategoryPage.next.click();
+
+    await uploadCandidatesAndInputHash(page, eml230b);
 
     await uploadPollingStations(page, eml110b_single);
 


### PR DESCRIPTION
Closes #3691 

## What & why
- Add playwright tests for GSB DSO election creation
- Added DSO page objects
- Added full flow test
- Added e2e tests for data entry for DSO with and without checks and corrections
- Remove CSO only restriction on Na 14-2 since this is also for a next session for DSO

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Locally run:
  - `pnpm run test:e2e-ui tests/data-entry-GSB`
  - `pnpm run test:e2e-ui tests/election`
  - `pnpm run test:e2e-ui tests/full-flow`

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

Do you expect any more playwright tests for DSO or is this sufficient?

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->