### PR TITLE
Update to pnpm 11.21.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "pnpm": "^11",
     "npm": "please-use-pnpm"
   },
-  "packageManager": "pnpm@11.7.0",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "dev": "pnpm check-server && vite",
     "dev:msw": "cross-env API_MODE=mock vite",


### PR DESCRIPTION
## What & why

Update to pnpm 11.21.0, see [release notes](https://pnpm.io/blog/releases/11.21-11.22). Not updating past 11.21.0 because nixpkgs (that I personally use) doesn't have a more recent version yet.

## How to test

CI still passes and pnpm works locally after updating.
