### PR TITLE
Remove old logic for radio button in keyboard navigation

### DIFF
--- a/frontend/src/features/data_entry/hooks/useFormKeyboardNavigation.test.tsx
+++ b/frontend/src/features/data_entry/hooks/useFormKeyboardNavigation.test.tsx
@@ -51,6 +51,66 @@ describe("useKeyboard", () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
+  test("Enter moves focus to next input", async () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <FormWithNavigation onSubmit={onSubmit}>
+        <input id="test-input" />
+        <div>
+          <input type="checkbox" id="checkbox1" />
+          <div>
+            <label htmlFor="checkbox">"buzzme"</label>
+          </div>
+        </div>
+        <div>
+          <input type="checkbox" id="checkbox2" />
+          <div>
+            <label htmlFor="checkbox">"buzzme"</label>
+          </div>
+        </div>
+        <div>
+          <input type="radio" id="radio1" />
+          <div>
+            <label htmlFor="radio">"buzzme"</label>
+          </div>
+        </div>
+        <div>
+          <input type="radio" id="radio2" />
+          <div>
+            <label htmlFor="radio">"buzzme"</label>
+          </div>
+        </div>
+        <button id="test-submit-button" type="submit">
+          Submit
+        </button>
+      </FormWithNavigation>,
+    );
+    const user = userEvent.setup();
+
+    const firstCheckbox = screen.getByTestId("checkbox1");
+    const secondCheckbox = screen.getByTestId("checkbox2");
+    const firstRadio = screen.getByTestId("radio1");
+    const secondRadio = screen.getByTestId("radio2");
+    const submitButton = screen.getByTestId("test-submit-button");
+
+    await user.type(screen.getByTestId("test-input"), "hello world");
+    await user.keyboard("{enter}");
+    expect(firstCheckbox).toHaveFocus();
+
+    await user.keyboard("{enter}");
+    expect(secondCheckbox).toHaveFocus();
+
+    await user.keyboard("{enter}");
+    expect(firstRadio).toHaveFocus();
+
+    await user.keyboard("{enter}");
+    expect(secondRadio).toHaveFocus();
+
+    await user.keyboard("{enter}");
+    expect(submitButton).toHaveFocus();
+  });
+
   test("Enter submits when submit button has focus", async () => {
     const onSubmit = vi.fn((e: SubmitEvent) => {
       e.preventDefault();

--- a/frontend/src/features/data_entry/hooks/useFormKeyboardNavigation.ts
+++ b/frontend/src/features/data_entry/hooks/useFormKeyboardNavigation.ts
@@ -98,8 +98,6 @@ export function useFormKeyboardNavigation(): RefObject<HTMLFormElement | null> {
             if (event.shiftKey || (submitButton && document.activeElement === submitButton)) {
               //ref.current.submit fails in testing environment (jsdom)
               innerRef.current?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-            } else if (event.target instanceof HTMLInputElement && event.target.type === "radio") {
-              submitButton?.focus();
             } else {
               moveFocus("down");
             }


### PR DESCRIPTION
## What & why

Resolves #3864 

Removes and old line from `useFormKeyboardNavigation`, so radio buttons will behave the same as checkboxes when pressing enter during focus. 

This line has been in the code for almost two years (#377 -> [commit](https://github.com/kiesraad/abacus/commit/c04b5be83111e01d529f4c5a94c7a3d573af3d13#diff-6e7f96ed4afcfe209368f99b8b6d67aa0e59dd5e2253318ebd9f02f99ba972ccR85)). No tests fail when removing this line and I am unable to find something broken. 

Added tests to cover the enter behavior for inputs. 

## How to test

1. Log in as GSB invoerder
2. Claim a data entry in DSO election
3. Focus on a radio button, check if pressing enter makes it go to the next radio button

## Reviewer notes

`useFormKeyboardNavigation` is only used in the data entry forms + `CheckAndSaveForm` at the end of data entry. 