### PR TITLE
Update and deny yanked dependencies

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -644,9 +644,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -35,6 +35,7 @@ deny = [
 multiple-versions = "allow"
 
 [advisories]
+yanked = "deny"
 ignore = [
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is transitively used by Typst, see https://github.com/trishume/syntect/issues/537" },
     { id = "RUSTSEC-2024-0436", reason = "paste is transitively used by Typst (biblatex, https://github.com/typst/biblatex/issues/87) and by utoipa-axum; unmaintained but no vulnerability" },

--- a/backend/fuzz/Cargo.lock
+++ b/backend/fuzz/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## What & why

- Update the chacha20 crate to version 0.10.2 because version 0.10.1 was yanked, see upstream issue https://github.com/RustCrypto/stream-ciphers/pull/583.
- Let cargo-deny also deny yanked dependencies, so that cargo-deny reports usage of yanked dependencies as an error instead of a warning.

## How to test

[Install cargo-deny](https://github.com/embarkstudios/cargo-deny#usage), then `cargo deny check` in the `backend` directory should no longer report the yanked chacha20 dependency.
