### PR TITLE
Prevent more Vite warnings

### DIFF
--- a/frontend/src/types/openapi.test.ts
+++ b/frontend/src/types/openapi.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 
 import { generate } from "../../scripts/openapi/generator";
 
-const FRONTEND_ROOT = path.join(__dirname, "../..");
+const FRONTEND_ROOT = path.join(import.meta.dirname, "../..");
 const BACKEND_ROOT = path.join(FRONTEND_ROOT, "..", "backend");
 
 const OPEN_API_JSON_PATH = `${BACKEND_ROOT}/openapi.json`;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,9 +4,10 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 import { coverageConfigDefaults, defineConfig, mergeConfig } from "vitest/config";
 
-import viteConfig from "./vite.config";
+import viteConfig from "./vite.config.ts";
 
-const dirname = typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const dirname =
+  typeof import.meta.dirname !== "undefined" ? import.meta.dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig((configEnv) =>
   mergeConfig(

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,13 +1,9 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 import { coverageConfigDefaults, defineConfig, mergeConfig } from "vitest/config";
 
 import viteConfig from "./vite.config.ts";
-
-const dirname =
-  typeof import.meta.dirname !== "undefined" ? import.meta.dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig((configEnv) =>
   mergeConfig(
@@ -30,7 +26,7 @@ export default defineConfig((configEnv) =>
             extends: true,
             plugins: [
               storybookTest({
-                configDir: path.join(dirname, ".storybook"),
+                configDir: path.join(import.meta.dirname, ".storybook"),
                 storybookScript: "pnpm storybook --ci",
               }),
             ],


### PR DESCRIPTION
## What & why

Prevent more warnings about the Vite config using features that are unsupported by `configLoader: 'native'`

Prevents these warnings:
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:                                                                                                
  - `__dirname` (vitest.config.ts:9:24). Use `import.meta.dirname` instead                                                     
  - import "./vite.config" without a file extension (vitest.config.ts:7:24). Add the file extension                            
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

Verify that the Vite warnings are gone when running the tests for example

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->