### PR TITLE
Download button with content

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -32,8 +32,10 @@ const preview: Preview = {
     },
     backgrounds: {
       options: {
-        dark: { name: "Dark", value: "#333" },
-        light: { name: "Light", value: "#f9fafb" },
+        light: { name: "gray-50", value: "#f9fafb" },
+        red: { name: "red-100", value: "#fbe9ed" },
+        green: { name: "green-100", value: "#e7f3ee" },
+        blue: { name: "blue-100", value: "#e7eef9" },
       },
     },
   },

--- a/frontend/src/components/ui/DownloadButton/DownloadButton.module.css
+++ b/frontend/src/components/ui/DownloadButton/DownloadButton.module.css
@@ -1,61 +1,75 @@
-.DownloadButton {
-  width: 100%;
+.downloadButton {
   max-width: 32rem;
-  color: var(--interactive-default);
-  border-color: var(--bg-gray-darkest);
-  background: var(--button-color-secondary);
   border-radius: 0.5rem;
-  text-decoration: none;
+  overflow: hidden;
 
-  display: inline-flex;
-  gap: 0.75rem;
-  padding: 1rem;
-  cursor: pointer;
+  display: flex;
+  flex-direction: column;
 
-  svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    stroke-width: 0;
-    stroke: var(--base-blue);
-    fill: var(--base-blue);
+  > div {
+    background-color: var(--blue-700);
+    padding: var(--space-md);
+    color: var(--base-white);
+    font-family: var(--font-number);
+    font-size: var(--font-size-xs);
+    line-height: 1rem;
   }
 
-  & > span {
-    display: inline-flex;
-    flex-direction: column;
-
-    .title {
-      font-weight: bold;
-    }
-
-    .subtitle {
-      color: var(--gray-600);
-    }
-  }
-
-  &.disabled {
-    pointer-events: none;
-    cursor: not-allowed;
-
-    & > span .title {
-      color: var(--gray-400);
-    }
-  }
-
-  &:hover {
-    .title {
-      text-decoration: underline;
-    }
-  }
-
-  &:focus,
-  &:focus-visible {
-    .title {
-      text-decoration: underline;
-    }
-  }
-
-  &:visited {
+  a {
     color: var(--interactive-default);
+    background: var(--button-color-secondary);
+    text-decoration: none;
+
+    display: flex;
+    gap: 0.75rem;
+    padding: 1rem;
+    cursor: pointer;
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      stroke-width: 0;
+      stroke: var(--base-blue);
+      fill: var(--base-blue);
+    }
+
+    & > span {
+      display: inline-flex;
+      flex-direction: column;
+
+      .title {
+        font-weight: bold;
+      }
+
+      .subtitle {
+        color: var(--gray-600);
+      }
+    }
+
+    &.disabled {
+      pointer-events: none;
+      cursor: not-allowed;
+
+      & > span .title {
+        color: var(--gray-400);
+      }
+    }
+
+    &:hover {
+      .title {
+        text-decoration: underline;
+      }
+    }
+
+    &:focus,
+    &:focus-visible {
+      .title {
+        text-decoration: underline;
+      }
+    }
+
+    &:visited {
+      color: var(--interactive-default);
+    }
   }
 }

--- a/frontend/src/components/ui/DownloadButton/DownloadButton.stories.tsx
+++ b/frontend/src/components/ui/DownloadButton/DownloadButton.stories.tsx
@@ -4,6 +4,9 @@ import { DownloadButton } from "./DownloadButton";
 
 const meta = {
   component: DownloadButton,
+  globals: {
+    backgrounds: { value: "blue" },
+  },
 } satisfies Meta<typeof DownloadButton>;
 
 export default meta;
@@ -15,6 +18,30 @@ export const Default: Story = {
     href: "#",
     title: "Download definitieve documenten eerste zitting",
     subtitle: "ZIP-bestand, 225kb",
+  },
+};
+
+export const WithContent: Story = {
+  args: {
+    children: (
+      <>
+        Organisatie: AB2027_Juinduinen
+        <br />
+        Organisatorische eenheid: Abacus 1.2
+        <br />
+        Algemene naam: Gemeente Juinen
+        <br />
+        Geldig vanaf: 10 maart 2027
+        <br />
+        Geldig tot en met: 9 september 2027
+        <br />
+        Handtekeningalgoritme: SHA256withRSA
+      </>
+    ),
+    icon: "download",
+    href: "#",
+    title: "Publieke sleutel HSB Juinen AB2027_Juinduinen",
+    subtitle: "Download crt-bestand",
   },
 };
 

--- a/frontend/src/components/ui/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/components/ui/DownloadButton/DownloadButton.tsx
@@ -1,9 +1,9 @@
-import type { AnchorHTMLAttributes } from "react";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { IconDownload, IconFile } from "@/components/generated/icons";
-import { cn } from "@/utils/classnames";
 import cls from "./DownloadButton.module.css";
 
 export interface DownloadButtonProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  children?: ReactNode;
   icon: "file" | "download";
   title: string;
   href: string;
@@ -13,6 +13,7 @@ export interface DownloadButtonProps extends AnchorHTMLAttributes<HTMLAnchorElem
 }
 
 export function DownloadButton({
+  children,
   icon,
   title,
   subtitle,
@@ -24,17 +25,15 @@ export function DownloadButton({
   const Icon = icon === "file" ? IconFile : IconDownload;
 
   return (
-    <a
-      href={href}
-      className={cn(cls.DownloadButton, cls[icon], isDisabled || isLoading ? cls.disabled : "")}
-      title={title}
-      {...htmlAnchorProps}
-    >
-      <Icon />
-      <span>
-        <span className={cls.title}>{title}</span>
-        {subtitle && <span className={cls.subtitle}>{subtitle}</span>}
-      </span>
-    </a>
+    <div className={cls.downloadButton}>
+      {children && <div>{children}</div>}
+      <a href={href} className={isDisabled || isLoading ? cls.disabled : undefined} title={title} {...htmlAnchorProps}>
+        <Icon />
+        <span>
+          <span className={cls.title}>{title}</span>
+          {subtitle && <span className={cls.subtitle}>{subtitle}</span>}
+        </span>
+      </a>
+    </div>
   );
 }


### PR DESCRIPTION
## What & why

Part of https://github.com/kiesraad/abacus/issues/3770

The download button for EML Signing in Epic https://github.com/kiesraad/abacus/issues/3374 needs to show a summary of the certificate. This PR is to add this feature to the DownloadButton, in order to do the following:


```tsx
<DownloadButton
  icon="download"
  href="certificate"
  title="Publieke sleutel HSB Juinen AB2027_Juinduinen"
  subtitle="Download crt-bestand"
>
  Organisatie: AB2027_Juinduinen<br />
  Organisatorische eenheid: Abacus 1.2<br />
  Algemene naam: Gemeente Juinen<br />
  Geldig vanaf: 10 maart 2027<br />
  Geldig tot en met: 9 september 2027<br />
  Handtekeningalgoritme: SHA256withRSA
</DownloadButton>
```

<img width="551" height="244" alt="image" src="https://github.com/user-attachments/assets/85a153e5-ac33-4bc8-bd0f-b47130e2a136" />



## How to test

Check that the button [in Storybook](https://regeling-lid-kandidaat.abacus-test.nl/storybook/?path=/story/components-ui-downloadbutton--with-content) matches what will be expected [in Figma](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=21130-81329&m=dev&t=0az4JensjIAzVo91-1).
<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

CSS change is best viewed with "Hide whitespace" in GitHub

Also added Abacus colors as Storybook background colors, and selected blue background for the DownloadButton stories.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->