### PR TITLE
Added DSO specific validation feedback texts

### DIFF
--- a/frontend/src/components/ui/Feedback/Feedback.stories.tsx
+++ b/frontend/src/components/ui/Feedback/Feedback.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
 import { expect } from "storybook/test";
-import { csbElectionMockData, electionMockData } from "@/testing/api-mocks/ElectionMockData";
+import { csbElectionMockData, electionMockData, getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
 import { validationResultMockData } from "@/testing/api-mocks/ValidationResultMockData";
 import { roleValues, type ValidationResultCode } from "@/types/generated/openapi";
 import { Feedback } from "./Feedback";
@@ -16,9 +16,10 @@ const meta = {
       control: { type: "multi-select" },
     },
     election: {
-      options: ["GSB", "CSB"],
+      options: ["GSB DSO", "GSB CSO", "CSB"],
       mapping: {
-        GSB: electionMockData,
+        "GSB CSO": getElectionMockData({ counting_method: "CSO" }).election,
+        "GSB DSO": getElectionMockData({ counting_method: "DSO" }).election,
         CSB: csbElectionMockData,
       },
     },

--- a/frontend/src/i18n/feedback-structure.test.tsx
+++ b/frontend/src/i18n/feedback-structure.test.tsx
@@ -26,4 +26,18 @@ describe("feedback translations structure", () => {
       }
     }
   });
+
+  test("validate feedback_GSB_DSO.json", () => {
+    const feedback = translations.feedback_GSB_DSO;
+    const feedbackItems = Object.values(feedback);
+
+    for (const entry of feedbackItems) {
+      const keys = Object.keys(entry.coordinator);
+
+      // No other keys than below allowed
+      for (const key of keys) {
+        expect(["title", "content", "actions"]).toContain(key);
+      }
+    }
+  });
 });

--- a/frontend/src/i18n/locales/nl/feedback_GSB_DSO.json
+++ b/frontend/src/i18n/locales/nl/feedback_GSB_DSO.json
@@ -1,0 +1,86 @@
+{
+  "F201": {
+    "coordinator": {
+      "content": "Controleer in rubriek 2.3 of er een onverklaard verschil opgelost wordt als het juiste getal bij D wordt ingevuld."
+    }
+  },
+  "F202": {
+    "coordinator": {
+      "content": "Controleer in rubriek 2.3 of er een onverklaard verschil opgelost wordt als de juiste getallen bij E en H worden ingevuld."
+    }
+  },
+  "F203": {
+    "coordinator": {
+      "content": "Controleer in rubriek 2.3 of er een onverklaard verschil opgelost wordt als het juiste getal bij H wordt ingevuld."
+    }
+  },
+  "F204": {
+    "coordinator": {
+      "content": "Controleer in rubriek 2.3 of er een onverklaard verschil opgelost wordt als de juiste getallen bij E en E.1 t/m E.n worden ingevuld."
+    }
+  },
+  "F301": {
+    "coordinator": {
+      "actions": "<ul><li>Herstel de fout door op papier het juiste getal in te (laten) vullen.</li><li>Controleer ook of er een onverklaard verschil ontstaat.</li><li>Pas zo nodig rubriek 2.3.2 aan, en volg de instructies over hertellen die daar staan.</li></ul>"
+    }
+  },
+  "F302": {
+    "coordinator": {
+      "actions": "<ul><li>Maak een corrigendum waarin de juiste optie geselecteerd wordt.</li></ul>"
+    }
+  },
+  "F303": {
+    "coordinator": {
+      "actions": "<ul><li>Maak een corrigendum waarin de juiste optie geselecteerd wordt.</li></ul>"
+    }
+  },
+  "F304": {
+    "coordinator": {
+      "content": "Is op het proces-verbaal duidelijk aangegeven welk van de opties bedoeld is?",
+      "actions": "<ul><li>Zo ja: laat dat dan overnemen in Abacus.</li><li>Zo nee: maak een corrigendum waarin de juiste optie geselecteerd wordt.</li></ul>"
+    }
+  },
+  "F305": {
+    "coordinator": {
+      "actions": "<ul><li>Corrigeer de rekenfout door een corrigendum te (laten) maken waarop I en/of J leeg zijn.</li><li>Kijk ook of het corrigeren van de fout een onverklaard verschil introduceert (zie 2.3.2).</li><li>Hertel dan de stembiljetten en het aantal toegelaten kiezers. Hertel tot de fout gevonden is, of alles één keer herteld is.</li><li>Vul nieuwe telresultaten op het corrigendum in.</li></ul>"
+    }
+  },
+  "F306": {
+    "coordinator": {
+      "actions": "<ul><li>Corrigeer de rekenfout in een corrigendum.</li><li>Kijk ook of het corrigeren van de fout een onverklaard verschil introduceert (zie 2.3.2).</li><li>Hertel dan de stembiljetten en het aantal toegelaten kiezers. Hertel tot de fout gevonden is, of alles één keer herteld is.</li><li>Vul nieuwe telresultaten op het corrigendum in.</li></ul>"
+    }
+  },
+  "F307": {
+    "coordinator": {
+      "actions": "<ul><li>Corrigeer de rekenfout in een corrigendum.</li><li>Kijk ook of het corrigeren van de fout een onverklaard verschil introduceert (zie 2.3.2).</li><li>Hertel dan de stembiljetten en het aantal toegelaten kiezers. Hertel tot de fout gevonden is, of alles één keer herteld is.</li><li>Vul nieuwe telresultaten op het corrigendum in.</li></ul>"
+    }
+  },
+  "F308": {
+    "coordinator": {
+      "actions": "<ul><li>Corrigeer de rekenfout in een corrigendum.</li><li>Kijk ook of het corrigeren van de fout een onverklaard verschil introduceert (zie 2.3.2).</li><li>Hertel dan de stembiljetten en het aantal toegelaten kiezers. Hertel tot de fout gevonden is, of alles één keer herteld is.</li><li>Vul nieuwe telresultaten op het corrigendum in.</li></ul>"
+    }
+  },
+  "F309": {
+    "coordinator": {
+      "actions": "<ul><li>Corrigeer de rekenfout in een corrigendum.</li><li>Kijk ook of het corrigeren van de fout een onverklaard verschil introduceert (zie 2.3.2).</li><li>Hertel dan de stembiljetten en het aantal toegelaten kiezers. Hertel tot de fout gevonden is, of alles één keer herteld is.</li><li>Vul nieuwe telresultaten op het corrigendum in.</li></ul>"
+    }
+  },
+  "F401": {
+    "coordinator": {
+      "content": "Kijk of het corrigeren van de fout een onverklaard verschil in rubriek 2.3 wegneemt.",
+      "actions": "<ul><li>Zo ja: maak een corrigendum en corrigeer daarin de optelfout. Corrigeer ook rubriek 2.3 in het corrigendum.</li><li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+    }
+  },
+  "F402": {
+    "coordinator": {
+      "content": "Reken de optelling in het papieren proces-verbaal na.\nKijk of het corrigeren van de fout een onverklaard verschil in rubriek 2.3 wegneemt.",
+      "actions": "<ul><li>Zo ja: maak een corrigendum en corrigeer daarin de optelfout. Corrigeer ook rubriek 2.3 in het corrigendum.</li><li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+    }
+  },
+  "F403": {
+    "coordinator": {
+      "content": "Kijk of het corrigeren van de fout een onverklaard verschil in rubriek 2.3 wegneemt.",
+      "actions": "<ul><li>Zo ja: maak een corrigendum en corrigeer daarin de optelfout. Corrigeer ook rubriek 2.3 in het corrigendum.</li><li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>"
+    }
+  }
+}

--- a/frontend/src/i18n/locales/nl/nl.ts
+++ b/frontend/src/i18n/locales/nl/nl.ts
@@ -23,6 +23,7 @@ import extra_investigation from "./extra_investigation.json";
 import feedback from "./feedback.json";
 import feedback_CSB from "./feedback_CSB.json";
 import feedback_GSB from "./feedback_GSB.json";
+import feedback_GSB_DSO from "./feedback_GSB_DSO.json";
 import form_errors from "./form_errors.json";
 import generic from "./generic.json";
 import initialise from "./initialise.json";
@@ -62,6 +63,7 @@ const nl = {
   feedback,
   feedback_CSB,
   feedback_GSB,
+  feedback_GSB_DSO,
   form_errors,
   initialise,
   investigations,

--- a/frontend/src/i18n/translate.test.tsx
+++ b/frontend/src/i18n/translate.test.tsx
@@ -3,7 +3,7 @@ import { renderToString } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 
 import { locale, translations } from "./i18n";
-import { hasTranslation, t, translate, tx } from "./translate";
+import { hasTranslation, t, tOrDefault, translate, tx, txOrDefault } from "./translate";
 
 function updateTestTranslation(value: string) {
   translations[locale].test = value;
@@ -32,6 +32,15 @@ describe("i18n", () => {
     updateTestTranslation("Hello {item}! {pov} are my {thing}.");
     expect(t("test", { item: "World", pov: "You", thing: "sunshine" })).toEqual("Hello World! You are my sunshine.");
 
+    // key does not exist, return fallback
+    expect(tOrDefault("foo.bar", undefined, t("election.title.singular"))).toEqual("Verkiezing");
+    // key does not exist, return fallback which is undefined
+    expect(tOrDefault("foo.bar", undefined, undefined)).toEqual(undefined);
+    // key does exist, with vars provided
+    expect(tOrDefault("test", { item: "World", pov: "You", thing: "sunshine" }, t("election.title.singular"))).toEqual(
+      "Hello World! You are my sunshine.",
+    );
+
     // element interpolation
     {
       updateTestTranslation("Visit my homepage <link>here</link>");
@@ -40,7 +49,7 @@ describe("i18n", () => {
       expect(renderToString(translated)).toEqual(expected);
     }
 
-    // basic html support
+    // basic HTML support
     {
       updateTestTranslation("That's a <strong>bold</strong> statement!");
       const expected = "That&#x27;s a <strong>bold</strong> statement!";
@@ -62,6 +71,27 @@ describe("i18n", () => {
       const expected = "That&#x27;s a <em>nice</em> statement!";
       const translated = tx("test", { italic: (content) => <em>{content}</em> }, { what: "nice" });
       expect(renderToString(translated)).toEqual(expected);
+    }
+
+    {
+      const expected = "That&#x27;s a <em>nice</em> statement!";
+      const translated = tx("test", { italic: (content) => <em>{content}</em> }, { what: "nice" });
+      // key does not exist, return fallback
+      expect(
+        renderToString(
+          txOrDefault("foo.bar", { italic: (content) => <em>{content}</em> }, { what: "nice" }, translated),
+        ),
+      ).toEqual(expected);
+      // key does not exist, return fallback which is undefined
+      expect(
+        renderToString(
+          txOrDefault("foo.bar", { italic: (content) => <em>{content}</em> }, { what: "nice" }, undefined),
+        ),
+      ).toEqual("");
+      // key does exist
+      expect(
+        renderToString(txOrDefault("test", { italic: (content) => <em>{content}</em> }, { what: "nice" }, undefined)),
+      ).toEqual(expected);
     }
   });
 });

--- a/frontend/src/i18n/translate.ts
+++ b/frontend/src/i18n/translate.ts
@@ -76,13 +76,18 @@ export function t(k: TranslationPath, vars?: Record<string, string | number>): s
   return translate(k);
 }
 
+// get translation for a given key, return fallback if not found
+export function tOrDefault<T>(k: string, vars: Record<string, string | number> | undefined, fallback: T): string | T {
+  return hasTranslation(k) ? t(k, vars) : fallback;
+}
+
 /**
  * Translate a text and optionally interpolate variables and elements
  *
  * @param k translation key
  * @param elements React elements to interpolate
  * @param vars variables to interpolate
- * @returns a translated string
+ * @returns a ReactElement with translation
  * @example
  *
  * return (
@@ -102,4 +107,14 @@ export function tx(
   const allowed = elements ? [...DEFAULT_ALLOWED_TAGS, ...Object.keys(elements)] : DEFAULT_ALLOWED_TAGS;
 
   return renderAst(parse(text, allowed), elements);
+}
+
+// get ReactElement with translation for a given key, return fallback if not found
+export function txOrDefault<T>(
+  k: string,
+  elements: Record<string, RenderFunction> | undefined,
+  vars: Record<string, string | number> | undefined,
+  fallback: T,
+): ReactElement | T {
+  return hasTranslation(k) ? tx(k, elements, vars) : fallback;
 }

--- a/frontend/src/utils/ValidationResults.test.ts
+++ b/frontend/src/utils/ValidationResults.test.ts
@@ -196,20 +196,20 @@ describe("getTranslations", () => {
   });
 
   test("should return CSO coordinator translations for GSB validation result for CSO election with DSO override", () => {
-    expect(getTranslations(GSBCSOElection, validationResultMockData.F201, "coordinator")).toEqual({
-      code: "F.201",
-      title: t("feedback_GSB.F201.coordinator.title"),
-      content: tx("feedback_GSB.F201.coordinator.content"),
-      actions: tx("feedback_GSB.F201.coordinator.actions"),
+    expect(getTranslations(GSBCSOElection, validationResultMockData.F401, "coordinator")).toEqual({
+      code: "F.401",
+      title: t("feedback_GSB.F401.coordinator.title"),
+      content: tx("feedback_GSB.F401.coordinator.content", undefined, { political_group_number: 1 }),
+      actions: tx("feedback_GSB.F401.coordinator.actions"),
     });
   });
 
   test("should return DSO coordinator translations for GSB validation result for DSO election with DSO override", () => {
-    expect(getTranslations(GSBDSOElection, validationResultMockData.F201, "coordinator")).toEqual({
-      code: "F.201",
-      title: t("feedback_GSB.F201.coordinator.title"),
-      content: tx("feedback_GSB_DSO.F201.coordinator.content"),
-      actions: tx("feedback_GSB.F201.coordinator.actions"),
+    expect(getTranslations(GSBDSOElection, validationResultMockData.F401, "coordinator")).toEqual({
+      code: "F.401",
+      title: t("feedback_GSB.F401.coordinator.title"),
+      content: tx("feedback_GSB_DSO.F401.coordinator.content", undefined, { political_group_number: 1 }),
+      actions: tx("feedback_GSB_DSO.F401.coordinator.actions"),
     });
   });
 });

--- a/frontend/src/utils/ValidationResults.test.ts
+++ b/frontend/src/utils/ValidationResults.test.ts
@@ -195,21 +195,29 @@ describe("getTranslations", () => {
     });
   });
 
+  test("should return coordinator translations for GSB validation result with vars in title", () => {
+    expect(getTranslations(GSBCSOElection, validationResultMockData.F403, "coordinator")).toEqual({
+      code: "F.403",
+      title: t("feedback_GSB.F403.coordinator.title", { political_group_number: 1 }),
+      actions: tx("feedback_GSB.F403.coordinator.actions", undefined, { political_group_number: 1 }),
+    });
+  });
+
   test("should return CSO coordinator translations for GSB validation result for CSO election with DSO override", () => {
     expect(getTranslations(GSBCSOElection, validationResultMockData.F401, "coordinator")).toEqual({
       code: "F.401",
-      title: t("feedback_GSB.F401.coordinator.title"),
+      title: t("feedback_GSB.F401.coordinator.title", { political_group_number: 1 }),
       content: tx("feedback_GSB.F401.coordinator.content", undefined, { political_group_number: 1 }),
-      actions: tx("feedback_GSB.F401.coordinator.actions"),
+      actions: tx("feedback_GSB.F401.coordinator.actions", undefined, { political_group_number: 1 }),
     });
   });
 
   test("should return DSO coordinator translations for GSB validation result for DSO election with DSO override", () => {
     expect(getTranslations(GSBDSOElection, validationResultMockData.F401, "coordinator")).toEqual({
       code: "F.401",
-      title: t("feedback_GSB.F401.coordinator.title"),
+      title: t("feedback_GSB.F401.coordinator.title", { political_group_number: 1 }),
       content: tx("feedback_GSB_DSO.F401.coordinator.content", undefined, { political_group_number: 1 }),
-      actions: tx("feedback_GSB_DSO.F401.coordinator.actions"),
+      actions: tx("feedback_GSB_DSO.F401.coordinator.actions", undefined, { political_group_number: 1 }),
     });
   });
 });

--- a/frontend/src/utils/ValidationResults.test.ts
+++ b/frontend/src/utils/ValidationResults.test.ts
@@ -1,3 +1,4 @@
+import { renderToString } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 import { hasTranslation, t, tx } from "@/i18n/translate";
 import { electionMockData } from "@/testing/api-mocks/ElectionMockData";
@@ -196,28 +197,50 @@ describe("getTranslations", () => {
   });
 
   test("should return coordinator translations for GSB validation result with vars in title", () => {
-    expect(getTranslations(GSBCSOElection, validationResultMockData.F403, "coordinator")).toEqual({
-      code: "F.403",
-      title: t("feedback_GSB.F403.coordinator.title", { political_group_number: 1 }),
-      actions: tx("feedback_GSB.F403.coordinator.actions", undefined, { political_group_number: 1 }),
-    });
+    const feedback = getTranslations(GSBCSOElection, validationResultMockData.F403, "coordinator");
+    expect(feedback.code).toEqual("F.403");
+    expect(feedback.title).toEqual(
+      "Controleer het totaal van de lijst en E.1 in rubriek 3.2 (eerste zitting) of 2.2 (volgende zitting)",
+    );
+    expect(feedback.content).toBe(undefined);
+    expect(renderToString(feedback.actions)).toEqual(
+      [
+        "<ul><li>Controleer wat er fout is gegaan in rubriek 3.2 (eerste zitting) of 2.2 (volgende zitting) en herstel de fout.</li>",
+        "<li>Pas zo nodig rubriek 3.3.2 (eerste zitting) of 2.3.2 (volgende zitting) aan, en volg de instructies over hertellen die daar staan.</li></ul>",
+      ].join(""),
+    );
   });
 
   test("should return CSO coordinator translations for GSB validation result for CSO election with DSO override", () => {
-    expect(getTranslations(GSBCSOElection, validationResultMockData.F401, "coordinator")).toEqual({
-      code: "F.401",
-      title: t("feedback_GSB.F401.coordinator.title", { political_group_number: 1 }),
-      content: tx("feedback_GSB.F401.coordinator.content", undefined, { political_group_number: 1 }),
-      actions: tx("feedback_GSB.F401.coordinator.actions", undefined, { political_group_number: 1 }),
-    });
+    const feedback = getTranslations(GSBCSOElection, validationResultMockData.F401, "coordinator");
+    expect(feedback.code).toEqual("F.401");
+    expect(feedback.title).toEqual("Het totaal van de lijst is niet ingevuld");
+    expect(renderToString(feedback.content)).toEqual(
+      [
+        "Controleer of het proces-verbaal tijdens het telproces volledig is ingevuld (controleer ook E.1 in rubriek 3.2 (eerste zitting) of 2.2 (volgende zitting)).<br/>",
+        "Kijk of het corrigeren van de fout een onverklaard verschil wegneemt in rubriek 3.3 (eerste zitting) of 2.3 (volgende zitting).",
+      ].join(""),
+    );
+    expect(renderToString(feedback.actions)).toEqual(
+      [
+        "<ul><li>Zo ja: corrigeer de optelfout op het papieren proces-verbaal.</li>",
+        "<li>Zo nee: onderzoek wat er fout is gegaan en tel zo nodig de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>",
+      ].join(""),
+    );
   });
 
   test("should return DSO coordinator translations for GSB validation result for DSO election with DSO override", () => {
-    expect(getTranslations(GSBDSOElection, validationResultMockData.F401, "coordinator")).toEqual({
-      code: "F.401",
-      title: t("feedback_GSB.F401.coordinator.title", { political_group_number: 1 }),
-      content: tx("feedback_GSB_DSO.F401.coordinator.content", undefined, { political_group_number: 1 }),
-      actions: tx("feedback_GSB_DSO.F401.coordinator.actions", undefined, { political_group_number: 1 }),
-    });
+    const feedback = getTranslations(GSBDSOElection, validationResultMockData.F401, "coordinator");
+    expect(feedback.code).toEqual("F.401");
+    expect(feedback.title).toEqual("Het totaal van de lijst is niet ingevuld");
+    expect(renderToString(feedback.content)).toEqual(
+      "Kijk of het corrigeren van de fout een onverklaard verschil in rubriek 2.3 wegneemt.",
+    );
+    expect(renderToString(feedback.actions)).toEqual(
+      [
+        "<ul><li>Zo ja: maak een corrigendum en corrigeer daarin de optelfout. Corrigeer ook rubriek 2.3 in het corrigendum.</li>",
+        "<li>Zo nee: tel de stembiljetten en het aantal toegelaten kiezers opnieuw. Begin bij deze lijst, en hertel tot de fout gevonden is, of alles één keer herteld is.</li></ul>",
+      ].join(""),
+    );
   });
 });

--- a/frontend/src/utils/ValidationResults.test.ts
+++ b/frontend/src/utils/ValidationResults.test.ts
@@ -176,21 +176,40 @@ describe("dottedCode", () => {
 });
 
 describe("getTranslations", () => {
-  const gsbElection = { committee_category: "GSB" } as Election;
+  const GSBCSOElection = { committee_category: "GSB", counting_method: "CSO" } as Election;
+  const GSBDSOElection = { committee_category: "GSB", counting_method: "DSO" } as Election;
 
   test("should return typist translations for GSB validation result with default title", () => {
     expect(hasTranslation("feedback_GSB.F101.typist.title")).toBeFalsy();
-    expect(getTranslations(gsbElection, validationResultMockData.F101, "typist")).toEqual({
+    expect(getTranslations(GSBCSOElection, validationResultMockData.F101, "typist")).toEqual({
       code: "F.101",
       title: t("feedback.typist_title"),
     });
   });
 
   test("should return coordinator translations for GSB validation result", () => {
-    expect(getTranslations(gsbElection, validationResultMockData.F101, "coordinator")).toEqual({
+    expect(getTranslations(GSBCSOElection, validationResultMockData.F101, "coordinator")).toEqual({
       code: "F.101",
       title: t("feedback_GSB.F101.coordinator.title"),
       content: tx("feedback_GSB.F101.coordinator.content"),
+    });
+  });
+
+  test("should return CSO coordinator translations for GSB validation result for CSO election with DSO override", () => {
+    expect(getTranslations(GSBCSOElection, validationResultMockData.F201, "coordinator")).toEqual({
+      code: "F.201",
+      title: t("feedback_GSB.F201.coordinator.title"),
+      content: tx("feedback_GSB.F201.coordinator.content"),
+      actions: tx("feedback_GSB.F201.coordinator.actions"),
+    });
+  });
+
+  test("should return DSO coordinator translations for GSB validation result for DSO election with DSO override", () => {
+    expect(getTranslations(GSBDSOElection, validationResultMockData.F201, "coordinator")).toEqual({
+      code: "F.201",
+      title: t("feedback_GSB.F201.coordinator.title"),
+      content: tx("feedback_GSB_DSO.F201.coordinator.content"),
+      actions: tx("feedback_GSB.F201.coordinator.actions"),
     });
   });
 });

--- a/frontend/src/utils/ValidationResults.ts
+++ b/frontend/src/utils/ValidationResults.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { hasTranslation, t, tx } from "@/i18n/translate";
+import { t, tOrDefault, txOrDefault } from "@/i18n/translate";
 import type { Election, ValidationResult, ValidationResultCode } from "@/types/generated/openapi";
 import type { DataEntrySection } from "@/types/types";
 
@@ -175,14 +175,17 @@ export function getTranslations(
 ): ValidationResultTranslations {
   const defaultTitle = role === "typist" ? t(`feedback.typist_title`) : "";
 
-  const titlePath = `feedback_${election.committee_category}.${result.code}.${role}.title`;
-  const contentPath = `feedback_${election.committee_category}.${result.code}.${role}.content`;
-  const actionsPath = `feedback_${election.committee_category}.${result.code}.${role}.actions`;
+  const basePath = `feedback_${election.committee_category}.${result.code}.${role}`;
+  let title = tOrDefault(`${basePath}.title`, undefined, defaultTitle);
+  let content = txOrDefault(`${basePath}.content`, undefined, { ...result.context }, undefined);
+  let actions = txOrDefault(`${basePath}.actions`, undefined, { ...result.context }, undefined);
 
-  return {
-    code: dottedCode(result.code),
-    title: hasTranslation(titlePath) ? t(titlePath, { ...result.context }) : defaultTitle,
-    content: hasTranslation(contentPath) ? tx(contentPath, undefined, { ...result.context }) : undefined,
-    actions: hasTranslation(actionsPath) ? tx(actionsPath, undefined, { ...result.context }) : undefined,
-  };
+  if (election.counting_method === "DSO") {
+    const basePath = `feedback_${election.committee_category}_DSO.${result.code}.${role}`;
+    title = tOrDefault(`${basePath}.title`, undefined, title);
+    content = txOrDefault(`${basePath}.content`, undefined, { ...result.context }, content);
+    actions = txOrDefault(`${basePath}.actions`, undefined, { ...result.context }, actions);
+  }
+
+  return { code: dottedCode(result.code), title, content, actions };
 }

--- a/frontend/src/utils/ValidationResults.ts
+++ b/frontend/src/utils/ValidationResults.ts
@@ -176,13 +176,13 @@ export function getTranslations(
   const defaultTitle = role === "typist" ? t(`feedback.typist_title`) : "";
 
   const basePath = `feedback_${election.committee_category}.${result.code}.${role}`;
-  let title = tOrDefault(`${basePath}.title`, undefined, defaultTitle);
+  let title = tOrDefault(`${basePath}.title`, { ...result.context }, defaultTitle);
   let content = txOrDefault(`${basePath}.content`, undefined, { ...result.context }, undefined);
   let actions = txOrDefault(`${basePath}.actions`, undefined, { ...result.context }, undefined);
 
   if (election.counting_method === "DSO") {
     const basePath = `feedback_${election.committee_category}_DSO.${result.code}.${role}`;
-    title = tOrDefault(`${basePath}.title`, undefined, title);
+    title = tOrDefault(`${basePath}.title`, { ...result.context }, title);
     content = txOrDefault(`${basePath}.content`, undefined, { ...result.context }, content);
     actions = txOrDefault(`${basePath}.actions`, undefined, { ...result.context }, actions);
   }


### PR DESCRIPTION
Closes #3871 

## What & why

- Add DSO overrides for validation results and make sure they are used if applicable
- Update Feedback stories to add separate GSB CSO and DSO elections in the args to make testing easier

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

You can verify the texts via [storybook](https://link-nederland-informatie.abacus-test.nl/storybook/?path=/story/components-ui-feedback--gsb-coordinator&args=election:GSB+DSO;validationResults[0]:F101;validationResults[1]:F102;validationResults[2]:F111;validationResults[3]:F112;validationResults[4]:F121;validationResults[5]:F122;validationResults[6]:F131;validationResults[7]:F132;validationResults[8]:F133;validationResults[9]:F134;validationResults[10]:F135;validationResults[11]:F201;validationResults[12]:F202;validationResults[13]:F203;validationResults[14]:F204;validationResults[15]:F301;validationResults[16]:F302;validationResults[17]:F303;validationResults[18]:F304;validationResults[19]:F305;validationResults[20]:F306;validationResults[21]:F307;validationResults[22]:F308;validationResults[23]:F309;validationResults[24]:F310;validationResults[25]:F312;validationResults[26]:F401;validationResults[27]:F402;validationResults[28]:F403;validationResults[29]:W001;validationResults[30]:W002;validationResults[31]:W201;validationResults[32]:W202;validationResults[33]:W203;validationResults[34]:W204;validationResults[35]:W205;validationResults[36]:W206) by switching between election `GSB CSO` and `GSB DSO` in the args

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

Please carefully review against https://github.com/kiesraad/abacus-documentatie/blob/main/use-cases/validatieregels-plausibiliteitschecks-tellingen.md if anything is missing/wrong

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->