### PR TITLE
Models: Improve checkbox layout

### DIFF
--- a/backend/templates/common/scripts.typ
+++ b/backend/templates/common/scripts.typ
@@ -8,7 +8,7 @@
   category == "Municipal"
 ) { local } else { other }
 
-#let get_district_number = (district) => if (district.district == "Specific") { 
+#let get_district_number = (district) => if (district.district == "Specific") {
   if ("number" in district.key) {
     if (district.roman_numerals) { numbering("I", district.key.number) } else { district.key.number }
   } else { "" }
@@ -134,29 +134,44 @@
   ))
 }
 
-/// Display a checkbox, optionally already checked when the `checked` parameter is set to `true`
+/// Display a checkbox, optionally already checked when the `checked` parameter is set to `true`.
+/// Checkboxes with multiline labels are vertically aligned with the first line of the label.
 #let checkbox(checked: none, small: false, content) = {
-  let has_content = content != none and content != ""
-  let size = if checked == true or checked == none and not small { 14pt } else { 10pt }
+  let box_size = if checked == true or (checked == none and not small) { 14pt } else { 10pt }
+  let column_width = 14pt
+  let gutter = 6pt
+
+  let le_box = box(
+    width: box_size,
+    height: box_size,
+    inset: 2.5pt,
+    stroke: if checked == none or checked == true { 0.5pt + black } else {
+      (thickness: 0.4pt, dash: "densely-dotted", cap: "square")
+    },
+    clip: true,
+    fill: if checked == true { black } else { white },
+    if checked == true { checkmark() },
+  )
 
   block(width: 75%,
-    grid(
-      columns: if has_content { (14pt, 6pt, auto) } else { (size) },
-      align: horizon + center,
-      box(
-        width: size,
-        height: size,
-        inset: 2.5pt,
-        stroke: if checked == none or checked == true { 0.5pt + black } else {
-          (thickness: 0.4pt, dash: "densely-dotted", cap: "square")
-        },
-        clip: true,
-        fill: if checked == true { black } else { white },
-        if checked == true { checkmark() },
-      ),
-      if has_content { " " },
-      if has_content { align(left, content) },
-    )
+    layout(block_size => context { // `layout` is needed to give `block` a measurable width
+      let label_width = block_size.width - column_width - gutter
+      let line_height = measure([A]).height
+      let rendered_height = measure(content, width: label_width).height
+      let multiline = rendered_height >= (line_height * 2)
+
+      grid(
+        columns: (column_width, gutter, auto),
+        align: horizon + center,
+        grid.cell(
+          align: if multiline { top + center } else { horizon + center },
+          // From `top` we use half of the difference to move the box up.
+          if multiline { move(dy: (line_height - box_size) / 2, le_box) } else { le_box },
+        ),
+        " ",
+        align(left, content),
+      )
+    })
   )
 }
 


### PR DESCRIPTION
## What & why

Resolves https://github.com/kiesraad/abacus/issues/3886

This change ensures checkboxes in the Typst models are vertically center aligned to the first line of the label accompanying the checkbox. 

Default rendering vertically center aligns the checkbox in relation to the whole 'cell': 

<kbd>
<img width="1218" height="230" alt="image" src="https://github.com/user-attachments/assets/4402ab06-a21a-4e8f-b6bd-ec85bf550c70" />
</kbd>

<br><br>

We now compare the line height of the font to the rendered height of the label and adjust the position the checkbox when needed. Result: 

<kbd>
<img width="1204" height="298" alt="image" src="https://github.com/user-attachments/assets/7c7a1a96-3e29-4647-90f8-1dff2f6d9317" />
</kbd>

<br><br>


<kbd>
<img width="1212" height="353" alt="image" src="https://github.com/user-attachments/assets/178f8e7b-9092-43cc-9df1-fb966c59f72f" />
</kbd>

## How to test

Use `cargo run --bin gen-pdf` or `visual-diff.sh` or check the CI artifacts.


Run 
## Reviewer notes

Removed the `has_content` check, as it always resulted in `true` - also when no label was intended. The codebase uses e.g. `checkbox(small: true)[]`) to render a checkbox without label. So, the arm was, and will be, never activated. All functionality has been preserved (all rendered models yield identical PDF output).
