### PR TITLE
Use local AppData for Windows installation

### DIFF
--- a/packaging/windows/abacus.iss
+++ b/packaging/windows/abacus.iss
@@ -28,7 +28,7 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={userappdata}\{#MyAppName}
+DefaultDirName={localappdata}\{#MyAppName}
 ; Setup will not show the Select Destination Location wizard page.
 DisableDirPage=yes
 ; "ArchitecturesAllowed=x64compatible" specifies that Setup cannot run
@@ -181,7 +181,7 @@ begin
                     MB_YESNO, ['Database en backups verwijderen', 'Bewaren'],
                     0) of
         IDYES: begin
-          DelTree(ExpandConstant('{userappdata}\{#MyAppName}'), True, True, True);
+          DelTree(ExpandConstant('{app}'), True, True, True);
           MsgBox('Database en backups zijn verwijderd.', mbInformation, MB_OK);
         end;
         IDNO: MsgBox('Database en backups worden behouden.', mbInformation, MB_OK);


### PR DESCRIPTION
## What & why

Resolves #3925

## How to test

Run the installer on Windows, verify:
- The installation folder should be `%localappdata%\Abacus\`
- Application runs
- You are able to create backups
- When uninstalling, verify that all files are deleted when choosing that option (since the parameter changed)

## Reviewer notes

- I can provide a prebuilt installer.
- [InnoSetup constants](https://jrsoftware.org/ishelp/index.php?topic=consts)
  - `DefaultDirName={localappdata}\{#MyAppName}` is the installation folder. It makes `{app}` point to `%localappdata%\Abacus\`