### PR TITLE
Show error if wrong candidate list is uploaded for a district

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8260,6 +8260,7 @@
           "InvalidApportionmentState",
           "InvalidCommitteeSessionStatus",
           "InvalidData",
+          "InvalidDistrict",
           "InvalidHash",
           "InvalidJson",
           "InvalidPassword",

--- a/backend/src/eml/error.rs
+++ b/backend/src/eml/error.rs
@@ -12,6 +12,7 @@ pub enum EMLImportError {
     EMLError(eml_nl::EMLError),
     InvalidCandidate,
     InvalidDateFormat,
+    InvalidDistrict,
     InvalidPollingStation,
     InvalidVotingMethod,
     LimitedElectionsSupported,
@@ -21,6 +22,7 @@ pub enum EMLImportError {
     MismatchElectionDomain,
     MismatchNumberOfSeats,
     MismatchPreferenceThreshold,
+    MissingCommitteeNumber,
     MissingElectionDomain,
     MissingFileName,
     MissingManagingAuthority,
@@ -42,8 +44,6 @@ pub enum EMLImportError {
     TooManyPoliticalGroups,
     UnknownCommittee,
     UnsupportedDistrictElection,
-    InvalidDistrict,
-    MissingCommitteeNumber,
 }
 
 impl From<eml_nl::EMLError> for EMLImportError {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -268,9 +268,13 @@ impl APIError {
             }
             APIError::EmlImportError(err) => {
                 error!("Error importing EML file: {:?}", err);
+                let mut message = "EML import error".to_string();
+                if matches!(err, EMLImportError::InvalidDistrict) {
+                    message = format!("{message}: Invalid district")
+                }
                 (
                     StatusCode::BAD_REQUEST,
-                    ErrorResponse::new("EML import error", ErrorReference::EmlImportError, false),
+                    ErrorResponse::new(message, ErrorReference::EmlImportError, false),
                 )
             }
             APIError::EmlError(err) => {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -62,6 +62,7 @@ pub enum ErrorReference {
     InvalidApportionmentState,
     InvalidCommitteeSessionStatus,
     InvalidData,
+    InvalidDistrict,
     InvalidHash,
     InvalidJson,
     InvalidPassword,
@@ -271,8 +272,8 @@ impl APIError {
                 (
                     StatusCode::BAD_REQUEST,
                     ErrorResponse::new(
-                        "EML import error: Invalid district".to_string(),
-                        ErrorReference::EmlImportError,
+                        "EML import error".to_string(),
+                        ErrorReference::InvalidDistrict,
                         false,
                     ),
                 )

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -266,15 +266,26 @@ impl APIError {
                     ),
                 )
             }
-            APIError::EmlImportError(err) => {
-                error!("Error importing EML file: {:?}", err);
-                let mut message = "EML import error".to_string();
-                if matches!(err, EMLImportError::InvalidDistrict) {
-                    message = format!("{message}: Invalid district")
-                }
+            APIError::EmlImportError(EMLImportError::InvalidDistrict) => {
+                error!("Error importing EML file: Invalid district");
                 (
                     StatusCode::BAD_REQUEST,
-                    ErrorResponse::new(message, ErrorReference::EmlImportError, false),
+                    ErrorResponse::new(
+                        "EML import error: Invalid district".to_string(),
+                        ErrorReference::EmlImportError,
+                        false,
+                    ),
+                )
+            }
+            APIError::EmlImportError(err) => {
+                error!("Error importing EML file: {:?}", err);
+                (
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::new(
+                        "EML import error".to_string(),
+                        ErrorReference::EmlImportError,
+                        false,
+                    ),
                 )
             }
             APIError::EmlError(err) => {

--- a/frontend/src/features/election_create/components/SelectGSB.test.tsx
+++ b/frontend/src/features/election_create/components/SelectGSB.test.tsx
@@ -95,7 +95,7 @@ describe("SelectGSB component", () => {
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     const user = userEvent.setup();
     overrideOnce("post", "/api/elections/import/validate", 400, {
-      error: "Invalid district",
+      error: "Eml import error",
       fatal: false,
       reference: "EmlImportError",
     });

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
@@ -73,6 +73,28 @@ describe("UploadCandidatesDefinition component", () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
+  test("Shows an error when uploading wrong candidates list file for district of GSB", async () => {
+    const state = { election, numberOfVoters: 0, electionDefinitionData: "mocked" };
+    const dispatch = vi.fn();
+    vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
+    overrideOnce("post", "/api/elections/import/validate", 400, {
+      error: "EML import error: Invalid district",
+      fatal: false,
+      reference: "EmlImportError",
+    });
+
+    await renderPage();
+    await uploadFile(file);
+
+    expect(screen.queryByLabelText("Geen bestand gekozen")).not.toBeInTheDocument();
+    expect(screen.getAllByText(filename).length).toBe(2);
+    expect(screen.getByRole("alert")).toHaveTextContent("Verkeerde kandidatenlijsten");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Het bestand foo.txt bevat kandidatenlijsten voor een andere kieskring. Kies een bestand met de kandidatenlijsten voor de juiste kieskring.",
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
   test("Shows error when frontend determines candidates list file is too large", async () => {
     const state = { election, numberOfVoters: 0, electionDefinitionData: "mocked" };
     const dispatch = vi.fn();

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.test.tsx
@@ -78,9 +78,9 @@ describe("UploadCandidatesDefinition component", () => {
     const dispatch = vi.fn();
     vi.spyOn(useElectionCreateContext, "useElectionCreateContext").mockReturnValue({ state, dispatch });
     overrideOnce("post", "/api/elections/import/validate", 400, {
-      error: "EML import error: Invalid district",
+      error: "EML import error",
       fatal: false,
-      reference: "EmlImportError",
+      reference: "InvalidDistrict",
     });
 
     await renderPage();

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -13,7 +13,6 @@ import type {
   ElectionDefinitionValidateResponse,
 } from "@/types/generated/openapi";
 import { fileTooLargeError, isFileTooLarge } from "@/utils/uploadFileSize";
-
 import { useElectionCreateContext } from "../hooks/useElectionCreateContext";
 import { CheckHash } from "./CheckHash";
 
@@ -21,10 +20,11 @@ import { CheckHash } from "./CheckHash";
 export function UploadCandidatesDefinition() {
   const { state, dispatch } = useElectionCreateContext();
   const navigate = useNavigate();
-  const [error, setError] = useState<ReactNode | undefined>();
+  const [error, setError] = useState<{ title: string; message: ReactNode } | undefined>();
   const [file, setFile] = useState<File | undefined>();
   const createPath: ELECTION_IMPORT_VALIDATE_REQUEST_PATH = `/api/elections/import/validate`;
   const { create } = useCrud<ElectionDefinitionValidateResponse>({ createPath });
+  const defaultErrorTitle = t("election.invalid_candidates_definition.title");
 
   // if no election data was stored, navigate back to beginning
   if (!state.electionDefinitionData) {
@@ -36,7 +36,7 @@ export function UploadCandidatesDefinition() {
     const currentFile = e.target.files ? e.target.files[0] : undefined;
     if (currentFile !== undefined) {
       if (await isFileTooLarge(currentFile)) {
-        setError(fileTooLargeError(currentFile));
+        setError({ title: defaultErrorTitle, message: fileTooLargeError(currentFile) });
         return;
       }
 
@@ -61,13 +61,21 @@ export function UploadCandidatesDefinition() {
       } else if (isError(response)) {
         // Response code 413 indicates that the file is too large
         if (response instanceof ApiError && response.code === 413) {
-          setError(fileTooLargeError(currentFile));
-        } else {
-          setError(
-            tx("election.invalid_candidates_definition.description", {
+          setError({ title: defaultErrorTitle, message: fileTooLargeError(currentFile) });
+        } else if (response instanceof ApiError && response.message.includes("EML import error: Invalid district")) {
+          setError({
+            title: t("election.wrong_candidates_definition.title"),
+            message: tx("election.wrong_candidates_definition.description", {
               file: () => <strong>{currentFile.name}</strong>,
             }),
-          );
+          });
+        } else {
+          setError({
+            title: defaultErrorTitle,
+            message: tx("election.invalid_candidates_definition.description", {
+              file: () => <strong>{currentFile.name}</strong>,
+            }),
+          });
         }
       }
     } else {
@@ -102,7 +110,7 @@ export function UploadCandidatesDefinition() {
           await navigate("/elections/create/polling-stations");
         }
       } else if (isError(response) && response instanceof ApiError && response.reference === "InvalidHash") {
-        setError(response.message);
+        setError({ title: defaultErrorTitle, message: response.message });
       }
     }
 
@@ -120,7 +128,7 @@ export function UploadCandidatesDefinition() {
           },
         })}
         redactedHash={state.candidateDefinitionRedactedHash}
-        error={error}
+        error={error ? error.message : undefined}
         onSubmit={(chunks) => void onSubmit(chunks)}
       />
     );
@@ -132,8 +140,8 @@ export function UploadCandidatesDefinition() {
         <FormLayout>
           <FormLayout.Section>
             {error && (
-              <Alert type="error" title={t("election.invalid_candidates_definition.title")} inline>
-                <p>{error}</p>
+              <Alert type="error" title={error.title} inline>
+                <p>{error.message}</p>
               </Alert>
             )}
 

--- a/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
+++ b/frontend/src/features/election_create/components/UploadCandidatesDefinition.tsx
@@ -62,7 +62,7 @@ export function UploadCandidatesDefinition() {
         // Response code 413 indicates that the file is too large
         if (response instanceof ApiError && response.code === 413) {
           setError({ title: defaultErrorTitle, message: fileTooLargeError(currentFile) });
-        } else if (response instanceof ApiError && response.message.includes("EML import error: Invalid district")) {
+        } else if (response instanceof ApiError && response.reference === "InvalidDistrict") {
           setError({
             title: t("election.wrong_candidates_definition.title"),
             message: tx("election.wrong_candidates_definition.description", {

--- a/frontend/src/i18n/locales/nl/election.json
+++ b/frontend/src/i18n/locales/nl/election.json
@@ -106,5 +106,9 @@
     "DSO_description": "Op de verkiezingsdag tellen de stembureaus de stemmen per kandidaat",
     "title": "Type stemopneming in"
   },
+  "wrong_candidates_definition": {
+    "description": "Het bestand <file>filename</file> bevat kandidatenlijsten voor een andere kieskring. Kies een bestand met de kandidatenlijsten voor de juiste kieskring.",
+    "title": "Verkeerde kandidatenlijsten"
+  },
   "you_cannot_start_data_entry_yet": "Je kan nog geen telresultaten invoeren."
 }

--- a/frontend/src/i18n/locales/nl/error.json
+++ b/frontend/src/i18n/locales/nl/error.json
@@ -28,6 +28,7 @@
     "InvalidApportionmentState": "De zetelverdeling is niet in de juiste status voor deze actie",
     "InvalidCommitteeSessionStatus": "De zitting is niet in de juiste status voor deze actie",
     "InvalidData": "De invoer is niet geldig",
+    "InvalidDistrict": "De kieskring in het EML-bestand correspondeert niet met de kieskring van het gekozen stembureau",
     "InvalidHash": "De hash is niet geldig",
     "InvalidJson": "De JSON is niet geldig",
     "InvalidPassword": "Het opgegeven wachtwoord is onjuist",

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1301,6 +1301,7 @@ export const errorReferenceValues = [
   "InvalidApportionmentState",
   "InvalidCommitteeSessionStatus",
   "InvalidData",
+  "InvalidDistrict",
   "InvalidHash",
   "InvalidJson",
   "InvalidPassword",


### PR DESCRIPTION
Closes #3840

## What & why

<img width="629" height="432" alt="Screenshot from 2026-09-03 17-00-00" src="https://github.com/user-attachments/assets/2c217738-c755-46de-9be1-a47b4ceba2ca" />

<!-- What does this change do, and why is it needed? Link the issue(s). -->

## How to test

- Upload [Verkiezingsdefinitie_PS2023_Limburg.eml.xml](https://github.com/user-attachments/files/31798833/Verkiezingsdefinitie_PS2023_Limburg.eml.xml)
- Choose GSB
- Choose Venlo
- Upload [Kandidatenlijsten_PS2023_Limburg_Maastricht.eml.xml](https://github.com/user-attachments/files/31798840/Kandidatenlijsten_PS2023_Limburg_Maastricht.eml.xml)
- Verify that the error in the screenshot above is shown instead of the default error
- Upload [Kandidatenlijsten_PS2023_Gelderland_Arnhem.eml.xml](https://github.com/user-attachments/files/31798851/Kandidatenlijsten_PS2023_Gelderland_Arnhem.eml.xml)
- Verify that the default error is shown

<!-- Setup needed, specific steps to trigger edge cases, the expected result. -->

## Reviewer notes

<!-- Suggested review order, non-obvious parts, anything that needs context. -->

<!--
## Checklist
- [x] Single, focused change: unrelated changes split into separate PRs
- [x] I've self-reviewed the diff
- [x] Formatter and linter pass locally
- [x] Tests added/updated and passing
- [x] Description explains how to test
-->