### PR TITLE
Add Water Authority support of test election generator

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8588,7 +8588,8 @@
           "second_data_entry",
           "turnout",
           "candidate_distribution_slope",
-          "political_group_distribution_slope"
+          "political_group_distribution_slope",
+          "gsbs"
         ],
         "properties": {
           "candidate_distribution_slope": {
@@ -8625,6 +8626,10 @@
           "generate_p22_2_variants": {
             "type": "boolean",
             "description": "Generate multiple elections, each resulting in a different P 22-2 variant"
+          },
+          "gsbs": {
+            "$ref": "#/components/schemas/RandomRange",
+            "description": "Amount of GSBs"
           },
           "political_group_distribution_slope": {
             "$ref": "#/components/schemas/RandomRange"

--- a/backend/src/bin/gen-test-election.rs
+++ b/backend/src/bin/gen-test-election.rs
@@ -155,6 +155,10 @@ struct Args {
     #[arg(long, default_value = "1100", value_parser = parse_range::<u32>)]
     political_group_distribution_slope: Range<u32>,
 
+    /// Amount of GSBs
+    #[arg(long, default_value = "5..10", value_parser = parse_range::<u32>)]
+    gsbs: Range<u32>,
+
     /// Export the election definition, candidate list and polling stations to a directory
     #[arg(long)]
     export_definition: Option<PathBuf>,
@@ -182,6 +186,7 @@ impl From<Args> for GenerateElectionArgs {
             political_group_distribution_slope: RandomRange(
                 args.political_group_distribution_slope,
             ),
+            gsbs: RandomRange(args.gsbs),
         }
     }
 }

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -1,14 +1,14 @@
 use std::error::Error;
 
 use chrono::{Datelike, Days, NaiveDate, TimeDelta};
-use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom};
+use rand::{RngExt, SeedableRng, rngs::StdRng, seq::IndexedRandom};
 use sqlx::{SqliteConnection, SqlitePool};
 use tracing::{info, warn};
 
 use crate::{
     SqlitePoolExt,
     domain::{
-        committee_session::{CommitteeSession, CommitteeSessionCreateRequest},
+        committee_session::{CommitteeSession, CommitteeSessionCreateRequest, CommitteeSessionId},
         committee_session_status::CommitteeSessionStatus,
         data_entry::{
             DataEntryId, DataEntrySource, DataEntryStatus, Definitive, FirstEntryFinalised,
@@ -40,7 +40,7 @@ use crate::{
             votes_counts::VotesCounts,
             yes_no::YesNo,
         },
-        sub_committee::SubCommitteeFirstSession,
+        sub_committee::{SubCommitteeFirstSession, SubCommitteeNumber},
         validate::Validate,
     },
     repository::{
@@ -111,6 +111,42 @@ async fn generate_csb_data_entries(
     Ok(second_entries > 0)
 }
 
+#[expect(clippy::too_many_arguments)]
+async fn generate_csb_sub_committee(
+    conn: &mut SqliteConnection,
+    rng: &mut StdRng,
+    args: &GenerateElectionArgs,
+    committee_session_id: CommitteeSessionId,
+    number: SubCommitteeNumber,
+    name: &str,
+    election: &ElectionWithPoliticalGroups,
+    votes: Option<Vec<Vec<u32>>>,
+) -> Result<bool, Box<dyn Error>> {
+    let sub_committee_first_session = create_sub_committee(
+        conn,
+        committee_session_id,
+        number,
+        name,
+        CommitteeCategory::GSB,
+    )
+    .await
+    .map_err(|e| format!("{e:?}"))?;
+
+    if args.with_data_entry {
+        generate_csb_data_entries(
+            conn,
+            rng,
+            args,
+            sub_committee_first_session,
+            election,
+            votes,
+        )
+        .await
+    } else {
+        Ok(false)
+    }
+}
+
 /// Generate polling stations and data entries for a GSB election
 async fn generate_gsb_election_data(
     rng: &mut StdRng,
@@ -171,65 +207,41 @@ async fn generate_csb_election_data(
                 .expect("Municipal elections should have a domain id")
                 .parse()
                 .expect("domain_id should be numeric");
-            let sub_committee_first_session = create_sub_committee(
+            generate_csb_sub_committee(
                 tx,
+                rng,
+                args,
                 committee_session.id,
                 number,
                 &election.location,
-                CommitteeCategory::GSB,
+                election,
+                votes,
             )
-            .await
-            .map_err(|e| format!("{e:?}"))?;
-
-            if args.with_data_entry {
-                generate_csb_data_entries(
-                    tx,
-                    rng,
-                    args,
-                    sub_committee_first_session,
-                    election,
-                    votes,
-                )
-                .await?
-            } else {
-                false
-            }
-        }
-        ElectionCategory::Provincial => {
-            todo!()
+            .await?
         }
         ElectionCategory::WaterAuthority => {
-            let mut data_entry_completes = Vec::new();
-            for i in 0..2 {
-                let number = i;
-                let sub_committee_first_session = create_sub_committee(
-                    tx,
-                    committee_session.id,
-                    number,
-                    &locality(rng),
-                    CommitteeCategory::GSB,
-                )
-                .await
-                .map_err(|e| format!("{e:?}"))?;
-
-                if args.with_data_entry {
-                    data_entry_completes.push(
-                        generate_csb_data_entries(
-                            tx,
-                            rng,
-                            args,
-                            sub_committee_first_session,
-                            election,
-                            votes.clone(),
-                        )
-                        .await?,
+            // We need at least one GSB
+            let gsbs = rng.random_range(args.gsbs.clone()).max(1);
+            let mut data_entry_complete = args.with_data_entry;
+            for number in 1..=gsbs {
+                let name = locality(rng);
+                data_entry_complete = data_entry_complete
+                    && generate_csb_sub_committee(
+                        tx,
+                        rng,
+                        args,
+                        committee_session.id,
+                        number,
+                        name,
+                        election,
+                        votes.clone(),
                     )
-                } else {
-                    data_entry_completes.push(false);
-                };
+                    .await?;
             }
-
-            !data_entry_completes.contains(&false)
+            data_entry_complete
+        }
+        ElectionCategory::Provincial => {
+            todo!("Provincial CSB election generation not supported")
         }
     };
 
@@ -1146,6 +1158,7 @@ mod tests {
             committee_category,
             counting_method,
             election_category: ElectionCategory::Municipal,
+            election_category,
             political_groups: RandomRange(3..4),
             candidates_per_group: RandomRange(3..10),
             polling_stations: RandomRange(3..4),
@@ -1159,6 +1172,7 @@ mod tests {
             turnout: RandomRange(60..85),
             candidate_distribution_slope: RandomRange(1100..1101),
             political_group_distribution_slope: RandomRange(1100..1101),
+            gsbs: RandomRange(5..10),
         }
     }
 

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -1149,15 +1149,15 @@ mod tests {
         test_data_gen::RandomRange,
     };
 
-    fn municipal(
+    fn election(
         committee_category: CommitteeCategory,
+        election_category: ElectionCategory,
         counting_method: Option<VoteCountingMethod>,
     ) -> GenerateElectionArgs {
         GenerateElectionArgs {
             custom_name: None,
             committee_category,
             counting_method,
-            election_category: ElectionCategory::Municipal,
             election_category,
             political_groups: RandomRange(3..4),
             candidates_per_group: RandomRange(3..10),
@@ -1179,12 +1179,18 @@ mod tests {
     #[sqlx::test]
     async fn test_create_test_election(pool: SqlitePool) {
         use CommitteeCategory::*;
+        use ElectionCategory::*;
         use VoteCountingMethod::*;
 
         let creation_results = [
-            create_test_election(&municipal(GSB, Some(CSO)), &pool, None).await,
-            create_test_election(&municipal(GSB, Some(DSO)), &pool, None).await,
-            create_test_election(&municipal(CSB, None), &pool, None).await,
+            create_test_election(&election(GSB, Municipal, Some(CSO)), &pool, None).await,
+            create_test_election(&election(GSB, Municipal, Some(DSO)), &pool, None).await,
+            create_test_election(&election(CSB, Municipal, None), &pool, None).await,
+            create_test_election(&election(CSB, Municipal, None), &pool, None).await,
+            create_test_election(&election(GSB, WaterAuthority, Some(CSO)), &pool, None).await,
+            create_test_election(&election(GSB, WaterAuthority, Some(DSO)), &pool, None).await,
+            create_test_election(&election(CSB, WaterAuthority, None), &pool, None).await,
+            create_test_election(&election(CSB, WaterAuthority, None), &pool, None).await,
         ];
 
         let mut conn = pool.acquire().await.unwrap();

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -50,7 +50,7 @@ use crate::{
         user_repo::UserId,
     },
     service::create_sub_committee,
-    test_data_gen::{GenerateElectionArgs, RandomRange},
+    test_data_gen::{GenerateElectionArgs, RandomRange, data::locality},
 };
 
 #[derive(Debug)]
@@ -160,34 +160,77 @@ async fn generate_csb_election_data(
     election: &ElectionWithPoliticalGroups,
     votes: Option<Vec<Vec<u32>>>,
 ) -> Result<(Vec<PollingStation>, bool), Box<dyn Error>> {
-    let data_entry_complete = if election.category == ElectionCategory::Municipal {
-        let number = election
-            .domain
-            .as_ref()
-            .expect("Municipal elections should have a domain")
-            .id
-            .as_ref()
-            .expect("Municipal elections should have a domain id")
-            .parse()
-            .expect("domain_id should be numeric");
-        let sub_committee_first_session = create_sub_committee(
-            tx,
-            committee_session.id,
-            number,
-            &election.location,
-            CommitteeCategory::GSB,
-        )
-        .await
-        .map_err(|e| format!("{e:?}"))?;
+    let data_entry_complete = match election.category {
+        ElectionCategory::Municipal => {
+            let number = election
+                .domain
+                .as_ref()
+                .expect("Municipal elections should have a domain")
+                .id
+                .as_ref()
+                .expect("Municipal elections should have a domain id")
+                .parse()
+                .expect("domain_id should be numeric");
+            let sub_committee_first_session = create_sub_committee(
+                tx,
+                committee_session.id,
+                number,
+                &election.location,
+                CommitteeCategory::GSB,
+            )
+            .await
+            .map_err(|e| format!("{e:?}"))?;
 
-        if args.with_data_entry {
-            generate_csb_data_entries(tx, rng, args, sub_committee_first_session, election, votes)
+            if args.with_data_entry {
+                generate_csb_data_entries(
+                    tx,
+                    rng,
+                    args,
+                    sub_committee_first_session,
+                    election,
+                    votes,
+                )
                 .await?
-        } else {
-            false
+            } else {
+                false
+            }
         }
-    } else {
-        false
+        ElectionCategory::Provincial => {
+            todo!()
+        }
+        ElectionCategory::WaterAuthority => {
+            let mut data_entry_completes = Vec::new();
+            for i in 0..2 {
+                let number = i;
+                let sub_committee_first_session = create_sub_committee(
+                    tx,
+                    committee_session.id,
+                    number,
+                    &locality(rng),
+                    CommitteeCategory::GSB,
+                )
+                .await
+                .map_err(|e| format!("{e:?}"))?;
+
+                if args.with_data_entry {
+                    data_entry_completes.push(
+                        generate_csb_data_entries(
+                            tx,
+                            rng,
+                            args,
+                            sub_committee_first_session,
+                            election,
+                            votes.clone(),
+                        )
+                        .await?,
+                    )
+                } else {
+                    data_entry_completes.push(false);
+                };
+            }
+
+            !data_entry_completes.contains(&false)
+        }
     };
 
     let new_status = match (args.with_data_entry, data_entry_complete) {

--- a/backend/src/test_data_gen/mod.rs
+++ b/backend/src/test_data_gen/mod.rs
@@ -70,6 +70,9 @@ pub struct GenerateElectionArgs {
 
     pub candidate_distribution_slope: RandomRange,
     pub political_group_distribution_slope: RandomRange,
+
+    /// Amount of GSBs
+    pub gsbs: RandomRange,
 }
 
 impl<'de> Deserialize<'de> for RandomRange {

--- a/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
+++ b/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
@@ -199,7 +199,10 @@ export function GenerateTestElectionForm() {
             </ChoiceList>
             {RANGE_FIELDS.map((field) => {
               // Skip GSB's field when only one GSB is ever generated
-              if (field.key === "gsbs" && (formState.committee_category === "GSB" || formState.election_category === "Municipal")) {
+              if (
+                field.key === "gsbs" &&
+                (formState.committee_category === "GSB" || formState.election_category === "Municipal")
+              ) {
                 return null;
               }
 

--- a/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
+++ b/frontend/src/features/dev/components/GenerateTestElectionForm.tsx
@@ -22,6 +22,7 @@ import { StringFormData } from "@/utils/stringFormData";
 const RANGE_HINT = "Gebruik notatie zoals 10..50 of 9..=45 of een enkel getal zoals 40";
 
 const RANGE_FIELDS = [
+  { key: "gsbs", label: "Aantal GSB's", placeholder: "5..10" },
   { key: "political_groups", label: "Aantal politieke partijen", placeholder: "20..50" },
   { key: "candidates_per_group", label: "Aantal kandidaten per partij", placeholder: "10..50" },
   { key: "polling_stations", label: "Aantal stembureaus", placeholder: "50..200" },
@@ -197,6 +198,11 @@ export function GenerateTestElectionForm() {
               ))}
             </ChoiceList>
             {RANGE_FIELDS.map((field) => {
+              // Skip GSB's field when only one GSB is ever generated
+              if (field.key === "gsbs" && (formState.committee_category === "GSB" || formState.election_category === "Municipal")) {
+                return null;
+              }
+
               const input = (
                 <InputField
                   id={field.key}

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -1441,6 +1441,8 @@ export interface GenerateElectionArgs {
   generate_drawing_lots: boolean;
   /** Generate multiple elections, each resulting in a different P 22-2 variant */
   generate_p22_2_variants: boolean;
+  /** Amount of GSBs */
+  gsbs: RandomRange;
   political_group_distribution_slope: RandomRange;
   /** Number of political groups to create */
   political_groups: RandomRange;


### PR DESCRIPTION
## What & why

Closes #3918
Add support for Water Authority to test election generator


## How to test
Create elections via `/dev` "Genereer testverkiezing"

## Reviewer notes
Check for correct visibility of input field "Aantal GSB's"
Check that multiple GSB's are generated as provided by "Aantal GSB's"
Duplicate GSB names are very much possible, I'm not sure if we need to bother avoiding them though, let me know.

<!--
## Checklist

- [ ] Single, focused change: unrelated changes split into separate PRs
- [ ] I've self-reviewed the diff
- [ ] Formatter and linter pass locally
- [ ] Tests added/updated and passing
- [ ] Description explains how to test
-->