### PR TITLE
Add DSO-related checkboxes to EML output

### DIFF
--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -7,6 +7,7 @@ pub mod hash;
 use apportionment::CandidateNominationDetails;
 use chrono::{DateTime, Local};
 use eml_nl::{
+    EMLError,
     common::{
         AuthorityIdentifier, ContestIdentifier, ElectionTree, ManagingAuthority, PersonName,
         ReportingUnitIdentifier,
@@ -33,7 +34,6 @@ use eml_nl::{
         Gender, ReportingUnitIdentifierId, StringValue, StringValueData, VotingChannelType,
         VotingMethod,
     },
-    EMLError,
 };
 pub use error::EMLImportError;
 pub use hash::{EmlHash, RedactedEmlHash};
@@ -46,7 +46,7 @@ use crate::{
             ElectionDomain, ElectionWithPoliticalGroups, NewElection, PGNumber, RegionKey,
             RegisteredPoliticalGroup,
         },
-        results::{political_group_candidate_votes::PoliticalGroupCandidateVotes, Results},
+        results::{Results, political_group_candidate_votes::PoliticalGroupCandidateVotes},
         tabulation::{CommitteeSpecificTotals, ElectionTotals},
     },
     eml::committees::ElectionTreeDetails,
@@ -1113,16 +1113,16 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        committee_session::{committee_session_fixture, CommitteeSessionId},
+        committee_session::{CommitteeSessionId, committee_session_fixture},
         data_entry::{DataEntryId, DataEntrySource},
-        election::{tests::election_fixture, ElectionCategory},
+        election::{ElectionCategory, tests::election_fixture},
         polling_station::{
-            test_helpers::polling_stations_fixture, PollingStationFirstSession,
-            PollingStationForSession,
+            PollingStationFirstSession, PollingStationForSession,
+            test_helpers::polling_stations_fixture,
         },
         results::{
-            count::Count, political_group_candidate_votes::CandidateVotes, tests::example_results,
-            Results,
+            Results, count::Count, political_group_candidate_votes::CandidateVotes,
+            tests::example_results,
         },
     };
 
@@ -1312,9 +1312,11 @@ mod tests {
             total_votes_csb.eligible_voter_count,
             StringValue::from_value(1001u64)
         );
-        assert!(!total_votes_csb
-            .uncounted_votes
-            .contains_key(&UncountedVotesReason::ValidVoterCards));
+        assert!(
+            !total_votes_csb
+                .uncounted_votes
+                .contains_key(&UncountedVotesReason::ValidVoterCards)
+        );
         assert!(result_csb.reporting_unit_votes.is_empty());
 
         // GSB elections take the eligible voter count from the election (default number_of_voters=1000)
@@ -1337,12 +1339,14 @@ mod tests {
                 .get(&UncountedVotesReason::ValidVoterCards),
             None
         );
-        assert!(!result_gsb
-            .reporting_unit_votes
-            .first()
-            .unwrap()
-            .uncounted_votes
-            .contains_key(&UncountedVotesReason::ValidVoterCards));
+        assert!(
+            !result_gsb
+                .reporting_unit_votes
+                .first()
+                .unwrap()
+                .uncounted_votes
+                .contains_key(&UncountedVotesReason::ValidVoterCards)
+        );
     }
 
     #[test]

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -41,13 +41,14 @@ pub use hash::{EmlHash, RedactedEmlHash};
 use crate::{
     domain::{
         committee_session::CommitteeSession,
+        data_entry::DataEntrySourceNumber,
         election::{
             Candidate, CandidateGender, CandidateNumber, CommitteeCategory, CommitteeDistrict,
             ElectionDomain, ElectionWithPoliticalGroups, NewElection, PGNumber, RegionKey,
             RegisteredPoliticalGroup,
         },
-        results::{Results, political_group_candidate_votes::PoliticalGroupCandidateVotes},
-        tabulation::{CommitteeSpecificTotals, ElectionTotals},
+        results::political_group_candidate_votes::PoliticalGroupCandidateVotes,
+        tabulation::{CommitteeSpecificTotals, ElectionTotals, GSBTotals},
     },
     eml::committees::ElectionTreeDetails,
 };
@@ -711,11 +712,20 @@ impl ElectionWithPoliticalGroups {
 
         // GSB elections include reporting unit votes in the count
         let builder = if self.committee_category == CommitteeCategory::GSB {
+            let CommitteeSpecificTotals::GSB(ref gsb_totals) = totals.committee_specific else {
+                unreachable!();
+            };
+
             builder.reporting_unit_votes(
                 results
                     .iter()
                     .map(|(data_source, ps_res)| {
-                        self.as_eml_reporting_unit_votes(committee_session, data_source, ps_res)
+                        self.as_eml_reporting_unit_votes(
+                            committee_session,
+                            data_source,
+                            ps_res,
+                            gsb_totals,
+                        )
                     })
                     .collect::<Result<Vec<_>, EMLError>>()?,
             )
@@ -772,6 +782,7 @@ impl ElectionWithPoliticalGroups {
         committee_session: &CommitteeSession,
         data_source: &crate::domain::data_entry::DataEntrySource,
         results: &crate::domain::results::Results,
+        gsb_totals: &crate::domain::tabulation::GSBTotals,
     ) -> Result<ReportingUnitVotes, EMLError> {
         let mut builder = ReportingUnitVotes::builder()
             .identifier(ReportingUnitIdentifier::new(
@@ -826,7 +837,9 @@ impl ElectionWithPoliticalGroups {
                 UncountedVotesReason::FewerBallotsCounted,
                 *results.differences_counts().fewer_ballots_count,
             );
-        builder = add_reporting_unit_investigations(builder, committee_session, results);
+
+        builder =
+            add_reporting_unit_investigations(builder, committee_session, data_source, gsb_totals);
         builder.build()
     }
 
@@ -963,67 +976,44 @@ fn build_candidate_result(
 fn add_reporting_unit_investigations(
     mut builder: ReportingUnitVotesBuilder,
     committee_session: &CommitteeSession,
-    results: &crate::domain::results::Results,
+    data_source: &crate::domain::data_entry::DataEntrySource,
+    gsb_totals: &crate::domain::tabulation::GSBTotals,
 ) -> ReportingUnitVotesBuilder {
     if !committee_session.is_next_session() {
-        match results {
-            Results::DSOFirstSession(dso_first_session_result) => {
-                builder = builder.investigation(
-                    InvestigationReason::UnexplainedDifference,
-                    dso_first_session_result
-                        .checks_and_corrections
-                        .reason_investigation_own_initiative
-                        .unaccounted_difference,
-                );
-
-                builder = builder.investigation(
-                    InvestigationReason::OtherError,
-                    dso_first_session_result
-                        .checks_and_corrections
-                        .reason_investigation_own_initiative
-                        .other_error,
-                );
-
-                if let Some(corrected_results_own_initiative) = dso_first_session_result
-                    .checks_and_corrections
-                    .corrected_results_own_initiative
-                    .as_bool()
-                {
-                    builder = builder.investigation(
+        let DataEntrySourceNumber::PollingStation(ref number) = data_source.number() else {
+            unreachable!()
+        };
+        match gsb_totals {
+            GSBTotals::DSO(investigations) => {
+                builder = builder
+                    .investigation(
+                        InvestigationReason::UnexplainedDifference,
+                        investigations.unaccounted_difference.contains(number),
+                    )
+                    .investigation(
+                        InvestigationReason::OtherError,
+                        investigations.other_error.contains(number),
+                    )
+                    .investigation(
                         InvestigationReason::ResultCorrected,
-                        corrected_results_own_initiative,
-                    );
-                }
+                        investigations.corrected_results.contains(number),
+                    )
             }
-            Results::CSOFirstSession(cso_first_session_result) => {
-                if let Some(extra_investigation_other_reason) = cso_first_session_result
-                    .extra_investigation
-                    .extra_investigation_other_reason
-                    .as_bool()
-                {
-                    builder = builder.investigation(
+            GSBTotals::CSO(investigations) => {
+                builder = builder
+                    .investigation(
                         InvestigationReason::OtherReason,
-                        extra_investigation_other_reason,
-                    );
-                }
-
-                if let Some(ballots_recounted_extra_investigation) = cso_first_session_result
-                    .extra_investigation
-                    .ballots_recounted_extra_investigation
-                    .as_bool()
-                {
-                    builder = builder.investigation(
+                        investigations.investigated_other_reason.contains(number),
+                    )
+                    .investigation(
                         InvestigationReason::PartiallyRecountedBallots,
-                        ballots_recounted_extra_investigation,
-                    );
-                }
-
-                builder = builder.investigation(
-                    InvestigationReason::AdmittedVotersReestablished,
-                    cso_first_session_result.admitted_voters_have_been_recounted(),
-                );
+                        investigations.ballots_recounted.contains(number),
+                    )
+                    .investigation(
+                        InvestigationReason::AdmittedVotersReestablished,
+                        investigations.admitted_voters_recounted.contains(number),
+                    )
             }
-            Results::DSONextSession(_) | Results::CSONextSession(_) | Results::GSB(_) => {}
         }
     };
 

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -1022,7 +1022,7 @@ fn add_reporting_unit_investigations(
                     cso_first_session_result.admitted_voters_have_been_recounted(),
                 );
             }
-            _ => {}
+            Results::DSONextSession(_) | Results::CSONextSession(_) | Results::GSB(_) => {}
         }
     };
 

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -46,9 +46,7 @@ use crate::{
             ElectionDomain, ElectionWithPoliticalGroups, NewElection, PGNumber, RegionKey,
             RegisteredPoliticalGroup,
         },
-        results::{
-            political_group_candidate_votes::PoliticalGroupCandidateVotes, yes_no::YesNo, Results,
-        },
+        results::{political_group_candidate_votes::PoliticalGroupCandidateVotes, Results},
         tabulation::{CommitteeSpecificTotals, ElectionTotals},
     },
     eml::committees::ElectionTreeDetails,
@@ -986,13 +984,16 @@ fn add_reporting_unit_investigations(
                         .other_error,
                 );
 
-                builder = builder.investigation(
-                    InvestigationReason::ResultCorrected,
-                    dso_first_session_result
-                        .checks_and_corrections
-                        .corrected_results_own_initiative
-                        == YesNo::yes(),
-                );
+                if let Some(corrected_results_own_initiative) = dso_first_session_result
+                    .checks_and_corrections
+                    .corrected_results_own_initiative
+                    .as_bool()
+                {
+                    builder = builder.investigation(
+                        InvestigationReason::ResultCorrected,
+                        corrected_results_own_initiative,
+                    );
+                }
             }
             Results::CSOFirstSession(cso_first_session_result) => {
                 if let Some(extra_investigation_other_reason) = cso_first_session_result
@@ -1112,16 +1113,16 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        committee_session::{CommitteeSessionId, committee_session_fixture},
+        committee_session::{committee_session_fixture, CommitteeSessionId},
         data_entry::{DataEntryId, DataEntrySource},
-        election::{ElectionCategory, tests::election_fixture},
+        election::{tests::election_fixture, ElectionCategory},
         polling_station::{
-            PollingStationFirstSession, PollingStationForSession,
-            test_helpers::polling_stations_fixture,
+            test_helpers::polling_stations_fixture, PollingStationFirstSession,
+            PollingStationForSession,
         },
         results::{
-            Results, count::Count, political_group_candidate_votes::CandidateVotes,
-            tests::example_results,
+            count::Count, political_group_candidate_votes::CandidateVotes, tests::example_results,
+            Results,
         },
     };
 
@@ -1311,11 +1312,9 @@ mod tests {
             total_votes_csb.eligible_voter_count,
             StringValue::from_value(1001u64)
         );
-        assert!(
-            !total_votes_csb
-                .uncounted_votes
-                .contains_key(&UncountedVotesReason::ValidVoterCards)
-        );
+        assert!(!total_votes_csb
+            .uncounted_votes
+            .contains_key(&UncountedVotesReason::ValidVoterCards));
         assert!(result_csb.reporting_unit_votes.is_empty());
 
         // GSB elections take the eligible voter count from the election (default number_of_voters=1000)
@@ -1338,14 +1337,12 @@ mod tests {
                 .get(&UncountedVotesReason::ValidVoterCards),
             None
         );
-        assert!(
-            !result_gsb
-                .reporting_unit_votes
-                .first()
-                .unwrap()
-                .uncounted_votes
-                .contains_key(&UncountedVotesReason::ValidVoterCards)
-        );
+        assert!(!result_gsb
+            .reporting_unit_votes
+            .first()
+            .unwrap()
+            .uncounted_votes
+            .contains_key(&UncountedVotesReason::ValidVoterCards));
     }
 
     #[test]

--- a/backend/src/eml/mod.rs
+++ b/backend/src/eml/mod.rs
@@ -7,7 +7,6 @@ pub mod hash;
 use apportionment::CandidateNominationDetails;
 use chrono::{DateTime, Local};
 use eml_nl::{
-    EMLError,
     common::{
         AuthorityIdentifier, ContestIdentifier, ElectionTree, ManagingAuthority, PersonName,
         ReportingUnitIdentifier,
@@ -34,6 +33,7 @@ use eml_nl::{
         Gender, ReportingUnitIdentifierId, StringValue, StringValueData, VotingChannelType,
         VotingMethod,
     },
+    EMLError,
 };
 pub use error::EMLImportError;
 pub use hash::{EmlHash, RedactedEmlHash};
@@ -46,7 +46,9 @@ use crate::{
             ElectionDomain, ElectionWithPoliticalGroups, NewElection, PGNumber, RegionKey,
             RegisteredPoliticalGroup,
         },
-        results::political_group_candidate_votes::PoliticalGroupCandidateVotes,
+        results::{
+            political_group_candidate_votes::PoliticalGroupCandidateVotes, yes_no::YesNo, Results,
+        },
         tabulation::{CommitteeSpecificTotals, ElectionTotals},
     },
     eml::committees::ElectionTreeDetails,
@@ -965,36 +967,64 @@ fn add_reporting_unit_investigations(
     committee_session: &CommitteeSession,
     results: &crate::domain::results::Results,
 ) -> ReportingUnitVotesBuilder {
-    if !committee_session.is_next_session()
-        && let crate::domain::results::Results::CSOFirstSession(first_session_result) = results
-    {
-        if let Some(extra_investigation_other_reason) = first_session_result
-            .extra_investigation
-            .extra_investigation_other_reason
-            .as_bool()
-        {
-            builder = builder.investigation(
-                InvestigationReason::OtherReason,
-                extra_investigation_other_reason,
-            );
-        }
+    if !committee_session.is_next_session() {
+        match results {
+            Results::DSOFirstSession(dso_first_session_result) => {
+                builder = builder.investigation(
+                    InvestigationReason::UnexplainedDifference,
+                    dso_first_session_result
+                        .checks_and_corrections
+                        .reason_investigation_own_initiative
+                        .unaccounted_difference,
+                );
 
-        if let Some(ballots_recounted_extra_investigation) = first_session_result
-            .extra_investigation
-            .ballots_recounted_extra_investigation
-            .as_bool()
-        {
-            builder = builder.investigation(
-                InvestigationReason::PartiallyRecountedBallots,
-                ballots_recounted_extra_investigation,
-            );
-        }
+                builder = builder.investigation(
+                    InvestigationReason::OtherError,
+                    dso_first_session_result
+                        .checks_and_corrections
+                        .reason_investigation_own_initiative
+                        .other_error,
+                );
 
-        builder = builder.investigation(
-            InvestigationReason::AdmittedVotersReestablished,
-            first_session_result.admitted_voters_have_been_recounted(),
-        );
-    }
+                builder = builder.investigation(
+                    InvestigationReason::ResultCorrected,
+                    dso_first_session_result
+                        .checks_and_corrections
+                        .corrected_results_own_initiative
+                        == YesNo::yes(),
+                );
+            }
+            Results::CSOFirstSession(cso_first_session_result) => {
+                if let Some(extra_investigation_other_reason) = cso_first_session_result
+                    .extra_investigation
+                    .extra_investigation_other_reason
+                    .as_bool()
+                {
+                    builder = builder.investigation(
+                        InvestigationReason::OtherReason,
+                        extra_investigation_other_reason,
+                    );
+                }
+
+                if let Some(ballots_recounted_extra_investigation) = cso_first_session_result
+                    .extra_investigation
+                    .ballots_recounted_extra_investigation
+                    .as_bool()
+                {
+                    builder = builder.investigation(
+                        InvestigationReason::PartiallyRecountedBallots,
+                        ballots_recounted_extra_investigation,
+                    );
+                }
+
+                builder = builder.investigation(
+                    InvestigationReason::AdmittedVotersReestablished,
+                    cso_first_session_result.admitted_voters_have_been_recounted(),
+                );
+            }
+            _ => {}
+        }
+    };
 
     builder
 }


### PR DESCRIPTION
## What & why

Implements #3688 

Adds DSO-related checkboxes to the EML builder. 
<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test
Quick test: 
- Go to elections/12/report/committee-session/12/download
- Download ZIP and open Telling_AB2026_Juinen.eml.xml
- Verify the values of the child nodes of `<kr:ReportingUnitInvestigations>`

Full test:
- Go to election Waterschap Rivier en Polder 2026
- As both typists, enter a combination to test in 'Controles en correcties'
- Finish data entry as both typists
- As coordinator, finalize data entry
- Download ZIP en open Telling_AB2026_Heemdamseburg.eml.xml
- Verify the values of the child nodes of `<kr:ReportingUnitInvestigations>`

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->