### PR TITLE
Set up cargo-deny

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -125,6 +125,28 @@ jobs:
           path: backend/target/doc
           retention-days: 30
 
+  cargo-deny:
+    name: Cargo deny
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    env:
+      CARGO_TERM_COLOR: always
+      BINSTALL_DISABLE_TELEMETRY: "true"
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - name: Setup Rust
+        run: rustup toolchain install
+      - name: Install Binstall
+        uses: cargo-bins/cargo-binstall@e00d2c94cc0067b77737821097a62d91c0301baa # main
+      - name: Install cargo-deny
+        run: cargo binstall --no-confirm cargo-deny
+      # Advisories are checked in the scheduled cargo-deny.yml workflow, so that
+      # newly published RUSTSEC advisories do not break PRs.
+      - name: Check bans, licenses and sources
+        run: cargo deny check bans licenses sources
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,47 @@
+name: Cargo deny advisories
+
+# Checks Cargo dependencies against the RUSTSEC advisory database.
+# Runs on schedule and whenever dependencies are updated.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+  pull_request:
+    paths:
+      - "backend/**/Cargo.toml"
+      - "backend/**/Cargo.lock"
+      - "backend/deny.toml"
+      - ".github/workflows/cargo-deny.yml"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  BINSTALL_DISABLE_TELEMETRY: "true"
+
+concurrency:
+  group: cargo-deny-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  advisories:
+    name: Check advisories
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - name: Setup Rust
+        run: rustup toolchain install
+      - name: Install Binstall
+        uses: cargo-bins/cargo-binstall@e00d2c94cc0067b77737821097a62d91c0301baa # main
+      - name: Install cargo-deny
+        run: cargo binstall cargo-deny
+      - name: Check advisories (backend workspace)
+        run: cargo deny check advisories
+      - name: Check advisories (fuzz workspace)
+        run: cargo deny --manifest-path fuzz/Cargo.toml --config deny.toml check advisories
+      - name: Check advisories (apportionment fuzz workspace)
+        run: cargo deny --manifest-path apportionment/fuzz/Cargo.toml --config deny.toml check advisories

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -1,0 +1,46 @@
+[graph]
+targets = [
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-apple-darwin" },
+]
+
+all-features = true
+
+[licenses]
+version = 2
+private = { ignore = true }
+allow = [
+    "0BSD",
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "EUPL-1.2",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+[bans]
+deny = [
+    { crate = "openssl", use-instead = "rustls" },
+    { crate = "openssl-sys", use-instead = "rustls" },
+    { crate = "ring", use-instead = "aws-lc-rs" },
+]
+multiple-versions = "allow"
+
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2024-0320", reason = "yaml-rust is transitively used by Typst, see https://github.com/trishume/syntect/issues/537" },
+    { id = "RUSTSEC-2024-0436", reason = "paste is transitively used by Typst (biblatex, https://github.com/typst/biblatex/issues/87) and by utoipa-axum; unmaintained but no vulnerability" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode is used by Typst, see https://github.com/trishume/syntect/issues/606" },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser is unmaintained; Typst does not have a fix, see https://github.com/kiesraad/abacus/issues/3849 for direct usage" },
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml <0.41 DoS (quadratic duplicate-attribute check) pulled transitively by Typst (citationberg, plist); no release depending on quick-xml >=0.41 available upstream yet, see https://github.com/tafia/quick-xml/issues/969" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml <0.41 DoS (unbounded namespace-declaration allocation) pulled transitively by Typst (citationberg, plist); no release depending on quick-xml >=0.41 available upstream yet, see https://github.com/tafia/quick-xml/issues/969" },
+    { id = "RUSTSEC-2026-0206", reason = "rustybuzz is unmaintained (maintainer recommends harfrust); pulled transitively by Typst; no migration available upstream yet, see https://github.com/harfbuzz/rustybuzz/issues/166" },
+]


### PR DESCRIPTION
## What & why

Set up [cargo-deny](https://github.com/embarkstudios/cargo-deny) to audit our Cargo dependencies:
- Check licenses, so that we don't accidentally include e.g. GPL dependencies
- Ban dependencies, in our case [openssl](https://crates.io/crates/openssl) and [ring](https://crates.io/crates/ring) because we use [aws-lc-rs](https://crates.io/crates/aws-lc-rs)
- Check [RUSTSEC advisories](https://rustsec.org/) and ignore them e.g. because no upstream patches are available yet

This setup is inspired by the [e-KS cargo-deny config](https://github.com/kiesraad/e-ks/blob/main/deny.toml).

cargo-deny is run in CI:
- The 'Build, lint & test' workflow is expanded with a cargo-deny job that checks bans, licenses and sources. Advisories are not checked to prevent PRs from being blocked by a new security advisory.
- A new 'Cargo deny advisories' workflow checks advisories on a schedule and whenever Cargo dependencies are updated.

Resolves #3581.

## How to test

See CI or run `cargo deny check` locally.
