### PR TITLE
Remove check for `corrected_results_csb_request` in tabulation

### DIFF
--- a/backend/src/domain/tabulation.rs
+++ b/backend/src/domain/tabulation.rs
@@ -438,9 +438,7 @@ impl DSOInvestigations {
         }
 
         // whether the investigation has led to corrected results
-        if checks.corrected_results_own_initiative.as_bool() == Some(true)
-            || checks.corrected_results_csb_request.as_bool() == Some(true)
-        {
+        if checks.corrected_results_own_initiative.as_bool() == Some(true) {
             self.corrected_results.push(polling_station.number());
         }
     }


### PR DESCRIPTION
## What & why
As announced in this [comment](https://github.com/kiesraad/abacus/pull/3808#discussion_r3821962862), and discussed in this [mattermost thread](https://digilab.overheid.nl/chat/kiesraad/pl/wks7y99ao3yt8csmwhu753shzh), the check for corrected_results_csb_request will be removed in `DSOInvestigations::append_result`

## How to test
Not sure how to test, as it was essentially dead code.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->