### PR TITLE
Move selection of GSB to before uploading candidate lists in frontend import flow

### DIFF
--- a/frontend/src/features/election_create/components/ElectionCreate.test.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreate.test.tsx
@@ -30,7 +30,13 @@ import { getRouter, type Router } from "@/testing/router";
 import { overrideOnce, server } from "@/testing/server";
 import { TestUserProvider } from "@/testing/TestUserProvider";
 import { screen, setupTestRouter, waitFor } from "@/testing/test-utils";
-import type { CommitteeCategory, Election, RegionDetails, VoteCountingMethod } from "@/types/generated/openapi";
+import type {
+  CommitteeCategory,
+  Election,
+  RegionDetails,
+  RegionKey,
+  VoteCountingMethod,
+} from "@/types/generated/openapi";
 import { electionCreateRoutes } from "../routes";
 
 const Providers = ({
@@ -130,8 +136,8 @@ async function setCommitteeCategory(election: Election = electionMockData) {
   await user.click(screen.getByRole("button", { name: "Volgende" }));
 }
 
-async function uploadCandidateDefinition(file: File, election: Election = electionMockData) {
-  mockValidateResponse({ election });
+async function uploadCandidateDefinition(file: File, election: Election = electionMockData, gsbSelected?: RegionKey) {
+  mockValidateResponse({ election, gsbSelected: gsbSelected });
 
   // Wait for the candidate page to be loaded
   expect(await screen.findByRole("heading", { level: 2, name: "Importeer kandidatenlijsten" })).toBeVisible();
@@ -139,17 +145,25 @@ async function uploadCandidateDefinition(file: File, election: Election = electi
   expect(await screen.findByRole("heading", { level: 2, name: "Controleer kandidatenlijsten" })).toBeVisible();
 }
 
-async function inputCandidateHash(election: Election = electionMockData) {
-  mockValidateResponse({ election });
+async function inputCandidateHash(election: Election = electionMockData, gsbSelected?: RegionKey) {
+  mockValidateResponse({ election, gsbSelected: gsbSelected });
   await inputHash();
 }
 
-async function importDefinitions(router: Router, file: File, election: Election = electionMockData) {
+async function importDefinitions(
+  router: Router,
+  file: File,
+  election: Election = electionMockData,
+  gsbSelected?: RegionDetails,
+) {
   await uploadElectionDefinition(router, file, election);
   await inputElectionHash(election);
   await setCommitteeCategory(election);
-  await uploadCandidateDefinition(file, election);
-  await inputCandidateHash(election);
+  if (gsbSelected) {
+    await selectGSB(election, gsbSelected);
+  }
+  await uploadCandidateDefinition(file, election, gsbSelected?.key);
+  await inputCandidateHash(election, gsbSelected?.key);
 }
 
 async function selectGSB(election: Election, gsb: RegionDetails) {
@@ -522,11 +536,8 @@ describe("Election create pages", () => {
       server.use(importHandler);
       const router = renderWithRouter();
       const user = userEvent.setup();
-      await importDefinitions(router, file, election);
+      await importDefinitions(router, file, election, gsbSelected);
 
-      if (gsbSelected) {
-        await selectGSB(election, gsbSelected);
-      }
       const location = gsbSelected?.name ?? election.location;
 
       // polling stations

--- a/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
+++ b/frontend/src/features/election_create/components/ElectionCreateContextProvider.tsx
@@ -150,7 +150,7 @@ function reducer(state: ElectionCreateState, action: ElectionCreateAction): Elec
     case "SET_COUNTING_METHOD_TYPE":
       return { ...state, countingMethod: action.countingMethod };
     case "SET_COMMITTEE_CATEGORY":
-      return { ...state, committeeCategory: action.committeeCategory };
+      return { ...state, committeeCategory: action.committeeCategory, gsbSelected: undefined };
     case "SET_NUMBER_OF_VOTERS":
       return {
         ...state,

--- a/frontend/src/features/election_create/components/SelectCommitteeCategory.test.tsx
+++ b/frontend/src/features/election_create/components/SelectCommitteeCategory.test.tsx
@@ -1,12 +1,16 @@
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
-import { csbElectionMockData, electionImportValidateMockResponse } from "@/testing/api-mocks/ElectionMockData";
+import {
+  csbElectionMockData,
+  electionImportValidateMockResponse,
+  electionMockData,
+} from "@/testing/api-mocks/ElectionMockData";
 import { overrideOnce } from "@/testing/server";
 import { renderReturningRouter, screen } from "@/testing/test-utils";
-import type { CommitteeCategory as CommitteeCategoryType, NewElection } from "@/types/generated/openapi";
+import type { CommitteeCategory, ElectionCategory, NewElection } from "@/types/generated/openapi";
 import * as useElectionCreateContext from "../hooks/useElectionCreateContext";
-import { CommitteeCategory } from "./CommitteeCategory";
 import { ElectionCreateContextProvider } from "./ElectionCreateContextProvider";
+import { SelectCommitteeCategory } from "./SelectCommitteeCategory";
 
 const election = { name: "Naam", location: "Plek", committee_category: "GSB" } as NewElection;
 
@@ -15,26 +19,32 @@ describe("CommitteeCategory component", () => {
     const state = {};
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
-    const router = renderReturningRouter(<CommitteeCategory />);
+    const router = renderReturningRouter(<SelectCommitteeCategory />);
 
     expect(router.state.location.pathname).toEqual("/elections/create");
   });
 
-  test("GSB: Navigates to candidate list upload page", async () => {
-    const state = { election, committeeCategory: "GSB" as CommitteeCategoryType };
+  test.each<[string, CommitteeCategory, ElectionCategory, string]>([
+    ["GSB for a municipal election", "GSB", "Municipal", "/elections/create/list-of-candidates"],
+    ["GSB for a provincial election", "GSB", "Provincial", "/elections/create/select-gsb"],
+    ["GSB for a water authority election", "GSB", "WaterAuthority", "/elections/create/select-gsb"],
+  ])("%s", async (_, committeeCategory, electionCategory, expected) => {
+    const state = { election: { ...election, category: electionCategory }, committeeCategory: committeeCategory };
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     overrideOnce(
       "post",
       "/api/elections/import/validate",
       200,
-      electionImportValidateMockResponse({ matchingElection: false, numberOfVoters: 2000 }),
+      electionImportValidateMockResponse({
+        election: committeeCategory === "CSB" ? csbElectionMockData : electionMockData,
+      }),
     );
     const user = userEvent.setup();
 
     const router = renderReturningRouter(
       <ElectionCreateContextProvider>
-        <CommitteeCategory />
+        <SelectCommitteeCategory />
       </ElectionCreateContextProvider>,
     );
 
@@ -42,7 +52,11 @@ describe("CommitteeCategory component", () => {
     expect(screen.getByRole("radio", { name: "Gemeentelijk stembureau (GSB)" })).toBeChecked();
     const optionCsb = screen.getByRole("radio", { name: "Centraal stembureau (CSB)" });
     expect(optionCsb).not.toBeChecked();
-    expect(optionCsb).not.toBeDisabled();
+    if (electionCategory === "Provincial") {
+      expect(optionCsb).toBeDisabled();
+    } else {
+      expect(optionCsb).not.toBeDisabled();
+    }
 
     await user.click(screen.getByRole("button", { name: "Volgende" }));
 
@@ -51,35 +65,11 @@ describe("CommitteeCategory component", () => {
       committeeCategory: "GSB",
     });
 
-    expect(router.state.location.pathname).toEqual("/elections/create/list-of-candidates");
-  });
-
-  test("CSB option is disabled for provincial elections", async () => {
-    const state = { election: { ...election, category: "Provincial" } as NewElection };
-    const dispatch = vi.fn();
-    vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
-    const user = userEvent.setup();
-
-    const router = renderReturningRouter(
-      <ElectionCreateContextProvider>
-        <CommitteeCategory />
-      </ElectionCreateContextProvider>,
-    );
-
-    expect(await screen.findByRole("heading", { name: "Type stembureau" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Gemeentelijk stembureau (GSB)" })).toBeChecked();
-    expect(screen.getByRole("radio", { name: "Centraal stembureau (CSB)" })).toBeDisabled();
-    await user.click(screen.getByRole("button", { name: "Volgende" }));
-
-    expect(dispatch).toHaveBeenCalledWith({
-      type: "SET_COMMITTEE_CATEGORY",
-      committeeCategory: "GSB",
-    });
-    expect(router.state.location.pathname).toEqual("/elections/create/list-of-candidates");
+    expect(router.state.location.pathname).toEqual(expected);
   });
 
   test("CSB: Navigates to candidate list upload page", async () => {
-    const state = { election, committeeCategory: "CSB" as CommitteeCategoryType };
+    const state = { election, committeeCategory: "CSB" as CommitteeCategory };
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     overrideOnce(
@@ -92,7 +82,7 @@ describe("CommitteeCategory component", () => {
 
     const router = renderReturningRouter(
       <ElectionCreateContextProvider>
-        <CommitteeCategory />
+        <SelectCommitteeCategory />
       </ElectionCreateContextProvider>,
     );
 

--- a/frontend/src/features/election_create/components/SelectCommitteeCategory.test.tsx
+++ b/frontend/src/features/election_create/components/SelectCommitteeCategory.test.tsx
@@ -25,6 +25,8 @@ describe("CommitteeCategory component", () => {
   });
 
   test.each<[string, CommitteeCategory, ElectionCategory, string]>([
+    ["CSB for a municipal election", "CSB", "Municipal", "/elections/create/list-of-candidates"],
+    ["CSB for a water authority election", "CSB", "WaterAuthority", "/elections/create/list-of-candidates"],
     ["GSB for a municipal election", "GSB", "Municipal", "/elections/create/list-of-candidates"],
     ["GSB for a provincial election", "GSB", "Provincial", "/elections/create/select-gsb"],
     ["GSB for a water authority election", "GSB", "WaterAuthority", "/elections/create/select-gsb"],
@@ -49,9 +51,15 @@ describe("CommitteeCategory component", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Type stembureau" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Gemeentelijk stembureau (GSB)" })).toBeChecked();
+    const optionGsb = screen.getByRole("radio", { name: "Gemeentelijk stembureau (GSB)" });
     const optionCsb = screen.getByRole("radio", { name: "Centraal stembureau (CSB)" });
-    expect(optionCsb).not.toBeChecked();
+    if (committeeCategory === "CSB") {
+      expect(optionGsb).not.toBeChecked();
+      expect(optionCsb).toBeChecked();
+    } else {
+      expect(optionGsb).toBeChecked();
+      expect(optionCsb).not.toBeChecked();
+    }
     if (electionCategory === "Provincial") {
       expect(optionCsb).toBeDisabled();
     } else {
@@ -62,40 +70,9 @@ describe("CommitteeCategory component", () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       type: "SET_COMMITTEE_CATEGORY",
-      committeeCategory: "GSB",
+      committeeCategory: committeeCategory,
     });
 
     expect(router.state.location.pathname).toEqual(expected);
-  });
-
-  test("CSB: Navigates to candidate list upload page", async () => {
-    const state = { election, committeeCategory: "CSB" as CommitteeCategory };
-    const dispatch = vi.fn();
-    vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
-    overrideOnce(
-      "post",
-      "/api/elections/import/validate",
-      200,
-      electionImportValidateMockResponse({ election: csbElectionMockData }),
-    );
-    const user = userEvent.setup();
-
-    const router = renderReturningRouter(
-      <ElectionCreateContextProvider>
-        <SelectCommitteeCategory />
-      </ElectionCreateContextProvider>,
-    );
-
-    expect(await screen.findByRole("heading", { name: "Type stembureau" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Gemeentelijk stembureau (GSB)" })).not.toBeChecked();
-    expect(screen.getByRole("radio", { name: "Centraal stembureau (CSB)" })).toBeChecked();
-    await user.click(screen.getByRole("button", { name: "Volgende" }));
-
-    expect(dispatch).toHaveBeenCalledWith({
-      type: "SET_COMMITTEE_CATEGORY",
-      committeeCategory: "CSB",
-    });
-
-    expect(router.state.location.pathname).toEqual("/elections/create/list-of-candidates");
   });
 });

--- a/frontend/src/features/election_create/components/SelectCommitteeCategory.tsx
+++ b/frontend/src/features/election_create/components/SelectCommitteeCategory.tsx
@@ -11,7 +11,7 @@ import { StringFormData } from "@/utils/stringFormData";
 import { isOneOf } from "@/utils/typeChecks";
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 
-export function CommitteeCategory() {
+export function SelectCommitteeCategory() {
   const { state, dispatch } = useElectionCreateContext();
   const navigate = useNavigate();
   const [error] = useState<ReactNode | undefined>();
@@ -36,7 +36,13 @@ export function CommitteeCategory() {
       type: "SET_COMMITTEE_CATEGORY",
       committeeCategory,
     });
-    await navigate("/elections/create/list-of-candidates");
+    if (committeeCategory === "CSB" || state.election?.category === "Municipal") {
+      // Go to upload candidate lists directly
+      await navigate("/elections/create/list-of-candidates");
+    } else {
+      // PS/WS elections need a GSB to be selected first
+      await navigate("/elections/create/select-gsb");
+    }
   }
 
   return (

--- a/frontend/src/features/election_create/components/SelectGSB.test.tsx
+++ b/frontend/src/features/election_create/components/SelectGSB.test.tsx
@@ -51,7 +51,7 @@ describe("SelectGSB component", () => {
     ]);
   });
 
-  test("Selecting a GSB validates and navigates to polling stations", async () => {
+  test("Selecting a GSB validates and navigates to upload candidate lists", async () => {
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     const user = userEvent.setup();
@@ -87,7 +87,7 @@ describe("SelectGSB component", () => {
       });
     });
     expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(router.state.location.pathname).toEqual("/elections/create/polling-stations");
+    expect(router.state.location.pathname).toEqual("/elections/create/list-of-candidates");
   });
 
   test("Shows an error if validation fails", async () => {

--- a/frontend/src/features/election_create/components/SelectGSB.test.tsx
+++ b/frontend/src/features/election_create/components/SelectGSB.test.tsx
@@ -110,6 +110,6 @@ describe("SelectGSB component", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Gemeentelijk stembureau kan niet worden geselecteerd");
     expect(dispatch).not.toHaveBeenCalled();
-    expect(router.state.location.pathname).not.toEqual("/elections/create/polling-stations");
+    expect(router.state.location.pathname).toEqual("/");
   });
 });

--- a/frontend/src/features/election_create/components/SelectGSB.tsx
+++ b/frontend/src/features/election_create/components/SelectGSB.tsx
@@ -47,7 +47,7 @@ export function SelectGSB() {
         response: response.data,
         gsbSelected: gsb.key,
       });
-      await navigate("/elections/create/polling-stations");
+      await navigate("/elections/create/list-of-candidates");
     } else if (isError(response)) {
       setError(response.message);
     }

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
@@ -117,8 +117,8 @@ describe("UploadCandidatesDefinition component", () => {
     test.each<[string, CommitteeCategory, ElectionCategory, string]>([
       ["CSB", "CSB", "Municipal", "/elections/create/check-and-save"],
       ["GSB for a municipal election", "GSB", "Municipal", "/elections/create/polling-stations"],
-      ["GSB for a provincial election", "GSB", "Provincial", "/elections/create/select-gsb"],
-      ["GSB for a water authority election", "GSB", "WaterAuthority", "/elections/create/select-gsb"],
+      ["GSB for a provincial election", "GSB", "Provincial", "/elections/create/polling-stations"],
+      ["GSB for a water authority election", "GSB", "WaterAuthority", "/elections/create/polling-stations"],
     ])("%s", async (_, committeeCategory, electionCategory, expected) => {
       const state = {
         ...hashState,

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
@@ -114,15 +114,13 @@ describe("UploadCandidatesDefinition component", () => {
       await user.click(screen.getByRole("button", { name: "Volgende" }));
     }
 
-    test.each<[string, CommitteeCategory, ElectionCategory, string]>([
-      ["CSB", "CSB", "Municipal", "/elections/create/check-and-save"],
-      ["GSB for a municipal election", "GSB", "Municipal", "/elections/create/polling-stations"],
-      ["GSB for a provincial election", "GSB", "Provincial", "/elections/create/polling-stations"],
-      ["GSB for a water authority election", "GSB", "WaterAuthority", "/elections/create/polling-stations"],
-    ])("%s", async (_, committeeCategory, electionCategory, expected) => {
+    test.each<[CommitteeCategory, string]>([
+      ["CSB", "/elections/create/check-and-save"],
+      ["GSB", "/elections/create/polling-stations"],
+    ])("%s", async (committeeCategory, expected) => {
       const state = {
         ...hashState,
-        election: { ...election, category: electionCategory },
+        election: { ...election, category: "Municipal" as ElectionCategory },
         committeeCategory,
       };
 

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -47,6 +47,7 @@ export function UploadCandidatesDefinition() {
         candidate_data: data,
         election_hash: state.electionDefinitionHash,
         election_data: state.electionDefinitionData,
+        selected_region: state.gsbSelected,
       });
 
       if (isSuccess(response)) {
@@ -88,6 +89,7 @@ export function UploadCandidatesDefinition() {
         election_hash: state.electionDefinitionHash,
         election_data: state.electionDefinitionData,
         candidate_hash: chunks,
+        selected_region: state.gsbSelected,
       });
       if (isSuccess(response)) {
         dispatch({
@@ -96,13 +98,8 @@ export function UploadCandidatesDefinition() {
         });
         if (state.committeeCategory === "CSB") {
           await navigate("/elections/create/check-and-save");
-        } else if (state.election?.category === "Municipal") {
-          // GR elections have the GSB defined in the election definition
-          // so we can go directly to the polling stations step
-          await navigate("/elections/create/polling-stations");
         } else {
-          // PS/WS elections need a GSB to be selected
-          await navigate("/elections/create/select-gsb");
+          await navigate("/elections/create/polling-stations");
         }
       } else if (isError(response) && response instanceof ApiError && response.reference === "InvalidHash") {
         setError(response.message);

--- a/frontend/src/features/election_create/routes.tsx
+++ b/frontend/src/features/election_create/routes.tsx
@@ -1,10 +1,10 @@
 import type { RouteObject } from "react-router";
 
 import { CheckAndSave } from "./components/CheckAndSave";
-import { CommitteeCategory } from "./components/CommitteeCategory";
 import { CountingMethodType } from "./components/CountingMethodType";
 import { ElectionCreateLayout } from "./components/ElectionCreateLayout";
 import { NumberOfVoters } from "./components/NumberOfVoters";
+import { SelectCommitteeCategory } from "./components/SelectCommitteeCategory";
 import { SelectGSB } from "./components/SelectGSB";
 import { UploadCandidatesDefinition } from "./components/UploadCandidatesDefinition";
 import { UploadElectionDefinition } from "./components/UploadElectionDefinition";
@@ -15,9 +15,9 @@ export const electionCreateRoutes: RouteObject[] = [
     Component: ElectionCreateLayout,
     children: [
       { index: true, Component: UploadElectionDefinition, handle: { roles: ["administrator"] } },
-      { path: "committee-category", Component: CommitteeCategory, handle: { roles: ["administrator"] } },
-      { path: "list-of-candidates", Component: UploadCandidatesDefinition, handle: { roles: ["administrator"] } },
+      { path: "committee-category", Component: SelectCommitteeCategory, handle: { roles: ["administrator"] } },
       { path: "select-gsb", Component: SelectGSB, handle: { roles: ["administrator"] } },
+      { path: "list-of-candidates", Component: UploadCandidatesDefinition, handle: { roles: ["administrator"] } },
       { path: "polling-stations", Component: UploadPollingStationDefinition, handle: { roles: ["administrator"] } },
       { path: "counting-method-type", Component: CountingMethodType, handle: { roles: ["administrator"] } },
       { path: "number-of-voters", Component: NumberOfVoters, handle: { roles: ["administrator"] } },

--- a/frontend/src/testing/api-mocks/ElectionMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionMockData.ts
@@ -502,7 +502,7 @@ export interface ElectionImportValidateMockOptions {
   gsbSelected?: RegionKey;
 }
 
-/// Get a mock response for election import validaton
+/// Get a mock response for election import validation
 /// Defaults to GSB GR
 export function electionImportValidateMockResponse({
   election,


### PR DESCRIPTION
Closes #3903

## What & why

This change is needed to be able to verify the candidate list against the district of the selected GSB.
Also renamed the component `CommitteeCategory.tsx` to `SelectCommitteeCategory.tsx` to prevent needing overrides for the `CommitteeCategory` type

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

Go through the election import flow for various GSB categories and CSB and check that the order is now correct as in the updated [Figma design](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=23891-14974&m=dev)

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist

- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->