### PR TITLE
Report endpoints check committee session is part of election

### DIFF
--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -393,6 +393,7 @@ mod tests {
         response::{IntoResponse, Response},
     };
     use chrono::NaiveDateTime;
+    use http_body_util::BodyExt;
     use sqlx::SqlitePool;
     use test_log::test;
 
@@ -411,10 +412,10 @@ mod tests {
     async fn call_handlers_gsb(
         pool: SqlitePool,
         coordinator_role: Role,
+        election_id: ElectionId,
     ) -> Vec<(&'static str, Response)> {
         let user = User::test_user(coordinator_role, UserId::from(1));
         let audit = AuditService::new(Some(user.clone()), None);
-        let election_id = ElectionId::from(5);
         let committee_session_id = CommitteeSessionId::from(5);
 
         #[rustfmt::skip]
@@ -427,11 +428,11 @@ mod tests {
     async fn call_handlers_csb(
         pool: SqlitePool,
         coordinator_role: Role,
+        election_id: ElectionId,
     ) -> Vec<(&'static str, Response)> {
         let mut conn = pool.acquire().await.unwrap();
         let user = User::test_user(coordinator_role, UserId::from(1));
         let audit = AuditService::new(Some(user.clone()), None);
-        let election_id = ElectionId::from(8);
         let committee_session_id = CommitteeSessionId::from(801);
 
         // Change committee session status to completed
@@ -464,25 +465,50 @@ mod tests {
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_gsb_election_committee_category_authorization_err(pool: SqlitePool) {
-        let results = call_handlers_gsb(pool, Role::CoordinatorCSB).await;
+        let results = call_handlers_gsb(pool, Role::CoordinatorCSB, ElectionId::from(5)).await;
         assert_committee_category_authorization_err(results).await;
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_5_with_results"))))]
     async fn test_gsb_election_committee_category_authorization_ok(pool: SqlitePool) {
-        let results = call_handlers_gsb(pool, Role::CoordinatorGSB).await;
+        let results = call_handlers_gsb(pool, Role::CoordinatorGSB, ElectionId::from(5)).await;
         assert_committee_category_authorization_ok(results);
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_csb_election_committee_category_authorization_err(pool: SqlitePool) {
-        let results = call_handlers_csb(pool, Role::CoordinatorGSB).await;
+        let results = call_handlers_csb(pool, Role::CoordinatorGSB, ElectionId::from(8)).await;
         assert_committee_category_authorization_err(results).await;
     }
 
     #[test(sqlx::test(fixtures(path = "../../fixtures", scripts("election_8_csb_with_results"))))]
     async fn test_csb_election_committee_category_authorization_ok(pool: SqlitePool) {
-        let results = call_handlers_csb(pool, Role::CoordinatorCSB).await;
+        let results = call_handlers_csb(pool, Role::CoordinatorCSB, ElectionId::from(8)).await;
         assert_committee_category_authorization_ok(results);
+    }
+
+    #[test(sqlx::test(fixtures(
+        path = "../../fixtures",
+        scripts("election_5_with_results", "election_8_csb_with_results")
+    )))]
+    async fn test_err_election_committee_session_mismatch(pool: SqlitePool) {
+        // Passing non-matching election ids
+        let gsb_results =
+            call_handlers_gsb(pool.clone(), Role::CoordinatorGSB, ElectionId::from(4)).await;
+        let csb_results = call_handlers_csb(pool, Role::CoordinatorCSB, ElectionId::from(7)).await;
+
+        for (handler, response) in gsb_results.into_iter().chain(csb_results) {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            let error: ErrorResponse = serde_json::from_slice(&body).unwrap();
+            assert_eq!(
+                error.reference,
+                ErrorReference::EntryNotFound,
+                "handler '{handler}'"
+            );
+            assert_eq!(
+                error.error, "Committee session does not match election",
+                "handler '{handler}'"
+            );
+        }
     }
 }

--- a/backend/src/api/report.rs
+++ b/backend/src/api/report.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use chrono::{DateTime, Datelike, Local};
 use pdf_gen::zip::{ZipResponse, ZipResponseError, slugify_filename, zip_single_file};
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 use tracing::error;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
@@ -13,7 +13,7 @@ use crate::{
     APIError, AppState, ErrorResponse,
     api::middleware::authentication::RouteAuthorization,
     domain::{
-        committee_session::CommitteeSessionId,
+        committee_session::{CommitteeSession, CommitteeSessionId},
         election::{ElectionId, ElectionWithPoliticalGroups},
         report::files::{get_files_csb_election, get_files_gsb_election},
         role::Role,
@@ -92,6 +92,24 @@ pub fn with_zip_extension(filename: &str) -> String {
     format!("{}.zip", base)
 }
 
+pub async fn get_election_committee_session(
+    conn: &mut SqliteConnection,
+    election_id: ElectionId,
+    committee_session_id: CommitteeSessionId,
+) -> Result<(ElectionWithPoliticalGroups, CommitteeSession), APIError> {
+    let committee_session = committee_session_repo::get(conn, committee_session_id).await?;
+    if committee_session.election_id != election_id {
+        return Err(APIError::NotFound(
+            "Committee session does not match election".to_string(),
+            ErrorReference::EntryNotFound,
+        ));
+    }
+
+    let election = election_repo::get(conn, election_id).await?;
+
+    Ok((election, committee_session))
+}
+
 /// Download a zip containing a PDF for the PV and the EML with GSB election results
 #[utoipa::path(
     get,
@@ -128,8 +146,8 @@ pub async fn election_download_zip_results_gsb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
 
-    let election = election_repo::get(&mut conn, election_id).await?;
-    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+    let (election, committee_session) =
+        get_election_committee_session(&mut conn, election_id, committee_session_id).await?;
     let files = get_files_gsb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -208,8 +226,8 @@ pub async fn election_download_zip_results_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
 
-    let election = election_repo::get(&mut conn, election_id).await?;
-    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+    let (election, committee_session) =
+        get_election_committee_session(&mut conn, election_id, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -274,8 +292,8 @@ pub async fn election_download_zip_attachment_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
 
-    let election = election_repo::get(&mut conn, election_id).await?;
-    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+    let (election, committee_session) =
+        get_election_committee_session(&mut conn, election_id, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 
@@ -335,8 +353,8 @@ pub async fn election_download_zip_total_counts_csb(
         committee_session_repo::get_committee_category(&mut conn, committee_session_id).await?;
     user.role().is_authorized(committee_category)?;
 
-    let election = election_repo::get(&mut conn, election_id).await?;
-    let committee_session = committee_session_repo::get(&mut conn, committee_session_id).await?;
+    let (election, committee_session) =
+        get_election_committee_session(&mut conn, election_id, committee_session_id).await?;
     let files = get_files_csb_election(&pool, audit_service, committee_session.id).await?;
     drop(conn);
 


### PR DESCRIPTION
## What & why

Resolves #3924

The endpoints in `report.rs` were not checking if the given `CommitteeSessionId` was part of the election given by `ElectionId`. This PR adds a function which validates if `committee_session.election_id` matches the given `election_id`. A test has also been added.

## How to test

- Validate the code
- Try to call one of these endpoints with a mismatching `election_id`


## Reviewer notes

N/A