### PR TITLE
Public key upload reminder

### DIFF
--- a/backend/.sqlx/query-e988f3341c3474bee3630d26f816dd50543a37cff2b708a201874f24b59e773d.json
+++ b/backend/.sqlx/query-e988f3341c3474bee3630d26f816dd50543a37cff2b708a201874f24b59e773d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            UPDATE signing_keypair\n            SET show_reminder = $1\n            WHERE election_id = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "e988f3341c3474bee3630d26f816dd50543a37cff2b708a201874f24b59e773d"
+}

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6260,6 +6260,7 @@
           "UserDeleted",
           "ElectionCreated",
           "ElectionUpdated",
+          "PublicKeyUploadReminderDismissed",
           "CommitteeSessionCreated",
           "CommitteeSessionDeleted",
           "CommitteeSessionUpdated",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3220,6 +3220,65 @@
         ]
       }
     },
+    "/api/elections/{election_id}/dismiss_public_key_upload_reminder": {
+      "put": {
+        "summary": "administrator",
+        "operationId": "dismiss_public_key_upload_reminder",
+        "parameters": [
+          {
+            "name": "election_id",
+            "in": "path",
+            "description": "Election database id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ElectionId"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Public key upload reminder dismissed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookie_auth": [
+              "administrator"
+            ]
+          }
+        ]
+      }
+    },
     "/api/elections/{election_id}/download_n_10_1": {
       "get": {
         "summary": "administrator, coordinator_gsb",
@@ -7949,6 +8008,9 @@
             "items": {
               "$ref": "#/components/schemas/PollingStation"
             }
+          },
+          "show_keypair_reminder": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/backend/src/api/election.rs
+++ b/backend/src/api/election.rs
@@ -41,7 +41,7 @@ use crate::{
         polling_stations_from_eml_str,
     },
     infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
-    repository::{committee_session_repo, election_repo, user_repo::User},
+    repository::{committee_session_repo, election_repo, signing_keypair_repo, user_repo::User},
     service::{create_sub_committee, list_polling_stations_for_session},
 };
 
@@ -81,6 +81,9 @@ pub struct ElectionDetailsResponse {
     pub election: ElectionWithPoliticalGroups,
     pub polling_stations: Vec<PollingStationResponse>,
     pub investigations: Vec<PollingStationInvestigation>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[schema(nullable = false)]
+    pub show_keypair_reminder: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -205,6 +208,8 @@ pub async fn election_details(
         list_polling_stations_for_session(&mut conn, &current_committee_session).await?;
     let investigations = session_pss.investigations();
     let polling_stations = session_pss.into_responses(election_id);
+    let show_keypair_reminder =
+        signing_keypair_repo::get_show_reminder(&mut conn, election_id).await?;
 
     Ok(Json(ElectionDetailsResponse {
         current_committee_session,
@@ -212,6 +217,7 @@ pub async fn election_details(
         election,
         polling_stations,
         investigations,
+        show_keypair_reminder,
     }))
 }
 

--- a/backend/src/api/signing.rs
+++ b/backend/src/api/signing.rs
@@ -1,6 +1,7 @@
 use axum::{
     Json,
     extract::{Path, State},
+    http::StatusCode,
     response::IntoResponse,
 };
 use axum_extra::response::Attachment;
@@ -18,7 +19,7 @@ use crate::{
         role::Role,
     },
     error::ErrorReference,
-    repository::election_repo,
+    repository::{election_repo, signing_keypair_repo},
 };
 
 pub fn router() -> OpenApiRouter<AppState> {
@@ -27,6 +28,36 @@ pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(certificate).authorize(ADMIN))
         .routes(routes!(certificate_details).authorize(ADMIN))
+        .routes(routes!(dismiss_public_key_upload_reminder).authorize(ADMIN))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/elections/{election_id}/dismiss_public_key_upload_reminder",
+    responses(
+        (status = 204, description = "Public key upload reminder dismissed"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 404, description = "Not Found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    ),
+    params(
+        ("election_id" = ElectionId, description = "Election database id"),
+    ),
+)]
+pub async fn dismiss_public_key_upload_reminder(
+    State(pool): State<SqlitePool>,
+    Path(election_id): Path<ElectionId>,
+) -> Result<StatusCode, APIError> {
+    let mut conn = pool.acquire().await?;
+    let updated = signing_keypair_repo::set_show_reminder(&mut conn, election_id, false).await?;
+    if !updated {
+        return Err(APIError::NotFound(
+            "No signing keypair found for this election".into(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[derive(Serialize, ToSchema, Debug)]

--- a/backend/src/api/signing.rs
+++ b/backend/src/api/signing.rs
@@ -12,15 +12,27 @@ use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
-    APIError, AppState, ErrorResponse,
+    APIError, AppState, ErrorResponse, SqlitePoolExt,
     api::middleware::authentication::RouteAuthorization,
     domain::{
         election::{CommitteeCategory, ElectionId},
         role::Role,
     },
     error::ErrorReference,
+    infra::audit_log::{AsAuditEvent, AuditEventLevel, AuditEventType, AuditService},
     repository::{election_repo, signing_keypair_repo},
 };
+
+#[derive(Serialize)]
+struct PublicKeyUploadReminderDismissedAuditData {
+    pub election_id: ElectionId,
+    pub election_name: String,
+}
+
+impl AsAuditEvent for PublicKeyUploadReminderDismissedAuditData {
+    const EVENT_TYPE: AuditEventType = AuditEventType::PublicKeyUploadReminderDismissed;
+    const EVENT_LEVEL: AuditEventLevel = AuditEventLevel::Success;
+}
 
 pub fn router() -> OpenApiRouter<AppState> {
     const ADMIN: &[Role] = &[Role::Administrator];
@@ -46,16 +58,32 @@ pub fn router() -> OpenApiRouter<AppState> {
 )]
 pub async fn dismiss_public_key_upload_reminder(
     State(pool): State<SqlitePool>,
+    audit_service: AuditService,
     Path(election_id): Path<ElectionId>,
 ) -> Result<StatusCode, APIError> {
-    let mut conn = pool.acquire().await?;
-    let updated = signing_keypair_repo::set_show_reminder(&mut conn, election_id, false).await?;
+    let mut tx = pool.begin_immediate().await?;
+    let election = election_repo::get(&mut tx, election_id).await?;
+
+    let updated = signing_keypair_repo::set_show_reminder(&mut tx, election_id, false).await?;
     if !updated {
         return Err(APIError::NotFound(
             "No signing keypair found for this election".into(),
             ErrorReference::EntryNotFound,
         ));
     }
+
+    audit_service
+        .log(
+            &mut tx,
+            &PublicKeyUploadReminderDismissedAuditData {
+                election_id,
+                election_name: election.name,
+            },
+            None,
+        )
+        .await?;
+
+    tx.commit().await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/src/infra/audit_log/audit_event.rs
+++ b/backend/src/infra/audit_log/audit_event.rs
@@ -110,6 +110,8 @@ pub enum AuditEventType {
     // election events
     ElectionCreated,
     ElectionUpdated,
+    // signing events
+    PublicKeyUploadReminderDismissed,
     // committee session events
     CommitteeSessionCreated,
     CommitteeSessionDeleted,

--- a/backend/src/repository/signing_keypair_repo.rs
+++ b/backend/src/repository/signing_keypair_repo.rs
@@ -44,6 +44,25 @@ pub async fn get_show_reminder(
     .await
 }
 
+pub async fn set_show_reminder(
+    conn: &mut SqliteConnection,
+    election_id: ElectionId,
+    show_reminder: bool,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query!(
+        r#"
+            UPDATE signing_keypair
+            SET show_reminder = $1
+            WHERE election_id = $2
+        "#,
+        show_reminder,
+        election_id
+    )
+    .execute(conn)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
 pub async fn create(
     conn: &mut SqliteConnection,
     election_id: ElectionId,
@@ -107,6 +126,48 @@ mod tests {
         assert_eq!(
             get_private_key(&mut conn, election_id).await.unwrap(),
             Some(private_key)
+        );
+        assert_eq!(
+            get_show_reminder(&mut conn, election_id).await.unwrap(),
+            Some(true)
+        );
+    }
+
+    #[test(sqlx::test(fixtures("../../fixtures/election_1.sql")))]
+    async fn test_set_show_reminder(pool: SqlitePool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let election_id = ElectionId::from(1);
+
+        // no keypair, nothing to update
+        assert!(
+            !set_show_reminder(&mut conn, election_id, false)
+                .await
+                .unwrap()
+        );
+
+        create(
+            &mut conn,
+            election_id,
+            String::from("testing"),
+            Zeroizing::new(Vec::from("123456")),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            set_show_reminder(&mut conn, election_id, false)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            get_show_reminder(&mut conn, election_id).await.unwrap(),
+            Some(false)
+        );
+
+        assert!(
+            set_show_reminder(&mut conn, election_id, true)
+                .await
+                .unwrap()
         );
         assert_eq!(
             get_show_reminder(&mut conn, election_id).await.unwrap(),

--- a/backend/src/test_data_gen/generators.rs
+++ b/backend/src/test_data_gen/generators.rs
@@ -4,6 +4,7 @@ use chrono::{Datelike, Days, NaiveDate, TimeDelta};
 use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom};
 use sqlx::{SqliteConnection, SqlitePool};
 use tracing::{info, warn};
+use zeroize::Zeroizing;
 
 use crate::{
     SqlitePoolExt,
@@ -46,7 +47,7 @@ use crate::{
     repository::{
         committee_session_repo,
         data_entry_repo::{self, list_results_for_committee_session},
-        election_repo, polling_station_repo,
+        election_repo, polling_station_repo, signing_keypair_repo,
         user_repo::UserId,
     },
     service::create_sub_committee,
@@ -201,6 +202,7 @@ async fn generate_csb_election_data(
     Ok((Vec::new(), data_entry_complete))
 }
 
+#[expect(clippy::too_many_lines)]
 pub async fn create_test_election(
     args: &GenerateElectionArgs,
     pool: &SqlitePool,
@@ -213,6 +215,18 @@ pub async fn create_test_election(
     // generate and store the election
     let election =
         election_repo::create(&mut tx, generate_election(&mut rng, args, votes.as_ref())).await?;
+
+    // TODO generate an actual signing keypair in issue #3769
+    // stub record for signing keypair
+    if election.committee_category == CommitteeCategory::GSB {
+        signing_keypair_repo::create(
+            &mut tx,
+            election.id,
+            "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----".to_string(),
+            Zeroizing::new(Vec::new()),
+        )
+        .await?
+    }
 
     // generate the committee session for the election
     let mut committee_session = committee_session_repo::create(

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -34,13 +34,15 @@ export function Messages() {
       {message.title && <strong className="heading-md">{message.title}</strong>}
       {message.text && (
         <p>
-          {message.text.split("\n").map((line, lineIndex) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: we can use the index as key since there is no unique id
-            <Fragment key={lineIndex}>
-              {line}
-              <br />
-            </Fragment>
-          ))}
+          {typeof message.text === "string"
+            ? message.text.split("\n").map((line, lineIndex) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: we can use the index as key since there is no unique id
+                <Fragment key={lineIndex}>
+                  {line}
+                  <br />
+                </Fragment>
+              ))
+            : message.text}
         </p>
       )}
     </Alert>

--- a/frontend/src/features/data_entry/components/AbortDataEntryControl.test.tsx
+++ b/frontend/src/features/data_entry/components/AbortDataEntryControl.test.tsx
@@ -37,6 +37,7 @@ describe("AbortDataEntryControl", () => {
       pollingStation: undefined,
       investigations: [],
       investigation: undefined,
+      showKeypairReminder: undefined,
       refetch: () =>
         Promise.resolve({
           status: ApiResponseStatus.Success,

--- a/frontend/src/features/election_management/components/ElectionCertificatePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionCertificatePage.test.tsx
@@ -1,15 +1,27 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import * as ReactRouter from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ElectionCertificatePage } from "@/features/election_management/components/ElectionCertificatePage";
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
-import { ElectionCertificateDetailsRequestHandler, ElectionRequestHandler } from "@/testing/api-mocks/RequestHandlers";
-import { server } from "@/testing/server";
-import { render, screen } from "@/testing/test-utils";
+import { MessagesProvider } from "@/hooks/messages/MessagesProvider";
+import * as useMessages from "@/hooks/messages/useMessages";
+import { tx } from "@/i18n/translate";
+import { getElectionMockData } from "@/testing/api-mocks/ElectionMockData";
+import {
+  DismissPublicKeyUploadReminderRequestHandler,
+  ElectionCertificateDetailsRequestHandler,
+  ElectionRequestHandler,
+} from "@/testing/api-mocks/RequestHandlers";
+import { overrideOnce, server } from "@/testing/server";
+import { render, screen, spyOnHandler, waitFor } from "@/testing/test-utils";
 
 async function renderPage() {
   render(
-    <ElectionProvider electionId={1}>
-      <ElectionCertificatePage />
-    </ElectionProvider>,
+    <MessagesProvider>
+      <ElectionProvider electionId={1}>
+        <ElectionCertificatePage />
+      </ElectionProvider>
+    </MessagesProvider>,
   );
 
   return expect(await screen.findByRole("heading", { level: 1, name: "Publieke sleutel" })).toBeVisible();
@@ -17,7 +29,11 @@ async function renderPage() {
 
 describe("ElectionCertificatePage", () => {
   beforeEach(() => {
-    server.use(ElectionCertificateDetailsRequestHandler, ElectionRequestHandler);
+    server.use(
+      ElectionCertificateDetailsRequestHandler,
+      ElectionRequestHandler,
+      DismissPublicKeyUploadReminderRequestHandler,
+    );
   });
 
   test("renders certificate information", async () => {
@@ -41,5 +57,64 @@ describe("ElectionCertificatePage", () => {
     );
 
     expect(downloadLink).toHaveAttribute("href", "/api/elections/1/certificate");
+  });
+
+  test("renders keypair reminder when showKeypairReminder is true", async () => {
+    overrideOnce("get", "/api/elections/1", 200, { ...getElectionMockData(), show_keypair_reminder: true });
+
+    await renderPage();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Registreer Abacus-instantie GSB Heemdamseburg bij de Kiesraad" }),
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Upload het crt-bestand naar het overdrachtsplatform",
+      }),
+    ).toBeVisible();
+    expect(screen.getByText("Doe dit uiterlijk twee dagen voor de dag van stemming.")).toBeVisible();
+  });
+
+  test("does not render keypair reminder when showKeypairReminder is false", async () => {
+    overrideOnce("get", "/api/elections/1", 200, { ...getElectionMockData(), show_keypair_reminder: false });
+
+    await renderPage();
+    expect(screen.getByRole("heading", { level: 2, name: "Publieke sleutel Abacus-instantie GSB Heemdamseburg" }));
+
+    expect(
+      screen.queryByRole("heading", {
+        level: 3,
+        name: "Upload het crt-bestand naar het overdrachtsplatform",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Doe dit uiterlijk twee dagen voor de dag van stemming.")).not.toBeInTheDocument();
+  });
+
+  test("confirming the upload updates the reminder, sets a message and navigates to election home page", async () => {
+    const navigate = vi.fn();
+    const pushMessage = vi.fn();
+    vi.spyOn(ReactRouter, "useNavigate").mockImplementation(() => navigate);
+    vi.spyOn(useMessages, "useMessages").mockReturnValue({
+      pushMessage,
+      popMessages: vi.fn(() => []),
+      hasMessages: vi.fn(() => false),
+    });
+    const dismissReminder = spyOnHandler(DismissPublicKeyUploadReminderRequestHandler);
+    overrideOnce("get", "/api/elections/1", 200, { ...getElectionMockData(), show_keypair_reminder: true });
+    const user = userEvent.setup();
+
+    await renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Ik heb dit gedaan" }));
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith("/elections/1");
+    });
+    expect(dismissReminder).toHaveBeenCalledOnce();
+    expect(pushMessage).toHaveBeenCalledWith({
+      title: "Publieke sleutel geregistreerd",
+      text: tx("election_certificate.upload.message.text"),
+    });
   });
 });

--- a/frontend/src/features/election_management/components/ElectionCertificatePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionCertificatePage.tsx
@@ -1,29 +1,51 @@
+import { useNavigate } from "react-router";
+import { isSuccess } from "@/api/ApiResult";
+import { useCrud } from "@/api/useCrud";
 import { useInitialApiGet } from "@/api/useInitialApiGet";
 import { Footer } from "@/components/footer/Footer";
 import { IconCertificate } from "@/components/generated/icons";
 import { PageTitle } from "@/components/page_title/PageTitle";
+import { Button } from "@/components/ui/Button/Button";
 import { DownloadButton } from "@/components/ui/DownloadButton/DownloadButton";
 import { Icon } from "@/components/ui/Icon/Icon";
 import cls from "@/features/election_management/components/ElectionManagement.module.css";
 import { useElection } from "@/hooks/election/useElection";
+import { useMessages } from "@/hooks/messages/useMessages";
 import { t } from "@/i18n/translate";
 import type {
   CERTIFICATE_DETAILS_REQUEST_PATH,
   CERTIFICATE_REQUEST_PATH,
   CertificateDetailsResponse,
+  DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH,
 } from "@/types/generated/openapi";
 import { formatDateFullWithoutWeekday } from "@/utils/dateTime";
 
 const formatDate = (date: string) => formatDateFullWithoutWeekday(new Date(date));
 
 export function ElectionCertificatePage() {
-  const { election } = useElection();
+  const { election, showKeypairReminder } = useElection();
+  const navigate = useNavigate();
+  const { pushMessage } = useMessages();
 
   const detailsUrl: CERTIFICATE_DETAILS_REQUEST_PATH = `/api/elections/${election.id}/certificate_details`;
   const downloadUrl: CERTIFICATE_REQUEST_PATH = `/api/elections/${election.id}/certificate`;
+  const dismissReminderUrl: DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH = `/api/elections/${election.id}/dismiss_public_key_upload_reminder`;
 
   const { requestState } = useInitialApiGet<CertificateDetailsResponse>(detailsUrl);
   const certificate = requestState.status === "success" && requestState.data;
+
+  const { update: dismissReminder, isLoading } = useCrud({ updatePath: dismissReminderUrl, throwAllErrors: true });
+
+  async function handleUploadDone() {
+    const result = await dismissReminder({});
+    if (isSuccess(result)) {
+      pushMessage({
+        title: t("election_certificate.upload.message.title"),
+        text: t("election_certificate.upload.message.text"),
+      });
+      void navigate(`/elections/${election.id}`);
+    }
+  }
 
   const pageTitle = t("election_certificate.certificate");
 
@@ -44,7 +66,11 @@ export function ElectionCertificatePage() {
             <Icon size="lg" color="default" icon={<IconCertificate />} />
           </div>
           <div>
-            <h2 className="form_title">{t("election_certificate.subtitle", { committee })}</h2>
+            <h2 className="form_title">
+              {t(`election_certificate.subtitle.${showKeypairReminder ? "before_upload" : "after_upload"}`, {
+                committee,
+              })}
+            </h2>
             <section className="sm flex-column">
               <p>{t("election_certificate.explanation")}</p>
               <h3>{t("election_certificate.certificate")}</h3>
@@ -72,6 +98,17 @@ export function ElectionCertificatePage() {
                 t("loading")
               )}
             </section>
+            {showKeypairReminder && (
+              <section className="sm flex-column mt-xl">
+                <h3>{t("election_certificate.upload.title")}</h3>
+                <p>{t("election_certificate.upload.explanation")}</p>
+                <div className="mt-md-lg">
+                  <Button variant="primary" size="md" disabled={isLoading} onClick={() => void handleUploadDone()}>
+                    {t("election_certificate.upload.done")}
+                  </Button>
+                </div>
+              </section>
+            )}
           </div>
         </article>
       </main>

--- a/frontend/src/features/election_management/components/ElectionCertificatePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionCertificatePage.tsx
@@ -23,7 +23,7 @@ import { formatDateFullWithoutWeekday } from "@/utils/dateTime";
 const formatDate = (date: string) => formatDateFullWithoutWeekday(new Date(date));
 
 export function ElectionCertificatePage() {
-  const { election, showKeypairReminder } = useElection();
+  const { election, showKeypairReminder, refetch } = useElection();
   const navigate = useNavigate();
   const { pushMessage } = useMessages();
 
@@ -43,6 +43,7 @@ export function ElectionCertificatePage() {
         title: t("election_certificate.upload.message.title"),
         text: tx("election_certificate.upload.message.text"),
       });
+      await refetch();
       void navigate(`/elections/${election.id}`);
     }
   }

--- a/frontend/src/features/election_management/components/ElectionCertificatePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionCertificatePage.tsx
@@ -11,7 +11,7 @@ import { Icon } from "@/components/ui/Icon/Icon";
 import cls from "@/features/election_management/components/ElectionManagement.module.css";
 import { useElection } from "@/hooks/election/useElection";
 import { useMessages } from "@/hooks/messages/useMessages";
-import { t } from "@/i18n/translate";
+import { t, tx } from "@/i18n/translate";
 import type {
   CERTIFICATE_DETAILS_REQUEST_PATH,
   CERTIFICATE_REQUEST_PATH,
@@ -41,7 +41,7 @@ export function ElectionCertificatePage() {
     if (isSuccess(result)) {
       pushMessage({
         title: t("election_certificate.upload.message.title"),
-        text: t("election_certificate.upload.message.text"),
+        text: tx("election_certificate.upload.message.text"),
       });
       void navigate(`/elections/${election.id}`);
     }

--- a/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.test.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { electionManagementRoutes } from "@/features/election_management/routes";
 import { ElectionProvider } from "@/hooks/election/ElectionProvider";
 import { ElectionStatusProvider } from "@/hooks/election/ElectionStatusProvider";
+import { MessagesProvider } from "@/hooks/messages/MessagesProvider";
 import {
   getCommitteeSessionListMockData,
   getCSBCommitteeSessionMockData,
@@ -18,6 +19,7 @@ import { getCSBElectionMockData, getElectionMockData } from "@/testing/api-mocks
 import {
   CommitteeSessionCreateHandler,
   CommitteeSessionDeleteHandler,
+  DismissPublicKeyUploadReminderRequestHandler,
   ElectionRequestHandler,
 } from "@/testing/api-mocks/RequestHandlers";
 import { getRouter, type Router } from "@/testing/router";
@@ -34,7 +36,9 @@ const renderGSBPage = async (userRole: Role) => {
     <TestUserProvider userRole={userRole}>
       <ElectionProvider electionId={1}>
         <ElectionStatusProvider electionId={1}>
-          <ElectionHomePage />
+          <MessagesProvider>
+            <ElectionHomePage />
+          </MessagesProvider>
         </ElectionStatusProvider>
       </ElectionProvider>
     </TestUserProvider>,
@@ -49,7 +53,9 @@ const renderCSBPage = async () => {
     <TestUserProvider userRole={"coordinator_csb"}>
       <ElectionProvider electionId={2}>
         <ElectionStatusProvider electionId={2}>
-          <ElectionHomePage />
+          <MessagesProvider>
+            <ElectionHomePage />
+          </MessagesProvider>
         </ElectionStatusProvider>
       </ElectionProvider>
     </TestUserProvider>,
@@ -288,7 +294,9 @@ describe("ElectionHomePage", () => {
             <TestUserProvider userRole="coordinator_gsb">
               <ElectionProvider electionId={1}>
                 <ElectionStatusProvider electionId={1}>
-                  <RouterProvider router={router} />
+                  <MessagesProvider>
+                    <RouterProvider router={router} />
+                  </MessagesProvider>
                 </ElectionStatusProvider>
               </ElectionProvider>
             </TestUserProvider>
@@ -643,6 +651,59 @@ describe("ElectionHomePage", () => {
           ["N 10-1", "Inlegvellen controles en correcties per stembureau"],
           ["Na 31-1 inlegvel", "Inlegvel controles en correcties bij GSB proces-verbaal"],
         ]);
+      });
+    });
+
+    describe("Certificate registration alert", () => {
+      test("Shows alert for administrator and hides it after confirming", async () => {
+        const user = userEvent.setup();
+        const dismissReminder = spyOnHandler(DismissPublicKeyUploadReminderRequestHandler);
+        server.use(ElectionRequestHandler, DismissPublicKeyUploadReminderRequestHandler);
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(
+              { ...getElectionMockData(), show_keypair_reminder: true } satisfies ElectionDetailsResponse,
+              { status: 200 },
+            ),
+          ),
+        );
+        await renderGSBPage("administrator");
+
+        const alert = await screen.findByRole("alert");
+        expect(within(alert).getByText("Publieke sleutel registreren", { selector: "strong" })).toBeVisible();
+        expect(within(alert).getByRole("paragraph")).toHaveTextContent(
+          "Je moet de publieke sleutel van dit gemeentelijk stembureau registreren. Doe dit door de sleutel te uploaden naar het overdrachtsplatform van Kiesraad. Doe dit uiterlijk twee dagen voor de dag van stemming.",
+        );
+        expect(within(alert).getByRole("link", { name: "Publieke sleutel registreren" })).toHaveAttribute(
+          "href",
+          "/certificate",
+        );
+
+        const election_information_table = await screen.findByTestId("election-information-table");
+        expect(within(election_information_table).getByRole("row", { name: /Publieke sleutel/ })).toHaveTextContent(
+          "Nog niet geregistreerd",
+        );
+
+        overrideOnce("get", "/api/elections/1", 200, { ...getElectionMockData(), show_keypair_reminder: false });
+        await user.click(within(alert).getByRole("button", { name: "Ik heb dit al gedaan" }));
+        expect(alert).not.toBeInTheDocument();
+        expect(dismissReminder).toHaveBeenCalledOnce();
+        expect(within(election_information_table).getByRole("row", { name: /Publieke sleutel/ })).toHaveTextContent(
+          "Bekijken en downloaden",
+        );
+      });
+
+      test("Does not show alert for coordinator", async () => {
+        server.use(
+          http.get("/api/elections/1", () =>
+            HttpResponse.json(
+              { ...getElectionMockData(), show_keypair_reminder: true } satisfies ElectionDetailsResponse,
+              { status: 200 },
+            ),
+          ),
+        );
+        await renderGSBPage("coordinator_gsb");
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 
 import { DEFAULT_CANCEL_REASON } from "@/api/ApiClient";
+import { isSuccess } from "@/api/ApiResult";
 import { useCrud } from "@/api/useCrud";
 import { MissingCommitteeSessionDetailsModal } from "@/components/committee_session/MissingCommitteeSessionDetailsModal";
 import { Footer } from "@/components/footer/Footer";
 import { IconTrash } from "@/components/generated/icons";
+import { Messages } from "@/components/messages/Messages";
 import { PageTitle } from "@/components/page_title/PageTitle";
 import { Alert } from "@/components/ui/Alert/Alert";
 import { Button } from "@/components/ui/Button/Button";
@@ -13,11 +15,12 @@ import { Modal } from "@/components/ui/Modal/Modal";
 import { Table } from "@/components/ui/Table/Table";
 import { useElection } from "@/hooks/election/useElection";
 import { useUserRole } from "@/hooks/user/useUserRole";
-import { t } from "@/i18n/translate";
+import { t, tx } from "@/i18n/translate";
 import type {
   COMMITTEE_SESSION_CREATE_REQUEST_PATH,
   COMMITTEE_SESSION_DELETE_REQUEST_PATH,
   CommitteeSession,
+  DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH,
   Election,
 } from "@/types/generated/openapi";
 import { cn } from "@/utils/classnames";
@@ -191,13 +194,25 @@ function DSONextSessionDownloadSection({ election }: DownloadSectionProps) {
 export function ElectionHomePage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { currentCommitteeSession, committeeSessions, election, investigations, pollingStations, refetch } =
-    useElection();
+  const {
+    currentCommitteeSession,
+    committeeSessions,
+    election,
+    investigations,
+    pollingStations,
+    showKeypairReminder,
+    refetch,
+  } = useElection();
   const { isCoordinator, role } = useUserRole();
   const [showAddCommitteeSessionModal, setShowAddCommitteeSessionModal] = useState(false);
   const createPath: COMMITTEE_SESSION_CREATE_REQUEST_PATH = `/api/elections/${election.id}/committee_sessions`;
   const removePath: COMMITTEE_SESSION_DELETE_REQUEST_PATH = `/api/elections/${currentCommitteeSession.election_id}/committee_sessions/${currentCommitteeSession.id}`;
   const { create, remove } = useCrud({ createPath, removePath, throwAllErrors: true });
+  const dismissReminderPath: DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH = `/api/elections/${election.id}/dismiss_public_key_upload_reminder`;
+  const { update: dismissReminder, isLoading: isUpdatingReminder } = useCrud({
+    updatePath: dismissReminderPath,
+    throwAllErrors: true,
+  });
   const showDeleteModal = hasBooleanProperty(location.state, "showDeleteModal") && location.state.showDeleteModal;
 
   // re-fetch election when component mounts
@@ -237,6 +252,7 @@ export function ElectionHomePage() {
           <h1>{election.name}</h1>
         </section>
       </header>
+      <Messages />
       {showAddCommitteeSessionModal && (
         <Modal title={t("election_management.investigation_ordered_by_csb")} onClose={toggleAddCommitteeSessionModal}>
           <p>{t("election_management.only_add_if_ordered")}</p>
@@ -310,6 +326,35 @@ export function ElectionHomePage() {
           </nav>
         </Modal>
       )}
+      {role === "administrator" && election.committee_category === "GSB" && showKeypairReminder && (
+        <Alert type="notify">
+          <strong className="heading-md">{t("election_management.alert_register.title")}</strong>
+          <p>
+            {tx("election_management.alert_register.explanation", undefined, {
+              committee: t(`committee_category.${election.committee_category}.short`).toLowerCase(),
+            })}
+          </p>
+          <nav className={cls.alertActions}>
+            <Button.Link to="certificate" size="md">
+              {t("election_management.alert_register.register")}
+            </Button.Link>
+            <Button
+              variant="secondary"
+              size="md"
+              disabled={isUpdatingReminder}
+              onClick={() => {
+                void dismissReminder({}).then((result) => {
+                  if (isSuccess(result)) {
+                    void refetch();
+                  }
+                });
+              }}
+            >
+              {t("election_management.alert_register.register_already_done")}
+            </Button>
+          </nav>
+        </Alert>
+      )}
       {election.committee_category === "GSB" && pollingStations.length === 0 && (
         <Alert type="warning">
           <strong className="heading-md" id="noPollingStationsWarningAlertTitle">
@@ -357,6 +402,7 @@ export function ElectionHomePage() {
               committeeSession={currentCommitteeSession}
               numberOfPollingStations={pollingStations.length}
               role={role}
+              publicKeyRegistered={!showKeypairReminder}
             />
           </div>
           {election.committee_category === "GSB" &&

--- a/frontend/src/features/election_management/components/ElectionHomePage.tsx
+++ b/frontend/src/features/election_management/components/ElectionHomePage.tsx
@@ -190,143 +190,23 @@ function DSONextSessionDownloadSection({ election }: DownloadSectionProps) {
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: TODO function should be refactored
-export function ElectionHomePage() {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const {
-    currentCommitteeSession,
-    committeeSessions,
-    election,
-    investigations,
-    pollingStations,
-    showKeypairReminder,
-    refetch,
-  } = useElection();
-  const { isCoordinator, role } = useUserRole();
-  const [showAddCommitteeSessionModal, setShowAddCommitteeSessionModal] = useState(false);
-  const createPath: COMMITTEE_SESSION_CREATE_REQUEST_PATH = `/api/elections/${election.id}/committee_sessions`;
-  const removePath: COMMITTEE_SESSION_DELETE_REQUEST_PATH = `/api/elections/${currentCommitteeSession.election_id}/committee_sessions/${currentCommitteeSession.id}`;
-  const { create, remove } = useCrud({ createPath, removePath, throwAllErrors: true });
+function Alerts() {
+  const { election, pollingStations, showKeypairReminder, refetch } = useElection();
+  const { role } = useUserRole();
+
   const dismissReminderPath: DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH = `/api/elections/${election.id}/dismiss_public_key_upload_reminder`;
   const { update: dismissReminder, isLoading: isUpdatingReminder } = useCrud({
     updatePath: dismissReminderPath,
     throwAllErrors: true,
   });
-  const showDeleteModal = hasBooleanProperty(location.state, "showDeleteModal") && location.state.showDeleteModal;
 
-  // re-fetch election when component mounts
-  useEffect(() => {
-    const abortController = new AbortController();
-    void refetch(abortController);
-    return () => {
-      abortController.abort(DEFAULT_CANCEL_REASON);
-    };
-  }, [refetch]);
-
-  function toggleAddCommitteeSessionModal() {
-    setShowAddCommitteeSessionModal(!showAddCommitteeSessionModal);
-  }
-
-  function handleCommitteeSessionCreate() {
-    void create({}).then(() => {
-      void refetch();
-    });
-  }
-
-  function handleCommitteeSessionDelete() {
-    void remove().then(() => {
-      void refetch();
-    });
-  }
-
-  function toggleDeleteCommitteeSessionModal() {
-    void navigate(".", { replace: true });
+  if (election.committee_category !== "GSB") {
+    return null;
   }
 
   return (
     <>
-      <PageTitle title={`${t("election.title.details")} - Abacus`} />
-      <header>
-        <section>
-          <h1>{election.name}</h1>
-        </section>
-      </header>
-      <Messages />
-      {showAddCommitteeSessionModal && (
-        <Modal title={t("election_management.investigation_ordered_by_csb")} onClose={toggleAddCommitteeSessionModal}>
-          <p>{t("election_management.only_add_if_ordered")}</p>
-          <p>{t("election_management.if_gsb_correction")}</p>
-          <nav>
-            <Button
-              variant="primary"
-              size="xl"
-              onClick={() => {
-                handleCommitteeSessionCreate();
-                toggleAddCommitteeSessionModal();
-              }}
-            >
-              {t("election_management.yes_add_session")}
-            </Button>
-            <Button variant="secondary" onClick={toggleAddCommitteeSessionModal}>
-              {t("cancel")}
-            </Button>
-          </nav>
-        </Modal>
-      )}
-      {showDeleteModal && investigations.length === 0 && (
-        <Modal title={`${t("election_management.delete_session")}?`} onClose={toggleDeleteCommitteeSessionModal}>
-          <p>
-            {t("election_management.delete_session_are_you_sure", {
-              sessionLabel: committeeSessionLabel(
-                election.committee_category,
-                currentCommitteeSession.number,
-                true,
-                true,
-              ),
-            })}
-          </p>
-          <nav>
-            <Button
-              leftIcon={<IconTrash />}
-              variant="primary-destructive"
-              size="xl"
-              onClick={() => {
-                handleCommitteeSessionDelete();
-                toggleDeleteCommitteeSessionModal();
-              }}
-            >
-              {t("election_management.yes_delete_session")}
-            </Button>
-            <Button variant="secondary" onClick={toggleDeleteCommitteeSessionModal}>
-              {t("cancel")}
-            </Button>
-          </nav>
-        </Modal>
-      )}
-      {showDeleteModal && investigations.length > 0 && (
-        <Modal title={t("election_management.delete_investigations_first")} onClose={toggleDeleteCommitteeSessionModal}>
-          <p>
-            {t("election_management.delete_investigations_first_are_you_sure", {
-              sessionLabel: committeeSessionLabel(
-                election.committee_category,
-                currentCommitteeSession.number,
-                true,
-                true,
-              ),
-            })}
-          </p>
-          <nav>
-            <Button variant="primary" size="xl" onClick={() => void navigate("investigations")}>
-              {t("election_management.view_investigations")}
-            </Button>
-            <Button variant="secondary" onClick={toggleDeleteCommitteeSessionModal}>
-              {t("cancel")}
-            </Button>
-          </nav>
-        </Modal>
-      )}
-      {role === "administrator" && election.committee_category === "GSB" && showKeypairReminder && (
+      {role === "administrator" && showKeypairReminder && (
         <Alert type="notify">
           <strong className="heading-md">{t("election_management.alert_register.title")}</strong>
           <p>
@@ -355,7 +235,7 @@ export function ElectionHomePage() {
           </nav>
         </Alert>
       )}
-      {election.committee_category === "GSB" && pollingStations.length === 0 && (
+      {pollingStations.length === 0 && (
         <Alert type="warning">
           <strong className="heading-md" id="noPollingStationsWarningAlertTitle">
             {t("election_management.no_polling_stations")}
@@ -366,6 +246,140 @@ export function ElectionHomePage() {
           </p>
         </Alert>
       )}
+    </>
+  );
+}
+
+interface CommitteeSessionModalsProps {
+  showAddModal: boolean;
+  onCloseAddModal: () => void;
+}
+
+function CommitteeSessionModals({ showAddModal, onCloseAddModal }: CommitteeSessionModalsProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { currentCommitteeSession, election, investigations, refetch } = useElection();
+  const showDeleteModal = hasBooleanProperty(location.state, "showDeleteModal") && location.state.showDeleteModal;
+
+  const createPath: COMMITTEE_SESSION_CREATE_REQUEST_PATH = `/api/elections/${election.id}/committee_sessions`;
+  const removePath: COMMITTEE_SESSION_DELETE_REQUEST_PATH = `/api/elections/${currentCommitteeSession.election_id}/committee_sessions/${currentCommitteeSession.id}`;
+  const { create, remove } = useCrud({ createPath, removePath, throwAllErrors: true });
+
+  function closeDeleteModal() {
+    void navigate(".", { replace: true });
+  }
+
+  if (showAddModal) {
+    return (
+      <Modal title={t("election_management.investigation_ordered_by_csb")} onClose={onCloseAddModal}>
+        <p>{t("election_management.only_add_if_ordered")}</p>
+        <p>{t("election_management.if_gsb_correction")}</p>
+        <nav>
+          <Button
+            variant="primary"
+            size="xl"
+            onClick={() => {
+              void create({}).then(() => void refetch());
+              onCloseAddModal();
+            }}
+          >
+            {t("election_management.yes_add_session")}
+          </Button>
+          <Button variant="secondary" onClick={onCloseAddModal}>
+            {t("cancel")}
+          </Button>
+        </nav>
+      </Modal>
+    );
+  }
+
+  if (!showDeleteModal) {
+    return null;
+  }
+
+  if (investigations.length > 0) {
+    return (
+      <Modal title={t("election_management.delete_investigations_first")} onClose={closeDeleteModal}>
+        <p>
+          {t("election_management.delete_investigations_first_are_you_sure", {
+            sessionLabel: committeeSessionLabel(
+              election.committee_category,
+              currentCommitteeSession.number,
+              true,
+              true,
+            ),
+          })}
+        </p>
+        <nav>
+          <Button variant="primary" size="xl" onClick={() => void navigate("investigations")}>
+            {t("election_management.view_investigations")}
+          </Button>
+          <Button variant="secondary" onClick={closeDeleteModal}>
+            {t("cancel")}
+          </Button>
+        </nav>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal title={`${t("election_management.delete_session")}?`} onClose={closeDeleteModal}>
+      <p>
+        {t("election_management.delete_session_are_you_sure", {
+          sessionLabel: committeeSessionLabel(election.committee_category, currentCommitteeSession.number, true, true),
+        })}
+      </p>
+      <nav>
+        <Button
+          leftIcon={<IconTrash />}
+          variant="primary-destructive"
+          size="xl"
+          onClick={() => {
+            void remove().then(() => void refetch());
+            closeDeleteModal();
+          }}
+        >
+          {t("election_management.yes_delete_session")}
+        </Button>
+        <Button variant="secondary" onClick={closeDeleteModal}>
+          {t("cancel")}
+        </Button>
+      </nav>
+    </Modal>
+  );
+}
+
+export function ElectionHomePage() {
+  const { currentCommitteeSession, committeeSessions, election, pollingStations, showKeypairReminder, refetch } =
+    useElection();
+  const { isCoordinator, role } = useUserRole();
+  const [showAddCommitteeSessionModal, setShowAddCommitteeSessionModal] = useState(false);
+
+  // re-fetch election when component mounts
+  useEffect(() => {
+    const abortController = new AbortController();
+    void refetch(abortController);
+    return () => {
+      abortController.abort(DEFAULT_CANCEL_REASON);
+    };
+  }, [refetch]);
+
+  return (
+    <>
+      <PageTitle title={`${t("election.title.details")} - Abacus`} />
+      <header>
+        <section>
+          <h1>{election.name}</h1>
+        </section>
+      </header>
+      <Messages />
+      <Alerts />
+      <CommitteeSessionModals
+        showAddModal={showAddCommitteeSessionModal}
+        onCloseAddModal={() => {
+          setShowAddCommitteeSessionModal(false);
+        }}
+      />
       <main className={cls.electionHome}>
         <article>
           <div className="mb-xl">
@@ -389,7 +403,13 @@ export function ElectionHomePage() {
             {isCoordinator &&
               election.committee_category === "GSB" &&
               currentCommitteeSession.status === "completed" && (
-                <Button variant="secondary" size="sm" onClick={toggleAddCommitteeSessionModal}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setShowAddCommitteeSessionModal(true);
+                  }}
+                >
                   {t("election_management.prepare_new_session")}
                 </Button>
               )}

--- a/frontend/src/features/election_management/components/ElectionInformationTable.test.tsx
+++ b/frontend/src/features/election_management/components/ElectionInformationTable.test.tsx
@@ -16,10 +16,13 @@ const renderGSBTable = (
   electionNumberOfVoters: number,
   committeeSessionNumber: number,
   committeeSessionStatus: CommitteeSessionStatus,
+  publicKeyRegistered?: boolean,
 ) => {
   render(
     <TestUserProvider userRole={userRole}>
       <ElectionInformationTable
+        role={userRole}
+        publicKeyRegistered={publicKeyRegistered}
         election={{
           id: 1,
           name: "Gemeenteraadsverkiezingen 2026",
@@ -177,8 +180,8 @@ describe("ElectionInformationTable", () => {
       });
     });
 
-    test("renders a table with the election information for administrator", async () => {
-      renderGSBTable("administrator", 1234, 1, "created");
+    test("renders a table with the election information for administrator with registered public key", async () => {
+      renderGSBTable("administrator", 1234, 1, "created", true);
 
       const election_information_table = await screen.findByTestId("election-information-table");
       expect(election_information_table).toBeVisible();
@@ -188,6 +191,7 @@ describe("ElectionInformationTable", () => {
         ["Lijsten en kandidaten", "1 lijst en 1 kandidaat"],
         ["Aantal kiesgerechtigden", "1.234"],
         ["Type stembureau", "Gemeentelijk stembureau"],
+        ["Publieke sleutel", "Bekijken en downloaden"],
         ["Stembureaus", "1 stembureau"],
         ["Type stemopneming", "Decentrale stemopneming"],
       ]);
@@ -198,6 +202,43 @@ describe("ElectionInformationTable", () => {
       await waitFor(() => {
         expect(navigate).toHaveBeenCalledWith("number-of-voters");
       });
+
+      expect(tableRows[5]!.textContent).toEqual("Publieke sleutelBekijken en downloaden");
+      tableRows[5]!.click();
+      await waitFor(() => {
+        expect(navigate).toHaveBeenCalledWith("certificate");
+      });
+    });
+
+    test("renders a table with the election information for administrator with unregistered public key", async () => {
+      renderGSBTable("administrator", 1234, 1, "created", false);
+
+      const election_information_table = await screen.findByTestId("election-information-table");
+      expect(election_information_table).toBeVisible();
+      expect(election_information_table).toHaveTableContent([
+        ["Verkiezing", "Gemeenteraadsverkiezingen 2026, 30 november"],
+        ["Kiesgebied", "0035 - Gemeente Heemdamseburg"],
+        ["Lijsten en kandidaten", "1 lijst en 1 kandidaat"],
+        ["Aantal kiesgerechtigden", "1.234"],
+        ["Type stembureau", "Gemeentelijk stembureau"],
+        ["Publieke sleutel", "Nog niet geregistreerd"],
+        ["Stembureaus", "1 stembureau"],
+        ["Type stemopneming", "Decentrale stemopneming"],
+      ]);
+
+      const tableRows = within(election_information_table).getAllByRole("row");
+      expect(tableRows[5]!.textContent).toEqual("Publieke sleutelNog niet geregistreerd");
+      tableRows[5]!.click();
+      await waitFor(() => {
+        expect(navigate).toHaveBeenCalledWith("certificate");
+      });
+    });
+
+    test("does not render public key row for coordinator", async () => {
+      renderGSBTable("coordinator_gsb", 1234, 1, "created");
+
+      const election_information_table = await screen.findByTestId("election-information-table");
+      expect(within(election_information_table).queryByText("Publieke sleutel")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/election_management/components/ElectionInformationTable.tsx
+++ b/frontend/src/features/election_management/components/ElectionInformationTable.tsx
@@ -11,6 +11,7 @@ interface ElectionInformationTableProps {
   committeeSession: CommitteeSession;
   numberOfPollingStations: number;
   role?: Role;
+  publicKeyRegistered?: boolean;
 }
 
 function getListsAndCandidatesLabel(election: ElectionWithPoliticalGroups) {
@@ -29,6 +30,7 @@ export function ElectionInformationTable({
   committeeSession,
   numberOfPollingStations,
   role,
+  publicKeyRegistered,
 }: ElectionInformationTableProps) {
   const rowLink =
     committeeSession.number === 1 &&
@@ -84,7 +86,11 @@ export function ElectionInformationTable({
                 <Table.HeaderCell scope="row" className="normal">
                   {t("election_certificate.certificate")}
                 </Table.HeaderCell>
-                <Table.Cell className="underlined">{t("election_certificate.details")}</Table.Cell>
+                <Table.Cell className="underlined">
+                  {publicKeyRegistered
+                    ? t("election_certificate.details")
+                    : t("election_certificate.not_yet_registered")}
+                </Table.Cell>
               </Table.Row>
             )}
             <Table.Row key={election.id} to="polling-stations">

--- a/frontend/src/features/election_management/components/ElectionManagement.module.css
+++ b/frontend/src/features/election_management/components/ElectionManagement.module.css
@@ -20,6 +20,11 @@
   }
 }
 
+.alertActions {
+  display: flex;
+  gap: 1rem;
+}
+
 .electionInformationTable {
   width: 58.5rem;
 }

--- a/frontend/src/hooks/election/ElectionProvider.tsx
+++ b/frontend/src/hooks/election/ElectionProvider.tsx
@@ -26,6 +26,7 @@ export function ElectionProvider({ children, electionId }: ElectionProviderProps
             election: data.election,
             pollingStations: data.polling_stations,
             investigations: data.investigations,
+            showKeypairReminder: data.show_keypair_reminder,
             refetch,
           }}
         >

--- a/frontend/src/hooks/election/ElectionProviderContext.tsx
+++ b/frontend/src/hooks/election/ElectionProviderContext.tsx
@@ -15,6 +15,7 @@ export interface iElectionProviderContext {
   election: ElectionWithPoliticalGroups;
   pollingStations: Required<PollingStation[]>;
   investigations: PollingStationInvestigation[];
+  showKeypairReminder?: boolean;
   refetch: (controller?: AbortController) => Promise<ApiResult<ElectionDetailsResponse>>;
 }
 

--- a/frontend/src/hooks/election/useElection.ts
+++ b/frontend/src/hooks/election/useElection.ts
@@ -10,7 +10,15 @@ export function useElection(pollingStationId?: number) {
     throw new Error("useElection must be used within an ElectionProvider");
   }
 
-  const { currentCommitteeSession, committeeSessions, election, pollingStations, investigations, refetch } = context;
+  const {
+    currentCommitteeSession,
+    committeeSessions,
+    election,
+    pollingStations,
+    investigations,
+    showKeypairReminder,
+    refetch,
+  } = context;
   const pollingStation = pollingStations.find((ps) => ps.id === pollingStationId);
   const investigation = pollingStation
     ? investigations.find((psi) => psi.polling_station_id === pollingStation.id)
@@ -24,6 +32,7 @@ export function useElection(pollingStationId?: number) {
     pollingStation,
     investigations,
     investigation,
+    showKeypairReminder,
     refetch,
   };
 }

--- a/frontend/src/hooks/election/useElectionDataRequest.ts
+++ b/frontend/src/hooks/election/useElectionDataRequest.ts
@@ -1,19 +1,7 @@
 import { useInitialApiGetWithErrors } from "@/api/useInitialApiGet";
-import type {
-  CommitteeSession,
-  ELECTION_DETAILS_REQUEST_PATH,
-  ElectionWithPoliticalGroups,
-  PollingStation,
-  PollingStationInvestigation,
-} from "@/types/generated/openapi";
+import type { ELECTION_DETAILS_REQUEST_PATH, ElectionDetailsResponse } from "@/types/generated/openapi";
 
 export function useElectionDataRequest(electionId: number) {
   const path: ELECTION_DETAILS_REQUEST_PATH = `/api/elections/${electionId}`;
-  return useInitialApiGetWithErrors<{
-    current_committee_session: CommitteeSession;
-    committee_sessions: CommitteeSession[];
-    election: ElectionWithPoliticalGroups;
-    polling_stations: PollingStation[];
-    investigations: PollingStationInvestigation[];
-  }>(path);
+  return useInitialApiGetWithErrors<ElectionDetailsResponse>(path);
 }

--- a/frontend/src/hooks/messages/MessagesContext.ts
+++ b/frontend/src/hooks/messages/MessagesContext.ts
@@ -1,11 +1,11 @@
-import { createContext } from "react";
+import { createContext, type ReactElement } from "react";
 
 import type { AlertType } from "@/types/ui";
 
 export interface Message {
   type?: AlertType;
   title?: string;
-  text?: string;
+  text?: string | ReactElement;
 }
 
 export interface iMessageContext {

--- a/frontend/src/i18n/locales/nl/election_certificate.json
+++ b/frontend/src/i18n/locales/nl/election_certificate.json
@@ -7,7 +7,20 @@
   "explanation": "Abacus ondertekent officiële bestanden met een digitale (RSA) handtekening. De handtekening wordt gezet met een private sleutel. Die is geheim en blijft op deze computer. Met de bijbehorende publieke sleutel kan iedereen controleren dat bestanden echt op deze computer zijn gemaakt en niet zijn gewijzigd.",
   "not_after": "Geldig tot en met",
   "not_before": "Geldig vanaf",
+  "not_yet_registered": "Nog niet geregistreerd",
   "organizational_unit": "Organisatorische eenheid",
   "signature_algorithm": "Handtekeningalgoritme",
-  "subtitle": "Publieke sleutel Abacus-instantie {committee}"
+  "subtitle": {
+    "before_upload": "Registreer Abacus-instantie {committee} bij de Kiesraad",
+    "after_upload": "Publieke sleutel Abacus-instantie {committee}"
+  },
+  "upload": {
+    "title": "Upload het crt-bestand naar het overdrachtsplatform",
+    "explanation": "Doe dit uiterlijk twee dagen voor de dag van stemming.",
+    "done": "Ik heb dit gedaan",
+    "message": {
+      "title": "Publieke sleutel geregistreerd",
+      "text": "Let op: Upload de publieke sleutel zelf naar het overdrachtsplatform van de Kiesraad."
+    }
+  }
 }

--- a/frontend/src/i18n/locales/nl/election_certificate.json
+++ b/frontend/src/i18n/locales/nl/election_certificate.json
@@ -20,7 +20,7 @@
     "done": "Ik heb dit gedaan",
     "message": {
       "title": "Publieke sleutel geregistreerd",
-      "text": "Let op: Upload de publieke sleutel zelf naar het overdrachtsplatform van de Kiesraad."
+      "text": "<strong>Let op:</strong> Upload de publieke sleutel zelf naar het overdrachtsplatform van de Kiesraad."
     }
   }
 }

--- a/frontend/src/i18n/locales/nl/election_management.json
+++ b/frontend/src/i18n/locales/nl/election_management.json
@@ -3,6 +3,12 @@
   "add_polling_stations_first": "De invoerfase kan pas gestart worden als er stembureaus zijn toegevoegd.",
   "add_the_date_and_time": "Voer de datum en tijd in waarop de zitting van het gemeentelijke stembureau officieel is geopend.",
   "add_the_location": "Vul de plaatsnaam in. Bijvoorbeeld <em>Amersfoort</em>",
+  "alert_register": {
+    "title": "Publieke sleutel registreren",
+    "explanation": "Je moet de publieke sleutel van dit {committee} registreren. Doe dit door de sleutel te uploaden naar het overdrachtsplatform van Kiesraad. <strong>Doe dit uiterlijk twee dagen voor de dag van stemming.</strong>",
+    "register": "Publieke sleutel registreren",
+    "register_already_done": "Ik heb dit al gedaan"
+  },
   "began_on": "Begon op",
   "committee_session_details": "Details van de zitting",
   "custom_committee_session_details": "Details van {sessionLabel}",

--- a/frontend/src/i18n/locales/nl/log.json
+++ b/frontend/src/i18n/locales/nl/log.json
@@ -43,6 +43,7 @@
     "PollingStationUpdated": "Stembureau bijgewerkt",
     "PollingStationsImported": "Stembureaus geïmporteerd",
     "PollingStationsExported": "Stembureaus geëxporteerd",
+    "PublicKeyUploadReminderDismissed": "Publieke sleutel uploadherinnering afgevinkt",
     "UnknownEvent": "Onbekende gebeurtenis",
     "UserAccountUpdated": "Eigen account bijgewerkt",
     "UserCreated": "Gebruikersaccount aangemaakt",

--- a/frontend/src/testing/api-mocks/ElectionMockData.ts
+++ b/frontend/src/testing/api-mocks/ElectionMockData.ts
@@ -358,7 +358,7 @@ export const getElectionMockData = (
   election: Partial<ElectionWithPoliticalGroups> = {},
   committeeSession: Partial<CommitteeSession> = {},
   investigations: PollingStationInvestigation[] = mockInvestigations,
-): Required<ElectionDetailsResponse> => {
+): ElectionDetailsResponse => {
   const updatedCommitteeSession = getCommitteeSessionMockData(committeeSession);
 
   // If committee session number > 1, add prev_data_entry_id to polling stations
@@ -386,7 +386,7 @@ export const getElectionMockData = (
 export const getCSBElectionMockData = (
   election: Partial<ElectionWithPoliticalGroups> = {},
   committeeSession: Partial<CommitteeSession> = {},
-): Required<ElectionDetailsResponse> => {
+): ElectionDetailsResponse => {
   const updatedCommitteeSession = getCSBCommitteeSessionMockData(committeeSession);
 
   return {
@@ -403,8 +403,8 @@ export const getCSBElectionMockData = (
 };
 
 export const investigationListMockResponse: InvestigationListResponse = { investigations: mockInvestigations };
-export const electionDetailsMockResponse: Required<ElectionDetailsResponse> = getElectionMockData();
-export const csbElectionDetailsMockResponse: Required<ElectionDetailsResponse> = getCSBElectionMockData();
+export const electionDetailsMockResponse = getElectionMockData();
+export const csbElectionDetailsMockResponse = getCSBElectionMockData();
 
 export const electionMockData = electionDetailsMockResponse.election;
 export const provincialElectionMockData = getElectionMockData(electionListMockResponse.elections[4]).election;

--- a/frontend/src/testing/api-mocks/RequestHandlers.ts
+++ b/frontend/src/testing/api-mocks/RequestHandlers.ts
@@ -64,6 +64,8 @@ import type {
   DELETE_DECEASED_CANDIDATE_REQUEST_BODY,
   DELETE_DECEASED_CANDIDATE_REQUEST_PARAMS,
   DELETE_DECEASED_CANDIDATE_REQUEST_PATH,
+  DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PARAMS,
+  DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH,
   ELECTION_DETAILS_REQUEST_PARAMS,
   ELECTION_DETAILS_REQUEST_PATH,
   ELECTION_IMPORT_REQUEST_BODY,
@@ -345,6 +347,13 @@ export const ElectionCertificateDetailsRequestHandler = http.get<
   };
   return HttpResponse.json(response, { status: 200 });
 });
+
+export const DismissPublicKeyUploadReminderRequestHandler = http.put<
+  ParamsToString<DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PARAMS>
+>(
+  "/api/elections/1/dismiss_public_key_upload_reminder" satisfies DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH,
+  () => new HttpResponse(null, { status: 204 }),
+);
 
 // get election details handler
 export const CSBElectionRequestHandler = http.get<
@@ -692,6 +701,7 @@ export const handlers: HttpHandler[] = [
   ElectionRequestHandler,
   ElectionStatusRequestHandler,
   ElectionCertificateDetailsRequestHandler,
+  DismissPublicKeyUploadReminderRequestHandler,
   CSBElectionStatusRequestHandler,
   GSBABElectionImportRequestHandler,
   GSBGRElectionImportRequestHandler,

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -240,6 +240,13 @@ export type COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_PATH =
   `/api/elections/${ElectionId}/committee_sessions/${CommitteeSessionId}/status`;
 export type COMMITTEE_SESSION_STATUS_CHANGE_REQUEST_BODY = CommitteeSessionStatusChangeRequest;
 
+// /api/elections/{election_id}/dismiss_public_key_upload_reminder
+export interface DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PARAMS {
+  election_id: ElectionId;
+}
+export type DISMISS_PUBLIC_KEY_UPLOAD_REMINDER_REQUEST_PATH =
+  `/api/elections/${ElectionId}/dismiss_public_key_upload_reminder`;
+
 // /api/elections/{election_id}/download_n_10_1
 export interface ELECTION_DOWNLOAD_N_10_1_REQUEST_PARAMS {
   election_id: ElectionId;
@@ -1120,6 +1127,7 @@ export interface ElectionDetailsResponse {
   election: ElectionWithPoliticalGroups;
   investigations: PollingStationInvestigation[];
   polling_stations: PollingStation[];
+  show_keypair_reminder?: boolean;
 }
 
 /**

--- a/frontend/src/types/generated/openapi.ts
+++ b/frontend/src/types/generated/openapi.ts
@@ -517,6 +517,7 @@ export const auditEventTypeValues = [
   "UserDeleted",
   "ElectionCreated",
   "ElectionUpdated",
+  "PublicKeyUploadReminderDismissed",
   "CommitteeSessionCreated",
   "CommitteeSessionDeleted",
   "CommitteeSessionUpdated",


### PR DESCRIPTION
## What & why

Resolves #3771

[Figma design](https://www.figma.com/design/zZlFr8tYiRyp4I26sh6eqp/Kiesraad---Abacus-optelsoftware?node-id=21130-80921&p=f&t=heBcrWJSb2GRqj8O-0)

Changes:
- Added endpoint to dismiss reminder
  - Including audit event `PublicKeyUploadReminderDismissed`
- Election endpoint now returns `show_keypair_reminder`. 
  - Only passed to frontend if keypair is available
- ElectionHomePage
  - Shows alert if `show_keypair_reminder` is `true`
  - Link text to certificate page in information table is different when reminder is shown
  - Reorganized code by extracting the alerts and modals to a separate function
- ElectionCertificatePage
  - Title is different based on `show_keypair_reminder`
  - Update reminder with dismissal button is shown if `show_keypair_reminder` is `true`
- Message texts now support `tx`, used for bold text in this case
- Tests added

## How to test

- Generate a GSB election
- Go to the election as an administrator

## Reviewer notes

- Review per commit
- Naming recommendations are welcome, had a hard time finding a name which was not too generic